### PR TITLE
feat(as-3316): change the back office api port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     container_name: api
     image: node:14-alpine
     ports:
-      - 3000:3000
+      - 3004:3000
     working_dir: /opt/app
     volumes:
       - ./packages/common:/opt/app/node_modules/@pins/common

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "PINS Back Office",
   "scripts": {
     "commit": "cz",
-    "commitlint": "commitlint --from 7c0a45c --to HEAD",
+    "commitlint": "commitlint --from 4b76eb9 --to HEAD",
     "test:e2e": "cd ./e2e-tests && npm run test:e2e TAGS='not @wip'",
     "test:e2e:postprocess": "cd ./e2e-tests && npm run test:e2e:postprocess",
     "test:e2e:files": "cd ./e2e-tests && ./create-large-test-files.sh",


### PR DESCRIPTION
Changed the Back Office API port from 3000 to 3004 so it doesn't clash with the Appeals Service API port when both the Back Office and Appeals Service dev environments are running together.

Also changed the commitlint from param which is used as a starting commit to validate the commit message format because it appears that some commits have been pushed with incorrectly formatted messages since this was last set.