### PR TITLE
BOCM-32: fix

### DIFF
--- a/apps/web/src/server/app/validation/validation.controller.js
+++ b/apps/web/src/server/app/validation/validation.controller.js
@@ -1,6 +1,6 @@
 import { to } from 'planning-inspectorate-libs';
 import { validationRoutesConfig as routes } from '../../config/routes.js';
-import { checkboxDataToCheckValuesObject } from '../../lib/helpers.js';
+import { checkboxDataToCheckValuesObject, arrayifyIfString } from '../../lib/helpers.js';
 import { findAllNewIncompleteAppeals, findAppealById } from './validation.service.js';
 import { validationLabelsMap, validationAppealOutcomeLabelsMap } from './validation.config.js';
 
@@ -273,12 +273,13 @@ export function getCheckAndConfirm(request, response) {
 	const appealWork = request.session.appealWork;
 
 	let incompleteReasons;
-	if (appealWork.incompleteAppealDetails) {
-		if (Array.isArray(appealWork.incompleteAppealDetails.incompleteReasons)) {
-			incompleteReasons = [...appealWork.incompleteAppealDetails.incompleteReasons];
-		} else if (typeof appealWork.incompleteAppealDetails.incompleteReasons === 'string') {
-			incompleteReasons = [appealWork.incompleteAppealDetails.incompleteReasons];
-		}
+	if (appealWork.incompleteAppealDetails && appealWork.incompleteAppealDetails.incompleteReasons) {
+		incompleteReasons = arrayifyIfString(appealWork.incompleteAppealDetails.incompleteReasons);
+	}
+
+	let missingOrWrongDocumentsReasons;
+	if (appealWork.incompleteAppealDetails && appealWork.incompleteAppealDetails.missingOrWrongDocumentsReasons) {
+		missingOrWrongDocumentsReasons = arrayifyIfString(appealWork.incompleteAppealDetails.missingOrWrongDocumentsReasons);
 	}
 
 	response.render(routes.checkAndConfirm.view, {
@@ -287,6 +288,7 @@ export function getCheckAndConfirm(request, response) {
 		appealData,
 		appealWork,
 		incompleteReasons,
+		missingOrWrongDocumentsReasons,
 		validationLabelsMap,
 		validationAppealOutcomeLabels: validationAppealOutcomeLabelsMap[appealWork.reviewOutcome]
 	});

--- a/apps/web/src/server/lib/helpers.js
+++ b/apps/web/src/server/lib/helpers.js
@@ -24,11 +24,33 @@ export const checkboxDataToCheckValuesObject = (checkboxData) => {
 	}
 };
 
-export const makeValidator_StringMatchesOrArrayContainsMatch = (valueToMatch) => (value) => {
+/**
+ * Factory which creates a function to be passed to an express-validator custom validator
+ * The factory function takes a string to match against
+ * The returned validator function takes either a string or an array of strings as input
+ * If value is an array, it returns true if the array contains the string to match against
+ * Else if value is a string, it returns true if it matches the string to match against
+ * Else it returns false
+ * @param {string} stringToMatch - the value to match against
+ * @returns {bool} - true if the string matches or if the array contains a match, else false
+ */
+export const makeValidator_StringMatchesOrArrayContainsMatch = (stringToMatch) => (value) => {
 	if (Array.isArray(value)) {
-		return value.includes(valueToMatch);
+		return value.includes(stringToMatch);
 	} else if (typeof value === 'string') {
-		return value === valueToMatch;
+		return value === stringToMatch;
 	}
 	return false;
+};
+
+/**
+ * Returns the supplied value wrapped in an array, if it is a string. Otherwise returns the value unmodified.
+ * Used to ensure checkbox values are always an array of ID strings, even when only one checkbox is checked,
+ * in which case the raw value would just be a string.
+ * @param {array<string> | string | any} value - the value to normalize
+ * @returns {array<string> | any} - an array containing the string, or the unmodified value if it is not a string
+ */
+export const arrayifyIfString = (value) => {
+	if (typeof value === 'string') return [value];
+	return value;
 };

--- a/apps/web/src/server/views/validation/check-and-confirm.njk
+++ b/apps/web/src/server/views/validation/check-and-confirm.njk
@@ -21,7 +21,7 @@
 					<li>
 						{{ validationLabelsMap.incompleteAppealReasons[item] }}
 						<ul class="govuk-list govuk-list--bullet">
-							{% for documentReason in appealWork.incompleteAppealDetails.missingOrWrongDocumentsReasons %}
+							{% for documentReason in missingOrWrongDocumentsReasons %}
 								<li>{{ validationLabelsMap.incompleteAppealMissingOrWrongDocumentsReasons[documentReason] }}</li>
 							{% endfor %}
 						</ul>


### PR DESCRIPTION
Fixed issue where missing or wrong docs reasons rendering was broken on check and confirm page if only one reason was selected

## Describe your changes

Added arrayifyIfString helper function and used it to normalise the incompleteReasons and missingOrWrongDocumentsReasons passed to the check and confirm template. This fixes an issue where if only one reason is selected, the template erroneously treats the string value as an array.

## Issue ticket number and link

N/A

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
