### PR TITLE
fix: check the commit message just entered rather than the git history

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-npm run commitlint
+npx commitlint --edit "$1"


### PR DESCRIPTION
When a commit is created we should be checking the format of the commit message that has just been entered not the git history, which is an action that would be done in the pipeline.

This change will do that and reject the commit if it's not formatted correctly with the following message

![image](https://user-images.githubusercontent.com/6839214/137144598-cb837105-468c-4d33-b2bf-5e4c9580221b.png)
