### PR TITLE
Fix/as 3877

### DIFF
--- a/packages/api/database/migrations/00054-amend-has-appeal-table.js
+++ b/packages/api/database/migrations/00054-amend-has-appeal-table.js
@@ -1,0 +1,612 @@
+const migration = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('HASAppeal', 'MissingOrWrongReasons', Sequelize.STRING(4000));
+    await queryInterface.addColumn('HASAppeal', 'MissingOrWrongDocuments', Sequelize.STRING(4000));
+    await queryInterface.addColumn(
+      'HASAppeal',
+      'MissingOrWrongOtherReason',
+      Sequelize.STRING(4000)
+    );
+    await queryInterface.sequelize.query('DROP TRIGGER [AfterInsertHASAppeal]');
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER [dbo].[AfterInsertHASAppeal] ON [dbo].[HASAppeal]
+      FOR INSERT
+      AS DECLARE @ID UNIQUEIDENTIFIER,
+          @AppealID UNIQUEIDENTIFIER,
+          @CheckSumRow INT;
+      BEGIN
+          SET NOCOUNT ON;
+          SELECT @ID = INSERTED.ID FROM INSERTED;
+          SELECT @AppealID = INSERTED.AppealID FROM INSERTED;
+
+          SELECT @CheckSumRow = CHECKSUM(@AppealID,
+              INSERTED.[RecommendedSiteVisitTypeID],
+              INSERTED.[SiteVisitTypeID],
+              INSERTED.[CaseOfficerFirstName],
+              INSERTED.[CaseOfficerSurname],
+              INSERTED.[CaseOfficerID],
+              INSERTED.[LPAQuestionnaireReviewOutcomeID],
+              INSERTED.[LPAIncompleteReasons],
+              INSERTED.[ValidationOfficerFirstName],
+              INSERTED.[ValidationOfficerSurname],
+              INSERTED.[ValidationOfficerID],
+              INSERTED.[ValidationOutcomeID],
+              INSERTED.[InvalidReasonOtherDetails],
+              INSERTED.[InvalidAppealReasons],
+              INSERTED.[InspectorFirstName],
+              INSERTED.[InspectorSurname],
+              INSERTED.[InspectorID],
+              INSERTED.[InspectorSpecialismID],
+              INSERTED.[ScheduledSiteVisitDate],
+              INSERTED.[DecisionOutcomeID],
+              INSERTED.[DecisionLetterID],
+              INSERTED.[DecisionDate],
+              INSERTED.[EventUserID],
+              INSERTED.[EventUserName],
+              INSERTED.[DescriptionDevelopment],
+              INSERTED.[CaseOfficerEmail],
+              INSERTED.[InspectorEmail],
+              INSERTED.[ValidationOfficerEmail],
+              INSERTED.[AppealStartDate],
+              INSERTED.[AppealValidationDate],
+              INSERTED.[AppealValidDate],
+              INSERTED.[MissingOrWrongReasons],
+              INSERTED.[MissingOrWrongDocuments],
+              INSERTED.[MissingOrWrongOtherReason]) FROM INSERTED;
+
+          UPDATE [HASAppeal]
+          SET [LatestEvent] = 0
+          WHERE [AppealID] = @AppealID
+              AND [LatestEvent] = 1
+              AND [ID] <> @ID;
+
+          UPDATE [HASAppeal]
+          SET [CheckSumRow] = @CheckSumRow
+          WHERE [ID] = @ID;
+      END
+    `);
+    await queryInterface.sequelize.query(
+      'ALTER TABLE [dbo].[HASAppeal] ENABLE TRIGGER [AfterInsertHASAppeal]'
+    );
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateHASAppeal');
+    await queryInterface.sequelize.query(`
+      CREATE PROCEDURE CreateHASAppeal
+        @json VARCHAR(4000)
+      AS
+      DECLARE
+        @appealId CHAR(36),
+        @recommendedSiteVisitTypeId INT,
+        @siteVisitTypeId INT,
+        @caseOfficerFirstName NVARCHAR(64),
+        @caseOfficerSurname NVARCHAR(64),
+        @caseOfficerId CHAR(36),
+        @LpaQuestionnaireReviewOutcomeId INT,
+        @LpaIncompleteReasons NVARCHAR(4000),
+        @validationOfficerFirstName NVARCHAR(64),
+        @validationOfficerSurname NVARCHAR(64),
+        @validationOfficerId CHAR(36),
+        @validationOutcomeId INT,
+        @invalidReasonOtherDetails NVARCHAR(4000),
+        @invalidAppealReasons NVARCHAR(4000),
+        @inspectorFirstName NVARCHAR(64),
+        @inspectorSurname NVARCHAR(64),
+        @inspectorId CHAR(36),
+        @inspectorSpecialismId INT,
+        @scheduledSiteVisitDate DATE,
+        @decisionOutcomeId INT,
+        @decisionLetterId CHAR(36),
+        @decisionDate DATE,
+        @descriptionDevelopment NVARCHAR(4000),
+        @caseOfficerEmail NVARCHAR(255),
+        @inspectorEmail NVARCHAR(255),
+        @validationOfficerEmail NVARCHAR(255),
+        @appealStartDate DATE,
+        @appealValidationDate DATE,
+        @questionnaireDueDate DATE,
+        @appealValidDate DATE,
+        @missingOrWrongReasons NVARCHAR(4000),
+        @missingOrWrongDocuments NVARCHAR(4000),
+        @missingOrWrongOtherReason NVARCHAR(4000)
+      BEGIN
+        SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+        SELECT
+          @recommendedSiteVisitTypeId = RecommendedSiteVisitTypeID,
+          @siteVisitTypeId = SiteVisitTypeID,
+          @caseOfficerFirstName = CaseOfficerFirstName,
+          @caseOfficerSurname = CaseOfficerSurname,
+          @caseOfficerId = CaseOfficerID,
+          @lpaQuestionnaireReviewOutcomeId = LPAQuestionnaireReviewOutcomeID,
+          @lpaIncompleteReasons = LPAIncompleteReasons,
+          @validationOfficerFirstName = ValidationOfficerFirstName,
+          @validationOfficerSurname = ValidationOfficerSurname,
+          @validationOfficerId = ValidationOfficerID,
+          @validationOutcomeId = ValidationOutcomeID,
+          @invalidReasonOtherDetails = InvalidReasonOtherDetails,
+          @invalidAppealReasons = InvalidAppealReasons,
+          @inspectorFirstName = InspectorFirstName,
+          @inspectorSurname = InspectorSurname,
+          @inspectorId = InspectorID,
+          @inspectorSpecialismId = InspectorSpecialismID,
+          @scheduledSiteVisitDate = ScheduledSiteVisitDate,
+          @decisionOutcomeId = DecisionOutcomeID,
+          @decisionLetterId = DecisionLetterID,
+          @decisionDate = DecisionDate,
+          @descriptionDevelopment = DescriptionDevelopment,
+          @caseOfficerEmail = CaseOfficerEmail,
+          @inspectorEmail = InspectorEmail,
+          @validationOfficerEmail = ValidationOfficerEmail,
+          @appealStartDate = AppealStartDate,
+          @appealValidationDate = AppealValidationDate,
+          @questionnaireDueDate = QuestionnaireDueDate,
+          @appealValidDate = AppealValidDate,
+          @missingOrWrongReasons = MissingOrWrongReasons,
+          @missingOrWrongDocuments = MissingOrWrongDocuments,
+          @missingOrWrongOtherReason = MissingOrWrongOtherReason
+        FROM HASAppeal (NOLOCK)
+        WHERE AppealID = @appealId AND LatestEvent = 1;
+
+        IF JSON_VALUE(@json, '$.recommendedSiteVisitTypeId') IS NOT NULL
+          SET @recommendedSiteVisitTypeId = JSON_VALUE(@json, '$.recommendedSiteVisitTypeId')
+
+        IF JSON_VALUE(@json, '$.siteVisitTypeId') IS NOT NULL
+          SET @siteVisitTypeId = JSON_VALUE(@json, '$.siteVisitTypeId')
+
+        IF JSON_VALUE(@json, '$.caseOfficerFirstName') IS NOT NULL
+          SET @caseOfficerFirstName = JSON_VALUE(@json, '$.caseOfficerFirstName')
+
+        IF JSON_VALUE(@json, '$.caseOfficerSurname') IS NOT NULL
+          SET @caseOfficerSurname = JSON_VALUE(@json, '$.caseOfficerSurname')
+
+        IF JSON_VALUE(@json, '$.caseOfficerId') IS NOT NULL
+          SET @caseOfficerId = JSON_VALUE(@json, '$.caseOfficerId')
+
+        IF JSON_VALUE(@json, '$.lpaQuestionnaireReviewOutcomeId') IS NOT NULL
+          SET @lpaQuestionnaireReviewOutcomeId = JSON_VALUE(@json, '$.lpaQuestionnaireReviewOutcomeId')
+
+        IF JSON_VALUE(@json, '$.lpaIncompleteReasons') IS NOT NULL
+          SET @lpaIncompleteReasons = JSON_VALUE(@json, '$.lpaIncompleteReasons')
+
+        IF JSON_VALUE(@json, '$.validationOfficerFirstName') IS NOT NULL
+          SET @validationOfficerFirstName = JSON_VALUE(@json, '$.validationOfficerFirstName')
+
+        IF JSON_VALUE(@json, '$.validationOfficerSurname') IS NOT NULL
+          SET @validationOfficerSurname = JSON_VALUE(@json, '$.validationOfficerSurname')
+
+        IF JSON_VALUE(@json, '$.validationOfficerId') IS NOT NULL
+          SET @validationOfficerId = JSON_VALUE(@json, '$.validationOfficerId')
+
+        IF JSON_VALUE(@json, '$.validationOutcomeId') IS NOT NULL
+          SET @validationOutcomeId = JSON_VALUE(@json, '$.validationOutcomeId')
+
+        IF JSON_VALUE(@json, '$.invalidReasonOtherDetails') IS NOT NULL
+          SET @invalidReasonOtherDetails = JSON_VALUE(@json, '$.invalidReasonOtherDetails')
+
+        IF JSON_VALUE(@json, '$.invalidAppealReasons') IS NOT NULL
+          SET @invalidAppealReasons = JSON_VALUE(@json, '$.invalidAppealReasons')
+
+        IF JSON_VALUE(@json, '$.inspectorFirstName') IS NOT NULL
+          SET @inspectorFirstName = JSON_VALUE(@json, '$.inspectorFirstName')
+
+        IF JSON_VALUE(@json, '$.inspectorSurname') IS NOT NULL
+          SET @inspectorSurname = JSON_VALUE(@json, '$.inspectorSurname')
+
+        IF JSON_VALUE(@json, '$.inspectorId') IS NOT NULL
+          SET @inspectorId = JSON_VALUE(@json, '$.inspectorId')
+
+        IF JSON_VALUE(@json, '$.inspectorSpecialismId') IS NOT NULL
+          SET @inspectorSpecialismId = JSON_VALUE(@json, '$.inspectorSpecialismId')
+
+        IF JSON_VALUE(@json, '$.scheduledSiteVisitDate') IS NOT NULL
+          SET @scheduledSiteVisitDate = JSON_VALUE(@json, '$.scheduledSiteVisitDate')
+
+        IF JSON_VALUE(@json, '$.decisionOutcomeId') IS NOT NULL
+          SET @decisionOutcomeId = JSON_VALUE(@json, '$.decisionOutcomeId')
+
+        IF JSON_VALUE(@json, '$.decisionLetterId') IS NOT NULL
+          SET @decisionLetterId = JSON_VALUE(@json, '$.decisionLetterId')
+
+        IF JSON_VALUE(@json, '$.decisionDate') IS NOT NULL
+          SET @decisionDate = JSON_VALUE(@json, '$.decisionDate')
+
+        IF JSON_VALUE(@json, '$.descriptionDevelopment') IS NOT NULL
+          SET @descriptionDevelopment = JSON_VALUE(@json, '$.descriptionDevelopment')
+
+        IF JSON_VALUE(@json, '$.caseOfficerEmail') IS NOT NULL
+          SET @caseOfficerEmail = JSON_VALUE(@json, '$.caseOfficerEmail')
+
+        IF JSON_VALUE(@json, '$.inspectorEmail') IS NOT NULL
+          SET @inspectorEmail = JSON_VALUE(@json, '$.inspectorEmail')
+
+        IF JSON_VALUE(@json, '$.validationOfficerEmail') IS NOT NULL
+          SET @validationOfficerEmail = JSON_VALUE(@json, '$.validationOfficerEmail')
+
+        IF JSON_VALUE(@json, '$.appealStartDate') IS NOT NULL
+          SET @appealStartDate = JSON_VALUE(@json, '$.appealStartDate')
+
+        IF JSON_VALUE(@json, '$.appealValidationDate') IS NOT NULL
+          SET @appealValidationDate = JSON_VALUE(@json, '$.appealValidationDate')
+
+        IF JSON_VALUE(@json, '$.questionnaireDueDate') IS NOT NULL
+          SET @questionnaireDueDate = JSON_VALUE(@json, '$.questionnaireDueDate')
+
+        IF JSON_VALUE(@json, '$.appealValidDate') IS NOT NULL
+          SET @appealValidDate = JSON_VALUE(@json, '$.appealValidDate')
+
+        IF JSON_VALUE(@json, '$.missingOrWrongReasons') IS NOT NULL
+          SET @missingOrWrongReasons = JSON_VALUE(@json, '$.missingOrWrongReasons')
+
+        IF JSON_VALUE(@json, '$.missingOrWrongDocuments') IS NOT NULL
+          SET @missingOrWrongDocuments = JSON_VALUE(@json, '$.missingOrWrongDocuments')
+
+        IF JSON_VALUE(@json, '$.missingOrWrongOtherReason') IS NOT NULL
+          SET @missingOrWrongOtherReason = JSON_VALUE(@json, '$.missingOrWrongOtherReason')
+
+        INSERT INTO HASAppeal (
+          ID,
+          AppealID,
+          RecommendedSiteVisitTypeID,
+          SiteVisitTypeID,
+          CaseOfficerFirstName,
+          CaseOfficerSurname,
+          CaseOfficerID,
+          LPAQuestionnaireReviewOutcomeID,
+          LPAIncompleteReasons,
+          ValidationOfficerFirstName,
+          ValidationOfficerSurname,
+          ValidationOfficerID,
+          ValidationOutcomeID,
+          InvalidReasonOtherDetails,
+          InvalidAppealReasons,
+          InspectorFirstName,
+          InspectorSurname,
+          InspectorID,
+          InspectorSpecialismID,
+          ScheduledSiteVisitDate,
+          DecisionOutcomeID,
+          DecisionLetterID,
+          DecisionDate,
+          DescriptionDevelopment,
+          CaseOfficerEmail,
+          InspectorEmail,
+          ValidationOfficerEmail,
+          AppealStartDate,
+          AppealValidationDate,
+          QuestionnaireDueDate,
+          AppealValidDate,
+          MissingOrWrongReasons,
+          MissingOrWrongDocuments,
+          MissingOrWrongOtherReason
+        )
+        VALUES (
+          newid(),
+          @appealId,
+          @recommendedSiteVisitTypeId,
+          @siteVisitTypeId,
+          @caseOfficerFirstName,
+          @caseOfficerSurname,
+          @caseOfficerId,
+          @LpaQuestionnaireReviewOutcomeId,
+          @LpaIncompleteReasons,
+          @validationOfficerFirstName,
+          @validationOfficerSurname,
+          @validationOfficerId,
+          @validationOutcomeId,
+          @invalidReasonOtherDetails,
+          @invalidAppealReasons,
+          @inspectorFirstName,
+          @inspectorSurname,
+          @inspectorId,
+          @inspectorSpecialismId,
+          @scheduledSiteVisitDate,
+          @decisionOutcomeId,
+          @decisionLetterId,
+          @decisionDate,
+          @descriptionDevelopment,
+          @caseOfficerEmail,
+          @inspectorEmail,
+          @validationOfficerEmail,
+          @appealStartDate,
+          @appealValidationDate,
+          @questionnaireDueDate,
+          @appealValidDate,
+          @missingOrWrongReasons,
+          @missingOrWrongDocuments,
+          @missingOrWrongOtherReason
+        );
+      END
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('HASAppeal', 'MissingOrWrongReasons');
+    await queryInterface.removeColumn('HASAppeal', 'MissingOrWrongDocuments');
+    await queryInterface.removeColumn('HASAppeal', 'MissingOrWrongOtherReason');
+    await queryInterface.sequelize.query('DROP TRIGGER [AfterInsertHASAppeal]');
+    await queryInterface.sequelize.query(`
+      CREATE TRIGGER [dbo].[AfterInsertHASAppeal] ON [dbo].[HASAppeal]
+      FOR INSERT
+      AS DECLARE @ID UNIQUEIDENTIFIER,
+          @AppealID UNIQUEIDENTIFIER,
+          @CheckSumRow INT;
+      BEGIN
+          SET NOCOUNT ON;
+          SELECT @ID = INSERTED.ID FROM INSERTED;
+          SELECT @AppealID = INSERTED.AppealID FROM INSERTED;
+
+          SELECT @CheckSumRow = CHECKSUM(@AppealID,
+              INSERTED.[RecommendedSiteVisitTypeID],
+              INSERTED.[SiteVisitTypeID],
+              INSERTED.[CaseOfficerFirstName],
+              INSERTED.[CaseOfficerSurname],
+              INSERTED.[CaseOfficerID],
+              INSERTED.[LPAQuestionnaireReviewOutcomeID],
+              INSERTED.[LPAIncompleteReasons],
+              INSERTED.[ValidationOfficerFirstName],
+              INSERTED.[ValidationOfficerSurname],
+              INSERTED.[ValidationOfficerID],
+              INSERTED.[ValidationOutcomeID],
+              INSERTED.[InvalidReasonOtherDetails],
+              INSERTED.[InvalidAppealReasons],
+              INSERTED.[InspectorFirstName],
+              INSERTED.[InspectorSurname],
+              INSERTED.[InspectorID],
+              INSERTED.[InspectorSpecialismID],
+              INSERTED.[ScheduledSiteVisitDate],
+              INSERTED.[DecisionOutcomeID],
+              INSERTED.[DecisionLetterID],
+              INSERTED.[DecisionDate],
+              INSERTED.[EventUserID],
+              INSERTED.[EventUserName],
+              INSERTED.[DescriptionDevelopment],
+              INSERTED.[CaseOfficerEmail],
+              INSERTED.[InspectorEmail],
+              INSERTED.[ValidationOfficerEmail],
+              INSERTED.[AppealStartDate],
+              INSERTED.[AppealValidationDate],
+              INSERTED.[AppealValidDate]) FROM INSERTED;
+
+          UPDATE [HASAppeal]
+          SET [LatestEvent] = 0
+          WHERE [AppealID] = @AppealID
+              AND [LatestEvent] = 1
+              AND [ID] <> @ID;
+
+          UPDATE [HASAppeal]
+          SET [CheckSumRow] = @CheckSumRow
+          WHERE [ID] = @ID;
+      END
+    `);
+    await queryInterface.sequelize.query(
+      'ALTER TABLE [dbo].[HASAppeal] ENABLE TRIGGER [AfterInsertHASAppeal]'
+    );
+    await queryInterface.sequelize.query('DROP PROCEDURE CreateHASAppeal');
+    await queryInterface.sequelize.query(`
+      CREATE PROCEDURE CreateHASAppeal
+        @json VARCHAR(4000)
+      AS
+      DECLARE
+        @appealId CHAR(36),
+        @recommendedSiteVisitTypeId INT,
+        @siteVisitTypeId INT,
+        @caseOfficerFirstName NVARCHAR(64),
+        @caseOfficerSurname NVARCHAR(64),
+        @caseOfficerId CHAR(36),
+        @LpaQuestionnaireReviewOutcomeId INT,
+        @LpaIncompleteReasons NVARCHAR(4000),
+        @validationOfficerFirstName NVARCHAR(64),
+        @validationOfficerSurname NVARCHAR(64),
+        @validationOfficerId CHAR(36),
+        @validationOutcomeId INT,
+        @invalidReasonOtherDetails NVARCHAR(4000),
+        @invalidAppealReasons NVARCHAR(4000),
+        @inspectorFirstName NVARCHAR(64),
+        @inspectorSurname NVARCHAR(64),
+        @inspectorId CHAR(36),
+        @inspectorSpecialismId INT,
+        @scheduledSiteVisitDate DATE,
+        @decisionOutcomeId INT,
+        @decisionLetterId CHAR(36),
+        @decisionDate DATE,
+        @descriptionDevelopment NVARCHAR(4000),
+        @caseOfficerEmail NVARCHAR(255),
+        @inspectorEmail NVARCHAR(255),
+        @validationOfficerEmail NVARCHAR(255),
+        @appealStartDate DATE,
+        @appealValidationDate DATE,
+        @questionnaireDueDate DATE,
+        @appealValidDate DATE
+      BEGIN
+        SET @appealId = JSON_VALUE(@json, '$.appealId')
+
+        SELECT
+          @recommendedSiteVisitTypeId = RecommendedSiteVisitTypeID,
+          @siteVisitTypeId = SiteVisitTypeID,
+          @caseOfficerFirstName = CaseOfficerFirstName,
+          @caseOfficerSurname = CaseOfficerSurname,
+          @caseOfficerId = CaseOfficerID,
+          @lpaQuestionnaireReviewOutcomeId = LPAQuestionnaireReviewOutcomeID,
+          @lpaIncompleteReasons = LPAIncompleteReasons,
+          @validationOfficerFirstName = ValidationOfficerFirstName,
+          @validationOfficerSurname = ValidationOfficerSurname,
+          @validationOfficerId = ValidationOfficerID,
+          @validationOutcomeId = ValidationOutcomeID,
+          @invalidReasonOtherDetails = InvalidReasonOtherDetails,
+          @invalidAppealReasons = InvalidAppealReasons,
+          @inspectorFirstName = InspectorFirstName,
+          @inspectorSurname = InspectorSurname,
+          @inspectorId = InspectorID,
+          @inspectorSpecialismId = InspectorSpecialismID,
+          @scheduledSiteVisitDate = ScheduledSiteVisitDate,
+          @decisionOutcomeId = DecisionOutcomeID,
+          @decisionLetterId = DecisionLetterID,
+          @decisionDate = DecisionDate,
+          @descriptionDevelopment = DescriptionDevelopment,
+          @caseOfficerEmail = CaseOfficerEmail,
+          @inspectorEmail = InspectorEmail,
+          @validationOfficerEmail = ValidationOfficerEmail,
+          @appealStartDate = AppealStartDate,
+          @appealValidationDate = AppealValidationDate,
+          @questionnaireDueDate = QuestionnaireDueDate,
+          @appealValidDate = AppealValidDate
+        FROM HASAppeal (NOLOCK)
+        WHERE AppealID = @appealId AND LatestEvent = 1;
+
+        IF JSON_VALUE(@json, '$.recommendedSiteVisitTypeId') IS NOT NULL
+          SET @recommendedSiteVisitTypeId = JSON_VALUE(@json, '$.recommendedSiteVisitTypeId')
+
+        IF JSON_VALUE(@json, '$.siteVisitTypeId') IS NOT NULL
+          SET @siteVisitTypeId = JSON_VALUE(@json, '$.siteVisitTypeId')
+
+        IF JSON_VALUE(@json, '$.caseOfficerFirstName') IS NOT NULL
+          SET @caseOfficerFirstName = JSON_VALUE(@json, '$.caseOfficerFirstName')
+
+        IF JSON_VALUE(@json, '$.caseOfficerSurname') IS NOT NULL
+          SET @caseOfficerSurname = JSON_VALUE(@json, '$.caseOfficerSurname')
+
+        IF JSON_VALUE(@json, '$.caseOfficerId') IS NOT NULL
+          SET @caseOfficerId = JSON_VALUE(@json, '$.caseOfficerId')
+
+        IF JSON_VALUE(@json, '$.lpaQuestionnaireReviewOutcomeId') IS NOT NULL
+          SET @lpaQuestionnaireReviewOutcomeId = JSON_VALUE(@json, '$.lpaQuestionnaireReviewOutcomeId')
+
+        IF JSON_VALUE(@json, '$.lpaIncompleteReasons') IS NOT NULL
+          SET @lpaIncompleteReasons = JSON_VALUE(@json, '$.lpaIncompleteReasons')
+
+        IF JSON_VALUE(@json, '$.validationOfficerFirstName') IS NOT NULL
+          SET @validationOfficerFirstName = JSON_VALUE(@json, '$.validationOfficerFirstName')
+
+        IF JSON_VALUE(@json, '$.validationOfficerSurname') IS NOT NULL
+          SET @validationOfficerSurname = JSON_VALUE(@json, '$.validationOfficerSurname')
+
+        IF JSON_VALUE(@json, '$.validationOfficerId') IS NOT NULL
+          SET @validationOfficerId = JSON_VALUE(@json, '$.validationOfficerId')
+
+        IF JSON_VALUE(@json, '$.validationOutcomeId') IS NOT NULL
+          SET @validationOutcomeId = JSON_VALUE(@json, '$.validationOutcomeId')
+
+        IF JSON_VALUE(@json, '$.invalidReasonOtherDetails') IS NOT NULL
+          SET @invalidReasonOtherDetails = JSON_VALUE(@json, '$.invalidReasonOtherDetails')
+
+        IF JSON_VALUE(@json, '$.invalidAppealReasons') IS NOT NULL
+          SET @invalidAppealReasons = JSON_VALUE(@json, '$.invalidAppealReasons')
+
+        IF JSON_VALUE(@json, '$.inspectorFirstName') IS NOT NULL
+          SET @inspectorFirstName = JSON_VALUE(@json, '$.inspectorFirstName')
+
+        IF JSON_VALUE(@json, '$.inspectorSurname') IS NOT NULL
+          SET @inspectorSurname = JSON_VALUE(@json, '$.inspectorSurname')
+
+        IF JSON_VALUE(@json, '$.inspectorId') IS NOT NULL
+          SET @inspectorId = JSON_VALUE(@json, '$.inspectorId')
+
+        IF JSON_VALUE(@json, '$.inspectorSpecialismId') IS NOT NULL
+          SET @inspectorSpecialismId = JSON_VALUE(@json, '$.inspectorSpecialismId')
+
+        IF JSON_VALUE(@json, '$.scheduledSiteVisitDate') IS NOT NULL
+          SET @scheduledSiteVisitDate = JSON_VALUE(@json, '$.scheduledSiteVisitDate')
+
+        IF JSON_VALUE(@json, '$.decisionOutcomeId') IS NOT NULL
+          SET @decisionOutcomeId = JSON_VALUE(@json, '$.decisionOutcomeId')
+
+        IF JSON_VALUE(@json, '$.decisionLetterId') IS NOT NULL
+          SET @decisionLetterId = JSON_VALUE(@json, '$.decisionLetterId')
+
+        IF JSON_VALUE(@json, '$.decisionDate') IS NOT NULL
+          SET @decisionDate = JSON_VALUE(@json, '$.decisionDate')
+
+        IF JSON_VALUE(@json, '$.descriptionDevelopment') IS NOT NULL
+          SET @descriptionDevelopment = JSON_VALUE(@json, '$.descriptionDevelopment')
+
+        IF JSON_VALUE(@json, '$.caseOfficerEmail') IS NOT NULL
+          SET @caseOfficerEmail = JSON_VALUE(@json, '$.caseOfficerEmail')
+
+        IF JSON_VALUE(@json, '$.inspectorEmail') IS NOT NULL
+          SET @inspectorEmail = JSON_VALUE(@json, '$.inspectorEmail')
+
+        IF JSON_VALUE(@json, '$.validationOfficerEmail') IS NOT NULL
+          SET @validationOfficerEmail = JSON_VALUE(@json, '$.validationOfficerEmail')
+
+        IF JSON_VALUE(@json, '$.appealStartDate') IS NOT NULL
+          SET @appealStartDate = JSON_VALUE(@json, '$.appealStartDate')
+
+        IF JSON_VALUE(@json, '$.appealValidationDate') IS NOT NULL
+          SET @appealValidationDate = JSON_VALUE(@json, '$.appealValidationDate')
+
+        IF JSON_VALUE(@json, '$.questionnaireDueDate') IS NOT NULL
+          SET @questionnaireDueDate = JSON_VALUE(@json, '$.questionnaireDueDate')
+
+        IF JSON_VALUE(@json, '$.appealValidDate') IS NOT NULL
+          SET @appealValidDate = JSON_VALUE(@json, '$.appealValidDate')
+
+        INSERT INTO HASAppeal (
+          ID,
+          AppealID,
+          RecommendedSiteVisitTypeID,
+          SiteVisitTypeID,
+          CaseOfficerFirstName,
+          CaseOfficerSurname,
+          CaseOfficerID,
+          LPAQuestionnaireReviewOutcomeID,
+          LPAIncompleteReasons,
+          ValidationOfficerFirstName,
+          ValidationOfficerSurname,
+          ValidationOfficerID,
+          ValidationOutcomeID,
+          InvalidReasonOtherDetails,
+          InvalidAppealReasons,
+          InspectorFirstName,
+          InspectorSurname,
+          InspectorID,
+          InspectorSpecialismID,
+          ScheduledSiteVisitDate,
+          DecisionOutcomeID,
+          DecisionLetterID,
+          DecisionDate,
+          DescriptionDevelopment,
+          CaseOfficerEmail,
+          InspectorEmail,
+          ValidationOfficerEmail,
+          AppealStartDate,
+          AppealValidationDate,
+          QuestionnaireDueDate,
+          AppealValidDate
+        )
+        VALUES (
+          newid(),
+          @appealId,
+          @recommendedSiteVisitTypeId,
+          @siteVisitTypeId,
+          @caseOfficerFirstName,
+          @caseOfficerSurname,
+          @caseOfficerId,
+          @LpaQuestionnaireReviewOutcomeId,
+          @LpaIncompleteReasons,
+          @validationOfficerFirstName,
+          @validationOfficerSurname,
+          @validationOfficerId,
+          @validationOutcomeId,
+          @invalidReasonOtherDetails,
+          @invalidAppealReasons,
+          @inspectorFirstName,
+          @inspectorSurname,
+          @inspectorId,
+          @inspectorSpecialismId,
+          @scheduledSiteVisitDate,
+          @decisionOutcomeId,
+          @decisionLetterId,
+          @decisionDate,
+          @descriptionDevelopment,
+          @caseOfficerEmail,
+          @inspectorEmail,
+          @validationOfficerEmail,
+          @appealStartDate,
+          @appealValidationDate,
+          @questionnaireDueDate,
+          @appealValidDate
+        );
+      END
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00055-amend-appeal-data-view.js
+++ b/packages/api/database/migrations/00055-amend-appeal-data-view.js
@@ -1,0 +1,153 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW AppealData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW [dbo].[AppealData]
+      AS
+      SELECT
+        HASAppealSubmission.AppealID as appealId,
+        HASAppealSubmission.CreatorEmailAddress as creatorEmailAddress,
+        HASAppealSubmission.CreatorName as creatorName,
+        HASAppealSubmission.CreatorOriginalApplicant as creatorOriginalApplicant,
+        HASAppealSubmission.CreatorOnBehalfOf as creatorOnBehalfOf,
+        HASAppealSubmission.OriginalApplicationNumber as originalApplicationNumber,
+        HASAppealSubmission.SiteOwnership as siteOwnership,
+        HASAppealSubmission.SiteInformOwners as siteInformOwners,
+        HASAppealSubmission.SiteRestriction as siteRestriction,
+        HASAppealSubmission.SiteRestrictionDetails as siteRestrictionDetails,
+        HASAppealSubmission.SafetyConcern as safetyConcern,
+        HASAppealSubmission.SafetyConcernDetails as safetyConcernDetails,
+        HASAppealSubmission.SensitiveInformation as sensitiveInformation,
+        HASAppealSubmission.TermsAgreed as termsAgreed,
+        HASAppealSubmission.DecisionDate as appealDecisionDate,
+        HASAppealSubmission.SubmissionDate as submissionDate,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.CaseStatusID as caseStatusId,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.CaseOfficerFirstName as caseOfficerFirstName,
+        HASAppeal.CaseOfficerSurname as caseOfficerSurname,
+        HASAppeal.CaseOfficerEmail as caseOfficerEmail,
+        HASAppeal.ValidationOfficerFirstName as validationOfficerFirstName,
+        HASAppeal.ValidationOfficerSurname as validationOfficerSurname,
+        HASAppeal.ValidationOfficerEmail as validationOfficerEmail,
+        HASAppeal.ValidationOutcomeID as validationOutcomeId,
+        HASAppeal.InvalidReasonOtherDetails as invalidReasonOtherDetails,
+        HASAppeal.InvalidAppealReasons as invalidAppealReasons,
+        HASAppeal.InspectorFirstName as inspectorFirstName,
+        HASAppeal.InspectorSurname as inspectorSurname,
+        HASAppeal.InspectorEmail as inspectorEmail,
+        HASAppeal.ScheduledSiteVisitDate as scheduledSiteVisitDate,
+        HASAppealSubmission.DecisionDate as questionnaireDecisionDate,
+        HASAppeal.DescriptionDevelopment as descriptionDevelopment,
+        HASAppeal.AppealStartDate as appealStartDate,
+        HASAppeal.AppealValidationDate as appealValidationDate,
+        HASAppeal.AppealValidDate as appealValidDate,
+        HASAppeal.MissingOrWrongReasons as missingOrWrongReasons,
+        HASAppeal.MissingOrWrongDocuments as missingOrWrongDocuments,
+        HASAppeal.MissingOrWrongOtherReason as missingOrWrongOtherReason,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpRecommendedSiteVisitType.TypeName as recommendedSiteVisitTypeName,
+        LookUpSiteVisitType.TypeName as siteVisitTypeName,
+        LookUpInspectorSpecialism.Specialism as inspectorSpecialismName,
+        LookUpDecisionOutcome.Outcome as decisionOutcomeName,
+        LookUpValidationOutcome.Outcome as validationOutcomeName
+      FROM HASAppealSubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASAppealSubmission.AppealID = AppealLink.AppealId AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASAppealSubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpSiteVisitType AS LookUpRecommendedSiteVisitType (NOLOCK) ON HASAppeal.RecommendedSiteVisitTypeID = LookUpRecommendedSiteVisitType.ID
+      LEFT JOIN LookUpSiteVisitType (NOLOCK) ON HASAppeal.SiteVisitTypeID = LookUpSiteVisitType.ID
+      LEFT JOIN LookUpInspectorSpecialism (NOLOCK) ON HASAppeal.InspectorSpecialismID = LookUpInspectorSpecialism.ID
+      LEFT JOIN LookUpDecisionOutcome (NOLOCK) ON HASAppeal.DecisionOutcomeID = LookUpDecisionOutcome.ID
+      LEFT JOIN LookUpValidationOutcome (NOLOCK) ON HASAppeal.ValidationOutcomeID = LookUpValidationOutcome.ID
+      WHERE HASAppealSubmission.LatestEvent = 1
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW AppealData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW [dbo].[AppealData]
+      AS
+      SELECT
+        HASAppealSubmission.AppealID as appealId,
+        HASAppealSubmission.CreatorEmailAddress as creatorEmailAddress,
+        HASAppealSubmission.CreatorName as creatorName,
+        HASAppealSubmission.CreatorOriginalApplicant as creatorOriginalApplicant,
+        HASAppealSubmission.CreatorOnBehalfOf as creatorOnBehalfOf,
+        HASAppealSubmission.OriginalApplicationNumber as originalApplicationNumber,
+        HASAppealSubmission.SiteOwnership as siteOwnership,
+        HASAppealSubmission.SiteInformOwners as siteInformOwners,
+        HASAppealSubmission.SiteRestriction as siteRestriction,
+        HASAppealSubmission.SiteRestrictionDetails as siteRestrictionDetails,
+        HASAppealSubmission.SafetyConcern as safetyConcern,
+        HASAppealSubmission.SafetyConcernDetails as safetyConcernDetails,
+        HASAppealSubmission.SensitiveInformation as sensitiveInformation,
+        HASAppealSubmission.TermsAgreed as termsAgreed,
+        HASAppealSubmission.DecisionDate as appealDecisionDate,
+        HASAppealSubmission.SubmissionDate as submissionDate,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.CaseStatusID as caseStatusId,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.CaseOfficerFirstName as caseOfficerFirstName,
+        HASAppeal.CaseOfficerSurname as caseOfficerSurname,
+        HASAppeal.CaseOfficerEmail as caseOfficerEmail,
+        HASAppeal.ValidationOfficerFirstName as validationOfficerFirstName,
+        HASAppeal.ValidationOfficerSurname as validationOfficerSurname,
+        HASAppeal.ValidationOfficerEmail as validationOfficerEmail,
+        HASAppeal.ValidationOutcomeID as validationOutcomeId,
+        HASAppeal.InvalidReasonOtherDetails as invalidReasonOtherDetails,
+        HASAppeal.InvalidAppealReasons as invalidAppealReasons,
+        HASAppeal.InspectorFirstName as inspectorFirstName,
+        HASAppeal.InspectorSurname as inspectorSurname,
+        HASAppeal.InspectorEmail as inspectorEmail,
+        HASAppeal.ScheduledSiteVisitDate as scheduledSiteVisitDate,
+        HASAppealSubmission.DecisionDate as questionnaireDecisionDate,
+        HASAppeal.DescriptionDevelopment as descriptionDevelopment,
+        HASAppeal.AppealStartDate as appealStartDate,
+        HASAppeal.AppealValidationDate as appealValidationDate,
+        HASAppeal.AppealValidDate as appealValidDate,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpRecommendedSiteVisitType.TypeName as recommendedSiteVisitTypeName,
+        LookUpSiteVisitType.TypeName as siteVisitTypeName,
+        LookUpInspectorSpecialism.Specialism as inspectorSpecialismName,
+        LookUpDecisionOutcome.Outcome as decisionOutcomeName,
+        LookUpValidationOutcome.Outcome as validationOutcomeName
+      FROM HASAppealSubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASAppealSubmission.AppealID = AppealLink.AppealId AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASAppealSubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpSiteVisitType AS LookUpRecommendedSiteVisitType (NOLOCK) ON HASAppeal.RecommendedSiteVisitTypeID = LookUpRecommendedSiteVisitType.ID
+      LEFT JOIN LookUpSiteVisitType (NOLOCK) ON HASAppeal.SiteVisitTypeID = LookUpSiteVisitType.ID
+      LEFT JOIN LookUpInspectorSpecialism (NOLOCK) ON HASAppeal.InspectorSpecialismID = LookUpInspectorSpecialism.ID
+      LEFT JOIN LookUpDecisionOutcome (NOLOCK) ON HASAppeal.DecisionOutcomeID = LookUpDecisionOutcome.ID
+      LEFT JOIN LookUpValidationOutcome (NOLOCK) ON HASAppeal.ValidationOutcomeID = LookUpValidationOutcome.ID
+      WHERE HASAppealSubmission.LatestEvent = 1
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/api/database/migrations/00056-amend-questionnaire-data-view.js
+++ b/packages/api/database/migrations/00056-amend-questionnaire-data-view.js
@@ -1,0 +1,123 @@
+const migration = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW QuestionnaireData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW QuestionnaireData
+      AS
+      SELECT
+        HASLPASubmission.LPAQuestionnaireID as lpaQuestionnaireId,
+        HASLPASubmission.AppealID as appealId,
+        HASLPASubmission.SubmissionDate as submissionDate,
+        HASLPASubmission.SubmissionAccuracy as submissionAccuracy,
+        HASLPASubmission.SubmissionAccuracyDetails as submissionAccuracyDetails,
+        HASLPASubmission.ExtraConditions as extraConditions,
+        HASLPASubmission.ExtraConditionsDetails as extraConditionsDetails,
+        HASLPASubmission.AdjacentAppeals as adjacentAppeals,
+        HASLPASubmission.AdjacentAppealsNumbers as adjacentAppealsNumbers,
+        HASLPASubmission.CannotSeeLand as cannotSeeLand,
+        HASLPASubmission.SiteAccess as siteAccess,
+        HASLPASubmission.SiteAccessDetails as siteAccessDetails,
+        HASLPASubmission.SiteNeighbourAccess as siteNeighbourAccess,
+        HASLPASubmission.SiteNeighbourAccessDetails as siteNeighbourAccessDetails,
+        HASLPASubmission.HealthAndSafetyIssues as healthAndSafetyIssues,
+        HASLPASubmission.HealthAndSafetyDetails as healthAndSafetyDetails,
+        HASLPASubmission.AffectListedBuilding as affectListedBuilding,
+        HASLPASubmission.AffectListedBuildingDetails as affectListedBuildingDetails,
+        HASLPASubmission.GreenBelt as greenBelt,
+        HASLPASubmission.ConservationArea as conservationArea,
+        HASLPASubmission.OriginalPlanningApplicationPublicised as originalPlanningApplicationPublicised,
+        HASLPASubmission.DevelopmentNeighbourhoodPlanSubmitted as developmentNeighbourhoodPlanSubmitted,
+        HASLPASubmission.DevelopmentNeighbourhoodPlanChanges as developmentNeighbourhoodPlanChanges,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.LPAIncompleteReasons as lpaIncompleteReasons,
+        HASAppeal.QuestionnaireDueDate as questionnaireDueDate,
+        HASAppeal.MissingOrWrongReasons as missingOrWrongReasons,
+        HASAppeal.MissingOrWrongDocuments as missingOrWrongDocuments,
+        HASAppeal.MissingOrWrongOtherReason as missingOrWrongOtherReason,
+        LookUpQuestionnaireStatus.Status as questionnaireStatus,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpQuestionnaireOutcome.Outcome as lpaQuestionnaireOutcomeName
+      FROM HASLPASubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASLPASubmission.AppealId = AppealLink.AppealID AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASLPASubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpQuestionnaireStatus (NOLOCK) ON AppealLink.QuestionnaireStatusID = LookUpQuestionnaireStatus.ID
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpQuestionnaireOutcome (NOLOCK) ON HASAppeal.LPAQuestionnaireReviewOutcomeID = LookUpQuestionnaireOutcome.ID
+      WHERE HASLPASubmission.LPAQuestionnaireID = AppealLink.LPAQuestionnaireID
+      AND HASLPASubmission.LatestEvent = 1
+    `);
+  },
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP VIEW QuestionnaireData');
+    await queryInterface.sequelize.query(`
+      CREATE VIEW QuestionnaireData
+      AS
+      SELECT
+        HASLPASubmission.LPAQuestionnaireID as lpaQuestionnaireId,
+        HASLPASubmission.AppealID as appealId,
+        HASLPASubmission.SubmissionDate as submissionDate,
+        HASLPASubmission.SubmissionAccuracy as submissionAccuracy,
+        HASLPASubmission.SubmissionAccuracyDetails as submissionAccuracyDetails,
+        HASLPASubmission.ExtraConditions as extraConditions,
+        HASLPASubmission.ExtraConditionsDetails as extraConditionsDetails,
+        HASLPASubmission.AdjacentAppeals as adjacentAppeals,
+        HASLPASubmission.AdjacentAppealsNumbers as adjacentAppealsNumbers,
+        HASLPASubmission.CannotSeeLand as cannotSeeLand,
+        HASLPASubmission.SiteAccess as siteAccess,
+        HASLPASubmission.SiteAccessDetails as siteAccessDetails,
+        HASLPASubmission.SiteNeighbourAccess as siteNeighbourAccess,
+        HASLPASubmission.SiteNeighbourAccessDetails as siteNeighbourAccessDetails,
+        HASLPASubmission.HealthAndSafetyIssues as healthAndSafetyIssues,
+        HASLPASubmission.HealthAndSafetyDetails as healthAndSafetyDetails,
+        HASLPASubmission.AffectListedBuilding as affectListedBuilding,
+        HASLPASubmission.AffectListedBuildingDetails as affectListedBuildingDetails,
+        HASLPASubmission.GreenBelt as greenBelt,
+        HASLPASubmission.ConservationArea as conservationArea,
+        HASLPASubmission.OriginalPlanningApplicationPublicised as originalPlanningApplicationPublicised,
+        HASLPASubmission.DevelopmentNeighbourhoodPlanSubmitted as developmentNeighbourhoodPlanSubmitted,
+        HASLPASubmission.DevelopmentNeighbourhoodPlanChanges as developmentNeighbourhoodPlanChanges,
+        AppealLink.CaseReference as caseReference,
+        AppealLink.AppellantName as appellantName,
+        AppealLink.SiteAddressLineOne as siteAddressLineOne,
+        AppealLink.SiteAddressLineTwo as siteAddressLineTwo,
+        AppealLink.SiteAddressTown as siteAddressTown,
+        AppealLink.SiteAddressCounty as siteAddressCounty,
+        AppealLink.SiteAddressPostCode as siteAddressPostCode,
+        AppealLink.LocalPlanningAuthorityID as localPlanningAuthorityId,
+        HASAppeal.LPAIncompleteReasons as lpaIncompleteReasons,
+        HASAppeal.QuestionnaireDueDate as questionnaireDueDate,
+        LookUpQuestionnaireStatus.Status as questionnaireStatus,
+        LookUpCaseType.TypeName as caseTypeName,
+        LookUpCaseStage.StageName as caseStageName,
+        LookUpCaseStatus.StatusName as caseStatusName,
+        LookUpLPA.LPA19Name as localPlanningAuthorityName,
+        LookUpQuestionnaireOutcome.Outcome as lpaQuestionnaireOutcomeName
+      FROM HASLPASubmission (NOLOCK)
+      LEFT JOIN AppealLink (NOLOCK) ON HASLPASubmission.AppealId = AppealLink.AppealID AND AppealLink.LatestEvent = 1
+      LEFT JOIN HASAppeal (NOLOCK) ON HASLPASubmission.AppealID = HASAppeal.AppealId AND HASAppeal.LatestEvent = 1
+      LEFT JOIN LookUpQuestionnaireStatus (NOLOCK) ON AppealLink.QuestionnaireStatusID = LookUpQuestionnaireStatus.ID
+      LEFT JOIN LookUpCaseType (NOLOCK) ON AppealLink.CaseTypeID = LookUpCaseType.ID
+      LEFT JOIN LookUpCaseStage (NOLOCK) ON AppealLink.CaseStageID = LookUpCaseStage.ID
+      LEFT JOIN LookUpCaseStatus (NOLOCK) ON AppealLink.CaseStatusID = LookUpCaseStatus.ID
+      LEFT JOIN LookUpLPA (NOLOCK) ON AppealLink.LocalPlanningAuthorityID = LookUpLPA.LPA19Code
+      LEFT JOIN LookUpQuestionnaireOutcome (NOLOCK) ON HASAppeal.LPAQuestionnaireReviewOutcomeID = LookUpQuestionnaireOutcome.ID
+      WHERE HASLPASubmission.LPAQuestionnaireID = AppealLink.LPAQuestionnaireID
+      AND HASLPASubmission.LatestEvent = 1
+    `);
+  },
+};
+
+module.exports = migration;

--- a/packages/web-app/src/config/db-fields.js
+++ b/packages/web-app/src/config/db-fields.js
@@ -8,6 +8,9 @@ const dbFields = {
     appealValidationDate: 'appealValidationDate',
     questionnaireDueDate: 'questionnaireDueDate',
     appealValidDate: 'appealValidDate',
+    missingOrWrongReasons: 'missingOrWrongReasons',
+    missingOrWrongDocuments: 'missingOrWrongDocuments',
+    missingOrWrongOtherReason: 'missingOrWrongOtherReason',
   },
   appealLink: {
     questionnaireStatusId: 'questionnaireStatusId',

--- a/packages/web-app/src/config/review-appeal-submission.js
+++ b/packages/web-app/src/config/review-appeal-submission.js
@@ -6,66 +6,30 @@ const reviewOutcomeOption = {
   incomplete: '3',
 };
 
-const missingOrWrongReasons = {
-  noApplicationForm: {
-    text: 'Application form',
-  },
-  noDecisionNotice: {
-    text: 'Decision notice',
-  },
-  noGroundsOfAppeal: {
-    text: 'Grounds of appeal',
-  },
-  noSupportingDocuments: {
-    text: 'Supporting documents',
-  },
-  namesNotMatch: {
-    text: 'Names do not match',
-  },
-  sensitiveInformationIncluded: {
-    text: 'Sensitive information included',
+const labels = {
+  missingOrWrongReasons: {
+    1: 'Names do not match',
+    2: 'Sensitive information included',
+    3: 'Missing or wrong documents',
+    4: 'Inflammatory comments made',
+    5: 'Opened in error',
+    6: 'Wrong appeal type used',
+    7: 'Other',
   },
   missingOrWrongDocuments: {
-    text: 'Missing or wrong documents',
+    1: 'Application form',
+    2: 'Decision notice',
+    3: 'Grounds of appeal',
+    4: 'Supporting documents',
   },
-  inflammatoryComments: {
-    text: 'Inflammatory comments made',
-  },
-  openedInError: {
-    text: 'Opened in error',
-  },
-  wrongAppealType: {
-    text: 'Wrong appeal type used',
-  },
-  other: {
-    text: 'Other',
+  invalidAppealReasons: {
+    1: 'Out of time',
+    2: 'No right of appeal',
+    3: 'Not appealable',
+    4: 'LPA deemed application as invalid',
+    5: 'Other',
   },
 };
-
-const invalidAppealReasons = {
-  1: {
-    text: 'Out of time',
-  },
-  2: {
-    text: 'No right of appeal',
-  },
-  3: {
-    text: 'Not appealable',
-  },
-  4: {
-    text: 'LPA deemed application as invalid',
-  },
-  5: {
-    text: 'Other',
-  },
-};
-
-const allText = {
-  ...missingOrWrongReasons,
-  ...invalidAppealReasons,
-};
-
-const getText = (key) => allText[key]?.text || key;
 
 const reviewOutcomeConfigMap = {
   [reviewOutcomeOption.valid]: {
@@ -100,6 +64,6 @@ const getReviewOutcomeConfig = (reviewOutcome) => reviewOutcomeConfigMap[reviewO
 
 module.exports = {
   getReviewOutcomeConfig,
-  getText,
+  labels,
   reviewOutcomeOption,
 };

--- a/packages/web-app/src/config/review-appeal-submission.spec.js
+++ b/packages/web-app/src/config/review-appeal-submission.spec.js
@@ -1,20 +1,20 @@
 const {
-  getText,
+  labels,
   getReviewOutcomeConfig,
   reviewOutcomeOption,
 } = require('./review-appeal-submission');
 const views = require('./views');
 
 describe('review-appeal-submission', () => {
-  describe('getText', () => {
+  describe('labels', () => {
     it('should return the right text for an invalid appeal reason key', () => {
-      expect(getText('2')).toEqual('No right of appeal');
+      expect(labels.invalidAppealReasons[2]).toEqual('No right of appeal');
     });
     it('should return the right text for an missing or wrong reason key', () => {
-      expect(getText('inflammatoryComments')).toEqual('Inflammatory comments made');
+      expect(labels.missingOrWrongReasons[4]).toEqual('Inflammatory comments made');
     });
-    it('should return the the key if a matching text not found', () => {
-      expect(getText('aNonExistentKey')).toEqual('aNonExistentKey');
+    it('should return the right text for an missing or wrong document key', () => {
+      expect(labels.missingOrWrongDocuments[3]).toEqual('Grounds of appeal');
     });
   });
 

--- a/packages/web-app/src/controllers/check-and-confirm.js
+++ b/packages/web-app/src/controllers/check-and-confirm.js
@@ -6,7 +6,7 @@ const {
 } = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
 const {
-  getText,
+  labels,
   getReviewOutcomeConfig,
   reviewOutcomeOption,
 } = require('../config/review-appeal-submission');
@@ -17,7 +17,8 @@ const { saveAppealData, saveAppealLinkData } = require('../lib/api-wrapper');
 const viewData = (appealId, casework) => {
   const validAppealDetails = casework[hasAppeal.validAppealDetails];
   const invalidAppealReasons = casework[hasAppeal.invalidAppealReasons];
-  const missingOrWrongDetails = casework.missingOrWrong;
+  const missingOrWrongReasons = casework[hasAppeal.missingOrWrongReasons];
+  const missingOrWrongDocuments = casework[hasAppeal.missingOrWrongDocuments];
   const data = {
     pageTitle: 'Check and confirm',
     backLink: `/${getReviewOutcomeConfig(casework[hasAppeal.reviewOutcome]).view}`,
@@ -36,8 +37,12 @@ const viewData = (appealId, casework) => {
     };
   }
 
-  if (missingOrWrongDetails) {
-    data.missingOrWrongDetails = missingOrWrongDetails;
+  if (missingOrWrongReasons) {
+    data.missingOrWrongDetails = {
+      reasons: missingOrWrongReasons && JSON.parse(missingOrWrongReasons),
+      documentReasons: missingOrWrongDocuments && JSON.parse(missingOrWrongDocuments),
+      otherReason: casework[hasAppeal.missingOrWrongOtherReason],
+    };
   }
 
   return data;
@@ -52,7 +57,7 @@ const getCheckAndConfirm = (req, res) => {
     ...viewData(appeal.appealId, casework),
     appealData: appeal,
     checkAndConfirmConfig: getReviewOutcomeConfig(casework[hasAppeal.reviewOutcome]),
-    getText,
+    labels,
   };
 
   res.render(currentPage, options);
@@ -99,7 +104,7 @@ const postCheckAndConfirm = async (req, res) => {
     ...viewData(appeal.appealId, casework),
     appealData: appeal,
     checkAndConfirmConfig: getReviewOutcomeConfig(casework[hasAppeal.reviewOutcome]),
-    getText,
+    labels,
   };
 
   saveAndContinue({

--- a/packages/web-app/src/controllers/check-and-confirm.spec.js
+++ b/packages/web-app/src/controllers/check-and-confirm.spec.js
@@ -3,7 +3,7 @@ const views = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
 const { mockReq, mockRes } = require('../../test/utils/mocks');
 const {
-  getText,
+  labels,
   reviewOutcomeOption,
   getReviewOutcomeConfig,
 } = require('../config/review-appeal-submission');
@@ -21,11 +21,6 @@ describe('controllers/check-and-confirm', () => {
   const otherReason = 'Another invalid reason';
   const missingReasons = ['other', 'outOfTime'];
   const missingDocumentReasons = ['noApplicationForm'];
-  const missingOrWrong = {
-    reasons: missingReasons,
-    documentReasons: missingDocumentReasons,
-    otherReason,
-  };
 
   let req;
   let res;
@@ -56,7 +51,7 @@ describe('controllers/check-and-confirm', () => {
         validAppealDetails,
         appealData: req.session.appeal,
         checkAndConfirmConfig: getReviewOutcomeConfig(reviewOutcomeOption.valid),
-        getText,
+        labels,
       };
 
       getCheckAndConfirm(req, res);
@@ -85,7 +80,7 @@ describe('controllers/check-and-confirm', () => {
         invalidAppealDetails: { reasons: invalidAppealReasons, otherReason },
         appealData: req.session.appeal,
         checkAndConfirmConfig: getReviewOutcomeConfig(reviewOutcomeOption.invalid),
-        getText,
+        labels,
       };
 
       getCheckAndConfirm(req, res);
@@ -100,7 +95,9 @@ describe('controllers/check-and-confirm', () => {
           appeal: { appealId },
           casework: {
             [hasAppeal.reviewOutcome]: reviewOutcomeOption.incomplete,
-            missingOrWrong,
+            [hasAppeal.missingOrWrongReasons]: JSON.stringify(missingReasons),
+            [hasAppeal.missingOrWrongDocuments]: JSON.stringify(missingDocumentReasons),
+            [hasAppeal.missingOrWrongOtherReason]: otherReason,
           },
         },
       };
@@ -110,10 +107,14 @@ describe('controllers/check-and-confirm', () => {
         backLink: `/${views.missingOrWrong}`,
         changeOutcomeLink: `/${views.reviewAppealSubmission}/${appealId}`,
         reviewOutcome: reviewOutcomeOption.incomplete,
-        missingOrWrongDetails: missingOrWrong,
+        missingOrWrongDetails: {
+          reasons: missingReasons,
+          documentReasons: missingDocumentReasons,
+          otherReason,
+        },
         appealData: req.session.appeal,
         checkAndConfirmConfig: getReviewOutcomeConfig(reviewOutcomeOption.incomplete),
-        getText,
+        labels,
       };
 
       getCheckAndConfirm(req, res);
@@ -144,7 +145,7 @@ describe('controllers/check-and-confirm', () => {
         reviewOutcome: reviewOutcomeOption.incomplete,
         appealData: req.session.appeal,
         checkAndConfirmConfig: getReviewOutcomeConfig(reviewOutcomeOption.incomplete),
-        getText,
+        labels,
       };
 
       await postCheckAndConfirm(req, res);

--- a/packages/web-app/src/controllers/invalid-appeal-details.js
+++ b/packages/web-app/src/controllers/invalid-appeal-details.js
@@ -5,14 +5,14 @@ const {
   checkAndConfirm: nextPage,
 } = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
-const { getText } = require('../config/review-appeal-submission');
+const { labels } = require('../config/review-appeal-submission');
 const { hasAppeal } = require('../config/db-fields');
 const { saveAppealData } = require('../lib/api-wrapper');
 
 const viewData = (appealId, caseReference, invalid) => ({
   pageTitle: 'Invalid appeal details',
   backLink: `/${previousPage}/${appealId}`,
-  getText,
+  labels,
   invalid,
   appealReference: caseReference,
 });
@@ -29,7 +29,7 @@ const getInvalidAppealDetails = (req, res) => {
   } = req;
   const options = {
     ...viewData(appealId, caseReference, { reasons, otherReason }),
-    getText,
+    labels,
   };
   res.render(currentPage, options);
 };

--- a/packages/web-app/src/controllers/invalid-appeal-details.spec.js
+++ b/packages/web-app/src/controllers/invalid-appeal-details.spec.js
@@ -2,7 +2,7 @@ const { getInvalidAppealDetails, postInvalidAppealDetails } = require('./invalid
 const views = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
 const { mockReq, mockRes } = require('../../test/utils/mocks');
-const { getText } = require('../config/review-appeal-submission');
+const { labels } = require('../config/review-appeal-submission');
 const { hasAppeal } = require('../config/db-fields');
 const { saveAppealData } = require('../lib/api-wrapper');
 
@@ -16,7 +16,7 @@ describe('controllers/invalid-appeal-details', () => {
   const expectedViewData = {
     pageTitle: 'Invalid appeal details',
     backLink: `/${views.reviewAppealSubmission}/${appealId}`,
-    getText,
+    labels,
     invalid: { reasons, otherReason },
     appealReference: caseReference,
   };

--- a/packages/web-app/src/controllers/missing-or-wrong.spec.js
+++ b/packages/web-app/src/controllers/missing-or-wrong.spec.js
@@ -2,7 +2,7 @@ const { getMissingOrWrong, postMissingOrWrong } = require('./missing-or-wrong');
 const views = require('../config/views');
 const saveAndContinue = require('../lib/save-and-continue');
 const { mockReq, mockRes } = require('../../test/utils/mocks');
-const { getText } = require('../config/review-appeal-submission');
+const { labels } = require('../config/review-appeal-submission');
 const { saveAppealData } = require('../lib/api-wrapper');
 const { hasAppeal } = require('../config/db-fields');
 
@@ -11,17 +11,14 @@ jest.mock('../lib/save-and-continue');
 describe('controllers/missing-or-wrong', () => {
   const appealId = '5c943cb9-e029-4094-a447-4b3256d6ede7';
   const caseReference = '1234567';
-  const missingReasons = ['other', 'outOfTime'];
-  const missingDocumentReasons = ['noApplicationForm'];
+  const reasons = ['3', '7'];
+  const documentReasons = ['3'];
   const otherReason = 'other description';
   const expectedViewData = {
     pageTitle: 'What is missing or wrong?',
     backLink: `/${views.reviewAppealSubmission}/${appealId}`,
-    getText,
-    missingOrWrong: {
-      reasons: [...missingReasons, ...missingDocumentReasons],
-      otherReason,
-    },
+    labels,
+    missingOrWrong: { reasons, documentReasons, otherReason },
     appealReference: caseReference,
   };
 
@@ -39,8 +36,9 @@ describe('controllers/missing-or-wrong', () => {
         session: {
           appeal: { appealId, caseReference },
           casework: {
-            [hasAppeal.invalidAppealReasons]: [...missingReasons, ...missingDocumentReasons],
-            [hasAppeal.invalidReasonOther]: otherReason,
+            [hasAppeal.missingOrWrongReasons]: reasons,
+            [hasAppeal.missingOrWrongDocuments]: documentReasons,
+            [hasAppeal.missingOrWrongOtherReason]: otherReason,
           },
         },
       };
@@ -56,8 +54,8 @@ describe('controllers/missing-or-wrong', () => {
     it('should call saveAndContinue with the correct params', () => {
       req = {
         body: {
-          'missing-or-wrong-reasons': missingReasons,
-          'missing-or-wrong-documents': missingDocumentReasons,
+          'missing-or-wrong-reasons': reasons,
+          'missing-or-wrong-documents': documentReasons,
           'other-reason': otherReason,
         },
         session: {
@@ -77,10 +75,13 @@ describe('controllers/missing-or-wrong', () => {
         viewData: expectedViewData,
         saveData: saveAppealData,
       });
-      expect(req.session.casework[hasAppeal.invalidAppealReasons]).toEqual(
-        JSON.stringify([...missingReasons, ...missingDocumentReasons])
+      expect(req.session.casework[hasAppeal.missingOrWrongReasons]).toEqual(
+        JSON.stringify(reasons)
       );
-      expect(req.session.casework[hasAppeal.invalidReasonOther]).toEqual(otherReason);
+      expect(req.session.casework[hasAppeal.missingOrWrongDocuments]).toEqual(
+        JSON.stringify(documentReasons)
+      );
+      expect(req.session.casework[hasAppeal.missingOrWrongOtherReason]).toEqual(otherReason);
     });
   });
 });

--- a/packages/web-app/src/validation/check-and-confirm.js
+++ b/packages/web-app/src/validation/check-and-confirm.js
@@ -1,12 +1,11 @@
 const { body } = require('express-validator');
 const { reviewOutcomeOption } = require('../config/review-appeal-submission');
+const { hasAppeal } = require('../config/db-fields');
 
 const checkAndConfirmValidation = () =>
   body('check-and-confirm-completed').custom((value, { req }) => {
-    if (
-      req.session.casework?.reviewOutcome === reviewOutcomeOption.incomplete &&
-      value !== 'true'
-    ) {
+    const { casework = {} } = req.session;
+    if (casework[hasAppeal.reviewOutcome] === reviewOutcomeOption.incomplete && value !== 'true') {
       throw new Error('Confirm if you have completed all follow-up tasks and emails');
     }
     return true;

--- a/packages/web-app/src/validation/check-and-confirm.spec.js
+++ b/packages/web-app/src/validation/check-and-confirm.spec.js
@@ -1,6 +1,7 @@
 const { validationResult } = require('express-validator');
 const { checkAndConfirmValidation } = require('./check-and-confirm');
 const { reviewOutcomeOption } = require('../config/review-appeal-submission');
+const { hasAppeal } = require('../config/db-fields');
 
 describe('validation/check-and-confirm', () => {
   let req;
@@ -32,10 +33,8 @@ describe('validation/check-and-confirm', () => {
         'check-and-confirm-completed': 'true',
       },
       session: {
-        appeal: {
-          casework: {
-            reviewOutcome: reviewOutcomeOption.incomplete,
-          },
+        casework: {
+          [hasAppeal.reviewOutcome]: reviewOutcomeOption.incomplete,
         },
       },
     };
@@ -52,7 +51,7 @@ describe('validation/check-and-confirm', () => {
       body: {},
       session: {
         casework: {
-          reviewOutcome: reviewOutcomeOption.incomplete,
+          [hasAppeal.reviewOutcome]: reviewOutcomeOption.incomplete,
         },
       },
     };

--- a/packages/web-app/src/validation/missing-or-wrong.js
+++ b/packages/web-app/src/validation/missing-or-wrong.js
@@ -1,22 +1,8 @@
 const { body } = require('express-validator');
 const validateCheckboxValueAgainstOptions = require('./utils/validate-checkbox-against-options');
 
-const validReasonOptions = [
-  'namesNotMatch',
-  'sensitiveInformationIncluded',
-  'missingOrWrongDocuments',
-  'inflammatoryComments',
-  'openedInError',
-  'wrongAppealType',
-  'other',
-];
-
-const validDocumentOptions = [
-  'noApplicationForm',
-  'noDecisionNotice',
-  'noGroundsOfAppeal',
-  'noSupportingDocuments',
-];
+const validReasonOptions = ['1', '2', '3', '4', '5', '6', '7'];
+const validDocumentOptions = ['1', '2', '3', '4'];
 
 const missingOrWrongAppealDetailsValidation = () => [
   body('missing-or-wrong-reasons')
@@ -30,7 +16,7 @@ const missingOrWrongAppealDetailsValidation = () => [
     .custom((value, { req }) => {
       const reasons = req.body['missing-or-wrong-reasons'];
       /* istanbul ignore else  */
-      if (reasons?.includes('missingOrWrongDocuments') && !value) {
+      if (reasons?.includes('3') && !value) {
         throw new Error('Select which documents are missing or wrong');
       }
       return true;
@@ -38,7 +24,7 @@ const missingOrWrongAppealDetailsValidation = () => [
   body('other-reason').custom((value, { req }) => {
     const reasons = req.body['missing-or-wrong-reasons'];
     /* istanbul ignore else  */
-    if (reasons && reasons.includes('other')) {
+    if (reasons && reasons.includes('7')) {
       if (!value || value.trim().length === 0) {
         throw new Error('Enter what is missing or wrong in the appeal submission');
       }

--- a/packages/web-app/src/validation/missing-or-wrong.spec.js
+++ b/packages/web-app/src/validation/missing-or-wrong.spec.js
@@ -15,8 +15,8 @@ describe('validation/missing-or-wrong', () => {
   it('should pass validation when given a value', async () => {
     req = {
       body: {
-        'missing-or-wrong-reasons': ['other', 'missingOrWrongDocuments'],
-        'missing-or-wrong-documents': 'noApplicationForm',
+        'missing-or-wrong-reasons': ['3', '7'],
+        'missing-or-wrong-documents': '1',
         'other-reason': 'other description',
       },
     };
@@ -49,7 +49,7 @@ describe('validation/missing-or-wrong', () => {
   it('should fail validation if "other" option is chosen but there is no description', async () => {
     req = {
       body: {
-        'missing-or-wrong-reasons': ['other'],
+        'missing-or-wrong-reasons': ['7'],
       },
     };
 
@@ -70,7 +70,7 @@ describe('validation/missing-or-wrong', () => {
   it('should fail validation if "missingOrWrongDocuments" option is chosen but no sub option selected', async () => {
     req = {
       body: {
-        'missing-or-wrong-reasons': ['missingOrWrongDocuments'],
+        'missing-or-wrong-reasons': ['3'],
       },
     };
 
@@ -88,10 +88,10 @@ describe('validation/missing-or-wrong', () => {
     ]);
   });
 
-  it('should fail validation if request contains a reason with a wrong name', async () => {
+  it('should fail validation if request contains a reason with an incorrect value', async () => {
     req = {
       body: {
-        'missing-or-wrong-reasons': ['other', 'missingOrWrongDocumentsss'],
+        'missing-or-wrong-reasons': ['8'],
       },
     };
 
@@ -109,10 +109,10 @@ describe('validation/missing-or-wrong', () => {
     ]);
   });
 
-  it('should fail validation if request contains a document reason with a wrong name', async () => {
+  it('should fail validation if request contains a document reason with an incorrect value', async () => {
     req = {
       body: {
-        'missing-or-wrong-documents': ['noApplicationForms', 'noDecisionNotice'],
+        'missing-or-wrong-documents': ['5'],
       },
     };
 

--- a/packages/web-app/src/views/check-and-confirm.njk
+++ b/packages/web-app/src/views/check-and-confirm.njk
@@ -18,23 +18,23 @@
 
 {% macro renderInvalidReason() %}
   {% for item in invalidAppealDetails.reasons %}
-    <li>{{ getText(item) + (' - ' + invalidAppealDetails.otherReason if item === '5') }}</li>
+    <li>{{ labels.invalidAppealReasons[item] + (' - ' + invalidAppealDetails.otherReason if item === '5') }}</li>
   {% endfor %}
 {% endmacro %}
 
 {% macro renderIncompleteReason() %}
   {% for item in missingOrWrongDetails.reasons %}
-    {% if item === 'missingOrWrongDocuments' %}
+    {% if item === '3' %}
       <li>
-        {{ getText(item) }}
+        {{ labels.missingOrWrongReasons[item] }}
         <ul class="govuk-list govuk-list--bullet">
           {% for documentReason in missingOrWrongDetails.documentReasons %}
-            <li>{{ getText(documentReason) }}</li>
+            <li>{{ labels.missingOrWrongDocuments[documentReason] }}</li>
           {% endfor %}
         </ul>
       </li>
     {% else %}
-      <li>{{ getText(item) + (' - ' + invalidAppealDetails.otherReason if item === 'other') }}</li>
+      <li>{{ labels.missingOrWrongReasons[item] + (' - ' + missingOrWrongDetails.otherReason if item === '7') }}</li>
     {% endif %}
   {% endfor %}
 {% endmacro %}

--- a/packages/web-app/src/views/invalid-appeal-details.njk
+++ b/packages/web-app/src/views/invalid-appeal-details.njk
@@ -41,27 +41,27 @@
     items: [
       {
         value: "1",
-        text: getText("1"),
+        text: labels.invalidAppealReasons[1],
         checked: invalid and invalid.reasons and invalid.reasons.includes('1')
       },
       {
         value: "2",
-        text: getText("2"),
+        text: labels.invalidAppealReasons[2],
         checked: invalid and invalid.reasons and invalid.reasons.includes('2')
       },
       {
         value: "3",
-        text: getText("3"),
+        text: labels.invalidAppealReasons[3],
         checked: invalid and invalid.reasons and invalid.reasons.includes('3')
       },
       {
         value: "4",
-        text: getText("4"),
+        text: labels.invalidAppealReasons[4],
         checked: invalid and invalid.reasons and invalid.reasons.includes('4')
       },
       {
         value: "5",
-        text: getText("5"),
+        text: labels.invalidAppealReasons[5],
         checked: invalid and invalid.reasons and invalid.reasons.includes('5'),
         conditional: {
           html: otherHtml

--- a/packages/web-app/src/views/missing-or-wrong.njk
+++ b/packages/web-app/src/views/missing-or-wrong.njk
@@ -8,17 +8,17 @@
 {% set documentsError = errors['missing-or-wrong-documents'].msg %}
 {% set otherError = errors['other-reason'].msg %}
 
-{% set noApplicationFormChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('noApplicationForm') %}
-{% set noDecisionNoticeChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('noDecisionNotice') %}
-{% set noGroundsOfAppealChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('noGroundsOfAppeal') %}
-{% set noSupportingDocumentsChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('noSupportingDocuments') %}
-{% set namesNotMatchChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('namesNotMatch') %}
-{% set sensitiveInformationIncludedChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('sensitiveInformationIncluded') %}
-{% set missingOrWrongDocumentsChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('missingOrWrongDocuments') %}
-{% set inflammatoryCommentsChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('inflammatoryComments') %}
-{% set openedInErrorChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('openedInError') %}
-{% set wrongAppealTypeChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('wrongAppealType') %}
-{% set otherChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('other') %}
+{% set noApplicationFormChecked = missingOrWrong.documentReasons and missingOrWrong.documentReasons.includes and missingOrWrong.documentReasons.includes('1') %}
+{% set noDecisionNoticeChecked = missingOrWrong.documentReasons and missingOrWrong.documentReasons.includes and missingOrWrong.documentReasons.includes('2') %}
+{% set noGroundsOfAppealChecked = missingOrWrong.documentReasons and missingOrWrong.documentReasons.includes and missingOrWrong.documentReasons.includes('3') %}
+{% set noSupportingDocumentsChecked = missingOrWrong.documentReasons and missingOrWrong.documentReasons.includes and missingOrWrong.documentReasons.includes('4') %}
+{% set namesNotMatchChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('1') %}
+{% set sensitiveInformationIncludedChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('2') %}
+{% set missingOrWrongDocumentsChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('3') %}
+{% set inflammatoryCommentsChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('4') %}
+{% set openedInErrorChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('5') %}
+{% set wrongAppealTypeChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('6') %}
+{% set otherChecked = missingOrWrong.reasons and missingOrWrong.reasons.includes and missingOrWrong.reasons.includes('7') %}
 
 {% block formContent %}
   <p class="govuk-body">Appeal reference: {{appealReference}}</p>
@@ -46,23 +46,23 @@
       },
       items: [
         {
-          value: "noApplicationForm",
-          text: getText("noApplicationForm"),
+          value: "1",
+          text: labels.missingOrWrongDocuments[1],
           checked: noApplicationFormChecked
         },
         {
-          value: "noDecisionNotice",
-          text: getText("noDecisionNotice"),
+          value: "2",
+          text: labels.missingOrWrongDocuments[2],
           checked: noDecisionNoticeChecked
         },
         {
-          value: "noGroundsOfAppeal",
-          text: getText("noGroundsOfAppeal"),
+          value: "3",
+          text: labels.missingOrWrongDocuments[3],
           checked: noGroundsOfAppealChecked
         },
         {
-          value: "noSupportingDocuments",
-          text: getText("noSupportingDocuments"),
+          value: "4",
+          text: labels.missingOrWrongDocuments[4],
           checked: noSupportingDocumentsChecked
         }
       ]
@@ -77,41 +77,41 @@
     },
     items: [
       {
-        value: "namesNotMatch",
-        text: getText("namesNotMatch"),
+        value: "1",
+        text: labels.missingOrWrongReasons[1],
         checked: namesNotMatchChecked
       },
       {
-        value: "sensitiveInformationIncluded",
-        text: getText("sensitiveInformationIncluded"),
+        value: "2",
+        text: labels.missingOrWrongReasons[2],
         checked: sensitiveInformationIncludedChecked
       },
       {
-        value: "missingOrWrongDocuments",
-        text: getText("missingOrWrongDocuments"),
+        value: "3",
+        text: labels.missingOrWrongReasons[3],
         checked: missingOrWrongDocumentsChecked,
         conditional: {
           html: missingOrWrongDocumentsHtml
         }
       },
       {
-        value: "inflammatoryComments",
-        text: getText("inflammatoryComments"),
+        value: "4",
+        text: labels.missingOrWrongReasons[4],
         checked: inflammatoryCommentsChecked
       },
       {
-        value: "openedInError",
-        text: getText("openedInError"),
+        value: "5",
+        text: labels.missingOrWrongReasons[5],
         checked: openedInErrorChecked
       },
       {
-        value: "wrongAppealType",
-        text: getText("wrongAppealType"),
+        value: "6",
+        text: labels.missingOrWrongReasons[6],
         checked: wrongAppealTypeChecked
       },
       {
-        value: "other",
-        text: getText("other"),
+        value: "7",
+        text: labels.missingOrWrongReasons[7],
         checked: otherChecked,
         conditional: {
           html: otherHtml


### PR DESCRIPTION
**Back Office - Something missing or wrong reasons are not displayed in Check confirm page**

Ticket - https://pins-ds.atlassian.net/browse/AS-3877

- Added `MissingOrWrongReasons`, `MissingOrWrongDocuments` and `MissingOrWrongOtherReason` to the `HASAppeal` table to store the data from the Something is Missing or Wrong page. Also updated the Stored Procedure and Trigger for this table to include these new fields and the appeal and questionnaire views to return the data.

- Updated the Something is Missing or Wrong page to save data into the new db fields.

- Updated the Check and Confirm page to display the Something is Missing Or Wrong reasons.

- Updated the validation for the 'I have completed all follow-up tasks and emails' field on the Check and Confirm page, which wasn't erroring if the box wasn't checked.