### PR TITLE
fix(web/appeals): fix upload file on statements form (boas-185)

### DIFF
--- a/apps/web/src/server/app/app.express.js
+++ b/apps/web/src/server/app/app.express.js
@@ -1,5 +1,4 @@
 import { installRequestLocalsMiddleware } from '@pins/express';
-import config from '@pins/web/environment/config.js';
 import bodyParser from 'body-parser';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
@@ -70,17 +69,15 @@ app.use(msalMiddleware);
 app.use(session);
 
 // CSRF middleware via session
-if (!config.isTest) {
-	app.use(
-		// where request uses multipart form body, then extract csrf token before verifying it
-		multer().none(),
-		csurf({ cookie: false }),
-		(request, response, next) => {
-			response.locals.csrfToken = request.csrfToken();
-			next();
-		}
-	);
-}
+app.use(
+	// @ts-ignore – Multer cannot be a string
+	multer(),
+	csurf({ cookie: false }),
+	(request, response, next) => {
+		response.locals.csrfToken = request.csrfToken();
+		next();
+	}
+);
 
 // Set the express view engine to nunjucks.
 nunjucksEnvironment.express(app);

--- a/apps/web/src/server/app/app.express.js
+++ b/apps/web/src/server/app/app.express.js
@@ -70,6 +70,7 @@ app.use(session);
 
 // CSRF middleware via session
 app.use(
+	// where request uses multipart form body, then extract csrf token before verifying it
 	// @ts-ignore – Multer cannot be a string
 	multer(),
 	csurf({ cookie: false }),


### PR DESCRIPTION
## Describe your changes

Passing Multer().none() to the express middleware fixes the JsDocs error but creates a new one when trying to upload files.
Now the whole instance of multer() is passed and the error is just ignored.

Also,

No reason to have this working differently on the test env.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/BOAS-185
## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
