### PR TITLE
BOCM-219 fix

### DIFF
--- a/apps/web/src/server/app/validation/validation.controller.js
+++ b/apps/web/src/server/app/validation/validation.controller.js
@@ -328,12 +328,14 @@ export function getCheckAndConfirm(request, response) {
 	let backURL;
 
 	if ('invalidAppealDetails' in appealWork) {
-		backURL = `/validation/${routes.reviewAppealRoute.path}/${appealData.AppealId}?direction=back`;
+		backURL = `/validation/${routes.invalidAppealOutcome.path}?direction=back`;
 	} else if ('incompleteAppealDetails' in appealWork) {
 		backURL = `/validation/${routes.incompleteAppealOutcome.path}?direction=back`;
 	} else {
 		backURL = `/validation/${routes.validAppealOutcome.path}?direction=back`;
 	}
+
+	const changeOutcomeURL = `/validation/${routes.reviewAppealRoute.path}/${appealData.AppealId}?direction=back`;
 
 	let invalidReasons;
 	if (appealWork.invalidAppealDetails && appealWork.invalidAppealDetails.invalidReasons) {
@@ -359,7 +361,7 @@ export function getCheckAndConfirm(request, response) {
 
 	response.render(routes.checkAndConfirm.view, {
 		backURL,
-		changeOutcomeURL: backURL,
+		changeOutcomeURL,
 		appealData,
 		appealWork,
 		invalidReasons,

--- a/apps/web/src/server/app/validation/validation.controller.js
+++ b/apps/web/src/server/app/validation/validation.controller.js
@@ -328,7 +328,7 @@ export function getCheckAndConfirm(request, response) {
 	let backURL;
 
 	if ('invalidAppealDetails' in appealWork) {
-		backURL = `/validation/${routes.invalidAppealOutcome.path}?direction=back`;
+		backURL = `/validation/${routes.reviewAppealRoute.path}/${appealData.AppealId}?direction=back`;
 	} else if ('incompleteAppealDetails' in appealWork) {
 		backURL = `/validation/${routes.incompleteAppealOutcome.path}?direction=back`;
 	} else {


### PR DESCRIPTION
Fix for incorrect back url on validation check and confirm page (for invalid outcome)

## Describe your changes

Updated back URL for validation journey check and confirm page, when user has selected invalid outcome for the review

## Issue ticket number and link

[BOCM-219](https://pins-ds.atlassian.net/browse/BOCM-219)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)
