### PR TITLE
Update Sass include paths to use node_modules

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@hapi/boom": "9.1.4",
+    "accessible-autocomplete": "2.0.4",
     "body-parser": "1.19.2",
     "classnames": "^2.3.1",
     "compression": "1.7.4",

--- a/apps/web/scripts/compile-css.js
+++ b/apps/web/scripts/compile-css.js
@@ -33,10 +33,10 @@ function compileCSS(input) {
 		loadPaths: [
 			resolvePath(`src/styles/env/${isProduction ? 'production' : 'development'}`),
 			resolvePath(`src/styles/dev/${isRelease ? 'release' : 'dev'}`),
-			// TODO: Find a better way to include these paths.
+			// TODO: Find a better way to include the `node_modules` folder.
 			// We are including the govuk-frontend to be fix the NPM workspaces module resolution issues
 			// as we can't import files directly from the node_modules folder.
-			path.resolve(require.resolve('govuk-frontend'), '../..')
+			path.resolve(require.resolve('govuk-frontend/package.json'), '../..')
 		]
 	};
 

--- a/apps/web/src/styles/7-components/InfoBox/InfoBox.scss
+++ b/apps/web/src/styles/7-components/InfoBox/InfoBox.scss
@@ -1,4 +1,4 @@
-@use "govuk/settings/_colours-applied" as colors;
+@use "govuk-frontend/govuk/settings/_colours-applied" as colors;
 
 .pi-info-box {
 	background-color: colors.govuk-colour("light-grey");

--- a/apps/web/src/styles/README.md
+++ b/apps/web/src/styles/README.md
@@ -32,6 +32,27 @@ Folder/File structure follows ITCSS, and everything else its a mixture of BEM an
 
 We use the [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/) design system with all its defaults.
 
+In order to import and use the GOV.UK mixins and functions or anything else we have to import them like this:
+
+```scss
+@use "govuk-frontend/govuk/base" as govuk;
+
+.test {
+	@include govuk.govuk-responsive-padding(4);
+	@include base.govuk-responsive-margin(6, 'bottom');
+}
+```
+
+This actually imports the follwing:
+
+```scss
+@import "settings/all";
+@import "tools/all";
+@import "helpers/all";
+```
+
+so you will have access to everything via `govuk.` namespace.
+
 ## Getting started
 
 There are a handful of things we need to do before we’re ready to go.

--- a/apps/web/src/styles/main.scss
+++ b/apps/web/src/styles/main.scss
@@ -1,5 +1,5 @@
 // Use the GDS Design System as a foundation
-@use "govuk/all" with (
+@use "govuk-frontend/govuk/all" with (
 	$govuk-assets-path: "/",
 	$govuk-images-path: "/images/",
 	$govuk-fonts-path: "/fonts/"
@@ -10,6 +10,9 @@
 // 1 - SETTINGS
 // 2 - DESIGN TOKENS
 // 3 - TOOLS (functions, mixins)
+
+// Vendors
+@use "accessible-autocomplete/src/autocomplete.css" as accessible-autocomplete;
 
 // 4 - GENERIC
 @use "4-generic/generic.box-sizing" as generic-box-sizing;

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hapi/boom": "9.1.4",
+        "accessible-autocomplete": "2.0.4",
         "body-parser": "1.19.2",
         "classnames": "^2.3.1",
         "compression": "1.7.4",
@@ -2422,6 +2423,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accessible-autocomplete": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+      "dependencies": {
+        "preact": "^8.3.1"
       }
     },
     "node_modules/acorn": {
@@ -8330,6 +8339,12 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/preact": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
+      "hasInstallScript": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12716,6 +12731,14 @@
         "negotiator": "0.6.3"
       }
     },
+    "accessible-autocomplete": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+      "requires": {
+        "preact": "^8.3.1"
+      }
+    },
     "acorn": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
@@ -17085,6 +17108,11 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "preact": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -18798,6 +18826,7 @@
         "@rollup/plugin-virtual": "^2.1.0",
         "@types/express": "^4.17.13",
         "@types/express-session": "^1.17.4",
+        "accessible-autocomplete": "2.0.4",
         "autoprefixer": "^10.4.2",
         "body-parser": "1.19.2",
         "chokidar-cli": "^3.0.0",


### PR DESCRIPTION
## Describe your changes

I have updated the sass include paths to use the node_modules folder instead of 1 by 1 basis, and added more info on how to use the GOVUK mixins and functions

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
