### PR TITLE
Feature/as 3747 saving appeal link

### DIFF
--- a/packages/api/database/migrations/00033-create-create-appeal-link-procedure.js
+++ b/packages/api/database/migrations/00033-create-create-appeal-link-procedure.js
@@ -1,0 +1,128 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+    CREATE PROCEDURE CreateAppealLink
+      @json NVARCHAR(4000)
+    AS
+    DECLARE
+      @appealId CHAR(36),
+      @lpaQuestionnaireId CHAR(36),
+      @caseReference INT,
+      @caseTypeId INT,
+      @caseStageId INT,
+      @caseStatusId INT,
+      @appellantName NVARCHAR(80),
+      @siteAddressLineOne NVARCHAR(60),
+      @siteAddressLineTwo NVARCHAR(60),
+      @siteAddressTown NVARCHAR(60),
+      @siteAddressCounty NVARCHAR(60),
+      @siteAddressPostcode NVARCHAR(8),
+      @localPlanningAuthorityId NVARCHAR(9),
+      @eventUserId CHAR(36),
+      @eventUserName NVARCHAR(256)
+    BEGIN
+      SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+      SELECT
+        @lpaQuestionnaireId = LPAQuestionnaireID,
+        @caseReference = CaseReference,
+        @caseTypeId = CaseTypeID,
+        @caseStageId = CaseStageID,
+        @caseStatusId = CaseStatusID,
+        @appellantName = AppellantName,
+        @siteAddressLineOne = SiteAddressLineOne,
+        @siteAddressLineTwo = SiteAddressLineTwo,
+        @siteAddressTown = SiteAddressTown,
+        @siteAddressCounty = SiteAddressCounty,
+        @siteAddressPostcode = SiteAddressPostcode,
+        @localPlanningAuthorityId = LocalPlanningAuthorityID
+      FROM AppealLink (NOLOCK)
+      WHERE AppealID = @appealId AND LatestEvent = 1;
+
+      IF JSON_VALUE(@json, '$.lpaQuestionnaireId') IS NOT NULL
+        SET @lpaQuestionnaireId = JSON_VALUE(@json, '$.lpaQuestionnaireId')
+
+      IF JSON_VALUE(@json, '$.caseReference') IS NOT NULL
+        SET @caseReference = JSON_VALUE(@json, '$.caseReference')
+
+      IF JSON_VALUE(@json, '$.caseTypeId') IS NOT NULL
+        SET @caseTypeId = JSON_VALUE(@json, '$.caseTypeId')
+
+      IF JSON_VALUE(@json, '$.caseStageId') IS NOT NULL
+        SET @caseStageId = JSON_VALUE(@json, '$.caseStageId')
+
+      IF JSON_VALUE(@json, '$.caseStatusId') IS NOT NULL
+        SET @caseStatusId = JSON_VALUE(@json, '$.caseStatusId')
+
+      IF JSON_VALUE(@json, '$.appellantName') IS NOT NULL
+        SET @appellantName = JSON_VALUE(@json, '$.appellantName')
+
+      IF JSON_VALUE(@json, '$.siteAddressLineOne') IS NOT NULL
+        SET @siteAddressLineOne = JSON_VALUE(@json, '$.siteAddressLineOne')
+
+      IF JSON_VALUE(@json, '$.siteAddressLineTwo') IS NOT NULL
+        SET @siteAddressLineTwo = JSON_VALUE(@json, '$.siteAddressLineTwo')
+
+      IF JSON_VALUE(@json, '$.siteAddressTown') IS NOT NULL
+        SET @siteAddressTown = JSON_VALUE(@json, '$.siteAddressTown')
+
+      IF JSON_VALUE(@json, '$.siteAddressCounty') IS NOT NULL
+        SET @siteAddressCounty = JSON_VALUE(@json, '$.siteAddressCounty')
+
+      IF JSON_VALUE(@json, '$.siteAddressPostcode') IS NOT NULL
+        SET @siteAddressPostcode = JSON_VALUE(@json, '$.siteAddressPostcode')
+
+      IF JSON_VALUE(@json, '$.localPlanningAuthorityId') IS NOT NULL
+        SET @localPlanningAuthorityId = JSON_VALUE(@json, '$.localPlanningAuthorityId')
+
+      IF JSON_VALUE(@json, '$.eventUserId') IS NOT NULL
+        SET @eventUserId = JSON_VALUE(@json, '$.eventUserId')
+
+      IF JSON_VALUE(@json, '$.eventUserName') IS NOT NULL
+        SET @eventUserName = JSON_VALUE(@json, '$.eventUserName')
+
+      INSERT INTO AppealLink (
+        ID,
+        AppealID,
+        LPAQuestionnaireID,
+        CaseReference,
+        CaseTypeID,
+        CaseStageID,
+        CaseStatusID,
+        AppellantName,
+        SiteAddressLineOne,
+        SiteAddressLineTwo,
+        SiteAddressTown,
+        SiteAddressCounty,
+        SiteAddressPostcode,
+        LocalPlanningAuthorityID,
+        EventUserID,
+        EventUserName
+      )
+      VALUES (
+        newid(),
+        @appealId,
+        @lpaQuestionnaireId,
+        @caseReference,
+        @caseTypeId,
+        @caseStageId,
+        @caseStatusId,
+        @appellantName,
+        @siteAddressLineOne,
+        @siteAddressLineTwo,
+        @siteAddressTown,
+        @siteAddressCounty,
+        @siteAddressPostcode,
+        @localPlanningAuthorityId,
+        @eventUserId,
+        @eventUserName
+      );
+    END
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateAppealLink');
+  },
+};
+
+module.exports = migration;

--- a/packages/api/src/controllers/appeal-link.js
+++ b/packages/api/src/controllers/appeal-link.js
@@ -1,0 +1,17 @@
+const { createAppealLinkRecord } = require('../lib/db-wrapper');
+const logger = require('../lib/logger');
+
+const postAppealLink = async (req, res) => {
+  try {
+    const { body } = req;
+    const result = await createAppealLinkRecord(body);
+    res.status(200).send(result);
+  } catch (err) {
+    logger.error({ err }, 'Failed to insert appeal link');
+    res.status(500).send('Failed to insert appeal link');
+  }
+};
+
+module.exports = {
+  postAppealLink,
+};

--- a/packages/api/src/controllers/appeal-link.spec.js
+++ b/packages/api/src/controllers/appeal-link.spec.js
@@ -1,0 +1,46 @@
+const { mockReq, mockRes } = require('../../test/utils/mocks');
+const mockDbRecord = require('../../test/data/appeal-link-submission-db-record');
+
+jest.mock('../lib/db-wrapper', () => ({
+  dbConnect: jest.fn(),
+  createRecord: jest
+    .fn()
+    .mockImplementationOnce(() => mockDbRecord)
+    .mockImplementationOnce(() => {
+      throw new Error('Internal Server Error');
+    }),
+  createAppealLinkRecord: jest
+    .fn()
+    .mockImplementationOnce(() => mockDbRecord)
+    .mockImplementationOnce(() => {
+      throw new Error('Internal Server Error');
+    }),
+}));
+
+const { postAppealLink } = require('./appeal-link');
+
+describe('controllers/appeal-link', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = mockReq();
+    res = mockRes();
+  });
+
+  describe('postAppealLink', () => {
+    it('should return the correct response when data can be inserted', async () => {
+      await postAppealLink(req, res);
+
+      expect(res.status).toBeCalledWith(200);
+      expect(res.send).toBeCalledWith(mockDbRecord);
+    });
+
+    it('should return the correct response when an error occurs', async () => {
+      await postAppealLink(req, res);
+
+      expect(res.status).toBeCalledWith(500);
+      expect(res.send).toBeCalledWith('Failed to insert appeal link');
+    });
+  });
+});

--- a/packages/api/src/controllers/appeal.js
+++ b/packages/api/src/controllers/appeal.js
@@ -1,13 +1,11 @@
-const { dbConnect, findAllAppeals, findOneAppeal, createHasAppeal } = require('../lib/db-wrapper');
+const { findAllAppeals, findOneAppeal, createHasAppealRecord } = require('../lib/db-wrapper');
 const logger = require('../lib/logger');
 const { getDocumentsMetadata } = require('../lib/documents-api-wrapper');
 const ApiError = require('../lib/api-error');
 
-const db = dbConnect();
-
 const getAllAppeals = async (req, res) => {
   try {
-    const appeals = await findAllAppeals(db);
+    const appeals = await findAllAppeals();
     res.status(200).send(appeals);
   } catch (err) {
     logger.error({ err }, 'Failed to get appeals');
@@ -23,7 +21,7 @@ const getOneAppeal = async (req, res) => {
       throw new ApiError('No AppealId given');
     }
 
-    const appeal = await findOneAppeal(db, appealId);
+    const appeal = await findOneAppeal(appealId);
     appeal.documents = await getDocumentsMetadata(appealId);
     res.status(200).send(appeal);
   } catch (err) {
@@ -35,7 +33,7 @@ const getOneAppeal = async (req, res) => {
 const postAppeal = async (req, res) => {
   try {
     const { body } = req;
-    const result = await createHasAppeal(db, body);
+    const result = await createHasAppealRecord(body);
     res.status(200).send(result);
   } catch (err) {
     logger.error({ err }, 'Failed to insert appeal');

--- a/packages/api/src/controllers/appeal.spec.js
+++ b/packages/api/src/controllers/appeal.spec.js
@@ -3,7 +3,6 @@ const mockDbRecord = require('../../test/data/has-appeal-submission-db-record');
 const mockDocumentsMetadata = require('../../test/data/documents-metadata');
 
 jest.mock('../lib/db-wrapper', () => ({
-  dbConnect: jest.fn(),
   findOneAppeal: jest
     .fn()
     .mockImplementationOnce(() => mockDbRecord)
@@ -16,7 +15,13 @@ jest.mock('../lib/db-wrapper', () => ({
     .mockImplementationOnce(() => {
       throw new Error('Internal Server Error');
     }),
-  createHasAppeal: jest
+  createRecord: jest
+    .fn()
+    .mockImplementationOnce(() => mockDbRecord)
+    .mockImplementationOnce(() => {
+      throw new Error('Internal Server Error');
+    }),
+  createHasAppealRecord: jest
     .fn()
     .mockImplementationOnce(() => mockDbRecord)
     .mockImplementationOnce(() => {

--- a/packages/api/src/controllers/questionnaire.js
+++ b/packages/api/src/controllers/questionnaire.js
@@ -1,18 +1,15 @@
 const {
-  dbConnect,
   findAllQuestionnaires,
   findOneQuestionnaire,
-  createHasAppeal,
+  createHasLpaSubmissionRecord,
 } = require('../lib/db-wrapper');
 const logger = require('../lib/logger');
 const { getDocumentsMetadata } = require('../lib/documents-api-wrapper');
 const ApiError = require('../lib/api-error');
 
-const db = dbConnect();
-
 const getAllQuestionnaires = async (req, res) => {
   try {
-    const questionnaires = await findAllQuestionnaires(db);
+    const questionnaires = await findAllQuestionnaires();
     res.status(200).send(questionnaires);
   } catch (err) {
     logger.error({ err }, 'Failed to get questionnaires');
@@ -28,7 +25,7 @@ const getOneQuestionnaire = async (req, res) => {
       throw new ApiError('No AppealId given');
     }
 
-    const questionnaire = await findOneQuestionnaire(db, appealId);
+    const questionnaire = await findOneQuestionnaire(appealId);
     questionnaire.documents = await getDocumentsMetadata(questionnaire.lpaQuestionnaireId);
     res.status(200).send(questionnaire);
   } catch (err) {
@@ -40,7 +37,7 @@ const getOneQuestionnaire = async (req, res) => {
 const postQuestionnaire = async (req, res) => {
   try {
     const { body } = req;
-    const result = await createHasAppeal(db, body);
+    const result = await createHasLpaSubmissionRecord(body);
     res.status(200).send(result);
   } catch (err) {
     logger.error({ err }, 'Failed to insert questionnaire');

--- a/packages/api/src/controllers/questionnaire.spec.js
+++ b/packages/api/src/controllers/questionnaire.spec.js
@@ -3,7 +3,6 @@ const mockDbRecord = require('../../test/data/has-lpa-submission-db-record');
 const mockDocumentsMetadata = require('../../test/data/documents-metadata');
 
 jest.mock('../lib/db-wrapper', () => ({
-  dbConnect: jest.fn(),
   findOneQuestionnaire: jest
     .fn()
     .mockImplementationOnce(() => mockDbRecord)
@@ -16,7 +15,13 @@ jest.mock('../lib/db-wrapper', () => ({
     .mockImplementationOnce(() => {
       throw new Error('Internal Server Error');
     }),
-  createHasAppeal: jest
+  createRecord: jest
+    .fn()
+    .mockImplementationOnce(() => mockDbRecord)
+    .mockImplementationOnce(() => {
+      throw new Error('Internal Server Error');
+    }),
+  createHasLpaSubmissionRecord: jest
     .fn()
     .mockImplementationOnce(() => mockDbRecord)
     .mockImplementationOnce(() => {

--- a/packages/api/src/lib/db-connect.js
+++ b/packages/api/src/lib/db-connect.js
@@ -1,0 +1,10 @@
+const Sequelize = require('sequelize');
+const config = require('../../database/config/config');
+
+const {
+  development: { username, password, database, host, dialect },
+} = config;
+
+const dbConnect = new Sequelize(database, username, password, { host, dialect });
+
+module.exports = dbConnect;

--- a/packages/api/src/lib/db-wrapper.js
+++ b/packages/api/src/lib/db-wrapper.js
@@ -1,23 +1,20 @@
-const Sequelize = require('sequelize');
 const ApiError = require('./api-error');
-const config = require('../../database/config/config');
+const db = require('./db-connect');
 
-const {
-  development: { username, password, database, host, dialect },
-} = config;
-
-const dbConnect = () => new Sequelize(database, username, password, { host, dialect });
-
-const createHasAppeal = (db, data) => {
+const createRecord = (procedure, data) => {
   try {
-    const query = `EXEC CreateHASAppeal @json = '${JSON.stringify(data)}'`;
-    return db.query(query);
+    const query = `EXEC ${procedure} @json = ?`;
+    return db.query(query, { replacements: [JSON.stringify(data)] });
   } catch (err) {
-    throw new ApiError(`Failed to create HAS appeal data with error - ${err.toString()}`);
+    throw new ApiError(`Failed to execute ${procedure} with error - ${err.toString()}`);
   }
 };
 
-const findAllAppeals = async (db) => {
+const createHasAppealRecord = (data) => createRecord('CreateHASAppeal', data);
+const createAppealLinkRecord = (data) => createRecord('CreateAppealLink', data);
+const createHasLpaSubmissionRecord = (data) => createRecord('CreateHASLPASubmission', data);
+
+const findAllAppeals = async () => {
   try {
     const query = 'SELECT * FROM AppealData WHERE caseReference IS NOT NULL AND CaseStageId = 1';
     const result = await db.query(query);
@@ -27,7 +24,7 @@ const findAllAppeals = async (db) => {
   }
 };
 
-const findOneAppeal = async (db, appealId) => {
+const findOneAppeal = async (appealId) => {
   try {
     const query = `SELECT * FROM AppealData WHERE AppealId = '${appealId}'`;
     const result = await db.query(query);
@@ -37,7 +34,7 @@ const findOneAppeal = async (db, appealId) => {
   }
 };
 
-const findAllQuestionnaires = async (db) => {
+const findAllQuestionnaires = async () => {
   try {
     const query = 'SELECT * FROM QuestionnaireData';
     const result = await db.query(query);
@@ -47,7 +44,7 @@ const findAllQuestionnaires = async (db) => {
   }
 };
 
-const findOneQuestionnaire = async (db, appealId) => {
+const findOneQuestionnaire = async (appealId) => {
   try {
     const query = `SELECT * FROM QuestionnaireData WHERE AppealId = '${appealId}'`;
     const result = await db.query(query);
@@ -58,8 +55,9 @@ const findOneQuestionnaire = async (db, appealId) => {
 };
 
 module.exports = {
-  dbConnect,
-  createHasAppeal,
+  createAppealLinkRecord,
+  createHasAppealRecord,
+  createHasLpaSubmissionRecord,
   findAllAppeals,
   findOneAppeal,
   findAllQuestionnaires,

--- a/packages/api/src/lib/db-wrapper.spec.js
+++ b/packages/api/src/lib/db-wrapper.spec.js
@@ -1,37 +1,48 @@
 const mockHasAppealSubmissionDbRecord = require('../../test/data/has-appeal-submission-db-record');
 const mockHasLpaSubmissionDbRecord = require('../../test/data/has-lpa-submission-db-record');
 const {
-  createHasAppeal,
+  createHasAppealRecord,
+  createAppealLinkRecord,
+  createHasLpaSubmissionRecord,
   findAllAppeals,
   findOneAppeal,
   findAllQuestionnaires,
   findOneQuestionnaire,
 } = require('./db-wrapper');
+const db = require('./db-connect');
 
-const db = {
+jest.mock('./db-connect', () => ({
   query: jest
     .fn()
+    .mockImplementationOnce(() => [[mockHasAppealSubmissionDbRecord]])
+    .mockImplementationOnce(() => {
+      throw new Error('Internal Server Error');
+    })
+    .mockImplementationOnce(() => [[mockHasAppealSubmissionDbRecord]])
+    .mockImplementationOnce(() => {
+      throw new Error('Internal Server Error');
+    })
+    .mockImplementationOnce(() => [[mockHasLpaSubmissionDbRecord]])
+    .mockImplementationOnce(() => {
+      throw new Error('Internal Server Error');
+    })
+    .mockImplementationOnce(() => [[mockHasLpaSubmissionDbRecord]])
+    .mockImplementationOnce(() => {
+      throw new Error('Internal Server Error');
+    })
     .mockImplementationOnce(() => [])
     .mockImplementationOnce(() => {
       throw new Error('Internal Server Error');
     })
-    .mockImplementationOnce(() => [[mockHasAppealSubmissionDbRecord]])
+    .mockImplementationOnce(() => [])
     .mockImplementationOnce(() => {
       throw new Error('Internal Server Error');
     })
-    .mockImplementationOnce(() => [[mockHasAppealSubmissionDbRecord]])
-    .mockImplementationOnce(() => {
-      throw new Error('Internal Server Error');
-    })
-    .mockImplementationOnce(() => [[mockHasLpaSubmissionDbRecord]])
-    .mockImplementationOnce(() => {
-      throw new Error('Internal Server Error');
-    })
-    .mockImplementationOnce(() => [[mockHasLpaSubmissionDbRecord]])
+    .mockImplementationOnce(() => [])
     .mockImplementationOnce(() => {
       throw new Error('Internal Server Error');
     }),
-};
+}));
 
 describe('lib/db-wrapper', () => {
   const data = { appealId: 'c5facec7-60df-4829-974d-ffa5b0a0a317' };
@@ -40,29 +51,15 @@ describe('lib/db-wrapper', () => {
     jest.clearAllMocks();
   });
 
-  describe('createHasAppeal', () => {
-    it('should return the inserted data when the query is successful', () => {
-      createHasAppeal(db, data);
-
-      expect(db.query).toBeCalledTimes(1);
-    });
-
-    it('should throw an error when an error occurs', () => {
-      expect(() => createHasAppeal(db, data)).toThrow(
-        'Failed to create HAS appeal data with error - Error: Internal Server Error'
-      );
-    });
-  });
-
   describe('findAllAppeals', () => {
     it('should return the fetched data when the query is successful', async () => {
-      const result = await findAllAppeals(db);
+      const result = await findAllAppeals();
 
       expect(result).toEqual([mockHasAppealSubmissionDbRecord]);
     });
 
     it('should throw an error when an error occurs', () => {
-      expect(() => findAllAppeals(db)).rejects.toThrow(
+      expect(() => findAllAppeals()).rejects.toThrow(
         'Failed to get appeals data with error - Error: Internal Server Error'
       );
     });
@@ -70,13 +67,13 @@ describe('lib/db-wrapper', () => {
 
   describe('findOneAppeal', () => {
     it('should return the fetched data when the query is successful', async () => {
-      const result = await findOneAppeal(db);
+      const result = await findOneAppeal();
 
       expect(result).toEqual(mockHasAppealSubmissionDbRecord);
     });
 
     it('should throw an error when an error occurs', () => {
-      expect(() => findOneAppeal(db)).rejects.toThrow(
+      expect(() => findOneAppeal()).rejects.toThrow(
         'Failed to get appeal data with error - Error: Internal Server Error'
       );
     });
@@ -84,13 +81,13 @@ describe('lib/db-wrapper', () => {
 
   describe('findAllQuestionnaires', () => {
     it('should return the fetched data when the query is successful', async () => {
-      const result = await findAllQuestionnaires(db);
+      const result = await findAllQuestionnaires();
 
       expect(result).toEqual([mockHasLpaSubmissionDbRecord]);
     });
 
     it('should throw an error when an error occurs', () => {
-      expect(() => findAllQuestionnaires(db)).rejects.toThrow(
+      expect(() => findAllQuestionnaires()).rejects.toThrow(
         'Failed to get questionnaires data with error - Error: Internal Server Error'
       );
     });
@@ -98,14 +95,56 @@ describe('lib/db-wrapper', () => {
 
   describe('findOneQuestionnaire', () => {
     it('should return the fetched data when the query is successful', async () => {
-      const result = await findOneQuestionnaire(db);
+      const result = await findOneQuestionnaire();
 
       expect(result).toEqual(mockHasLpaSubmissionDbRecord);
     });
 
     it('should throw an error when an error occurs', () => {
-      expect(() => findOneQuestionnaire(db)).rejects.toThrow(
+      expect(() => findOneQuestionnaire()).rejects.toThrow(
         'Failed to get questionnaire data with error - Error: Internal Server Error'
+      );
+    });
+  });
+
+  describe('createHasAppealRecord', () => {
+    it('should return the correct data when the query is successful', () => {
+      createHasAppealRecord(data);
+
+      expect(db.query).toBeCalledTimes(1);
+    });
+
+    it('should throw an error when an error occurs', () => {
+      expect(() => createHasAppealRecord(data)).toThrow(
+        'Failed to execute CreateHASAppeal with error - Error: Internal Server Error'
+      );
+    });
+  });
+
+  describe('createAppealLinkRecord', () => {
+    it('should return the correct data when the query is successful', () => {
+      createAppealLinkRecord(data);
+
+      expect(db.query).toBeCalledTimes(1);
+    });
+
+    it('should throw an error when an error occurs', () => {
+      expect(() => createAppealLinkRecord(data)).toThrow(
+        'Failed to execute CreateAppealLink with error - Error: Internal Server Error'
+      );
+    });
+  });
+
+  describe('createHasLpaSubmissionRecord', () => {
+    it('should return the correct data when the query is successful', () => {
+      createHasLpaSubmissionRecord(data);
+
+      expect(db.query).toBeCalledTimes(1);
+    });
+
+    it('should throw an error when an error occurs', () => {
+      expect(() => createHasLpaSubmissionRecord(data)).toThrow(
+        'Failed to execute CreateHASLPASubmission with error - Error: Internal Server Error'
       );
     });
   });

--- a/packages/api/src/routes/appeal-link.js
+++ b/packages/api/src/routes/appeal-link.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { postAppealLink } = require('../controllers/appeal-link');
+
+const router = express.Router();
+
+router.post('/', postAppealLink);
+
+module.exports = router;

--- a/packages/api/src/routes/appeal-link.spec.js
+++ b/packages/api/src/routes/appeal-link.spec.js
@@ -1,0 +1,11 @@
+const { postAppealLink } = require('../controllers/appeal-link');
+const { mockPost } = require('../../test/utils/mocks');
+
+describe('routes/appeal-link', () => {
+  it('should define the expected routes', () => {
+    // eslint-disable-next-line global-require
+    require('./appeal-link');
+
+    expect(mockPost).toHaveBeenCalledWith('/', postAppealLink);
+  });
+});

--- a/packages/api/src/routes/index.js
+++ b/packages/api/src/routes/index.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const appeal = require('./appeal');
+const appealLink = require('./appeal-link');
 const questionnaire = require('./questionnaire');
 const apiDocs = require('./api-docs');
 
 const router = express.Router();
 
 router.use('/api/v1/appeal', appeal);
+router.use('/api/v1/appeal-link', appealLink);
 router.use('/api/v1/questionnaire', questionnaire);
 router.use('/api-docs', apiDocs);
 

--- a/packages/api/src/routes/index.spec.js
+++ b/packages/api/src/routes/index.spec.js
@@ -1,4 +1,6 @@
-const appealRouter = require('./appeal');
+const appeal = require('./appeal');
+const appealLink = require('./appeal-link');
+const questionnaire = require('./questionnaire');
 const apiDocsRouter = require('./api-docs');
 const { mockUse } = require('../../test/utils/mocks');
 
@@ -7,7 +9,9 @@ describe('routes/index', () => {
     // eslint-disable-next-line global-require
     require('./index');
 
-    expect(mockUse).toHaveBeenCalledWith('/api/v1/appeal', appealRouter);
+    expect(mockUse).toHaveBeenCalledWith('/api/v1/appeal', appeal);
+    expect(mockUse).toHaveBeenCalledWith('/api/v1/appeal-link', appealLink);
+    expect(mockUse).toHaveBeenCalledWith('/api/v1/questionnaire', questionnaire);
     expect(mockUse).toHaveBeenCalledWith('/api-docs', apiDocsRouter);
   });
 });

--- a/packages/api/test/data/appeal-link-submission-db-record.js
+++ b/packages/api/test/data/appeal-link-submission-db-record.js
@@ -1,0 +1,20 @@
+const data = {
+  ID: '2f210b33-69c0-417c-963a-bb86d99d736f',
+  AppealID: '7f10de67-f4a9-4ad5-b2db-b4cc17e5e3a2',
+  LPAQuestionnaireID: '228c160a-3abb-4a9e-b95e-c5837b2bdf06',
+  CaseReference: 123456789,
+  CaseTypeID: 1,
+  CaseStageID: 1,
+  CaseStatusID: 1,
+  AppellantName: 'Appellant Name',
+  SiteAddressLineOne: 'Address Line 1',
+  SiteAddressLineTwo: 'Address Line 2',
+  SiteAddressTown: 'Town',
+  SiteAddressCounty: 'County',
+  SiteAddressPostcode: 'PP1 1PP',
+  LocalPlanningAuthorityID: 'E69999999',
+  EventUserID: 'ce9b1d01-0079-4e67-bd80-cd2ac87d1884',
+  EventUserName: 'Validation Officer Name',
+};
+
+module.exports = data;

--- a/packages/web-app/src/config/config.js
+++ b/packages/web-app/src/config/config.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 
 const config = {
   backOfficeApi: {
-    v1Url: `${process.env.BACK_OFFICE_API_URL}/api/v1`,
+    url: process.env.BACK_OFFICE_API_URL || 'http://localhost',
   },
   application: {
     defaultDateFormat: 'DD MMMM YYYY',

--- a/packages/web-app/src/controllers/check-and-confirm.js
+++ b/packages/web-app/src/controllers/check-and-confirm.js
@@ -11,6 +11,7 @@ const {
 } = require('../config/review-appeal-submission');
 const { sendStartEmailToLPA } = require('../lib/notify');
 const { hasAppeal } = require('../config/db-fields');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 const viewData = (appealId, casework) => {
   const validAppealDetails = casework[hasAppeal.validAppealDetails];
@@ -80,6 +81,7 @@ const postCheckAndConfirm = async (req, res) => {
     currentPage,
     nextPage,
     viewData: options,
+    saveData: saveAppealData,
   });
 };
 

--- a/packages/web-app/src/controllers/check-and-confirm.spec.js
+++ b/packages/web-app/src/controllers/check-and-confirm.spec.js
@@ -9,6 +9,7 @@ const {
 } = require('../config/review-appeal-submission');
 const { sendStartEmailToLPA } = require('../lib/notify');
 const { hasAppeal } = require('../config/db-fields');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 jest.mock('../lib/save-and-continue');
 jest.mock('../lib/notify');
@@ -155,6 +156,7 @@ describe('controllers/check-and-confirm', () => {
         currentPage: views.checkAndConfirm,
         nextPage: views.reviewComplete,
         viewData: expectedViewData,
+        saveData: saveAppealData,
       });
       expect(req.session.casework.completed).toEqual('true');
     });

--- a/packages/web-app/src/controllers/invalid-appeal-details.js
+++ b/packages/web-app/src/controllers/invalid-appeal-details.js
@@ -7,6 +7,7 @@ const {
 const saveAndContinue = require('../lib/save-and-continue');
 const { getText } = require('../config/review-appeal-submission');
 const { hasAppeal } = require('../config/db-fields');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 const viewData = (appealId, caseReference, invalid) => ({
   pageTitle: 'Invalid appeal details',
@@ -54,6 +55,7 @@ const postInvalidAppealDetails = (req, res) => {
     currentPage,
     nextPage,
     viewData: viewData(appealId, caseReference, { reasons, otherReason }),
+    saveData: saveAppealData,
   });
 };
 

--- a/packages/web-app/src/controllers/invalid-appeal-details.spec.js
+++ b/packages/web-app/src/controllers/invalid-appeal-details.spec.js
@@ -4,6 +4,7 @@ const saveAndContinue = require('../lib/save-and-continue');
 const { mockReq, mockRes } = require('../../test/utils/mocks');
 const { getText } = require('../config/review-appeal-submission');
 const { hasAppeal } = require('../config/db-fields');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 jest.mock('../lib/save-and-continue');
 
@@ -69,6 +70,7 @@ describe('controllers/invalid-appeal-details', () => {
         currentPage: views.invalidAppealDetails,
         nextPage: views.checkAndConfirm,
         viewData: expectedViewData,
+        saveData: saveAppealData,
       });
       expect(req.session.casework[hasAppeal.invalidAppealReasons]).toEqual(JSON.stringify(reasons));
       expect(req.session.casework[hasAppeal.invalidReasonOther]).toEqual(otherReason);

--- a/packages/web-app/src/controllers/missing-or-wrong.js
+++ b/packages/web-app/src/controllers/missing-or-wrong.js
@@ -1,5 +1,6 @@
 const toArray = require('../lib/to-array');
 const { getText } = require('../config/review-appeal-submission');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 const {
   reviewAppealSubmission: previousPage,
@@ -50,6 +51,7 @@ const postMissingOrWrong = (req, res) => {
     currentPage,
     nextPage,
     viewData: viewData(appealId, caseReference, missingOrWrong),
+    saveData: saveAppealData,
   });
 };
 

--- a/packages/web-app/src/controllers/missing-or-wrong.spec.js
+++ b/packages/web-app/src/controllers/missing-or-wrong.spec.js
@@ -3,6 +3,7 @@ const views = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
 const { mockReq, mockRes } = require('../../test/utils/mocks');
 const { getText } = require('../config/review-appeal-submission');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 jest.mock('../lib/save-and-continue');
 
@@ -71,6 +72,7 @@ describe('controllers/missing-or-wrong', () => {
         currentPage: views.missingOrWrong,
         nextPage: views.checkAndConfirm,
         viewData: expectedViewData,
+        saveData: saveAppealData,
       });
       expect(req.session.casework.missingOrWrong).toEqual(missingOrWrong);
     });

--- a/packages/web-app/src/controllers/review-appeal-submission.js
+++ b/packages/web-app/src/controllers/review-appeal-submission.js
@@ -9,6 +9,7 @@ const {
 const saveAndContinue = require('../lib/save-and-continue');
 const { reviewOutcomeOption } = require('../config/review-appeal-submission');
 const { hasAppeal } = require('../config/db-fields');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 const viewData = (reviewOutcome) => ({
   pageTitle: 'Review appeal submission',
@@ -46,7 +47,14 @@ const postReviewAppealSubmission = (req, res) => {
 
   req.session.casework[hasAppeal.reviewOutcome] = reviewOutcome;
 
-  saveAndContinue({ req, res, currentPage, nextPage, viewData: viewData(reviewOutcome) });
+  saveAndContinue({
+    req,
+    res,
+    currentPage,
+    nextPage,
+    viewData: viewData(reviewOutcome),
+    saveData: saveAppealData,
+  });
 };
 
 module.exports = {

--- a/packages/web-app/src/controllers/review-appeal-submission.spec.js
+++ b/packages/web-app/src/controllers/review-appeal-submission.spec.js
@@ -6,6 +6,7 @@ const views = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
 const { mockReq, mockRes } = require('../../test/utils/mocks');
 const { hasAppeal } = require('../config/db-fields');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 jest.mock('../lib/save-and-continue');
 
@@ -93,6 +94,7 @@ describe('controllers/review-appeal-submission', () => {
         currentPage: views.reviewAppealSubmission,
         nextPage: views.validAppealDetails,
         viewData: expectedViewData,
+        saveData: saveAppealData,
       });
       expect(req.session.casework[hasAppeal.reviewOutcome]).toEqual('1');
     });
@@ -123,6 +125,7 @@ describe('controllers/review-appeal-submission', () => {
           backLink: `/${views.appealsList}`,
           reviewOutcome: '2',
         },
+        saveData: saveAppealData,
       });
       expect(req.session.casework[hasAppeal.reviewOutcome]).toEqual('2');
     });
@@ -153,6 +156,7 @@ describe('controllers/review-appeal-submission', () => {
           backLink: `/${views.appealsList}`,
           reviewOutcome: req.body['review-outcome'],
         },
+        saveData: saveAppealData,
       });
       expect(req.session.casework[hasAppeal.reviewOutcome]).toEqual('3');
     });
@@ -183,6 +187,7 @@ describe('controllers/review-appeal-submission', () => {
           backLink: `/${views.appealsList}`,
           reviewOutcome: req.body['review-outcome'],
         },
+        saveData: saveAppealData,
       });
       expect(req.session.casework[hasAppeal.reviewOutcome]).toEqual(req.body['review-outcome']);
     });

--- a/packages/web-app/src/controllers/review-complete.js
+++ b/packages/web-app/src/controllers/review-complete.js
@@ -1,8 +1,10 @@
 const { reviewComplete: currentPage } = require('../config/views');
+const { hasAppeal } = require('../config/db-fields');
 
 const { getText, getReviewOutcomeConfig } = require('../config/review-appeal-submission');
 
-const checkAndConfirmConfig = (casework) => getReviewOutcomeConfig(casework.reviewOutcome);
+const checkAndConfirmConfig = (casework) =>
+  getReviewOutcomeConfig(casework[hasAppeal.reviewOutcome]);
 
 const viewData = (casework) => ({
   pageTitle: 'Review complete',

--- a/packages/web-app/src/controllers/review-complete.spec.js
+++ b/packages/web-app/src/controllers/review-complete.spec.js
@@ -1,6 +1,7 @@
 const { getReviewComplete } = require('./review-complete');
 const views = require('../config/views');
 const { mockReq, mockRes } = require('../../test/utils/mocks');
+const { hasAppeal } = require('../config/db-fields');
 
 const {
   getText,
@@ -24,7 +25,7 @@ describe('controllers/review-complete', () => {
       req = {
         session: {
           appeal: { id: appealId },
-          casework: { reviewComplete: reviewOutcomeOption.valid },
+          casework: { [hasAppeal.reviewOutcome]: reviewOutcomeOption.valid },
         },
       };
 
@@ -33,6 +34,7 @@ describe('controllers/review-complete', () => {
         hidePageTitle: 'true',
         reviewComplete: req.session.casework,
         appealData: req.session.appeal,
+        checkAndConfirmConfig: getReviewOutcomeConfig(reviewOutcomeOption.valid),
         getText,
       };
 
@@ -46,7 +48,7 @@ describe('controllers/review-complete', () => {
       req = {
         session: {
           appeal: { id: appealId },
-          casework: { reviewOutcome: reviewOutcomeOption.invalid },
+          casework: { [hasAppeal.reviewOutcome]: reviewOutcomeOption.invalid },
         },
       };
 
@@ -69,7 +71,7 @@ describe('controllers/review-complete', () => {
       req = {
         session: {
           appeal: { id: appealId },
-          casework: { reviewOutcome: reviewOutcomeOption.incomplete },
+          casework: { [hasAppeal.reviewOutcome]: reviewOutcomeOption.incomplete },
         },
       };
 

--- a/packages/web-app/src/controllers/valid-appeal-details.js
+++ b/packages/web-app/src/controllers/valid-appeal-details.js
@@ -5,6 +5,7 @@ const {
 } = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
 const { hasAppeal } = require('../config/db-fields');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 const viewData = (appealId, caseReference, valid) => ({
   pageTitle: 'Valid appeal details',
@@ -43,6 +44,7 @@ const postValidAppealDetails = (req, res) => {
     currentPage,
     nextPage,
     viewData: viewData(appealId, caseReference, validAppealDetails),
+    saveData: saveAppealData,
   });
 };
 

--- a/packages/web-app/src/controllers/valid-appeal-details.spec.js
+++ b/packages/web-app/src/controllers/valid-appeal-details.spec.js
@@ -2,6 +2,7 @@ const { getValidAppealDetails, postValidAppealDetails } = require('./valid-appea
 const views = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
 const { mockReq, mockRes } = require('../../test/utils/mocks');
+const { saveAppealData } = require('../lib/api-wrapper');
 
 jest.mock('../lib/save-and-continue');
 
@@ -63,6 +64,7 @@ describe('controllers/valid-appeal-details', () => {
         currentPage: views.validAppealDetails,
         nextPage: views.checkAndConfirm,
         viewData: expectedViewData,
+        saveData: saveAppealData,
       });
       expect(req.session.casework.descriptionDevelopment).toEqual(validAppealDetails);
     });

--- a/packages/web-app/src/lib/api-wrapper.js
+++ b/packages/web-app/src/lib/api-wrapper.js
@@ -4,10 +4,11 @@ const config = require('../config/config');
 const logger = require('./logger');
 
 const {
-  backOfficeApi: { v1Url: backOfficeUrl },
+  backOfficeApi: { url: backOfficeUrl },
 } = config;
-const appealDataUrl = `${backOfficeUrl}/appeal`;
-const questionnaireDataUrl = `${backOfficeUrl}/questionnaire`;
+const appealDataUrl = `${backOfficeUrl}/api/v1/appeal`;
+const appealLinkDataUrl = `${backOfficeUrl}/api/v1/appeal-link`;
+const questionnaireDataUrl = `${backOfficeUrl}/api/v1/questionnaire`;
 
 const formatDocumentsAndAddToData = (data) => {
   let newData = data;
@@ -94,9 +95,9 @@ const getAllQuestionnaires = async () => {
   }
 };
 
-const saveData = async (data) => {
+const saveData = async (url, data) => {
   try {
-    const response = await fetch(appealDataUrl, {
+    const response = await fetch(url, {
       method: 'POST',
       body: JSON.stringify(data),
       headers: { 'Content-Type': 'application/json' },
@@ -108,9 +109,16 @@ const saveData = async (data) => {
   }
 };
 
+const saveAppealData = (data) => saveData(appealDataUrl, data);
+const saveAppealLinkData = (data) => saveData(appealLinkDataUrl, data);
+const saveQuestionnaireData = (data) => saveData(questionnaireDataUrl, data);
+
 module.exports = {
   getAppealData,
   getAllAppeals,
   getAllQuestionnaires,
   saveData,
+  saveAppealData,
+  saveAppealLinkData,
+  saveQuestionnaireData,
 };

--- a/packages/web-app/src/lib/api-wrapper.spec.js
+++ b/packages/web-app/src/lib/api-wrapper.spec.js
@@ -1,5 +1,13 @@
 const fetch = require('node-fetch');
-const { getAppealData, getAllAppeals, getAllQuestionnaires, saveData } = require('./api-wrapper');
+const {
+  getAppealData,
+  getAllAppeals,
+  getAllQuestionnaires,
+  saveData,
+  saveAppealData,
+  saveAppealLinkData,
+  saveQuestionnaireData,
+} = require('./api-wrapper');
 const singleAppealDataRaw = require('../../test/data/single-appeal-data-raw');
 const singleAppealDataFormatted = require('../../test/data/single-appeal-data-formatted');
 const appealDataList = require('../../test/data/appeal-data-list');
@@ -253,6 +261,57 @@ describe('lib/apiWrapper', () => {
       expect(() => saveData(data)).rejects.toThrow(
         'Failed to save data with error - Error: Internal Server Error'
       );
+    });
+  });
+
+  describe('saveAppealData', () => {
+    it('should call fetch with the correct url and data', () => {
+      fetch.mockImplementation(() => ({
+        ok: true,
+      }));
+
+      saveAppealData(data);
+
+      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).toBeCalledWith('http://localhost/api/v1/appeal', {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+  });
+
+  describe('saveAppealLinkData', () => {
+    it('should call fetch with the correct url and data', () => {
+      fetch.mockImplementation(() => ({
+        ok: true,
+      }));
+
+      saveAppealLinkData(data);
+
+      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).toBeCalledWith('http://localhost/api/v1/appeal-link', {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+  });
+
+  describe('saveQuestionnaireData', () => {
+    it('should call fetch with the correct url and data', () => {
+      fetch.mockImplementation(() => ({
+        ok: true,
+      }));
+
+      saveQuestionnaireData(data);
+
+      expect(fetch).toBeCalledTimes(1);
+      expect(fetch).toBeCalledWith('http://localhost/api/v1/questionnaire', {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: { 'Content-Type': 'application/json' },
+      });
     });
   });
 });

--- a/packages/web-app/src/lib/save-and-continue.js
+++ b/packages/web-app/src/lib/save-and-continue.js
@@ -1,7 +1,6 @@
-const { saveData } = require('./api-wrapper');
 const logger = require('./logger');
 
-const saveAndContinue = ({ req, res, currentPage, nextPage, viewData }) => {
+const saveAndContinue = ({ req, res, currentPage, nextPage, viewData, saveData }) => {
   const {
     body: { errors = {}, errorSummary = [] },
     session: { appeal, casework, questionnaire },
@@ -17,6 +16,10 @@ const saveAndContinue = ({ req, res, currentPage, nextPage, viewData }) => {
   }
 
   try {
+    if (typeof saveData !== 'function') {
+      throw new Error('The saveData parameter must be a save data function');
+    }
+
     saveData({
       appealId: appeal.appealId,
       ...casework,


### PR DESCRIPTION
This update enables the saving of Appeal Link data

1. Added a stored procedure and endpoint in the api for saving the data

2. Updated the web-app to use a save data function which is passed into the saveAndContinue method and this will make it very easy to determine which table the data for a specific page is saved to. The caveat is that all the data for a single page needs to be saved to the same table.