### PR TITLE
Feature/as 3485 save statuses and dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
    VALUES
     ('6922c408-e80a-472b-8b00-9377daec083d', '5c45c22d-a39c-4844-bee1-2f6829b42238', '6ff8d0ef-3767-4258-b3d3-34d48fca238b',
     '2021-11-01', 1, null, 0, null, 0, null, 1, 1, 'Easy site access', 1, 'Easy site neighbour access', 1,
-    'There are some health and safety issues', 0, 'The site is not a listed building', 0, 0, 1, 1, 1, 1);
+    'There are some health and safety issues', 0, 'The site is not a listed building', 0, 0, 1, 1, 'The development neighbourhood plan changes', 1);
 
    INSERT INTO [AppealLink]
     ([ID], [AppealID],[LPAQuestionnaireID], [CaseReference], [CaseTypeID], [CaseStatusID], [AppellantName],

--- a/packages/api/database/migrations/00044-amend-has-appeal-table.js
+++ b/packages/api/database/migrations/00044-amend-has-appeal-table.js
@@ -1,0 +1,533 @@
+const migration = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('HASAppeal', 'AppealValidDate', Sequelize.DATE);
+    await queryInterface.removeColumn('HASAppeal', 'MinisterialTargetDate');
+    await queryInterface.sequelize.query('DROP TRIGGER [AfterInsertHASAppeal]');
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER [dbo].[AfterInsertHASAppeal] ON [dbo].[HASAppeal]
+      FOR INSERT
+      AS DECLARE @ID UNIQUEIDENTIFIER,
+          @AppealID UNIQUEIDENTIFIER,
+          @CheckSumRow INT;
+      BEGIN
+          SET NOCOUNT ON;
+          SELECT @ID = INSERTED.ID FROM INSERTED;
+          SELECT @AppealID = INSERTED.AppealID FROM INSERTED;
+
+          SELECT @CheckSumRow = CHECKSUM(@AppealID,
+              INSERTED.[RecommendedSiteVisitTypeID],
+              INSERTED.[SiteVisitTypeID],
+              INSERTED.[CaseOfficerFirstName],
+              INSERTED.[CaseOfficerSurname],
+              INSERTED.[CaseOfficerID],
+              INSERTED.[LPAQuestionnaireReviewOutcomeID],
+              INSERTED.[LPAIncompleteReasons],
+              INSERTED.[ValidationOfficerFirstName],
+              INSERTED.[ValidationOfficerSurname],
+              INSERTED.[ValidationOfficerID],
+              INSERTED.[ValidationOutcomeID],
+              INSERTED.[InvalidReasonOtherDetails],
+              INSERTED.[InvalidAppealReasons],
+              INSERTED.[InspectorFirstName],
+              INSERTED.[InspectorSurname],
+              INSERTED.[InspectorID],
+              INSERTED.[InspectorSpecialismID],
+              INSERTED.[ScheduledSiteVisitDate],
+              INSERTED.[DecisionOutcomeID],
+              INSERTED.[DecisionLetterID],
+              INSERTED.[DecisionDate],
+              INSERTED.[EventUserID],
+              INSERTED.[EventUserName],
+              INSERTED.[DescriptionDevelopment],
+              INSERTED.[CaseOfficerEmail],
+              INSERTED.[InspectorEmail],
+              INSERTED.[ValidationOfficerEmail],
+              INSERTED.[AppealStartDate],
+              INSERTED.[AppealValidationDate],
+              INSERTED.[AppealValidDate]) FROM INSERTED;
+
+          UPDATE [HASAppeal]
+          SET [LatestEvent] = 0
+          WHERE [AppealID] = @AppealID
+              AND [LatestEvent] = 1
+              AND [ID] <> @ID;
+
+          UPDATE [HASAppeal]
+          SET [CheckSumRow] = @CheckSumRow
+          WHERE [ID] = @ID;
+      END
+    `);
+    await queryInterface.sequelize.query(
+      'ALTER TABLE [dbo].[HASAppeal] ENABLE TRIGGER [AfterInsertHASAppeal]'
+    );
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateHASAppeal');
+    await queryInterface.sequelize.query(`
+      CREATE PROCEDURE CreateHASAppeal
+        @json VARCHAR(4000)
+      AS
+      DECLARE
+        @appealId CHAR(36),
+        @recommendedSiteVisitTypeId INT,
+        @siteVisitTypeId INT,
+        @caseOfficerFirstName NVARCHAR(64),
+        @caseOfficerSurname NVARCHAR(64),
+        @caseOfficerId CHAR(36),
+        @LpaQuestionnaireReviewOutcomeId INT,
+        @LpaIncompleteReasons NVARCHAR(4000),
+        @validationOfficerFirstName NVARCHAR(64),
+        @validationOfficerSurname NVARCHAR(64),
+        @validationOfficerId CHAR(36),
+        @validationOutcomeId INT,
+        @invalidReasonOtherDetails NVARCHAR(4000),
+        @invalidAppealReasons NVARCHAR(4000),
+        @inspectorFirstName NVARCHAR(64),
+        @inspectorSurname NVARCHAR(64),
+        @inspectorId CHAR(36),
+        @inspectorSpecialismId INT,
+        @scheduledSiteVisitDate DATE,
+        @decisionOutcomeId INT,
+        @decisionLetterId CHAR(36),
+        @decisionDate DATE,
+        @descriptionDevelopment NVARCHAR(4000),
+        @caseOfficerEmail NVARCHAR(255),
+        @inspectorEmail NVARCHAR(255),
+        @validationOfficerEmail NVARCHAR(255),
+        @appealStartDate DATE,
+        @appealValidationDate DATE,
+        @questionnaireDueDate DATE,
+        @appealValidDate DATE
+      BEGIN
+        SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+        SELECT
+          @recommendedSiteVisitTypeId = RecommendedSiteVisitTypeID,
+          @siteVisitTypeId = SiteVisitTypeID,
+          @caseOfficerFirstName = CaseOfficerFirstName,
+          @caseOfficerSurname = CaseOfficerSurname,
+          @caseOfficerId = CaseOfficerID,
+          @lpaQuestionnaireReviewOutcomeId = LPAQuestionnaireReviewOutcomeID,
+          @lpaIncompleteReasons = LPAIncompleteReasons,
+          @validationOfficerFirstName = ValidationOfficerFirstName,
+          @validationOfficerSurname = ValidationOfficerSurname,
+          @validationOfficerId = ValidationOfficerID,
+          @validationOutcomeId = ValidationOutcomeID,
+          @invalidReasonOtherDetails = InvalidReasonOtherDetails,
+          @invalidAppealReasons = InvalidAppealReasons,
+          @inspectorFirstName = InspectorFirstName,
+          @inspectorSurname = InspectorSurname,
+          @inspectorId = InspectorID,
+          @inspectorSpecialismId = InspectorSpecialismID,
+          @scheduledSiteVisitDate = ScheduledSiteVisitDate,
+          @decisionOutcomeId = DecisionOutcomeID,
+          @decisionLetterId = DecisionLetterID,
+          @decisionDate = DecisionDate,
+          @descriptionDevelopment = DescriptionDevelopment,
+          @caseOfficerEmail = CaseOfficerEmail,
+          @inspectorEmail = InspectorEmail,
+          @validationOfficerEmail = ValidationOfficerEmail,
+          @appealStartDate = AppealStartDate,
+          @appealValidationDate = AppealValidationDate,
+          @questionnaireDueDate = QuestionnaireDueDate,
+          @appealValidDate = AppealValidDate
+        FROM HASAppeal (NOLOCK)
+        WHERE AppealID = @appealId AND LatestEvent = 1;
+
+        IF JSON_VALUE(@json, '$.recommendedSiteVisitTypeId') IS NOT NULL
+          SET @recommendedSiteVisitTypeId = JSON_VALUE(@json, '$.recommendedSiteVisitTypeId')
+
+        IF JSON_VALUE(@json, '$.siteVisitTypeId') IS NOT NULL
+          SET @siteVisitTypeId = JSON_VALUE(@json, '$.siteVisitTypeId')
+
+        IF JSON_VALUE(@json, '$.caseOfficerFirstName') IS NOT NULL
+          SET @caseOfficerFirstName = JSON_VALUE(@json, '$.caseOfficerFirstName')
+
+        IF JSON_VALUE(@json, '$.caseOfficerSurname') IS NOT NULL
+          SET @caseOfficerSurname = JSON_VALUE(@json, '$.caseOfficerSurname')
+
+        IF JSON_VALUE(@json, '$.caseOfficerId') IS NOT NULL
+          SET @caseOfficerId = JSON_VALUE(@json, '$.caseOfficerId')
+
+        IF JSON_VALUE(@json, '$.lpaQuestionnaireReviewOutcomeId') IS NOT NULL
+          SET @lpaQuestionnaireReviewOutcomeId = JSON_VALUE(@json, '$.lpaQuestionnaireReviewOutcomeId')
+
+        IF JSON_VALUE(@json, '$.lpaIncompleteReasons') IS NOT NULL
+          SET @lpaIncompleteReasons = JSON_VALUE(@json, '$.lpaIncompleteReasons')
+
+        IF JSON_VALUE(@json, '$.validationOfficerFirstName') IS NOT NULL
+          SET @validationOfficerFirstName = JSON_VALUE(@json, '$.validationOfficerFirstName')
+
+        IF JSON_VALUE(@json, '$.validationOfficerSurname') IS NOT NULL
+          SET @validationOfficerSurname = JSON_VALUE(@json, '$.validationOfficerSurname')
+
+        IF JSON_VALUE(@json, '$.validationOfficerId') IS NOT NULL
+          SET @validationOfficerId = JSON_VALUE(@json, '$.validationOfficerId')
+
+        IF JSON_VALUE(@json, '$.validationOutcomeId') IS NOT NULL
+          SET @validationOutcomeId = JSON_VALUE(@json, '$.validationOutcomeId')
+
+        IF JSON_VALUE(@json, '$.invalidReasonOtherDetails') IS NOT NULL
+          SET @invalidReasonOtherDetails = JSON_VALUE(@json, '$.invalidReasonOtherDetails')
+
+        IF JSON_VALUE(@json, '$.invalidAppealReasons') IS NOT NULL
+          SET @invalidAppealReasons = JSON_VALUE(@json, '$.invalidAppealReasons')
+
+        IF JSON_VALUE(@json, '$.inspectorFirstName') IS NOT NULL
+          SET @inspectorFirstName = JSON_VALUE(@json, '$.inspectorFirstName')
+
+        IF JSON_VALUE(@json, '$.inspectorSurname') IS NOT NULL
+          SET @inspectorSurname = JSON_VALUE(@json, '$.inspectorSurname')
+
+        IF JSON_VALUE(@json, '$.inspectorId') IS NOT NULL
+          SET @inspectorId = JSON_VALUE(@json, '$.inspectorId')
+
+        IF JSON_VALUE(@json, '$.inspectorSpecialismId') IS NOT NULL
+          SET @inspectorSpecialismId = JSON_VALUE(@json, '$.inspectorSpecialismId')
+
+        IF JSON_VALUE(@json, '$.scheduledSiteVisitDate') IS NOT NULL
+          SET @scheduledSiteVisitDate = JSON_VALUE(@json, '$.scheduledSiteVisitDate')
+
+        IF JSON_VALUE(@json, '$.decisionOutcomeId') IS NOT NULL
+          SET @decisionOutcomeId = JSON_VALUE(@json, '$.decisionOutcomeId')
+
+        IF JSON_VALUE(@json, '$.decisionLetterId') IS NOT NULL
+          SET @decisionLetterId = JSON_VALUE(@json, '$.decisionLetterId')
+
+        IF JSON_VALUE(@json, '$.decisionDate') IS NOT NULL
+          SET @decisionDate = JSON_VALUE(@json, '$.decisionDate')
+
+        IF JSON_VALUE(@json, '$.descriptionDevelopment') IS NOT NULL
+          SET @descriptionDevelopment = JSON_VALUE(@json, '$.descriptionDevelopment')
+
+        IF JSON_VALUE(@json, '$.caseOfficerEmail') IS NOT NULL
+          SET @caseOfficerEmail = JSON_VALUE(@json, '$.caseOfficerEmail')
+
+        IF JSON_VALUE(@json, '$.inspectorEmail') IS NOT NULL
+          SET @inspectorEmail = JSON_VALUE(@json, '$.inspectorEmail')
+
+        IF JSON_VALUE(@json, '$.validationOfficerEmail') IS NOT NULL
+          SET @validationOfficerEmail = JSON_VALUE(@json, '$.validationOfficerEmail')
+
+        IF JSON_VALUE(@json, '$.appealStartDate') IS NOT NULL
+          SET @appealStartDate = JSON_VALUE(@json, '$.appealStartDate')
+
+        IF JSON_VALUE(@json, '$.appealValidationDate') IS NOT NULL
+          SET @appealValidationDate = JSON_VALUE(@json, '$.appealValidationDate')
+
+        IF JSON_VALUE(@json, '$.questionnaireDueDate') IS NOT NULL
+          SET @questionnaireDueDate = JSON_VALUE(@json, '$.questionnaireDueDate')
+
+        IF JSON_VALUE(@json, '$.appealValidDate') IS NOT NULL
+          SET @appealValidDate = JSON_VALUE(@json, '$.appealValidDate')
+
+        INSERT INTO HASAppeal (
+          ID,
+          AppealID,
+          RecommendedSiteVisitTypeID,
+          SiteVisitTypeID,
+          CaseOfficerFirstName,
+          CaseOfficerSurname,
+          CaseOfficerID,
+          LPAQuestionnaireReviewOutcomeID,
+          LPAIncompleteReasons,
+          ValidationOfficerFirstName,
+          ValidationOfficerSurname,
+          ValidationOfficerID,
+          ValidationOutcomeID,
+          InvalidReasonOtherDetails,
+          InvalidAppealReasons,
+          InspectorFirstName,
+          InspectorSurname,
+          InspectorID,
+          InspectorSpecialismID,
+          ScheduledSiteVisitDate,
+          DecisionOutcomeID,
+          DecisionLetterID,
+          DecisionDate,
+          DescriptionDevelopment,
+          CaseOfficerEmail,
+          InspectorEmail,
+          ValidationOfficerEmail,
+          AppealStartDate,
+          AppealValidationDate,
+          QuestionnaireDueDate,
+          AppealValidDate
+        )
+        VALUES (
+          newid(),
+          @appealId,
+          @recommendedSiteVisitTypeId,
+          @siteVisitTypeId,
+          @caseOfficerFirstName,
+          @caseOfficerSurname,
+          @caseOfficerId,
+          @LpaQuestionnaireReviewOutcomeId,
+          @LpaIncompleteReasons,
+          @validationOfficerFirstName,
+          @validationOfficerSurname,
+          @validationOfficerId,
+          @validationOutcomeId,
+          @invalidReasonOtherDetails,
+          @invalidAppealReasons,
+          @inspectorFirstName,
+          @inspectorSurname,
+          @inspectorId,
+          @inspectorSpecialismId,
+          @scheduledSiteVisitDate,
+          @decisionOutcomeId,
+          @decisionLetterId,
+          @decisionDate,
+          @descriptionDevelopment,
+          @caseOfficerEmail,
+          @inspectorEmail,
+          @validationOfficerEmail,
+          @appealStartDate,
+          @appealValidationDate,
+          @questionnaireDueDate,
+          @appealValidDate
+        );
+      END
+    `);
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('HASAppeal', 'AppealValidDate');
+    await queryInterface.addColumn('HASAppeal', 'MinisterialTargetDate', Sequelize.DATE);
+    await queryInterface.sequelize.query('DROP TRIGGER [AfterInsertHASAppeal]');
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER [dbo].[AfterInsertHASAppeal] ON [dbo].[HASAppeal]
+      FOR INSERT
+      AS DECLARE @ID UNIQUEIDENTIFIER,
+          @AppealID UNIQUEIDENTIFIER,
+          @CheckSumRow INT;
+      BEGIN
+          SET NOCOUNT ON;
+          SELECT @ID = INSERTED.ID FROM INSERTED;
+          SELECT @AppealID = INSERTED.AppealID FROM INSERTED;
+
+          SELECT @CheckSumRow = CHECKSUM(@AppealID,
+              INSERTED.[MinisterialTargetDate],
+              INSERTED.[RecommendedSiteVisitTypeID],
+              INSERTED.[SiteVisitTypeID],
+              INSERTED.[CaseOfficerFirstName],
+              INSERTED.[CaseOfficerSurname],
+              INSERTED.[CaseOfficerID],
+              INSERTED.[LPAQuestionnaireReviewOutcomeID],
+              INSERTED.[LPAIncompleteReasons],
+              INSERTED.[ValidationOfficerFirstName],
+              INSERTED.[ValidationOfficerSurname],
+              INSERTED.[ValidationOfficerID],
+              INSERTED.[ValidationOutcomeID],
+              INSERTED.[InvalidReasonOtherDetails],
+              INSERTED.[InvalidAppealReasons],
+              INSERTED.[InspectorFirstName],
+              INSERTED.[InspectorSurname],
+              INSERTED.[InspectorID],
+              INSERTED.[InspectorSpecialismID],
+              INSERTED.[ScheduledSiteVisitDate],
+              INSERTED.[DecisionOutcomeID],
+              INSERTED.[DecisionLetterID],
+              INSERTED.[DecisionDate],
+              INSERTED.[DescriptionDevelopment]) FROM INSERTED;
+
+          UPDATE [HASAppeal]
+          SET [LatestEvent] = 0
+          WHERE [AppealID] = @AppealID
+              AND [LatestEvent] = 1
+              AND [ID] <> @ID;
+
+          UPDATE [HASAppeal]
+          SET [CheckSumRow] = @CheckSumRow
+          WHERE [ID] = @ID;
+      END
+    `);
+    await queryInterface.sequelize.query(
+      'ALTER TABLE [dbo].[HASAppeal] ENABLE TRIGGER [AfterInsertHASAppeal]'
+    );
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateHASAppeal');
+    await queryInterface.sequelize.query(`
+      CREATE PROCEDURE CreateHASAppeal
+        @json VARCHAR(4000)
+      AS
+      DECLARE
+        @appealId CHAR(36),
+        @ministerialTargetDate DATE,
+        @recommendedSiteVisitTypeId INT,
+        @siteVisitTypeId INT,
+        @caseOfficerFirstName NVARCHAR(64),
+        @caseOfficerSurname NVARCHAR(64),
+        @caseOfficerId CHAR(36),
+        @LpaQuestionnaireReviewOutcomeId INT,
+        @LpaIncompleteReasons NVARCHAR(4000),
+        @validationOfficerFirstName NVARCHAR(64),
+        @validationOfficerSurname NVARCHAR(64),
+        @validationOfficerId CHAR(36),
+        @validationOutcomeId INT,
+        @invalidReasonOtherDetails NVARCHAR(4000),
+        @invalidAppealReasons NVARCHAR(4000),
+        @inspectorFirstName NVARCHAR(64),
+        @inspectorSurname NVARCHAR(64),
+        @inspectorId CHAR(36),
+        @inspectorSpecialismId INT,
+        @scheduledSiteVisitDate DATE,
+        @decisionOutcomeId INT,
+        @decisionLetterId CHAR(36),
+        @decisionDate DATE,
+        @descriptionDevelopment NVARCHAR(4000)
+      BEGIN
+        SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+        SELECT
+          @ministerialTargetDate = MinisterialTargetDate,
+          @recommendedSiteVisitTypeId = RecommendedSiteVisitTypeID,
+          @siteVisitTypeId = SiteVisitTypeID,
+          @caseOfficerFirstName = CaseOfficerFirstName,
+          @caseOfficerSurname = CaseOfficerSurname,
+          @caseOfficerId = CaseOfficerID,
+          @lpaQuestionnaireReviewOutcomeId = LPAQuestionnaireReviewOutcomeID,
+          @lpaIncompleteReasons = LPAIncompleteReasons,
+          @validationOfficerFirstName = ValidationOfficerFirstName,
+          @validationOfficerSurname = ValidationOfficerSurname,
+          @validationOfficerId = ValidationOfficerID,
+          @validationOutcomeId = ValidationOutcomeID,
+          @invalidReasonOtherDetails = InvalidReasonOtherDetails,
+          @invalidAppealReasons = InvalidAppealReasons,
+          @inspectorFirstName = InspectorFirstName,
+          @inspectorSurname = InspectorSurname,
+          @inspectorId = InspectorID,
+          @inspectorSpecialismId = InspectorSpecialismID,
+          @scheduledSiteVisitDate = ScheduledSiteVisitDate,
+          @decisionOutcomeId = DecisionOutcomeID,
+          @decisionLetterId = DecisionLetterID,
+          @decisionDate = DecisionDate,
+          @descriptionDevelopment = DescriptionDevelopment
+        FROM HASAppeal (NOLOCK)
+        WHERE AppealID = @appealId AND LatestEvent = 1;
+
+        IF JSON_VALUE(@json, '$.ministerialTargetDate') IS NOT NULL
+          SET @ministerialTargetDate = JSON_VALUE(@json, '$.ministerialTargetDate')
+
+        IF JSON_VALUE(@json, '$.recommendedSiteVisitTypeId') IS NOT NULL
+          SET @recommendedSiteVisitTypeId = JSON_VALUE(@json, '$.recommendedSiteVisitTypeId')
+
+        IF JSON_VALUE(@json, '$.siteVisitTypeId') IS NOT NULL
+          SET @siteVisitTypeId = JSON_VALUE(@json, '$.siteVisitTypeId')
+
+        IF JSON_VALUE(@json, '$.caseOfficerFirstName') IS NOT NULL
+          SET @caseOfficerFirstName = JSON_VALUE(@json, '$.caseOfficerFirstName')
+
+        IF JSON_VALUE(@json, '$.caseOfficerSurname') IS NOT NULL
+          SET @caseOfficerSurname = JSON_VALUE(@json, '$.caseOfficerSurname')
+
+        IF JSON_VALUE(@json, '$.caseOfficerId') IS NOT NULL
+          SET @caseOfficerId = JSON_VALUE(@json, '$.caseOfficerId')
+
+        IF JSON_VALUE(@json, '$.lpaQuestionnaireReviewOutcomeId') IS NOT NULL
+          SET @lpaQuestionnaireReviewOutcomeId = JSON_VALUE(@json, '$.lpaQuestionnaireReviewOutcomeId')
+
+        IF JSON_VALUE(@json, '$.lpaIncompleteReasons') IS NOT NULL
+          SET @lpaIncompleteReasons = JSON_VALUE(@json, '$.lpaIncompleteReasons')
+
+        IF JSON_VALUE(@json, '$.validationOfficerFirstName') IS NOT NULL
+          SET @validationOfficerFirstName = JSON_VALUE(@json, '$.validationOfficerFirstName')
+
+        IF JSON_VALUE(@json, '$.validationOfficerSurname') IS NOT NULL
+          SET @validationOfficerSurname = JSON_VALUE(@json, '$.validationOfficerSurname')
+
+        IF JSON_VALUE(@json, '$.validationOfficerId') IS NOT NULL
+          SET @validationOfficerId = JSON_VALUE(@json, '$.validationOfficerId')
+
+        IF JSON_VALUE(@json, '$.validationOutcomeId') IS NOT NULL
+          SET @validationOutcomeId = JSON_VALUE(@json, '$.validationOutcomeId')
+
+        IF JSON_VALUE(@json, '$.invalidReasonOtherDetails') IS NOT NULL
+          SET @invalidReasonOtherDetails = JSON_VALUE(@json, '$.invalidReasonOtherDetails')
+
+        IF JSON_VALUE(@json, '$.invalidAppealReasons') IS NOT NULL
+          SET @invalidAppealReasons = JSON_VALUE(@json, '$.invalidAppealReasons')
+
+        IF JSON_VALUE(@json, '$.inspectorFirstName') IS NOT NULL
+          SET @inspectorFirstName = JSON_VALUE(@json, '$.inspectorFirstName')
+
+        IF JSON_VALUE(@json, '$.inspectorSurname') IS NOT NULL
+          SET @inspectorSurname = JSON_VALUE(@json, '$.inspectorSurname')
+
+        IF JSON_VALUE(@json, '$.inspectorId') IS NOT NULL
+          SET @inspectorId = JSON_VALUE(@json, '$.inspectorId')
+
+        IF JSON_VALUE(@json, '$.inspectorSpecialismId') IS NOT NULL
+          SET @inspectorSpecialismId = JSON_VALUE(@json, '$.inspectorSpecialismId')
+
+        IF JSON_VALUE(@json, '$.scheduledSiteVisitDate') IS NOT NULL
+          SET @scheduledSiteVisitDate = JSON_VALUE(@json, '$.scheduledSiteVisitDate')
+
+        IF JSON_VALUE(@json, '$.decisionOutcomeId') IS NOT NULL
+          SET @decisionOutcomeId = JSON_VALUE(@json, '$.decisionOutcomeId')
+
+        IF JSON_VALUE(@json, '$.decisionLetterId') IS NOT NULL
+          SET @decisionLetterId = JSON_VALUE(@json, '$.decisionLetterId')
+
+        IF JSON_VALUE(@json, '$.decisionDate') IS NOT NULL
+          SET @decisionDate = JSON_VALUE(@json, '$.decisionDate')
+
+        IF JSON_VALUE(@json, '$.descriptionDevelopment') IS NOT NULL
+          SET @descriptionDevelopment = JSON_VALUE(@json, '$.descriptionDevelopment')
+
+        INSERT INTO HASAppeal (
+          ID,
+          AppealID,
+          MinisterialTargetDate,
+          RecommendedSiteVisitTypeID,
+          SiteVisitTypeID,
+          CaseOfficerFirstName,
+          CaseOfficerSurname,
+          CaseOfficerID,
+          LPAQuestionnaireReviewOutcomeID,
+          LPAIncompleteReasons,
+          ValidationOfficerFirstName,
+          ValidationOfficerSurname,
+          ValidationOfficerID,
+          ValidationOutcomeID,
+          InvalidReasonOtherDetails,
+          InvalidAppealReasons,
+          InspectorFirstName,
+          InspectorSurname,
+          InspectorID,
+          InspectorSpecialismID,
+          ScheduledSiteVisitDate,
+          DecisionOutcomeID,
+          DecisionLetterID,
+          DecisionDate,
+          DescriptionDevelopment
+        )
+        VALUES (
+          newid(),
+          @appealId,
+          @ministerialTargetDate,
+          @recommendedSiteVisitTypeId,
+          @siteVisitTypeId,
+          @caseOfficerFirstName,
+          @caseOfficerSurname,
+          @caseOfficerId,
+          @LpaQuestionnaireReviewOutcomeId,
+          @LpaIncompleteReasons,
+          @validationOfficerFirstName,
+          @validationOfficerSurname,
+          @validationOfficerId,
+          @validationOutcomeId,
+          @invalidReasonOtherDetails,
+          @invalidAppealReasons,
+          @inspectorFirstName,
+          @inspectorSurname,
+          @inspectorId,
+          @inspectorSpecialismId,
+          @scheduledSiteVisitDate,
+          @decisionOutcomeId,
+          @decisionLetterId,
+          @decisionDate,
+          @descriptionDevelopment
+        );
+      END
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00045-amend-appeal-data-view.js
+++ b/packages/api/database/migrations/00045-amend-appeal-data-view.js
@@ -1,0 +1,143 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW AppealData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW [dbo].[AppealData]
+      AS
+      SELECT
+        HASAppealSubmission.AppealID as appealId,
+        HASAppealSubmission.CreatorEmailAddress as creatorEmailAddress,
+        HASAppealSubmission.CreatorName as creatorName,
+        HASAppealSubmission.CreatorOriginalApplicant as creatorOriginalApplicant,
+        HASAppealSubmission.CreatorOnBehalfOf as creatorOnBehalfOf,
+        HASAppealSubmission.OriginalApplicationNumber as originalApplicationNumber,
+        HASAppealSubmission.SiteOwnership as siteOwnership,
+        HASAppealSubmission.SiteInformOwners as siteInformOwners,
+        HASAppealSubmission.SiteRestriction as siteRestriction,
+        HASAppealSubmission.SiteRestrictionDetails as siteRestrictionDetails,
+        HASAppealSubmission.SafetyConcern as safetyConcern,
+        HASAppealSubmission.SafetyConcernDetails as safetyConcernDetails,
+        HASAppealSubmission.SensitiveInformation as sensitiveInformation,
+        HASAppealSubmission.TermsAgreed as termsAgreed,
+        HASAppealSubmission.DecisionDate as appealDecisionDate,
+        HASAppealSubmission.SubmissionDate as submissionDate,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.CaseStatusID as caseStatusId,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.CaseOfficerFirstName as caseOfficerFirstName,
+        HASAppeal.CaseOfficerSurname as caseOfficerSurname,
+        HASAppeal.CaseOfficerEmail as caseOfficerEmail,
+        HASAppeal.ValidationOfficerFirstName as validationOfficerFirstName,
+        HASAppeal.ValidationOfficerSurname as validationOfficerSurname,
+        HASAppeal.ValidationOfficerEmail as validationOfficerEmail,
+        HASAppeal.InvalidReasonOtherDetails as invalidReasonOtherDetails,
+        HASAppeal.InvalidAppealReasons as invalidAppealReasons,
+        HASAppeal.InspectorFirstName as inspectorFirstName,
+        HASAppeal.InspectorSurname as inspectorSurname,
+        HASAppeal.InspectorEmail as inspectorEmail,
+        HASAppeal.ScheduledSiteVisitDate as scheduledSiteVisitDate,
+        HASAppealSubmission.DecisionDate as questionnaireDecisionDate,
+        HASAppeal.DescriptionDevelopment as descriptionDevelopment,
+        HASAppeal.AppealStartDate as appealStartDate,
+        HASAppeal.AppealValidationDate as appealValidationDate,
+        HASAppeal.AppealValidDate as appealValidDate,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpRecommendedSiteVisitType.TypeName as recommendedSiteVisitTypeName,
+        LookUpSiteVisitType.TypeName as siteVisitTypeName,
+        LookUpInspectorSpecialism.Specialism as inspectorSpecialismName,
+        LookUpDecisionOutcome.Outcome as decisionOutcomeName
+      FROM HASAppealSubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASAppealSubmission.AppealID = AppealLink.AppealId AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASAppealSubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpSiteVisitType AS LookUpRecommendedSiteVisitType (NOLOCK) ON HASAppeal.RecommendedSiteVisitTypeID = LookUpRecommendedSiteVisitType.ID
+      LEFT JOIN LookUpSiteVisitType (NOLOCK) ON HASAppeal.SiteVisitTypeID = LookUpSiteVisitType.ID
+      LEFT JOIN LookUpInspectorSpecialism (NOLOCK) ON HASAppeal.InspectorSpecialismID = LookUpInspectorSpecialism.ID
+      LEFT JOIN LookUpDecisionOutcome (NOLOCK) ON HASAppeal.DecisionOutcomeID = LookUpDecisionOutcome.ID
+      WHERE HASAppealSubmission.LatestEvent = 1
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW AppealData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW [dbo].[AppealData]
+      AS
+      SELECT
+        HASAppealSubmission.AppealID as appealId,
+        HASAppealSubmission.CreatorEmailAddress as creatorEmailAddress,
+        HASAppealSubmission.CreatorName as creatorName,
+        HASAppealSubmission.CreatorOriginalApplicant as creatorOriginalApplicant,
+        HASAppealSubmission.CreatorOnBehalfOf as creatorOnBehalfOf,
+        HASAppealSubmission.OriginalApplicationNumber as originalApplicationNumber,
+        HASAppealSubmission.SiteOwnership as siteOwnership,
+        HASAppealSubmission.SiteInformOwners as siteInformOwners,
+        HASAppealSubmission.SiteRestriction as siteRestriction,
+        HASAppealSubmission.SiteRestrictionDetails as siteRestrictionDetails,
+        HASAppealSubmission.SafetyConcern as safetyConcern,
+        HASAppealSubmission.SafetyConcernDetails as safetyConcernDetails,
+        HASAppealSubmission.SensitiveInformation as sensitiveInformation,
+        HASAppealSubmission.TermsAgreed as termsAgreed,
+        HASAppealSubmission.DecisionDate as appealDecisionDate,
+        HASAppealSubmission.SubmissionDate as submissionDate,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.CaseStatusID as caseStatusId,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.CaseOfficerFirstName as caseOfficerFirstName,
+        HASAppeal.CaseOfficerSurname as caseOfficerSurname,
+        HASAppeal.CaseOfficerEmail as caseOfficerEmail,
+        HASAppeal.ValidationOfficerFirstName as validationOfficerFirstName,
+        HASAppeal.ValidationOfficerSurname as validationOfficerSurname,
+        HASAppeal.ValidationOfficerEmail as validationOfficerEmail,
+        HASAppeal.InvalidReasonOtherDetails as invalidReasonOtherDetails,
+        HASAppeal.InvalidAppealReasons as invalidAppealReasons,
+        HASAppeal.InspectorFirstName as inspectorFirstName,
+        HASAppeal.InspectorSurname as inspectorSurname,
+        HASAppeal.InspectorEmail as inspectorEmail,
+        HASAppeal.ScheduledSiteVisitDate as scheduledSiteVisitDate,
+        HASAppealSubmission.DecisionDate as questionnaireDecisionDate,
+        HASAppeal.DescriptionDevelopment as descriptionDevelopment,
+        HASAppeal.AppealStartDate as appealStartDate,
+        HASAppeal.AppealValidationDate as appealValidationDate,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpRecommendedSiteVisitType.TypeName as recommendedSiteVisitTypeName,
+        LookUpSiteVisitType.TypeName as siteVisitTypeName,
+        LookUpInspectorSpecialism.Specialism as inspectorSpecialismName,
+        LookUpDecisionOutcome.Outcome as decisionOutcomeName
+      FROM HASAppealSubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASAppealSubmission.AppealID = AppealLink.AppealId AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASAppealSubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpSiteVisitType AS LookUpRecommendedSiteVisitType (NOLOCK) ON HASAppeal.RecommendedSiteVisitTypeID = LookUpRecommendedSiteVisitType.ID
+      LEFT JOIN LookUpSiteVisitType (NOLOCK) ON HASAppeal.SiteVisitTypeID = LookUpSiteVisitType.ID
+      LEFT JOIN LookUpInspectorSpecialism (NOLOCK) ON HASAppeal.InspectorSpecialismID = LookUpInspectorSpecialism.ID
+      LEFT JOIN LookUpDecisionOutcome (NOLOCK) ON HASAppeal.DecisionOutcomeID = LookUpDecisionOutcome.ID
+      WHERE HASAppealSubmission.LatestEvent = 1
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00046-amend-appeal-link-table.js
+++ b/packages/api/database/migrations/00046-amend-appeal-link-table.js
@@ -1,0 +1,88 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP TRIGGER [AfterInsertAppealLink]');
+    await queryInterface.sequelize.query(`
+            CREATE TRIGGER [dbo].[AfterInsertAppealLink] ON [dbo].[AppealLink]
+            FOR INSERT
+            AS DECLARE @ID UNIQUEIDENTIFIER,
+                @AppealID UNIQUEIDENTIFIER,
+                @CheckSumRow INT;
+            BEGIN
+                SET NOCOUNT ON;
+
+                SELECT @ID = INSERTED.[ID] FROM INSERTED;
+                SELECT @AppealID = INSERTED.[AppealID] FROM INSERTED;
+
+                SELECT @CheckSumRow = CHECKSUM(@AppealID,
+                  INSERTED.[CaseReference],
+                  INSERTED.[CaseTypeId],
+                  INSERTED.[CaseStageId],
+                  INSERTED.[CaseStatusId],
+                  INSERTED.[AppellantName],
+                  INSERTED.[SiteAddressLineOne],
+                  INSERTED.[SiteAddressLineTwo],
+                  INSERTED.[SiteAddressTown],
+                  INSERTED.[SiteAddressCounty],
+                  INSERTED.[SiteAddressPostCode],
+                  INSERTED.[LocalPlanningAuthorityID],
+                  INSERTED.[EventUserID],
+                  INSERTED.[EventUserName],
+                  INSERTED.[QuestionnaireStatusID]) FROM INSERTED;
+
+                UPDATE [AppealLink]
+                SET [LatestEvent] = 0
+                WHERE [AppealID] = @AppealID
+                    AND [LatestEvent] = 1
+                    AND [ID] <> @ID;
+
+                UPDATE [AppealLink]
+                SET [CheckSumRow] = @CheckSumRow
+                WHERE [ID] = @ID;
+            END
+        `);
+    await queryInterface.sequelize.query(
+      'ALTER TABLE [dbo].[AppealLink] ENABLE TRIGGER [AfterInsertAppealLink]'
+    );
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP TRIGGER [AfterInsertAppealLink]');
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER [dbo].[AfterInsertAppealLink] ON [dbo].[AppealLink]
+      FOR INSERT
+      AS DECLARE @ID UNIQUEIDENTIFIER,
+          @AppealID UNIQUEIDENTIFIER,
+          @CheckSumRow INT;
+      BEGIN
+          SET NOCOUNT ON;
+
+          SELECT @ID = INSERTED.[ID] FROM INSERTED;
+          SELECT @AppealID = INSERTED.[AppealID] FROM INSERTED;
+
+          SELECT @CheckSumRow = CHECKSUM(@AppealID,
+              INSERTED.[CaseReference],
+              INSERTED.[AppellantName],
+              INSERTED.[SiteAddressLineOne],
+              INSERTED.[SiteAddressLineTwo],
+              INSERTED.[SiteAddressTown],
+              INSERTED.[SiteAddressCounty],
+              INSERTED.[SiteAddressPostCode],
+              INSERTED.[LocalPlanningAuthorityID]) FROM INSERTED;
+
+          UPDATE [AppealLink]
+          SET [LatestEvent] = 0
+          WHERE [AppealID] = @AppealID
+              AND [LatestEvent] = 1
+              AND [ID] <> @ID;
+
+          UPDATE [AppealLink]
+          SET [CheckSumRow] = @CheckSumRow
+          WHERE [ID] = @ID;
+      END
+    `);
+    await queryInterface.sequelize.query(
+      'ALTER TABLE [dbo].[AppealLink] ENABLE TRIGGER [AfterInsertAppealLink]'
+    );
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00047-amend-create-appeal-link-procedure.js
+++ b/packages/api/database/migrations/00047-amend-create-appeal-link-procedure.js
@@ -1,0 +1,255 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateAppealLink');
+    await queryInterface.sequelize.query(`
+    CREATE PROCEDURE CreateAppealLink
+      @json NVARCHAR(4000)
+    AS
+    DECLARE
+      @appealId CHAR(36),
+      @lpaQuestionnaireId CHAR(36),
+      @caseReference INT,
+      @caseTypeId INT,
+      @caseStageId INT,
+      @caseStatusId INT,
+      @appellantName NVARCHAR(80),
+      @siteAddressLineOne NVARCHAR(60),
+      @siteAddressLineTwo NVARCHAR(60),
+      @siteAddressTown NVARCHAR(60),
+      @siteAddressCounty NVARCHAR(60),
+      @siteAddressPostcode NVARCHAR(8),
+      @localPlanningAuthorityId NVARCHAR(9),
+      @eventUserId CHAR(36),
+      @eventUserName NVARCHAR(256),
+      @questionnaireStatusId INT
+    BEGIN
+      SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+      SELECT
+        @lpaQuestionnaireId = LPAQuestionnaireID,
+        @caseReference = CaseReference,
+        @caseTypeId = CaseTypeID,
+        @caseStageId = CaseStageID,
+        @caseStatusId = CaseStatusID,
+        @appellantName = AppellantName,
+        @siteAddressLineOne = SiteAddressLineOne,
+        @siteAddressLineTwo = SiteAddressLineTwo,
+        @siteAddressTown = SiteAddressTown,
+        @siteAddressCounty = SiteAddressCounty,
+        @siteAddressPostcode = SiteAddressPostcode,
+        @localPlanningAuthorityId = LocalPlanningAuthorityID,
+        @questionnaireStatusId = QuestionnaireStatusID
+      FROM AppealLink (NOLOCK)
+      WHERE AppealID = @appealId AND LatestEvent = 1;
+
+      IF JSON_VALUE(@json, '$.lpaQuestionnaireId') IS NOT NULL
+        SET @lpaQuestionnaireId = JSON_VALUE(@json, '$.lpaQuestionnaireId')
+
+      IF JSON_VALUE(@json, '$.caseReference') IS NOT NULL
+        SET @caseReference = JSON_VALUE(@json, '$.caseReference')
+
+      IF JSON_VALUE(@json, '$.caseTypeId') IS NOT NULL
+        SET @caseTypeId = JSON_VALUE(@json, '$.caseTypeId')
+
+      IF JSON_VALUE(@json, '$.caseStageId') IS NOT NULL
+        SET @caseStageId = JSON_VALUE(@json, '$.caseStageId')
+
+      IF JSON_VALUE(@json, '$.caseStatusId') IS NOT NULL
+        SET @caseStatusId = JSON_VALUE(@json, '$.caseStatusId')
+
+      IF JSON_VALUE(@json, '$.appellantName') IS NOT NULL
+        SET @appellantName = JSON_VALUE(@json, '$.appellantName')
+
+      IF JSON_VALUE(@json, '$.siteAddressLineOne') IS NOT NULL
+        SET @siteAddressLineOne = JSON_VALUE(@json, '$.siteAddressLineOne')
+
+      IF JSON_VALUE(@json, '$.siteAddressLineTwo') IS NOT NULL
+        SET @siteAddressLineTwo = JSON_VALUE(@json, '$.siteAddressLineTwo')
+
+      IF JSON_VALUE(@json, '$.siteAddressTown') IS NOT NULL
+        SET @siteAddressTown = JSON_VALUE(@json, '$.siteAddressTown')
+
+      IF JSON_VALUE(@json, '$.siteAddressCounty') IS NOT NULL
+        SET @siteAddressCounty = JSON_VALUE(@json, '$.siteAddressCounty')
+
+      IF JSON_VALUE(@json, '$.siteAddressPostcode') IS NOT NULL
+        SET @siteAddressPostcode = JSON_VALUE(@json, '$.siteAddressPostcode')
+
+      IF JSON_VALUE(@json, '$.localPlanningAuthorityId') IS NOT NULL
+        SET @localPlanningAuthorityId = JSON_VALUE(@json, '$.localPlanningAuthorityId')
+
+      IF JSON_VALUE(@json, '$.eventUserId') IS NOT NULL
+        SET @eventUserId = JSON_VALUE(@json, '$.eventUserId')
+
+      IF JSON_VALUE(@json, '$.eventUserName') IS NOT NULL
+        SET @eventUserName = JSON_VALUE(@json, '$.eventUserName')
+
+      IF JSON_VALUE(@json, '$.questionnaireStatusId') IS NOT NULL
+        SET @questionnaireStatusId = JSON_VALUE(@json, '$.questionnaireStatusId')
+
+      INSERT INTO AppealLink (
+        ID,
+        AppealID,
+        LPAQuestionnaireID,
+        CaseReference,
+        CaseTypeID,
+        CaseStageID,
+        CaseStatusID,
+        AppellantName,
+        SiteAddressLineOne,
+        SiteAddressLineTwo,
+        SiteAddressTown,
+        SiteAddressCounty,
+        SiteAddressPostcode,
+        LocalPlanningAuthorityID,
+        EventUserID,
+        EventUserName,
+        QuestionnaireStatusID
+      )
+      VALUES (
+        newid(),
+        @appealId,
+        @lpaQuestionnaireId,
+        @caseReference,
+        @caseTypeId,
+        @caseStageId,
+        @caseStatusId,
+        @appellantName,
+        @siteAddressLineOne,
+        @siteAddressLineTwo,
+        @siteAddressTown,
+        @siteAddressCounty,
+        @siteAddressPostcode,
+        @localPlanningAuthorityId,
+        @eventUserId,
+        @eventUserName,
+        @questionnaireStatusId
+      );
+    END
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateAppealLink');
+    await queryInterface.sequelize.query(`
+      CREATE PROCEDURE CreateAppealLink
+        @json NVARCHAR(4000)
+      AS
+      DECLARE
+        @appealId CHAR(36),
+        @lpaQuestionnaireId CHAR(36),
+        @caseReference INT,
+        @caseTypeId INT,
+        @caseStageId INT,
+        @caseStatusId INT,
+        @appellantName NVARCHAR(80),
+        @siteAddressLineOne NVARCHAR(60),
+        @siteAddressLineTwo NVARCHAR(60),
+        @siteAddressTown NVARCHAR(60),
+        @siteAddressCounty NVARCHAR(60),
+        @siteAddressPostcode NVARCHAR(8),
+        @localPlanningAuthorityId NVARCHAR(9),
+        @eventUserId CHAR(36),
+        @eventUserName NVARCHAR(256)
+      BEGIN
+        SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+        SELECT
+          @lpaQuestionnaireId = LPAQuestionnaireID,
+          @caseReference = CaseReference,
+          @caseTypeId = CaseTypeID,
+          @caseStageId = CaseStageID,
+          @caseStatusId = CaseStatusID,
+          @appellantName = AppellantName,
+          @siteAddressLineOne = SiteAddressLineOne,
+          @siteAddressLineTwo = SiteAddressLineTwo,
+          @siteAddressTown = SiteAddressTown,
+          @siteAddressCounty = SiteAddressCounty,
+          @siteAddressPostcode = SiteAddressPostcode,
+          @localPlanningAuthorityId = LocalPlanningAuthorityID
+        FROM AppealLink (NOLOCK)
+        WHERE AppealID = @appealId AND LatestEvent = 1;
+
+        IF JSON_VALUE(@json, '$.lpaQuestionnaireId') IS NOT NULL
+          SET @lpaQuestionnaireId = JSON_VALUE(@json, '$.lpaQuestionnaireId')
+
+        IF JSON_VALUE(@json, '$.caseReference') IS NOT NULL
+          SET @caseReference = JSON_VALUE(@json, '$.caseReference')
+
+        IF JSON_VALUE(@json, '$.caseTypeId') IS NOT NULL
+          SET @caseTypeId = JSON_VALUE(@json, '$.caseTypeId')
+
+        IF JSON_VALUE(@json, '$.caseStageId') IS NOT NULL
+          SET @caseStageId = JSON_VALUE(@json, '$.caseStageId')
+
+        IF JSON_VALUE(@json, '$.caseStatusId') IS NOT NULL
+          SET @caseStatusId = JSON_VALUE(@json, '$.caseStatusId')
+
+        IF JSON_VALUE(@json, '$.appellantName') IS NOT NULL
+          SET @appellantName = JSON_VALUE(@json, '$.appellantName')
+
+        IF JSON_VALUE(@json, '$.siteAddressLineOne') IS NOT NULL
+          SET @siteAddressLineOne = JSON_VALUE(@json, '$.siteAddressLineOne')
+
+        IF JSON_VALUE(@json, '$.siteAddressLineTwo') IS NOT NULL
+          SET @siteAddressLineTwo = JSON_VALUE(@json, '$.siteAddressLineTwo')
+
+        IF JSON_VALUE(@json, '$.siteAddressTown') IS NOT NULL
+          SET @siteAddressTown = JSON_VALUE(@json, '$.siteAddressTown')
+
+        IF JSON_VALUE(@json, '$.siteAddressCounty') IS NOT NULL
+          SET @siteAddressCounty = JSON_VALUE(@json, '$.siteAddressCounty')
+
+        IF JSON_VALUE(@json, '$.siteAddressPostcode') IS NOT NULL
+          SET @siteAddressPostcode = JSON_VALUE(@json, '$.siteAddressPostcode')
+
+        IF JSON_VALUE(@json, '$.localPlanningAuthorityId') IS NOT NULL
+          SET @localPlanningAuthorityId = JSON_VALUE(@json, '$.localPlanningAuthorityId')
+
+        IF JSON_VALUE(@json, '$.eventUserId') IS NOT NULL
+          SET @eventUserId = JSON_VALUE(@json, '$.eventUserId')
+
+        IF JSON_VALUE(@json, '$.eventUserName') IS NOT NULL
+          SET @eventUserName = JSON_VALUE(@json, '$.eventUserName')
+
+        INSERT INTO AppealLink (
+          ID,
+          AppealID,
+          LPAQuestionnaireID,
+          CaseReference,
+          CaseTypeID,
+          CaseStageID,
+          CaseStatusID,
+          AppellantName,
+          SiteAddressLineOne,
+          SiteAddressLineTwo,
+          SiteAddressTown,
+          SiteAddressCounty,
+          SiteAddressPostcode,
+          LocalPlanningAuthorityID,
+          EventUserID,
+          EventUserName
+        )
+        VALUES (
+          newid(),
+          @appealId,
+          @lpaQuestionnaireId,
+          @caseReference,
+          @caseTypeId,
+          @caseStageId,
+          @caseStatusId,
+          @appellantName,
+          @siteAddressLineOne,
+          @siteAddressLineTwo,
+          @siteAddressTown,
+          @siteAddressCounty,
+          @siteAddressPostcode,
+          @localPlanningAuthorityId,
+          @eventUserId,
+          @eventUserName
+        );
+      END
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00048-amend-create-has-lpa-submission-procedure.js
+++ b/packages/api/database/migrations/00048-amend-create-has-lpa-submission-procedure.js
@@ -1,0 +1,392 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateHASLPASubmission');
+    await queryInterface.sequelize.query(`
+      CREATE PROCEDURE CreateHASLPASubmission
+        @json NVARCHAR(4000)
+      AS
+      DECLARE
+        @appealId CHAR(36),
+        @lpaQuestionnaireId CHAR(36),
+        @submissionDate DATE,
+        @submissionAccuracy BIT,
+        @submissionaccuracyDetails NVARCHAR(4000),
+        @extraConditions BIT,
+        @extraConditionsDetails NVARCHAR(4000),
+        @adjacentAppeals BIT,
+        @adjacentAppealsNumbers NVARCHAR(100),
+        @cannotSeeLand BIT,
+        @siteAccess BIT,
+        @siteAccessDetails NVARCHAR(4000),
+        @siteNeighbourAccess BIT,
+        @siteNeighbourAccessDetails NVARCHAR(4000),
+        @healthAndSafetyIssues BIT,
+        @healthAndSafetyDetails NVARCHAR(4000),
+        @affectListedBuilding BIT,
+        @affectListedBuildingDetails NVARCHAR(4000),
+        @greenBelt BIT,
+        @conservationArea BIT,
+        @originalPlanningApplicationPublicised BIT,
+        @developmentNeighbourhoodPlanSubmitted BIT,
+        @developmentNeighbourhoodPlanChanges NVARCHAR(4000),
+        @eventUserId CHAR(36),
+        @eventUserName NVARCHAR(256)
+      BEGIN
+        SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+        SELECT
+          @lpaQuestionnaireId = LPAQuestionnaireID,
+          @submissionDate = SubmissionDate,
+          @submissionAccuracy = SubmissionAccuracy,
+          @submissionaccuracyDetails = SubmissionaccuracyDetails,
+          @extraConditions = ExtraConditions,
+          @extraConditionsDetails = ExtraConditionsDetails,
+          @adjacentAppeals = AdjacentAppeals,
+          @adjacentAppealsNumbers = AdjacentAppealsNumbers,
+          @cannotSeeLand = CannotSeeLand,
+          @siteAccess = SiteAccess,
+          @siteAccessDetails = SiteAccessDetails,
+          @siteNeighbourAccess = SiteNeighbourAccess,
+          @siteNeighbourAccessDetails = SiteNeighbourAccessDetails,
+          @healthAndSafetyIssues = HealthAndSafetyIssues,
+          @healthAndSafetyDetails = HealthAndSafetyDetails,
+          @affectListedBuilding = AffectListedBuilding,
+          @affectListedBuildingDetails = AffectListedBuildingDetails,
+          @greenBelt = GreenBelt,
+          @conservationArea = ConservationArea,
+          @originalPlanningApplicationPublicised = OriginalPlanningApplicationPublicised,
+          @developmentNeighbourhoodPlanSubmitted = DevelopmentNeighbourhoodPlanSubmitted,
+          @developmentNeighbourhoodPlanChanges = DevelopmentNeighbourhoodPlanChanges,
+          @eventUserId = EventUserID,
+          @eventUserName = EventUserName
+        FROM HASLPASubmission (NOLOCK)
+        WHERE AppealID = @appealId AND LatestEvent = 1;
+
+        IF JSON_VALUE(@json, '$.lpaQuestionnaireId') IS NOT NULL
+          SET @lpaQuestionnaireId = JSON_VALUE(@json, '$.lpaQuestionnaireId')
+
+        IF JSON_VALUE(@json, '$.submissionDate') IS NOT NULL
+          SET @submissionDate = JSON_VALUE(@json, '$.submissionDate')
+
+        IF JSON_VALUE(@json, '$.submissionAccuracy') IS NOT NULL
+          SET @submissionAccuracy = JSON_VALUE(@json, '$.submissionAccuracy')
+
+        IF JSON_VALUE(@json, '$.submissionaccuracyDetails') IS NOT NULL
+          SET @submissionaccuracyDetails = JSON_VALUE(@json, '$.submissionaccuracyDetails')
+
+        IF JSON_VALUE(@json, '$.extraConditions') IS NOT NULL
+          SET @extraConditions = JSON_VALUE(@json, '$.extraConditions')
+
+        IF JSON_VALUE(@json, '$.extraConditionsDetails') IS NOT NULL
+          SET @extraConditionsDetails = JSON_VALUE(@json, '$.extraConditionsDetails')
+
+        IF JSON_VALUE(@json, '$.adjacentAppeals') IS NOT NULL
+          SET @adjacentAppeals = JSON_VALUE(@json, '$.adjacentAppeals')
+
+        IF JSON_VALUE(@json, '$.adjacentAppealsNumbers') IS NOT NULL
+          SET @adjacentAppealsNumbers = JSON_VALUE(@json, '$.adjacentAppealsNumbers')
+
+        IF JSON_VALUE(@json, '$.cannotSeeLand') IS NOT NULL
+          SET @cannotSeeLand = JSON_VALUE(@json, '$.cannotSeeLand')
+
+        IF JSON_VALUE(@json, '$.siteAccess') IS NOT NULL
+          SET @siteAccess = JSON_VALUE(@json, '$.siteAccess')
+
+        IF JSON_VALUE(@json, '$.siteAccessDetails') IS NOT NULL
+          SET @siteAccessDetails = JSON_VALUE(@json, '$.siteAccessDetails')
+
+        IF JSON_VALUE(@json, '$.siteNeighbourAccess') IS NOT NULL
+          SET @siteNeighbourAccess = JSON_VALUE(@json, '$.siteNeighbourAccess')
+
+        IF JSON_VALUE(@json, '$.siteNeighbourAccessDetails') IS NOT NULL
+          SET @siteNeighbourAccessDetails = JSON_VALUE(@json, '$.siteNeighbourAccessDetails')
+
+        IF JSON_VALUE(@json, '$.healthAndSafetyIssues') IS NOT NULL
+          SET @healthAndSafetyIssues = JSON_VALUE(@json, '$.healthAndSafetyIssues')
+
+        IF JSON_VALUE(@json, '$.healthAndSafetyDetails') IS NOT NULL
+          SET @healthAndSafetyDetails = JSON_VALUE(@json, '$.healthAndSafetyDetails')
+
+        IF JSON_VALUE(@json, '$.affectListedBuilding') IS NOT NULL
+          SET @affectListedBuilding = JSON_VALUE(@json, '$.affectListedBuilding')
+
+        IF JSON_VALUE(@json, '$.affectListedBuildingDetails') IS NOT NULL
+          SET @affectListedBuildingDetails = JSON_VALUE(@json, '$.affectListedBuildingDetails')
+
+        IF JSON_VALUE(@json, '$.greenBelt') IS NOT NULL
+          SET @greenBelt = JSON_VALUE(@json, '$.greenBelt')
+
+        IF JSON_VALUE(@json, '$.conservationArea') IS NOT NULL
+          SET @conservationArea = JSON_VALUE(@json, '$.conservationArea')
+
+        IF JSON_VALUE(@json, '$.originalPlanningApplicationPublicised') IS NOT NULL
+          SET @originalPlanningApplicationPublicised = JSON_VALUE(@json, '$.originalPlanningApplicationPublicised')
+
+        IF JSON_VALUE(@json, '$.developmentNeighbourhoodPlanSubmitted') IS NOT NULL
+          SET @developmentNeighbourhoodPlanSubmitted = JSON_VALUE(@json, '$.developmentNeighbourhoodPlanSubmitted')
+
+        IF JSON_VALUE(@json, '$.developmentNeighbourhoodPlanChanges') IS NOT NULL
+          SET @developmentNeighbourhoodPlanChanges = JSON_VALUE(@json, '$.developmentNeighbourhoodPlanChanges')
+
+        IF JSON_VALUE(@json, '$.eventUserId') IS NOT NULL
+          SET @eventUserId = JSON_VALUE(@json, '$.eventUserId')
+
+        IF JSON_VALUE(@json, '$.eventUserName') IS NOT NULL
+          SET @eventUserName = JSON_VALUE(@json, '$.eventUserName')
+
+        INSERT INTO HASLPASubmission (
+          ID,
+          AppealID,
+          LPAQuestionnaireID,
+          SubmissionDate,
+          SubmissionAccuracy,
+          SubmissionaccuracyDetails,
+          ExtraConditions,
+          ExtraConditionsDetails,
+          AdjacentAppeals,
+          AdjacentAppealsNumbers,
+          CannotSeeLand,
+          SiteAccess,
+          SiteAccessDetails,
+          SiteNeighbourAccess,
+          SiteNeighbourAccessDetails,
+          HealthAndSafetyIssues,
+          HealthAndSafetyDetails,
+          AffectListedBuilding,
+          AffectListedBuildingDetails,
+          GreenBelt,
+          ConservationArea,
+          OriginalPlanningApplicationPublicised,
+          DevelopmentNeighbourhoodPlanSubmitted,
+          DevelopmentNeighbourhoodPlanChanges,
+          EventUserID,
+          EventUserName
+        )
+        VALUES (
+          newid(),
+          @appealId,
+          @lpaQuestionnaireId,
+          @submissionDate,
+          @submissionAccuracy,
+          @submissionaccuracyDetails,
+          @extraConditions,
+          @extraConditionsDetails,
+          @adjacentAppeals,
+          @adjacentAppealsNumbers,
+          @cannotSeeLand,
+          @siteAccess,
+          @siteAccessDetails,
+          @siteNeighbourAccess,
+          @siteNeighbourAccessDetails,
+          @healthAndSafetyIssues,
+          @healthAndSafetyDetails,
+          @affectListedBuilding,
+          @affectListedBuildingDetails,
+          @greenBelt,
+          @conservationArea,
+          @originalPlanningApplicationPublicised,
+          @developmentNeighbourhoodPlanSubmitted,
+          @developmentNeighbourhoodPlanChanges,
+          @eventUserId,
+          @eventUserName
+        );
+      END
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateHASLPASubmission');
+    await queryInterface.sequelize.query(`
+      CREATE PROCEDURE CreateHASLPASubmission
+        @json NVARCHAR(4000)
+      AS
+      DECLARE
+        @appealId CHAR(36),
+        @lpaQuestionnaireId CHAR(36),
+        @submissionDate DATE,
+        @submissionAccuracy BIT,
+        @submissionaccuracyDetails NVARCHAR(4000),
+        @extraConditions BIT,
+        @extraConditionsDetails NVARCHAR(4000),
+        @adjacentAppeals BIT,
+        @adjacentAppealsNumbers NVARCHAR(100),
+        @cannotSeeLand BIT,
+        @siteAccess BIT,
+        @siteAccessDetails NVARCHAR(4000),
+        @siteNeighbourAccess BIT,
+        @siteNeighbourAccessDetails NVARCHAR(4000),
+        @healthAndSafetyIssues BIT,
+        @healthAndSafetyDetails NVARCHAR(4000),
+        @affectListedBuilding BIT,
+        @affectListedBuildingDetails NVARCHAR(4000),
+        @greenBelt BIT,
+        @conservationArea BIT,
+        @originalPlanningApplicationPublicised BIT,
+        @developmentNeighbourhoodPlanSubmitted BIT,
+        @developmentNeighbourhoodPlanChanges NVARCHAR(4000),
+        @eventUserId CHAR(36),
+        @eventUserName NVARCHAR(256)
+      BEGIN
+        SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+        SELECT
+          @lpaQuestionnaireId = LPAQuestionnaireID,
+          @submissionDate = SubmissionDate,
+          @submissionAccuracy = SubmissionAccuracy,
+          @submissionaccuracyDetails = SubmissionaccuracyDetails,
+          @extraConditions = ExtraConditions,
+          @extraConditionsDetails = ExtraConditionsDetails,
+          @adjacentAppeals = AdjacentAppeals,
+          @adjacentAppealsNumbers = AdjacentAppealsNumbers,
+          @cannotSeeLand = CannotSeeLand,
+          @siteAccess = SiteAccess,
+          @siteAccessDetails = SiteAccessDetails,
+          @siteNeighbourAccess = SiteNeighbourAccess,
+          @siteNeighbourAccessDetails = SiteNeighbourAccessDetails,
+          @healthAndSafetyIssues = HealthAndSafetyIssues,
+          @healthAndSafetyDetails = HealthAndSafetyDetails,
+          @affectListedBuilding = AffectListedBuilding,
+          @affectListedBuildingDetails = AffectListedBuildingDetails,
+          @greenBelt = GreenBelt,
+          @conservationArea = ConservationArea,
+          @originalPlanningApplicationPublicised = OriginalPlanningApplicationPublicised,
+          @developmentNeighbourhoodPlanSubmitted = DevelopmentNeighbourhoodPlanSubmitted,
+          @developmentNeighbourhoodPlanChanges = DevelopmentNeighbourhoodPlanChanges,
+          @eventUserId = EventUserID,
+          @eventUserName = EventUserName
+        FROM HASLPASubmission (NOLOCK)
+        WHERE AppealID = @appealId AND LatestEvent = 1;
+
+        IF JSON_VALUE(@json, '$.lpaQuestionnaireId') IS NOT NULL
+          SET @lpaQuestionnaireId = JSON_VALUE(@json, '$.lpaQuestionnaireId')
+
+        IF JSON_VALUE(@json, '$.submissionDate') IS NOT NULL
+          SET @submissionDate = JSON_VALUE(@json, '$.submissionDate')
+
+        IF JSON_VALUE(@json, '$.submissionAccuracy') IS NOT NULL
+          SET @submissionAccuracy = JSON_VALUE(@json, '$.submissionAccuracy')
+
+        IF JSON_VALUE(@json, '$.submissionaccuracyDetails') IS NOT NULL
+          SET @submissionaccuracyDetails = JSON_VALUE(@json, '$.submissionaccuracyDetails')
+
+        IF JSON_VALUE(@json, '$.extraConditions') IS NOT NULL
+          SET @extraConditions = JSON_VALUE(@json, '$.extraConditions')
+
+        IF JSON_VALUE(@json, '$.extraConditionsDetails') IS NOT NULL
+          SET @extraConditionsDetails = JSON_VALUE(@json, '$.extraConditionsDetails')
+
+        IF JSON_VALUE(@json, '$.adjacentAppeals') IS NOT NULL
+          SET @adjacentAppeals = JSON_VALUE(@json, '$.adjacentAppeals')
+
+        IF JSON_VALUE(@json, '$.adjacentAppealsNumbers') IS NOT NULL
+          SET @adjacentAppealsNumbers = JSON_VALUE(@json, '$.adjacentAppealsNumbers')
+
+        IF JSON_VALUE(@json, '$.cannotSeeLand') IS NOT NULL
+          SET @cannotSeeLand = JSON_VALUE(@json, '$.cannotSeeLand')
+
+        IF JSON_VALUE(@json, '$.siteAccess') IS NOT NULL
+          SET @siteAccess = JSON_VALUE(@json, '$.siteAccess')
+
+        IF JSON_VALUE(@json, '$.siteAccessDetails') IS NOT NULL
+          SET @siteAccessDetails = JSON_VALUE(@json, '$.siteAccessDetails')
+
+        IF JSON_VALUE(@json, '$.siteNeighbourAccess') IS NOT NULL
+          SET @siteNeighbourAccess = JSON_VALUE(@json, '$.siteNeighbourAccess')
+
+        IF JSON_VALUE(@json, '$.siteNeighbourAccessDetails') IS NOT NULL
+          SET @siteNeighbourAccessDetails = JSON_VALUE(@json, '$.siteNeighbourAccessDetails')
+
+        IF JSON_VALUE(@json, '$.healthAndSafetyIssues') IS NOT NULL
+          SET @healthAndSafetyIssues = JSON_VALUE(@json, '$.healthAndSafetyIssues')
+
+        IF JSON_VALUE(@json, '$.healthAndSafetyDetails') IS NOT NULL
+          SET @healthAndSafetyDetails = JSON_VALUE(@json, '$.healthAndSafetyDetails')
+
+        IF JSON_VALUE(@json, '$.affectListedBuilding') IS NOT NULL
+          SET @affectListedBuilding = JSON_VALUE(@json, '$.affectListedBuilding')
+
+        IF JSON_VALUE(@json, '$.affectListedBuildingDetails') IS NOT NULL
+          SET @affectListedBuildingDetails = JSON_VALUE(@json, '$.affectListedBuildingDetails')
+
+        IF JSON_VALUE(@json, '$.greenBelt') IS NOT NULL
+          SET @greenBelt = JSON_VALUE(@json, '$.greenBelt')
+
+        IF JSON_VALUE(@json, '$.conservationArea') IS NOT NULL
+          SET @conservationArea = JSON_VALUE(@json, '$.conservationArea')
+
+        IF JSON_VALUE(@json, '$.originalPlanningApplicationPublicised') IS NOT NULL
+          SET @originalPlanningApplicationPublicised = JSON_VALUE(@json, '$.originalPlanningApplicationPublicised')
+
+        IF JSON_VALUE(@json, '$.developmentNeighbourhoodPlanSubmitted') IS NOT NULL
+          SET @developmentNeighbourhoodPlanSubmitted = JSON_VALUE(@json, '$.developmentNeighbourhoodPlanSubmitted')
+
+        IF JSON_VALUE(@json, '$.developmentNeighbourhoodPlanChanges') IS NOT NULL
+          SET @developmentNeighbourhoodPlanChanges = JSON_VALUE(@json, '$.developmentNeighbourhoodPlanChanges')
+
+        IF JSON_VALUE(@json, '$.eventUserId') IS NOT NULL
+          SET @eventUserId = JSON_VALUE(@json, '$.eventUserId')
+
+        IF JSON_VALUE(@json, '$.eventUserName') IS NOT NULL
+          SET @eventUserName = JSON_VALUE(@json, '$.eventUserName')
+
+        INSERT INTO HASLPASubmission (
+          ID,
+          AppealID,
+          LPAQuestionnaireID,
+          SubmissionDate,
+          SubmissionAccuracy,
+          SubmissionaccuracyDetails,
+          ExtraConditions,
+          ExtraConditionsDetails,
+          AdjacentAppeals,
+          AdjacentAppealsNumbers,
+          CannotSeeLand,
+          SiteAccess,
+          SiteAccessDetails,
+          SiteNeighbourAccess,
+          SiteNeighbourAccessDetails,
+          HealthAndSafetyIssues,
+          HealthAndSafetyDetails,
+          AffectListedBuilding,
+          AffectListedBuildingDetails,
+          GreenBelt,
+          ConservationArea,
+          OriginalPlanningApplicationPublicised,
+          DevelopmentNeighbourhoodPlanSubmitted,
+          DevelopmentNeighbourhoodPlanChanges,
+          EventUserID,
+          EventUserName
+        )
+        VALUES (
+          newid(),
+          @appealId,
+          @lpaQuestionnaireId,
+          @submissionDate,
+          @submissionAccuracy,
+          @submissionaccuracyDetails,
+          @extraConditions,
+          @extraConditionsDetails,
+          @adjacentAppeals,
+          @adjacentAppealsNumbers,
+          @cannotSeeLand,
+          @siteAccess,
+          @siteAccessDetails,
+          @siteNeighbourAccess,
+          @siteNeighbourAccessDetails,
+          @healthAndSafetyIssues,
+          @healthAndSafetyDetails,
+          @affectListedBuilding,
+          @affectListedBuildingDetails,
+          @greenBelt,
+          @conservationArea,
+          @originalPlanningApplicationPublicised,
+          @developmentNeighbourhoodPlanSubmitted,
+          @developmentNeighbourhoodPlanChanges,
+          @eventUserId,
+          @eventUserName
+        );
+      END
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00049-amend-appeal-data-view.js
+++ b/packages/api/database/migrations/00049-amend-appeal-data-view.js
@@ -1,0 +1,147 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW AppealData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW [dbo].[AppealData]
+      AS
+      SELECT
+        HASAppealSubmission.AppealID as appealId,
+        HASAppealSubmission.CreatorEmailAddress as creatorEmailAddress,
+        HASAppealSubmission.CreatorName as creatorName,
+        HASAppealSubmission.CreatorOriginalApplicant as creatorOriginalApplicant,
+        HASAppealSubmission.CreatorOnBehalfOf as creatorOnBehalfOf,
+        HASAppealSubmission.OriginalApplicationNumber as originalApplicationNumber,
+        HASAppealSubmission.SiteOwnership as siteOwnership,
+        HASAppealSubmission.SiteInformOwners as siteInformOwners,
+        HASAppealSubmission.SiteRestriction as siteRestriction,
+        HASAppealSubmission.SiteRestrictionDetails as siteRestrictionDetails,
+        HASAppealSubmission.SafetyConcern as safetyConcern,
+        HASAppealSubmission.SafetyConcernDetails as safetyConcernDetails,
+        HASAppealSubmission.SensitiveInformation as sensitiveInformation,
+        HASAppealSubmission.TermsAgreed as termsAgreed,
+        HASAppealSubmission.DecisionDate as appealDecisionDate,
+        HASAppealSubmission.SubmissionDate as submissionDate,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.CaseStatusID as caseStatusId,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.CaseOfficerFirstName as caseOfficerFirstName,
+        HASAppeal.CaseOfficerSurname as caseOfficerSurname,
+        HASAppeal.CaseOfficerEmail as caseOfficerEmail,
+        HASAppeal.ValidationOfficerFirstName as validationOfficerFirstName,
+        HASAppeal.ValidationOfficerSurname as validationOfficerSurname,
+        HASAppeal.ValidationOfficerEmail as validationOfficerEmail,
+        HASAppeal.ValidationOutcomeID as validationOutcomeId,
+        HASAppeal.InvalidReasonOtherDetails as invalidReasonOtherDetails,
+        HASAppeal.InvalidAppealReasons as invalidAppealReasons,
+        HASAppeal.InspectorFirstName as inspectorFirstName,
+        HASAppeal.InspectorSurname as inspectorSurname,
+        HASAppeal.InspectorEmail as inspectorEmail,
+        HASAppeal.ScheduledSiteVisitDate as scheduledSiteVisitDate,
+        HASAppealSubmission.DecisionDate as questionnaireDecisionDate,
+        HASAppeal.DescriptionDevelopment as descriptionDevelopment,
+        HASAppeal.AppealStartDate as appealStartDate,
+        HASAppeal.AppealValidationDate as appealValidationDate,
+        HASAppeal.AppealValidDate as appealValidDate,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpRecommendedSiteVisitType.TypeName as recommendedSiteVisitTypeName,
+        LookUpSiteVisitType.TypeName as siteVisitTypeName,
+        LookUpInspectorSpecialism.Specialism as inspectorSpecialismName,
+        LookUpDecisionOutcome.Outcome as decisionOutcomeName,
+        LookUpValidationOutcome.Outcome as validationOutcomeName
+      FROM HASAppealSubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASAppealSubmission.AppealID = AppealLink.AppealId AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASAppealSubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpSiteVisitType AS LookUpRecommendedSiteVisitType (NOLOCK) ON HASAppeal.RecommendedSiteVisitTypeID = LookUpRecommendedSiteVisitType.ID
+      LEFT JOIN LookUpSiteVisitType (NOLOCK) ON HASAppeal.SiteVisitTypeID = LookUpSiteVisitType.ID
+      LEFT JOIN LookUpInspectorSpecialism (NOLOCK) ON HASAppeal.InspectorSpecialismID = LookUpInspectorSpecialism.ID
+      LEFT JOIN LookUpDecisionOutcome (NOLOCK) ON HASAppeal.DecisionOutcomeID = LookUpDecisionOutcome.ID
+      LEFT JOIN LookUpValidationOutcome (NOLOCK) ON HASAppeal.ValidationOutcomeID = LookUpValidationOutcome.ID
+      WHERE HASAppealSubmission.LatestEvent = 1
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW AppealData');
+    await queryInterface.sequelize.query(`
+    CREATE VIEW [dbo].[AppealData]
+    AS
+    SELECT
+      HASAppealSubmission.AppealID as appealId,
+      HASAppealSubmission.CreatorEmailAddress as creatorEmailAddress,
+      HASAppealSubmission.CreatorName as creatorName,
+      HASAppealSubmission.CreatorOriginalApplicant as creatorOriginalApplicant,
+      HASAppealSubmission.CreatorOnBehalfOf as creatorOnBehalfOf,
+      HASAppealSubmission.OriginalApplicationNumber as originalApplicationNumber,
+      HASAppealSubmission.SiteOwnership as siteOwnership,
+      HASAppealSubmission.SiteInformOwners as siteInformOwners,
+      HASAppealSubmission.SiteRestriction as siteRestriction,
+      HASAppealSubmission.SiteRestrictionDetails as siteRestrictionDetails,
+      HASAppealSubmission.SafetyConcern as safetyConcern,
+      HASAppealSubmission.SafetyConcernDetails as safetyConcernDetails,
+      HASAppealSubmission.SensitiveInformation as sensitiveInformation,
+      HASAppealSubmission.TermsAgreed as termsAgreed,
+      HASAppealSubmission.DecisionDate as appealDecisionDate,
+      HASAppealSubmission.SubmissionDate as submissionDate,
+      AppealLink.CaseReference as caseReference,
+      AppealLink.CaseStatusID as caseStatusId,
+      AppealLink.AppellantName as appellantName,
+      AppealLink.SiteAddressLineOne as siteAddressLineOne,
+      AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+      AppealLink.SiteAddressTown as siteAddressTown,
+      AppealLink.SiteAddressCounty as siteAddressCounty,
+      AppealLink.SiteAddressPostCode as siteAddressPostCode,
+      AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+      HASAppeal.CaseOfficerFirstName as caseOfficerFirstName,
+      HASAppeal.CaseOfficerSurname as caseOfficerSurname,
+      HASAppeal.CaseOfficerEmail as caseOfficerEmail,
+      HASAppeal.ValidationOfficerFirstName as validationOfficerFirstName,
+      HASAppeal.ValidationOfficerSurname as validationOfficerSurname,
+      HASAppeal.ValidationOfficerEmail as validationOfficerEmail,
+      HASAppeal.InvalidReasonOtherDetails as invalidReasonOtherDetails,
+      HASAppeal.InvalidAppealReasons as invalidAppealReasons,
+      HASAppeal.InspectorFirstName as inspectorFirstName,
+      HASAppeal.InspectorSurname as inspectorSurname,
+      HASAppeal.InspectorEmail as inspectorEmail,
+      HASAppeal.ScheduledSiteVisitDate as scheduledSiteVisitDate,
+      HASAppealSubmission.DecisionDate as questionnaireDecisionDate,
+      HASAppeal.DescriptionDevelopment as descriptionDevelopment,
+      HASAppeal.AppealStartDate as appealStartDate,
+      HASAppeal.AppealValidationDate as appealValidationDate,
+      HASAppeal.AppealValidDate as appealValidDate,
+      LookUpCaseType.TypeName as caseTypeName,
+      LookUpCaseStage.StageName as caseStageName,
+      LookUpCaseStatus.StatusName as caseStatusName,
+      LookUpLPA.LPA19Name as localPlanningAuthorityName,
+      LookUpRecommendedSiteVisitType.TypeName as recommendedSiteVisitTypeName,
+      LookUpSiteVisitType.TypeName as siteVisitTypeName,
+      LookUpInspectorSpecialism.Specialism as inspectorSpecialismName,
+      LookUpDecisionOutcome.Outcome as decisionOutcomeName
+    FROM HASAppealSubmission (NOLOCK)
+    LEFT JOIN AppealLink (NOLOCK) ON HASAppealSubmission.AppealID = AppealLink.AppealId AND AppealLink.LatestEvent = 1
+    LEFT JOIN HASAppeal (NOLOCK) ON HASAppealSubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+    LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+    LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+    LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+    LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+    LEFT JOIN LookUpSiteVisitType AS LookUpRecommendedSiteVisitType (NOLOCK) ON HASAppeal.RecommendedSiteVisitTypeID = LookUpRecommendedSiteVisitType.ID
+    LEFT JOIN LookUpSiteVisitType (NOLOCK) ON HASAppeal.SiteVisitTypeID = LookUpSiteVisitType.ID
+    LEFT JOIN LookUpInspectorSpecialism (NOLOCK) ON HASAppeal.InspectorSpecialismID = LookUpInspectorSpecialism.ID
+    LEFT JOIN LookUpDecisionOutcome (NOLOCK) ON HASAppeal.DecisionOutcomeID = LookUpDecisionOutcome.ID
+    WHERE HASAppealSubmission.LatestEvent = 1
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/seeders/lookup-case-stage.js
+++ b/packages/api/database/seeders/lookup-case-stage.js
@@ -1,0 +1,20 @@
+const seeder = {
+  up: (queryInterface) =>
+    queryInterface.bulkInsert('LookUpCaseStage', [
+      {
+        StageName: 'Received',
+      },
+      {
+        StageName: 'Initial Checks',
+      },
+      {
+        StageName: 'In Progress',
+      },
+      {
+        StageName: 'Closed',
+      },
+    ]),
+  down: (queryInterface) => queryInterface.bulkDelete('LookUpCaseStage', null, {}),
+};
+
+module.exports = seeder;

--- a/packages/web-app/src/config/db-fields.js
+++ b/packages/web-app/src/config/db-fields.js
@@ -4,6 +4,14 @@ const dbFields = {
     validAppealDetails: 'descriptionDevelopment',
     invalidAppealReasons: 'invalidAppealReasons',
     invalidReasonOther: 'invalidReasonOtherDetails',
+    appealStartDate: 'appealStartDate',
+    appealValidationDate: 'appealValidationDate',
+    questionnaireDueDate: 'questionnaireDueDate',
+    appealValidDate: 'appealValidDate',
+  },
+  appealLink: {
+    questionnaireStatusId: 'questionnaireStatusId',
+    caseStatusId: 'caseStatusId',
   },
 };
 

--- a/packages/web-app/src/controllers/check-and-confirm.spec.js
+++ b/packages/web-app/src/controllers/check-and-confirm.spec.js
@@ -124,7 +124,7 @@ describe('controllers/check-and-confirm', () => {
   });
 
   describe('postCheckAndConfirm', () => {
-    it('should call saveAndContinue with the correct params if reviewOutcome is incomplete', () => {
+    it('should call saveAndContinue with the correct params if reviewOutcome is incomplete', async () => {
       req = {
         body: {
           'check-and-confirm-completed': 'true',
@@ -147,7 +147,7 @@ describe('controllers/check-and-confirm', () => {
         getText,
       };
 
-      postCheckAndConfirm(req, res);
+      await postCheckAndConfirm(req, res);
 
       expect(saveAndContinue).toBeCalledTimes(1);
       expect(saveAndContinue).toBeCalledWith({
@@ -161,7 +161,7 @@ describe('controllers/check-and-confirm', () => {
       expect(req.session.casework.completed).toEqual('true');
     });
 
-    it('should send sendStartEmailToLPA if only reviewOutcome is valid', () => {
+    it('should send sendStartEmailToLPA if only reviewOutcome is valid', async () => {
       req = {
         body: {
           'check-and-confirm-completed': 'true',
@@ -174,7 +174,7 @@ describe('controllers/check-and-confirm', () => {
         },
       };
 
-      postCheckAndConfirm(req, res);
+      await postCheckAndConfirm(req, res);
       expect(sendStartEmailToLPA).not.toBeCalled();
 
       req.session.casework[hasAppeal.reviewOutcome] = reviewOutcomeOption.incomplete;
@@ -184,6 +184,10 @@ describe('controllers/check-and-confirm', () => {
       req.session.casework[hasAppeal.reviewOutcome] = reviewOutcomeOption.valid;
       postCheckAndConfirm(req, res);
       expect(sendStartEmailToLPA).toBeCalledTimes(1);
+    });
+
+    it('should throw an error if the review outcome is not set', () => {
+      expect(() => postCheckAndConfirm(req, res)).rejects.toThrow('No review outcome set');
     });
   });
 });

--- a/packages/web-app/src/lib/save-and-continue.js
+++ b/packages/web-app/src/lib/save-and-continue.js
@@ -23,7 +23,6 @@ const saveAndContinue = ({ req, res, currentPage, nextPage, viewData, saveData }
     saveData({
       appealId: appeal.appealId,
       ...casework,
-      ...questionnaire,
     });
     res.cookie('appealId', appeal.appealId);
     res.cookie(appeal.appealId, JSON.stringify(casework));

--- a/packages/web-app/src/validation/invalid-appeal-details.js
+++ b/packages/web-app/src/validation/invalid-appeal-details.js
@@ -13,7 +13,7 @@ const invalidAppealDetailsValidation = () => [
   body('other-reason').custom((value, { req }) => {
     const valueAsArray = toArray(req.body['invalid-appeal-reasons']);
     /* istanbul ignore else  */
-    if (valueAsArray.includes('other')) {
+    if (valueAsArray.includes('5')) {
       if (!value || value.trim().length === 0) {
         throw new Error('Enter why the appeal is invalid');
       }

--- a/packages/web-app/src/validation/invalid-appeal-details.spec.js
+++ b/packages/web-app/src/validation/invalid-appeal-details.spec.js
@@ -15,7 +15,7 @@ describe('validation/invalid-appeal-details', () => {
   it('should pass validation when given a value', async () => {
     req = {
       body: {
-        'invalid-appeal-reasons': ['other', 'outOfTime'],
+        'invalid-appeal-reasons': ['1', '5'],
         'other-reason': 'other description',
       },
     };
@@ -46,7 +46,7 @@ describe('validation/invalid-appeal-details', () => {
   it('should fail validation if "other" option is chosen but there is no description', async () => {
     req = {
       body: {
-        'invalid-appeal-reasons': ['other', 'outOfTime'],
+        'invalid-appeal-reasons': ['1', '5'],
       },
     };
 
@@ -67,7 +67,7 @@ describe('validation/invalid-appeal-details', () => {
   it('should fail validation if request contains a reason with a wrong name', async () => {
     req = {
       body: {
-        'invalid-appeal-reasons': ['noRightOfAppeal', 'outOfTimes'],
+        'invalid-appeal-reasons': ['noRightOfAppeal', '5'],
       },
     };
 

--- a/packages/web-app/src/views/missing-or-wrong.njk
+++ b/packages/web-app/src/views/missing-or-wrong.njk
@@ -8,10 +8,10 @@
 {% set documentsError = errors['missing-or-wrong-documents'].msg %}
 {% set otherError = errors['other-reason'].msg %}
 
-{% set noApplicationFormChecked = missingOrWrong.documentReasons and missingOrWrong.documentReasons.includes and missingOrWrong.documentReasons.includes('noApplicationForm') %}
-{% set noDecisionNoticeChecked = missingOrWrong.documentReasons and missingOrWrong.documentReasons.includes and missingOrWrong.documentReasons.includes('noDecisionNotice') %}
-{% set noGroundsOfAppealChecked = missingOrWrong.documentReasons and missingOrWrong.documentReasons.includes and missingOrWrong.documentReasons.includes('noGroundsOfAppeal') %}
-{% set noSupportingDocumentsChecked = missingOrWrong.documentReasons and missingOrWrong.documentReasons.includes and missingOrWrong.documentReasons.includes('noSupportingDocuments') %}
+{% set noApplicationFormChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('noApplicationForm') %}
+{% set noDecisionNoticeChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('noDecisionNotice') %}
+{% set noGroundsOfAppealChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('noGroundsOfAppeal') %}
+{% set noSupportingDocumentsChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('noSupportingDocuments') %}
 {% set namesNotMatchChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('namesNotMatch') %}
 {% set sensitiveInformationIncludedChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('sensitiveInformationIncluded') %}
 {% set missingOrWrongDocumentsChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('missingOrWrongDocuments') %}


### PR DESCRIPTION
This PR covers both AS-3042 and AS-3485.

Update schema with new fields and ensure that the correct values are updated in tables, stored procedures, triggers and views.

Also updated the web-app to set the correct date and status fields when the Validation Officers clicks the submit button on the Check and Confirm page.

Also fixed some unrelated unit tests that were displaying an error in the test run.