### PR TITLE
fix/BOAS-217-fix-npm-run-dev-in-Windows

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "NODE_ENV=test cross-env ava --no-worker-threads",
     "coverage": "c8 --reporter=html --reporter=text ava",
-    "dev": "npm run build && nodemon --experimental-json-modules -e js ./src/server.js",
+    "dev": "npm run prisma-generate && nodemon --experimental-json-modules -e js ./src/server.js",
     "start": "node ./src/server.js",
     "lint:js": "eslint src prisma/seed.js",
     "lint:js:fix": "eslint src prisma/seed.js --fix",
@@ -22,10 +22,9 @@
     "db:migrate": "npx prisma migrate dev",
     "db:migrate:prod": "npx prisma migrate deploy",
     "db:reset": "npx prisma migrate reset",
-    "db:seed": "npm run build && npx prisma db seed",
+    "db:seed": "npm run prisma-generate && npx prisma db seed",
     "prisma:format": "npx prisma format",
     "prisma-generate": "npx prisma generate",
-    "build": "npx prisma generate",
     "tscheck": "npx tsc -p jsconfig.json --maxNodeModuleJsDepth 0"
   },
   "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "test": "NODE_ENV=test cross-env ava --no-worker-threads",
     "coverage": "c8 --reporter=html --reporter=text ava",
-    "dev": "npm run prisma:generate && nodemon --experimental-json-modules -e js ./src/server.js",
+    "dev": "npm run build && nodemon --experimental-json-modules -e js ./src/server.js",
     "start": "node ./src/server.js",
     "lint:js": "eslint src prisma/seed.js",
     "lint:js:fix": "eslint src prisma/seed.js --fix",
@@ -22,10 +22,10 @@
     "db:migrate": "npx prisma migrate dev",
     "db:migrate:prod": "npx prisma migrate deploy",
     "db:reset": "npx prisma migrate reset",
-    "db:seed": "npm run prisma:generate && npx prisma db seed",
+    "db:seed": "npm run build && npx prisma db seed",
     "prisma:format": "npx prisma format",
-    "prisma:generate": "npx prisma generate",
-    "build": "npm run prisma:generate",
+    "prisma-generate": "npx prisma generate",
+    "build": "npx prisma generate",
     "tscheck": "npx tsc -p jsconfig.json --maxNodeModuleJsDepth 0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "release": "multi-semantic-release --ignore-packages=packages/**",
     "test": "turbo run test",
-    "tscheck": "turbo run prisma:generate && turbo run tscheck --parallel --filter=!@pins/api",
+    "tscheck": "turbo run prisma-generate && turbo run tscheck --parallel --filter=!@pins/api",
     "web": "npm run dev --workspace=@pins/web"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -2,46 +2,26 @@
 	"npmClient": "npm",
 	"pipeline": {
 		"build": {
-			"outputs": [
-				"src/server/static/scripts/**",
-				"src/server/static/styles/**"
-			],
-			"dependsOn": [
-				"^build",
-				"$NODE_ENV",
-				"$APP_RELEASE"
-			]
+			"outputs": ["src/server/static/scripts/**", "src/server/static/styles/**"],
+			"dependsOn": ["^build", "$NODE_ENV", "$APP_RELEASE"]
 		},
 		"build:release": {
-			"outputs": [
-				"src/server/static/scripts/**",
-				"src/server/static/styles/**"
-			],
-			"dependsOn": [
-				"^build",
-				"$NODE_ENV",
-				"$APP_RELEASE"
-			]
+			"outputs": ["src/server/static/scripts/**", "src/server/static/styles/**"],
+			"dependsOn": ["^build", "$NODE_ENV", "$APP_RELEASE"]
 		},
 		"test": {
-			"outputs": [
-				"coverage/**"
-			],
+			"outputs": ["coverage/**"],
 			"dependsOn": []
 		},
 		"lint:js": {
-			"dependsOn": [
-				"^build"
-			],
+			"dependsOn": ["^build"],
 			"outputs": []
 		},
 		"lint:js:fix": {
-			"dependsOn": [
-				"^build"
-			],
+			"dependsOn": ["^build"],
 			"outputs": []
 		},
-		"prisma:generate": {
+		"prisma-generate": {
 			"cache": false
 		},
 		"tscheck": {


### PR DESCRIPTION
## Describe your changes
npm run dev and git commit were both failing on a windows machine, giving a Lifecycle error.  It appears that npm run script commands in package.json that in turn call npm run commands have an in windows if there is a colon in the script name - eg prisma:generate in this case.  Changing to prisma-generate solves this issue, allowing run and commit to work.

## BOAS-217 - fix npm run dev in Windows

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
