### PR TITLE
Feature/as 3600 search appeals

### DIFF
--- a/packages/api/database/migrations/00053-amend-sp-view-appeal-search.js
+++ b/packages/api/database/migrations/00053-amend-sp-view-appeal-search.js
@@ -1,0 +1,46 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP PROCEDURE ViewAppealSearch');
+    await queryInterface.sequelize.query(`
+        CREATE OR ALTER PROCEDURE [dbo].[ViewAppealSearch]
+            (@strFind AS VARCHAR(MAX))
+        AS
+        BEGIN
+            SET NOCOUNT ON;
+            SELECT
+                AppealLink.AppealID AS appealId,
+                AppealLink.CaseReference AS caseReference,
+                AppealLink.AppellantName AS appellantName,
+                STUFF(ISNULL(', '+AppealLink.SiteAddressLineOne,'')+ISNULL(', '+AppealLink.SiteAddressLineTwo,'')+ISNULL(', '+AppealLink.SiteAddressTown,'')+ISNULL(', '+AppealLink.SiteAddressCounty,'')+ISNULL(', '+AppealLink.SiteAddressPostCode,''),1,2,'') AS siteAddress
+            FROM APPEALLINK
+            INNER JOIN HASAppealSubmission on AppealLink.AppealID = HASAppealSubmission.AppealID AND HASAppealSubmission.LatestEvent = 1
+            WHERE (PATINDEX('%'+@strFind+'%', AppealLink.SiteAddressPostcode) > 0
+                OR PATINDEX('%'+@strFind+'%', AppealLink.SiteAddressLineOne) > 0
+                OR PATINDEX('%'+@strFind+'%', CAST(AppealLink.CaseReference AS NVARCHAR)) > 0
+                OR PATINDEX('%'+@strFind+'%', AppealLink.AppellantName) > 0
+                OR PATINDEX('%'+@strFind+'%', HASAppealSubmission.OriginalApplicationNumber) > 0)
+            AND APPEALLINK.LATESTEVENT = 1
+            ORDER BY HASAppealSubmission.SubmissionDate ASC, AppealLink.AppellantName ASC
+        END
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP PROCEDURE ViewAppealSearch');
+    await queryInterface.sequelize.query(`
+        CREATE OR ALTER PROCEDURE [dbo].[ViewAppealSearch]
+            (@strFind AS VARCHAR(MAX))
+        AS
+        BEGIN
+            SET NOCOUNT ON;
+            SELECT  AppealID, CaseReference, AppellantName, STUFF(ISNULL(', '+SiteAddressLineOne,'')+ISNULL(', '+SiteAddressLineTwo,'')+ISNULL(', '+SiteAddressTown,'')+ISNULL(', '+SiteAddressCounty,'')+ISNULL(', '+SiteAddressPostCode,''),1,2,'') AS Address FROM APPEALLINK
+            WHERE (PATINDEX('%'+@strFind+'%', SiteAddressPostcode) > 0
+                OR PATINDEX('%'+@strFind+'%', SiteAddressLineOne) > 0
+                OR PATINDEX('%'+@strFind+'%', CAST(CaseReference AS NVARCHAR)) > 0
+                OR PATINDEX('%'+@strFind+'%', AppellantName) > 0)
+            AND APPEALLINK.LATESTEVENT = 1
+        END
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/src/lib/db-wrapper.js
+++ b/packages/api/src/lib/db-wrapper.js
@@ -11,10 +11,11 @@ const createRecord = (procedure, data) => {
   }
 };
 
-const searchAppeal = (data) => {
+const searchAppeal = async (data) => {
   try {
-    const query = `EXEC ViewAppealSearch @strFind = ?`;
-    return db.query(query, { replacements: [data] });
+    const query = 'EXEC ViewAppealSearch @strFind = ?';
+    const result = await db.query(query, { replacements: [data] });
+    return result[0];
   } catch (err) {
     throw new ApiError(`Failed to execute ViewAppealSearch with error - ${err.toString()}`);
   }

--- a/packages/web-app/src/config/views.js
+++ b/packages/web-app/src/config/views.js
@@ -16,6 +16,8 @@ const views = {
   questionnairesForReview: 'questionnaires-for-review',
   reviewQuestionnaireSubmission: 'review-questionnaire-submission',
   questionnairecheckAndConfirm: 'questionnaire-check-and-confirm',
+  search: 'search',
+  searchResults: 'search-results',
 };
 
 module.exports = views;

--- a/packages/web-app/src/controllers/appeal-details.js
+++ b/packages/web-app/src/controllers/appeal-details.js
@@ -1,8 +1,7 @@
-const { appealsList, appealDetails: currentPage } = require('../config/views');
+const { appealDetails: currentPage } = require('../config/views');
 
 const viewData = (appeal, questionnaire) => ({
   pageTitle: 'Appeal details',
-  backLink: `/${appealsList}`,
   appealData: {
     ...appeal,
   },

--- a/packages/web-app/src/controllers/appeal-details.spec.js
+++ b/packages/web-app/src/controllers/appeal-details.spec.js
@@ -27,7 +27,6 @@ describe('controllers/appeal-details', () => {
       expect(res.render).toBeCalledTimes(1);
       expect(res.render).toBeCalledWith(currentPage, {
         pageTitle: 'Appeal details',
-        backLink: '/appeals-list',
         appealData: {
           ...appeal,
         },

--- a/packages/web-app/src/controllers/appeal-search-results.js
+++ b/packages/web-app/src/controllers/appeal-search-results.js
@@ -1,0 +1,24 @@
+const { searchAppeals } = require('../lib/api-wrapper');
+const views = require('../config/views');
+const logger = require('../lib/logger');
+
+const getAppealSearchResults = async (req, res) => {
+  const { searchString } = req.params;
+  let searchResults = [];
+
+  try {
+    searchResults = await searchAppeals(searchString);
+  } catch (err) {
+    logger.error({ err }, 'Failed to get appeal search results');
+  }
+
+  res.render(views.searchResults, {
+    searchResults,
+    searchString,
+    pageTitle: 'Search results',
+  });
+};
+
+module.exports = {
+  getAppealSearchResults,
+};

--- a/packages/web-app/src/controllers/appeal-search-results.spec.js
+++ b/packages/web-app/src/controllers/appeal-search-results.spec.js
@@ -1,0 +1,66 @@
+const { getAppealSearchResults } = require('./appeal-search-results');
+const views = require('../config/views');
+const { mockReq, mockRes } = require('../../test/utils/mocks');
+const { searchAppeals } = require('../lib/api-wrapper');
+
+jest.mock('../lib/api-wrapper', () => ({
+  searchAppeals: jest.fn(),
+}));
+
+describe('controllers/appeal-search-results', () => {
+  const searchString = 'BS4';
+
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = mockReq;
+    res = mockRes();
+  });
+
+  describe('getAppealSearchResults', () => {
+    it('should render the view with correct data when data is returned', async () => {
+      searchAppeals.mockReturnValue([
+        {
+          appealId: 'dc075313-26dd-4977-9b8d-b14f820144fc',
+        },
+      ]);
+
+      req.params = {
+        searchString,
+      };
+
+      await getAppealSearchResults(req, res);
+
+      expect(res.render).toBeCalledTimes(1);
+      expect(res.render).toBeCalledWith(views.searchResults, {
+        searchResults: [
+          {
+            appealId: 'dc075313-26dd-4977-9b8d-b14f820144fc',
+          },
+        ],
+        searchString,
+        pageTitle: 'Search results',
+      });
+    });
+
+    it('should render the view with correct data when there is an error', async () => {
+      searchAppeals.mockImplementation(() => {
+        throw new Error('Internal Server Error');
+      });
+
+      req.params = {
+        searchString,
+      };
+
+      await getAppealSearchResults(req, res);
+
+      expect(res.render).toBeCalledTimes(1);
+      expect(res.render).toBeCalledWith(views.searchResults, {
+        searchResults: [],
+        searchString,
+        pageTitle: 'Search results',
+      });
+    });
+  });
+});

--- a/packages/web-app/src/controllers/appeal-search.js
+++ b/packages/web-app/src/controllers/appeal-search.js
@@ -1,0 +1,17 @@
+const views = require('../config/views');
+
+const getAppealSearch = async (req, res) => {
+  res.render(views.search, {
+    pageTitle: 'Dashboard',
+  });
+};
+
+const postAppealSearch = async (req, res) => {
+  const { searchString } = req.body;
+  res.redirect(`/${views.search}/${searchString}`);
+};
+
+module.exports = {
+  getAppealSearch,
+  postAppealSearch,
+};

--- a/packages/web-app/src/controllers/appeal-search.spec.js
+++ b/packages/web-app/src/controllers/appeal-search.spec.js
@@ -1,0 +1,39 @@
+const { getAppealSearch, postAppealSearch } = require('./appeal-search');
+const views = require('../config/views');
+const { mockReq, mockRes } = require('../../test/utils/mocks');
+
+describe('controllers/appeal-search', () => {
+  const searchString = 'BS4';
+
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = mockReq;
+    res = mockRes();
+  });
+
+  describe('getAppealSearch', () => {
+    it('should render the view with correct data', () => {
+      getAppealSearch(req, res);
+
+      expect(res.render).toBeCalledTimes(1);
+      expect(res.render).toBeCalledWith(views.search, {
+        pageTitle: 'Dashboard',
+      });
+    });
+  });
+
+  describe('postSearch', () => {
+    it('should redirect with the correct param', () => {
+      req.body = {
+        searchString,
+      };
+
+      postAppealSearch(req, res);
+
+      expect(res.redirect).toBeCalledTimes(1);
+      expect(res.redirect).toBeCalledWith(`/${views.search}/${searchString}`);
+    });
+  });
+});

--- a/packages/web-app/src/lib/api-wrapper.js
+++ b/packages/web-app/src/lib/api-wrapper.js
@@ -9,6 +9,7 @@ const {
 const appealDataUrl = `${backOfficeUrl}/api/v1/appeal`;
 const appealLinkDataUrl = `${backOfficeUrl}/api/v1/appeal-link`;
 const appealSubmissionDataUrl = `${backOfficeUrl}/api/v1/appeal-submission`;
+const appealSearchUrl = `${backOfficeUrl}/api/v1/appeal-search`;
 const questionnaireDataUrl = `${backOfficeUrl}/api/v1/questionnaire`;
 
 const formatDocumentsAndAddToData = (data) => {
@@ -115,6 +116,20 @@ const saveAppealLinkData = (data) => saveData(appealLinkDataUrl, data);
 const saveAppealSubmissionData = (data) => saveData(appealSubmissionDataUrl, data);
 const saveQuestionnaireData = (data) => saveData(questionnaireDataUrl, data);
 
+const searchAppeals = async (searchString) => {
+  try {
+    const appealApiResponse = await fetch(`${appealSearchUrl}/${searchString}`);
+
+    if (appealApiResponse.ok) {
+      return appealApiResponse.json();
+    }
+
+    return [];
+  } catch (err) {
+    throw new Error(`Failed to search appeals with error - ${err.toString()}`);
+  }
+};
+
 module.exports = {
   getAppealData,
   getAllAppeals,
@@ -124,4 +139,5 @@ module.exports = {
   saveAppealLinkData,
   saveAppealSubmissionData,
   saveQuestionnaireData,
+  searchAppeals,
 };

--- a/packages/web-app/src/lib/api-wrapper.spec.js
+++ b/packages/web-app/src/lib/api-wrapper.spec.js
@@ -8,6 +8,7 @@ const {
   saveAppealLinkData,
   saveAppealSubmissionData,
   saveQuestionnaireData,
+  searchAppeals,
 } = require('./api-wrapper');
 const singleAppealDataRaw = require('../../test/data/single-appeal-data-raw');
 const singleAppealDataFormatted = require('../../test/data/single-appeal-data-formatted');
@@ -15,6 +16,7 @@ const appealDataList = require('../../test/data/appeal-data-list');
 const singleQuestionnaireDataRaw = require('../../test/data/single-questionnaire-data-raw');
 const singleQuestionnaireDataFormatted = require('../../test/data/single-questionnaire-data-formatted');
 const questionnaireDataList = require('../../test/data/questionnaire-data-list');
+const appealSearchResults = require('../../test/data/appeal-search-results');
 
 const invalidDocumentList = [
   {
@@ -330,6 +332,39 @@ describe('lib/apiWrapper', () => {
         body: JSON.stringify(data),
         headers: { 'Content-Type': 'application/json' },
       });
+    });
+  });
+
+  describe('searchAppeals', () => {
+    it('should return the correct data when appeals are found', async () => {
+      fetch.mockImplementation(() => ({
+        ok: true,
+        json: jest.fn().mockReturnValue(appealSearchResults),
+      }));
+
+      const result = await searchAppeals();
+
+      expect(result).toEqual(appealSearchResults);
+    });
+
+    it('should return an empty array when appeals are not found', async () => {
+      fetch.mockImplementation(() => ({
+        ok: false,
+      }));
+
+      const result = await searchAppeals();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw an error when an error occurs', async () => {
+      fetch.mockImplementation(() => {
+        throw new Error('Internal Server Error');
+      });
+
+      expect(() => searchAppeals()).rejects.toThrow(
+        'Failed to search appeals with error - Error: Internal Server Error'
+      );
     });
   });
 });

--- a/packages/web-app/src/routes/appeal-search-results.js
+++ b/packages/web-app/src/routes/appeal-search-results.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { getAppealSearchResults } = require('../controllers/appeal-search-results');
+
+const router = express.Router();
+
+router.get('/:searchString', getAppealSearchResults);
+
+module.exports = router;

--- a/packages/web-app/src/routes/appeal-search-results.spec.js
+++ b/packages/web-app/src/routes/appeal-search-results.spec.js
@@ -1,0 +1,11 @@
+const { getAppealSearchResults } = require('../controllers/appeal-search-results');
+const { mockGet } = require('../../test/utils/mocks');
+
+describe('routes/appeal-search-results', () => {
+  it('should define the correct route', () => {
+    // eslint-disable-next-line global-require
+    require('./appeal-search-results');
+
+    expect(mockGet).toBeCalledWith('/:searchString', getAppealSearchResults);
+  });
+});

--- a/packages/web-app/src/routes/appeal-search.js
+++ b/packages/web-app/src/routes/appeal-search.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { getAppealSearch, postAppealSearch } = require('../controllers/appeal-search');
+
+const router = express.Router();
+
+router.get('/', getAppealSearch);
+router.post('/', postAppealSearch);
+
+module.exports = router;

--- a/packages/web-app/src/routes/appeal-search.spec.js
+++ b/packages/web-app/src/routes/appeal-search.spec.js
@@ -1,0 +1,12 @@
+const { getAppealSearch, postAppealSearch } = require('../controllers/appeal-search');
+const { mockGet, mockPost } = require('../../test/utils/mocks');
+
+describe('routes/appeal-search', () => {
+  it('should define the correct route', () => {
+    // eslint-disable-next-line global-require
+    require('./appeal-search');
+
+    expect(mockGet).toBeCalledWith('/', getAppealSearch);
+    expect(mockPost).toBeCalledWith('/', postAppealSearch);
+  });
+});

--- a/packages/web-app/src/routes/index.js
+++ b/packages/web-app/src/routes/index.js
@@ -11,16 +11,16 @@ const reviewComplete = require('./review-complete');
 const checkAndConfirm = require('./check-and-confirm');
 const questionnaireCheckAndConfirm = require('./questionnaire-check-and-confirm');
 const home = require('./home');
-
 const documentsServiceProxy = require('./document-service-proxy');
 const appealAlreadyReviewed = require('./appeal-already-reviewed');
 const questionnaireAlreadyReviewed = require('./questionnaire-already-reviewed');
-
 const views = require('../config/views');
 const handleAppealAlreadyReviewed = require('../lib/handle-appeal-already-reviewed');
 const getCaseData = require('../lib/get-case-data');
 const reviewQuestionnaireSubmission = require('./review-questionnaire-submission');
 const reviewQuestionnaireComplete = require('./review-questionnaire-complete');
+const appealSearch = require('./appeal-search');
+const appealSearchResults = require('./appeal-search-results');
 
 const router = express.Router();
 
@@ -51,5 +51,7 @@ router.use(`/${views.reviewQuestionnaireComplete}`, reviewQuestionnaireComplete)
 router.use(`/${views.questionnairesForReview}/${views.checkAndConfirm}`, checkAndConfirm);
 router.use(`/questionnaire-check-and-confirm`, questionnaireCheckAndConfirm);
 router.use(`/questionnaire-already-reviewed`, questionnaireAlreadyReviewed);
+router.use(`/${views.search}`, appealSearch);
+router.use(`/${views.search}`, appealSearchResults);
 
 module.exports = router;

--- a/packages/web-app/src/routes/index.spec.js
+++ b/packages/web-app/src/routes/index.spec.js
@@ -17,13 +17,15 @@ const reviewQuestionnaireSubmission = require('./review-questionnaire-submission
 const questionnaireCheckAndConfirm = require('./questionnaire-check-and-confirm');
 const questionnaireAlreadyReviewed = require('./questionnaire-already-reviewed');
 const appealDetails = require('./appeal-details');
+const appealSearch = require('./appeal-search');
+const appealSearchResults = require('./appeal-search-results');
 
 describe('routes/index', () => {
   it('should define the correct routes', () => {
     // eslint-disable-next-line global-require
     require('./index');
 
-    expect(mockUse).toBeCalledTimes(18);
+    expect(mockUse).toBeCalledTimes(20);
     expect(mockUse).toBeCalledWith('/', appealsList);
     expect(mockUse).toBeCalledWith('/', questionnairesList);
     expect(mockUse).toBeCalledWith('/', home);
@@ -64,5 +66,7 @@ describe('routes/index', () => {
     );
     expect(mockUse).toBeCalledWith(`/questionnaire-already-reviewed`, questionnaireAlreadyReviewed);
     expect(mockUse).toBeCalledWith(`/${views.appealDetails}/:appealId`, getCaseData, appealDetails);
+    expect(mockUse).toBeCalledWith(`/${views.search}`, appealSearch);
+    expect(mockUse).toBeCalledWith(`/${views.search}`, appealSearchResults);
   });
 });

--- a/packages/web-app/src/views/components/search-box.njk
+++ b/packages/web-app/src/views/components/search-box.njk
@@ -1,0 +1,16 @@
+{% from "components/button.njk" import button %}
+
+{% macro searchBox(labelText, hintText) %}
+  <div class="govuk-form-group">
+    <label class="govuk-label govuk-label--m" for="searchString">
+      {{ labelText }}
+    </label>
+    {% if hintText %}
+      <div id="event-name-hint" class="govuk-hint govuk-!-width-three-quarters">
+        {{ hintText }}
+      </div>
+    {% endif %}
+    <input class="govuk-input govuk-!-width-three-quarters" id="searchString" name="searchString" type="text">
+    {{ button('Search') }}
+  </div>
+{% endmacro %}

--- a/packages/web-app/src/views/search-results.njk
+++ b/packages/web-app/src/views/search-results.njk
@@ -1,0 +1,35 @@
+{% extends "layouts/main.njk" %}
+
+{% from "govuk/components/table/macro.njk" import govukTable %}
+
+{% set searchResultsDisplay = [] %}
+
+{% for result in searchResults %}
+  {% set searchResultsDisplay = (searchResultsDisplay.push([
+    { html: "<a href=\"/appeal-details/" + result.appealId + "\" class=\"govuk-link\">" + result.caseReference + "</a>" },
+    { text: result.appellantName },
+    { text: result.siteAddress }
+  ]), searchResultsDisplay) %}
+{% endfor %}
+
+{% block backButton %}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+  <p class="govuk-body">You searched for '{{ searchString }}'.</p>
+
+  {% if searchResultsDisplay | length %}
+    {{ govukTable({
+      head: [
+        { text: "Reference" },
+        { text: "Appellant name" },
+        { text: "Site address" }
+      ],
+      rows: searchResultsDisplay
+    }) }}
+  {% else %}
+    <p class="govuk-body">We couldn't find any appeals matching your search.</p>
+    <p class="govuk-body"><a href="/search" class="govuk-link">Back to search</a></p>
+  {% endif %}
+{% endblock %}

--- a/packages/web-app/src/views/search.njk
+++ b/packages/web-app/src/views/search.njk
@@ -1,0 +1,13 @@
+{% extends "layouts/form.njk" %}
+
+{% from "components/search-box.njk" import searchBox %}
+
+{% block backButton %}
+{% endblock %}
+
+{% block formContent %}
+  {{ searchBox(
+    'Search appeals',
+    'Search by appeal reference, site address, appellant/agent name or LPA application number.'
+  ) }}
+{% endblock %}

--- a/packages/web-app/test/data/appeal-search-results.js
+++ b/packages/web-app/test/data/appeal-search-results.js
@@ -1,0 +1,10 @@
+const appealSearchResults = [
+  {
+    appealId: '46bfe328-d13d-455a-a828-6a23195d580a',
+    caseReference: '123456789',
+    appellantName: 'An Appellant',
+    siteAddress: 'Address 1, Address 2, Town, Postcode',
+  },
+];
+
+module.exports = appealSearchResults;


### PR DESCRIPTION
Add appeals search and search results page.

This is connected and working with the appeals search api and the view appeals page.

Also updated the appeals search stored procedure to search the OriginalApplicationNumber field and to order the results by date then Appellant Name.