### PR TITLE
feat(as-3485): update db schema with new fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@
     [ExtraConditionsDetails], [AdjacentAppeals], [AdjacentAppealsNumbers], [CannotSeeLand], [SiteAccess], [SiteAccessDetails],
     [SiteNeighbourAccess], [SiteNeighbourAccessDetails], [HealthAndSafetyIssues], [HealthAndSafetyDetails], [AffectListedBuilding],
     [AffectListedBuildingDetails], [GreenBelt], [ConservationArea], [OriginalPlanningApplicationPublicised],
-    [DevelopmentNeighbourhoodPlanSubmitted], [DevelopmentNeighbourhoodPlanChanges], [QuestionnaireStatusID], [LatestEvent])
+    [DevelopmentNeighbourhoodPlanSubmitted], [DevelopmentNeighbourhoodPlanChanges], [LatestEvent])
    VALUES
     ('6922c408-e80a-472b-8b00-9377daec083d', '5c45c22d-a39c-4844-bee1-2f6829b42238', '6ff8d0ef-3767-4258-b3d3-34d48fca238b',
     '2021-11-01', 1, null, 0, null, 0, null, 1, 1, 'Easy site access', 1, 'Easy site neighbour access', 1,
-    'There are some health and safety issues', 0, 'The site is not a listed building', 0, 0, 1, 1, 1, 2, 1);
+    'There are some health and safety issues', 0, 'The site is not a listed building', 0, 0, 1, 1, 1, 1);
 
    INSERT INTO [AppealLink]
-    ([ID], [AppealID],[LPAQuestionnaireID], [CaseReference], [CaseTypeID], [CaseStageID], [CaseStatusID], [AppellantName],
+    ([ID], [AppealID],[LPAQuestionnaireID], [CaseReference], [CaseTypeID], [CaseStatusID], [AppellantName],
     [SiteAddressLineOne], [SiteAddressLineTwo], [SiteAddressTown], [SiteAddressCounty], [SiteAddressPostCode], [LocalPlanningAuthorityID],
-    [LatestEvent], [EventDateTime], [EventUserID], [EventUserName])
+    [QuestionnaireStatusID], [LatestEvent], [EventDateTime], [EventUserID], [EventUserName])
    VALUES
     ('9565dcf2-ebe6-42b1-8450-c8283abb8f53', '6ff8d0ef-3767-4258-b3d3-34d48fca238b', '5c45c22d-a39c-4844-bee1-2f6829b42238', 123456789,
-    null, 1, null, 'An Apellant', 'Address 1', 'Address 2', 'Town', 'Country', 'Postcode', 'E69999999', 1, null, null, null);
+    null, 1, 'An Apellant', 'Address 1', 'Address 2', 'Town', 'Country', 'Postcode', 'E69999999', 2, 1, null, null, null);
    ```
 
 ### Undoing migrations

--- a/packages/api/api/openapi.yaml
+++ b/packages/api/api/openapi.yaml
@@ -90,7 +90,7 @@ paths:
                     termsAgreed:
                       type: boolean
                       example: true
-                    decisionDate:
+                    appealDecisionDate:
                       type: "string"
                       example: "2021-11-12T00:00:00.000Z"
                     submissionDate:
@@ -99,7 +99,7 @@ paths:
                     caseReference:
                       type: "integer"
                       example: 123456789
-                    caseStageId:
+                    caseStatusId:
                       type: "integer"
                       example: 1
                     appellantName:
@@ -123,18 +123,75 @@ paths:
                     localPlanningAuthorityId:
                       type: "string"
                       example: "E69999999"
-                    typeName:
+                    caseOfficerFirstName:
                       type: "string"
-                      example: null
+                      example: "First Name"
+                    caseOfficerSurname:
+                      type: "string"
+                      example: "Surname"
+                    caseOfficerEmail:
+                      type: "string"
+                      example: "caseofficer@planninginspectorate.gov.uk"
+                    validationOfficerFirstName:
+                      type: "string"
+                      example: "First Name"
+                    validationOfficerSurname:
+                      type: "string"
+                      example: "Surname"
+                    validationOfficerEmail:
+                      type: "string"
+                      example: "validationofficer@planninginspectorate.gov.uk"
+                    invalidReasonOtherDetails:
+                      type: "string"
+                      example: "Other Details"
+                    invalidAppealReasons:
+                      type: "string"
+                      example: "'[1,3]'"
+                    inspectorFirstName:
+                      type: "string"
+                      example: "First name"
+                    inspectorSurname:
+                      type: "string"
+                      example: "Surname"
+                    inspectorEmail:
+                      type: "string"
+                      example: "inspector@planninginspectorate.gov.uk"
+                    scheduledSiteVisitDate:
+                      type: "string"
+                      example: "2021-11-10"
+                    questionnaireDecisionDate:
+                      type: "string"
+                      example: "2021-11-16"
+                    descriptionDevelopment:
+                      type: "string"
+                      example: "Description of the development"
+                    appealStartDate:
+                      type: "string"
+                      example: "2021-11-05"
+                    appealValidationDate:
+                      type: "string"
+                      example: "2021-11-16"
+                    caseTypeName:
+                      type: "string"
+                      example: "Householder Appeal (HAS)"
                     caseStageName:
                       type: "string"
                       example: "Received"
                     caseStatusName:
                       type: "string"
                       example: "Appeal Received"
-                    localPlanningAuthorityName:
+                    recommendedSiteVisitTypeName:
                       type: "string"
-                      example: "System Test Borough Council"
+                      example: "Unaccompanied"
+                    siteVisitTypeName:
+                      type: "string"
+                      example: "Accompanied"
+                    inspectorSpecialismName:
+                      type: "string"
+                      example: "General"
+                    decisionOutcomeName:
+                      type: "string"
+                      example: "Allowed"
         "404":
           description: "Not found"
   "/api/v1/appeal/{appealId}":
@@ -171,7 +228,7 @@ paths:
                     type: "string"
                     example: "An Agent"
                   creatorOriginalApplicant:
-                    type: boolean
+                    type: "boolean"
                     example: true
                   creatorOnBehalfOf:
                     type: "string"
@@ -201,9 +258,9 @@ paths:
                     type: "boolean"
                     example: true
                   termsAgreed:
-                    type: "boolean"
+                    type: boolean
                     example: true
-                  decisionDate:
+                  appealDecisionDate:
                     type: "string"
                     example: "2021-11-12T00:00:00.000Z"
                   submissionDate:
@@ -212,7 +269,7 @@ paths:
                   caseReference:
                     type: "integer"
                     example: 123456789
-                  caseStageId:
+                  caseStatusId:
                     type: "integer"
                     example: 1
                   appellantName:
@@ -236,18 +293,75 @@ paths:
                   localPlanningAuthorityId:
                     type: "string"
                     example: "E69999999"
-                  typeName:
+                  caseOfficerFirstName:
                     type: "string"
-                    example: null
+                    example: "First Name"
+                  caseOfficerSurname:
+                    type: "string"
+                    example: "Surname"
+                  caseOfficerEmail:
+                    type: "string"
+                    example: "caseofficer@planninginspectorate.gov.uk"
+                  validationOfficerFirstName:
+                    type: "string"
+                    example: "First Name"
+                  validationOfficerSurname:
+                    type: "string"
+                    example: "Surname"
+                  validationOfficerEmail:
+                    type: "string"
+                    example: "validationofficer@planninginspectorate.gov.uk"
+                  invalidReasonOtherDetails:
+                    type: "string"
+                    example: "Other Details"
+                  invalidAppealReasons:
+                    type: "string"
+                    example: "'[1,3]'"
+                  inspectorFirstName:
+                    type: "string"
+                    example: "First name"
+                  inspectorSurname:
+                    type: "string"
+                    example: "Surname"
+                  inspectorEmail:
+                    type: "string"
+                    example: "inspector@planninginspectorate.gov.uk"
+                  scheduledSiteVisitDate:
+                    type: "string"
+                    example: "2021-11-10"
+                  questionnaireDecisionDate:
+                    type: "string"
+                    example: "2021-11-16"
+                  descriptionDevelopment:
+                    type: "string"
+                    example: "Description of the development"
+                  appealStartDate:
+                    type: "string"
+                    example: "2021-11-05"
+                  appealValidationDate:
+                    type: "string"
+                    example: "2021-11-16"
+                  caseTypeName:
+                    type: "string"
+                    example: "Householder Appeal (HAS)"
                   caseStageName:
-                    type: "string"
-                    example: "Received"
+                      type: "string"
+                      example: "Received"
                   caseStatusName:
                     type: "string"
                     example: "Appeal Received"
-                  localPlanningAuthorityName:
+                  recommendedSiteVisitTypeName:
                     type: "string"
-                    example: "System Test Borough Council"
+                    example: "Unaccompanied"
+                  siteVisitTypeName:
+                    type: "string"
+                    example: "Accompanied"
+                  inspectorSpecialismName:
+                    type: "string"
+                    example: "General"
+                  decisionOutcomeName:
+                    type: "string"
+                    example: "Allowed"
                   documents:
                     type: "array"
                     items:
@@ -277,8 +391,6 @@ paths:
                         document_type:
                           type: "string"
                           example: "originalApplication"
-
-
         "404":
           description: "Not found"
   "/api/v1/appeal-link":
@@ -473,7 +585,7 @@ paths:
                       example: "Overdue"
                     caseTypeName:
                       type: "string"
-                      example: null
+                      example: "Householder Appeal (HAS)"
                     caseStageName:
                       type: "string"
                       example: "Received"
@@ -483,6 +595,9 @@ paths:
                     localPlanningAuthorityName:
                       type: "string"
                       example: "System Test Borough Council"
+                    lpaQuestionnaireOutcomeName:
+                      type: "string"
+                      example: "Complete"
         "404":
           description: "Not found"
   "/api/v1/questionnaire/{appealId}":
@@ -609,7 +724,7 @@ paths:
                       example: "Overdue"
                     caseTypeName:
                       type: "string"
-                      example: null
+                      example: "Householder Appeal (HAS)"
                     caseStageName:
                       type: "string"
                       example: "Received"
@@ -619,6 +734,9 @@ paths:
                     localPlanningAuthorityName:
                       type: "string"
                       example: "System Test Borough Council"
+                    lpaQuestionnaireOutcomeName:
+                      type: "string"
+                      example: "Complete"
                     documents:
                       type: "array"
                       items:

--- a/packages/api/database/migrations/00037-amend-has-appeal-table.js
+++ b/packages/api/database/migrations/00037-amend-has-appeal-table.js
@@ -1,0 +1,20 @@
+const migration = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('HASAppeal', 'CaseOfficerEmail', Sequelize.STRING(255));
+    await queryInterface.addColumn('HASAppeal', 'InspectorEmail', Sequelize.STRING(255));
+    await queryInterface.addColumn('HASAppeal', 'ValidationOfficerEmail', Sequelize.STRING(255));
+    await queryInterface.addColumn('HASAppeal', 'AppealStartDate', Sequelize.DATE);
+    await queryInterface.addColumn('HASAppeal', 'AppealValidationDate', Sequelize.DATE);
+    await queryInterface.addColumn('HASAppeal', 'QuestionnaireDueDate', Sequelize.DATE);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('HASAppeal', 'CaseOfficerEmail');
+    await queryInterface.removeColumn('HASAppeal', 'InspectorEmail');
+    await queryInterface.removeColumn('HASAppeal', 'ValidationOfficerEmail');
+    await queryInterface.removeColumn('HASAppeal', 'AppealStartDate');
+    await queryInterface.removeColumn('HASAppeal', 'AppealValidationDate');
+    await queryInterface.removeColumn('HASAppeal', 'QuestionnaireDueDate');
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00038-amend-has-lpa-submission-table.js
+++ b/packages/api/database/migrations/00038-amend-has-lpa-submission-table.js
@@ -1,0 +1,19 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.removeColumn('HASLPASubmission', 'QuestionnaireStatusID');
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('HASLPASubmission', 'QuestionnaireStatusID', Sequelize.INTEGER);
+    await queryInterface.addConstraint('HASLPASubmission', {
+      fields: ['QuestionnaireStatusID'],
+      type: 'foreign key',
+      name: 'FK_HASLPASubmission_LookUpQuestionnaireStatus',
+      references: {
+        table: 'LookUpQuestionnaireStatus',
+        field: 'ID',
+      },
+    });
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00039-amend-appeal-link-table copy.js
+++ b/packages/api/database/migrations/00039-amend-appeal-link-table copy.js
@@ -1,0 +1,19 @@
+const migration = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('AppealLink', 'QuestionnaireStatusID', Sequelize.INTEGER);
+    await queryInterface.addConstraint('AppealLink', {
+      fields: ['QuestionnaireStatusID'],
+      type: 'foreign key',
+      name: 'FK_AppealLink_LookUpQuestionnaireStatus',
+      references: {
+        table: 'LookUpQuestionnaireStatus',
+        field: 'ID',
+      },
+    });
+  },
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('AppealLink', 'QuestionnaireStatusID');
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00040-amend-appeal-data-view.js
+++ b/packages/api/database/migrations/00040-amend-appeal-data-view.js
@@ -1,0 +1,115 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW AppealData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW [dbo].[AppealData]
+      AS
+      SELECT
+        HASAppealSubmission.AppealID as appealId,
+        HASAppealSubmission.CreatorEmailAddress as creatorEmailAddress,
+        HASAppealSubmission.CreatorName as creatorName,
+        HASAppealSubmission.CreatorOriginalApplicant as creatorOriginalApplicant,
+        HASAppealSubmission.CreatorOnBehalfOf as creatorOnBehalfOf,
+        HASAppealSubmission.OriginalApplicationNumber as originalApplicationNumber,
+        HASAppealSubmission.SiteOwnership as siteOwnership,
+        HASAppealSubmission.SiteInformOwners as siteInformOwners,
+        HASAppealSubmission.SiteRestriction as siteRestriction,
+        HASAppealSubmission.SiteRestrictionDetails as siteRestrictionDetails,
+        HASAppealSubmission.SafetyConcern as safetyConcern,
+        HASAppealSubmission.SafetyConcernDetails as safetyConcernDetails,
+        HASAppealSubmission.SensitiveInformation as sensitiveInformation,
+        HASAppealSubmission.TermsAgreed as termsAgreed,
+        HASAppealSubmission.DecisionDate as appealDecisionDate,
+        HASAppealSubmission.SubmissionDate as submissionDate,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.CaseStatusID as caseStatusId,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.CaseOfficerFirstName as caseOfficerFirstName,
+        HASAppeal.CaseOfficerSurname as caseOfficerSurname,
+        HASAppeal.CaseOfficerEmail as caseOfficerEmail,
+        HASAppeal.ValidationOfficerFirstName as validationOfficerFirstName,
+        HASAppeal.ValidationOfficerSurname as validationOfficerSurname,
+        HASAppeal.ValidationOfficerEmail as validationOfficerEmail,
+        HASAppeal.InvalidReasonOtherDetails as invalidReasonOtherDetails,
+        HASAppeal.InvalidAppealReasons as invalidAppealReasons,
+        HASAppeal.InspectorFirstName as inspectorFirstName,
+        HASAppeal.InspectorSurname as inspectorSurname,
+        HASAppeal.InspectorEmail as inspectorEmail,
+        HASAppeal.ScheduledSiteVisitDate as scheduledSiteVisitDate,
+        HASAppealSubmission.DecisionDate as questionnaireDecisionDate,
+        HASAppeal.DescriptionDevelopment as descriptionDevelopment,
+        HASAppeal.AppealStartDate as appealStartDate,
+        HASAppeal.AppealValidationDate as appealValidationDate,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpRecommendedSiteVisitType.TypeName as recommendedSiteVisitTypeName,
+        LookUpSiteVisitType.TypeName as siteVisitTypeName,
+        LookUpInspectorSpecialism.Specialism as inspectorSpecialismName,
+        LookUpDecisionOutcome.Outcome as decisionOutcomeName
+      FROM HASAppealSubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASAppealSubmission.AppealID = AppealLink.AppealId AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASAppealSubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpSiteVisitType AS LookUpRecommendedSiteVisitType (NOLOCK) ON HASAppeal.RecommendedSiteVisitTypeID = LookUpRecommendedSiteVisitType.ID
+      LEFT JOIN LookUpSiteVisitType (NOLOCK) ON HASAppeal.SiteVisitTypeID = LookUpSiteVisitType.ID
+      LEFT JOIN LookUpInspectorSpecialism (NOLOCK) ON HASAppeal.InspectorSpecialismID = LookUpInspectorSpecialism.ID
+      LEFT JOIN LookUpDecisionOutcome (NOLOCK) ON HASAppeal.DecisionOutcomeID = LookUpDecisionOutcome.ID
+      WHERE HASAppealSubmission.LatestEvent = 1
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW AppealData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW [dbo].[AppealData]
+      AS
+      SELECT
+        HASAppealSubmission.AppealID as appealId,
+        HASAppealSubmission.CreatorEmailAddress as creatorEmailAddress,
+        HASAppealSubmission.CreatorName as creatorName,
+        HASAppealSubmission.CreatorOriginalApplicant as creatorOriginalApplicant,
+        HASAppealSubmission.CreatorOnBehalfOf as creatorOnBehalfOf,
+        HASAppealSubmission.OriginalApplicationNumber as originalApplicationNumber,
+        HASAppealSubmission.SiteOwnership as siteOwnership,
+        HASAppealSubmission.SiteInformOwners as siteInformOwners,
+        HASAppealSubmission.SiteRestriction as siteRestriction,
+        HASAppealSubmission.SiteRestrictionDetails as siteRestrictionDetails,
+        HASAppealSubmission.SafetyConcern as safetyConcern,
+        HASAppealSubmission.SafetyConcernDetails as safetyConcernDetails,
+        HASAppealSubmission.SensitiveInformation as sensitiveInformation,
+        HASAppealSubmission.TermsAgreed as termsAgreed,
+        HASAppealSubmission.DecisionDate as decisionDate,
+        HASAppealSubmission.SubmissionDate as submissionDate,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.CaseStatusID as caseStatusId,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        LookUpCaseType.TypeName as typeName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName
+      FROM HASAppealSubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASAppealSubmission.AppealID = AppealLink.AppealId AND AppealLink.LatestEvent = 1
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      WHERE HASAppealSubmission.LatestEvent = 1
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00041-amend-questionnaire-data-view.js
+++ b/packages/api/database/migrations/00041-amend-questionnaire-data-view.js
@@ -1,0 +1,115 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW QuestionnaireData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW QuestionnaireData
+      AS
+      SELECT
+        HASLPASubmission.LPAQuestionnaireID as lpaQuestionnaireId,
+        HASLPASubmission.AppealID as appealId,
+        HASLPASubmission.SubmissionDate as submissionDate,
+        HASLPASubmission.SubmissionAccuracy as submissionAccuracy,
+        HASLPASubmission.SubmissionAccuracyDetails as submissionAccuracyDetails,
+        HASLPASubmission.ExtraConditions as extraConditions,
+        HASLPASubmission.ExtraConditionsDetails as extraConditionsDetails,
+        HASLPASubmission.AdjacentAppeals as adjacentAppeals,
+        HASLPASubmission.AdjacentAppealsNumbers as adjacentAppealsNumbers,
+        HASLPASubmission.CannotSeeLand as cannotSeeLand,
+        HASLPASubmission.SiteAccess as siteAccess,
+        HASLPASubmission.SiteAccessDetails as siteAccessDetails,
+        HASLPASubmission.SiteNeighbourAccess as siteNeighbourAccess,
+        HASLPASubmission.SiteNeighbourAccessDetails as siteNeighbourAccessDetails,
+        HASLPASubmission.HealthAndSafetyIssues as healthAndSafetyIssues,
+        HASLPASubmission.HealthAndSafetyDetails as healthAndSafetyDetails,
+        HASLPASubmission.AffectListedBuilding as affectListedBuilding,
+        HASLPASubmission.AffectListedBuildingDetails as affectListedBuildingDetails,
+        HASLPASubmission.GreenBelt as greenBelt,
+        HASLPASubmission.ConservationArea as conservationArea,
+        HASLPASubmission.OriginalPlanningApplicationPublicised as originalPlanningApplicationPublicised,
+        HASLPASubmission.DevelopmentNeighbourhoodPlanSubmitted as developmentNeighbourhoodPlanSubmitted,
+        HASLPASubmission.DevelopmentNeighbourhoodPlanChanges as developmentNeighbourhoodPlanChanges,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.LPAIncompleteReasons as lpaIncompleteReasons,
+        HASAppeal.QuestionnaireDueDate as questionnaireDueDate,
+        LookUpQuestionnaireStatus.Status as questionnaireStatus,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpQuestionnaireOutcome.Outcome as lpaQuestionnaireOutcomeName
+      FROM HASLPASubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASLPASubmission.AppealId = AppealLink.AppealID AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASLPASubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpQuestionnaireStatus (NOLOCK) ON AppealLink.QuestionnaireStatusID = LookUpQuestionnaireStatus.ID
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpQuestionnaireOutcome (NOLOCK) ON HASAppeal.LPAQuestionnaireReviewOutcomeID = LookUpQuestionnaireOutcome.ID
+      WHERE HASLPASubmission.LPAQuestionnaireID = AppealLink.LPAQuestionnaireID
+      AND HASLPASubmission.LatestEvent = 1
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW QuestionnaireData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW QuestionnaireData
+      AS
+      SELECT
+        HASLPASubmission.LPAQuestionnaireID as lpaQuestionnaireId,
+        HASLPASubmission.AppealID as appealId,
+        HASLPASubmission.SubmissionDate as submissionDate,
+        HASLPASubmission.SubmissionAccuracy as submissionAccuracy,
+        HASLPASubmission.SubmissionAccuracyDetails as submissionAccuracyDetails,
+        HASLPASubmission.ExtraConditions as extraConditions,
+        HASLPASubmission.ExtraConditionsDetails as extraConditionsDetails,
+        HASLPASubmission.AdjacentAppeals as adjacentAppeals,
+        HASLPASubmission.AdjacentAppealsNumbers as adjacentAppealsNumbers,
+        HASLPASubmission.CannotSeeLand as cannotSeeLand,
+        HASLPASubmission.SiteAccess as siteAccess,
+        HASLPASubmission.SiteAccessDetails as siteAccessDetails,
+        HASLPASubmission.SiteNeighbourAccess as siteNeighbourAccess,
+        HASLPASubmission.SiteNeighbourAccessDetails as siteNeighbourAccessDetails,
+        HASLPASubmission.HealthAndSafetyIssues as healthAndSafetyIssues,
+        HASLPASubmission.HealthAndSafetyDetails as healthAndSafetyDetails,
+        HASLPASubmission.AffectListedBuilding as affectListedBuilding,
+        HASLPASubmission.AffectListedBuildingDetails as affectListedBuildingDetails,
+        HASLPASubmission.GreenBelt as greenBelt,
+        HASLPASubmission.ConservationArea as conservationArea,
+        HASLPASubmission.OriginalPlanningApplicationPublicised as originalPlanningApplicationPublicised,
+        HASLPASubmission.DevelopmentNeighbourhoodPlanSubmitted as developmentNeighbourhoodPlanSubmitted,
+        HASLPASubmission.DevelopmentNeighbourhoodPlanChanges as developmentNeighbourhoodPlanChanges,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        LookUpQuestionnaireStatus.Status as questionnaireStatus,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName
+      FROM HASLPASubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASLPASubmission.AppealId = AppealLink.AppealID AND AppealLink.LatestEvent = 1
+      LEFT JOIN LookUpQuestionnaireStatus (NOLOCK) ON AppealLink.QuestionnaireStatusID = LookUpQuestionnaireStatus.ID
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      WHERE HASLPASubmission.LPAQuestionnaireID = AppealLink.LPAQuestionnaireID
+      AND HASLPASubmission.LatestEvent = 1
+    `);
+  },
+};
+
+module.exports = migration;


### PR DESCRIPTION
1. Updated the schema with the following new db fields:
    - Appeal Validation date, which is set in the validation flow for the `Invalid` or `Something is missing or wrong` paths
    - Appeal Start date,  which is set in the validation flow for the `Valid` path
    - Questionnaire Due date,  which is set in the validation flow for the `Valid` path
    - Case officer email, which is displayed on the View Appeal page
    - Validation officer email, which is displayed on the View Appeal page
    - Inspector email, which is displayed on the View Appeal page

2. Moved the Questionnaire Status field from the `HASLPASubmission` table to the `AppealLink` table so it can be updated before the LPA Questionnaire has been completed.

3. Updated the `AppealData` and `QuestionnaireData` views to return additional fields.

4. Updated the API docs for the additional fields being returned in the views.

5. Updated the test data in the README.