### PR TITLE
fix(api): removes redundant build command (BOAS-217)

### DIFF
--- a/azure-pipelines-db-seed.yml
+++ b/azure-pipelines-db-seed.yml
@@ -46,10 +46,6 @@ jobs:
                     variable: DATABASE_URL
             - template: steps/node_script.yml@templates
               parameters:
-                script: npm run build
-                workingDirectory: $(Build.Repository.LocalPath)/apps/api
-            - template: steps/node_script.yml@templates
-              parameters:
                 environmentVariables:
                   DATABASE_URL: $(DATABASE_URL)
                 script: npm run db:seed


### PR DESCRIPTION
## Describe your changes

- removes redundant `npm run build` command when seeding

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
