### PR TITLE
fix(as-3039): populate user selected/entered data during page navigation

### DIFF
--- a/packages/web-app/src/controllers/review-questionnaire-submission.js
+++ b/packages/web-app/src/controllers/review-questionnaire-submission.js
@@ -200,10 +200,12 @@ const getReviewQuestionnaireSubmission = (req, res) => {
   } = req;
 
   const viewData = createPageData(appeal, questionnaire);
+  const values = questionnaire.missingOrIncorrectInformation;
 
   res.render(currentPage, {
     pageTitle: 'Review questionnaire',
     ...viewData,
+    values,
   });
 };
 
@@ -284,6 +286,7 @@ const postReviewQuestionnaireSubmission = (req, res) => {
   };
 
   req.session.questionnaire.missingOrIncorrectDocuments = missingOrIncorrectDocuments;
+  req.session.questionnaire.missingOrIncorrectInformation = values;
   req.session.questionnaire.outcome =
     missingOrIncorrectDocuments.length > 0 ? REVIEWOUTCOME.INCOMPLETE : REVIEWOUTCOME.COMPLETE;
 

--- a/packages/web-app/src/controllers/review-questionnaire-submission.test.js
+++ b/packages/web-app/src/controllers/review-questionnaire-submission.test.js
@@ -37,6 +37,7 @@ describe('controllers/review-questionnaire', () => {
       } = req;
 
       viewData = createPageData(appeal, questionnaire);
+      const values = questionnaire.missingOrIncorrectInformation;
 
       getReviewQuestionnaireSubmission(req, res);
 
@@ -44,6 +45,7 @@ describe('controllers/review-questionnaire', () => {
       expect(res.render).toBeCalledWith(currentPage, {
         pageTitle: 'Review questionnaire',
         ...viewData,
+        values,
       });
     });
 
@@ -53,6 +55,7 @@ describe('controllers/review-questionnaire', () => {
       } = req;
 
       viewData = createPageData(appeal, questionnaire);
+      const values = questionnaire.missingOrIncorrectInformation;
 
       getReviewQuestionnaireSubmission(req, res);
 
@@ -60,6 +63,7 @@ describe('controllers/review-questionnaire', () => {
       expect(res.render).toBeCalledWith(currentPage, {
         pageTitle: 'Review questionnaire',
         ...viewData,
+        values
       });
     });
 
@@ -71,6 +75,7 @@ describe('controllers/review-questionnaire', () => {
       } = req;
 
       viewData = createPageData(appeal, questionnaire);
+      const values = questionnaire.missingOrIncorrectInformation;
 
       getReviewQuestionnaireSubmission(req, res);
 
@@ -78,6 +83,7 @@ describe('controllers/review-questionnaire', () => {
       expect(res.render).toBeCalledWith(currentPage, {
         pageTitle: 'Review questionnaire',
         ...viewData,
+        values,
       });
     });
   });


### PR DESCRIPTION
This fix populates the values that the CO selected / Entered in the Review Questionnaire page whenever they navigated back to this page