### PR TITLE
Enable approvals prior to App Service slot swap

### DIFF
--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.2.1
+      ref: refs/tags/release/2.4.0
   pipelines:
     - pipeline: back-office-api-build
       source: Back Office API Build

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -56,6 +56,7 @@ extends:
               appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
+              tag: develop
           - template: ../steps/azure_web_app_slot_swap.yml
             parameters:
               appName: $(webAppName)

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.4.3
+      ref: refs/tags/release/2.5.0
   pipelines:
     - pipeline: back-office-api-build
       source: Back Office API Build

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.4.0
+      ref: refs/tags/release/2.4.2
   pipelines:
     - pipeline: back-office-api-build
       source: Back Office API Build

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.4.2
+      ref: refs/tags/release/2.4.3
   pipelines:
     - pipeline: back-office-api-build
       source: Back Office API Build

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -34,7 +34,7 @@ extends:
   template: stages/wrapper_cd.yml@templates
   parameters:
     deploymentStages:
-      - name: Deploy
+      - name: Stage
         deploymentSteps:
           - ${{ if eq(parameters.schemaMigration, true) }}:
             - checkout: self
@@ -57,6 +57,10 @@ extends:
               azurecrName: $(azurecrName)
               repository: $(repository)
               tag: develop
+      - name: Deploy
+        dependsOn:
+          - Stage
+        deploymentSteps:
           - template: ../steps/azure_web_app_slot_swap.yml
             parameters:
               appName: $(webAppName)

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -49,12 +49,19 @@ extends:
                   DATABASE_URL: $(DATABASE_URL)
                 script: npm run db:migrate:prod
                 workingDirectory: $(Build.Repository.LocalPath)/apps/api
-          - template: ../steps/azure_web_app_slot_swap_deploy.yml
+          - template: ../steps/azure_web_app_deploy.yml
             parameters:
               appName: $(webAppName)
               appResourceGroup: $(resourceGroup)
+              appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
+          - template: ../steps/azure_web_app_slot_swap.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              appStagingSlotName: staging
+              appTargetSlotName: production
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: apps/api/pipelines/azure-pipelines-variables.yml@self

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -56,7 +56,6 @@ extends:
               appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
-              tag: develop
       - name: Deploy
         dependsOn:
           - Stage

--- a/apps/api/pipelines/azure-pipelines-release.yml
+++ b/apps/api/pipelines/azure-pipelines-release.yml
@@ -21,7 +21,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.5.0
+      ref: refs/tags/release/2.5.1
   pipelines:
     - pipeline: back-office-api-build
       source: Back Office API Build

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -30,7 +30,7 @@ extends:
   template: stages/wrapper_cd.yml@templates
   parameters:
     deploymentStages:
-      - name: Deploy
+      - name: Stage
         deploymentSteps:
           - script: |
               buildName=$(versionNumber)_$(Build.BuildId)
@@ -45,6 +45,10 @@ extends:
               azurecrName: $(azurecrName)
               repository: $(repository)
               tag: develop
+      - name: Deploy
+        dependsOn:
+          - Stage
+        deploymentSteps:
           - template: ../steps/azure_web_app_slot_swap.yml
             parameters:
               appName: $(webAppName)

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.2.1
+      ref: refs/tags/release/2.4.0
   pipelines:
     - pipeline: back-office-web-build
       source: Back Office Web Build

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.4.0
+      ref: refs/tags/release/2.4.2
   pipelines:
     - pipeline: back-office-web-build
       source: Back Office Web Build

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -44,6 +44,7 @@ extends:
               appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
+              tag: develop
           - template: ../steps/azure_web_app_slot_swap.yml
             parameters:
               appName: $(webAppName)

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.4.2
+      ref: refs/tags/release/2.4.3
   pipelines:
     - pipeline: back-office-web-build
       source: Back Office Web Build

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.4.3
+      ref: refs/tags/release/2.5.0
   pipelines:
     - pipeline: back-office-web-build
       source: Back Office Web Build

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -37,12 +37,19 @@ extends:
               echo "Setting the name of the build to '$buildName'."
               echo "##vso[build.updatebuildnumber]$buildName"
             displayName: Set Build Number
-          - template: ../steps/azure_web_app_slot_swap_deploy.yml
+          - template: ../steps/azure_web_app_deploy.yml
             parameters:
               appName: $(webAppName)
               appResourceGroup: $(resourceGroup)
+              appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
+          - template: ../steps/azure_web_app_slot_swap.yml
+            parameters:
+              appName: $(webAppName)
+              appResourceGroup: $(resourceGroup)
+              appStagingSlotName: staging
+              appTargetSlotName: production
     globalVariables:
       - template: azure-pipelines-variables.yml@self
       - template: apps/web/pipelines/azure-pipelines-variables.yml@self

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -44,7 +44,6 @@ extends:
               appSlotName: staging
               azurecrName: $(azurecrName)
               repository: $(repository)
-              tag: develop
       - name: Deploy
         dependsOn:
           - Stage

--- a/apps/web/pipelines/azure-pipelines-release.yml
+++ b/apps/web/pipelines/azure-pipelines-release.yml
@@ -17,7 +17,7 @@ resources:
       type: github
       endpoint: Planning-Inspectorate
       name: Planning-Inspectorate/common-pipeline-templates
-      ref: refs/tags/release/2.5.0
+      ref: refs/tags/release/2.5.1
   pipelines:
     - pipeline: back-office-web-build
       source: Back Office Web Build


### PR DESCRIPTION
## Describe your changes

Splits the App Service deploy and slot swap steps into individual stages. This allows deployments in Test and Production environments to seek manual approval prior to swapping a deployment into a production slot thereby allowing a developer to check the staged deployment prior to go-live in the respective environment.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
