### PR TITLE
fix(pipelines): correct the pipelines trigger from master to main

### DIFF
--- a/e2e-tests/azure-pipelines-publish-cypress.yml
+++ b/e2e-tests/azure-pipelines-publish-cypress.yml
@@ -1,5 +1,5 @@
 trigger:
-  - master
+  - main
 
 resources:
   - repo: self

--- a/packages/api/azure-api-build.yml
+++ b/packages/api/azure-api-build.yml
@@ -8,7 +8,7 @@ trigger:
       # - feature/*
       # - fix/*
       # - subtask/*
-      - master
+      - main
   paths:
     include:
       - packages/api

--- a/packages/web-app/azure-web-app-build.yml
+++ b/packages/web-app/azure-web-app-build.yml
@@ -8,7 +8,7 @@ trigger:
       # - feature/*
       # - fix/*
       # - subtask/*
-      - master
+      - main
   paths:
     include:
       - packages/web-app


### PR DESCRIPTION
We're using `main` rather than `master` branch in the back office so we need to use this for the pipeline trigger too.