### PR TITLE
Change token used for pipeline templates

### DIFF
--- a/apps/api/pipelines/azure-pipelines-build.yml
+++ b/apps/api/pipelines/azure-pipelines-build.yml
@@ -8,7 +8,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      endpoint: Back Office Token
+      endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
 
 extends:

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -23,7 +23,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      endpoint: Back Office Token
+      endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
   pipelines:
     - pipeline: back-office-api-build

--- a/apps/web/pipelines/azure-pipelines-build.yml
+++ b/apps/web/pipelines/azure-pipelines-build.yml
@@ -8,7 +8,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      endpoint: Back Office Token
+      endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
 
 extends:

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -19,7 +19,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      endpoint: Back Office Token
+      endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
   pipelines:
     - pipeline: back-office-web-build


### PR DESCRIPTION
## Describe your changes

Swap token used by the pipelines to get templates. The "Planning-Inspectorate" token is automatically created and uses the GitHub Azure Pipelines app instead of an OAuth token. This will stop the token expiring and the need for it to be refreshed.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
