### PR TITLE
fix(api/applications): dashboard-sector-names-ordering (BOAS-180)

### DIFF
--- a/apps/api/src/server/applications/case-admin-officer/case-admin-officer.controller.js
+++ b/apps/api/src/server/applications/case-admin-officer/case-admin-officer.controller.js
@@ -21,5 +21,13 @@ const mapApplicationsWithSectorAndSubSector = (applications) => {
 export const getApplications = async (request, response) => {
 	const applications = await caseRepository.getAll();
 
+	// sort ascending order of subsector abbreviation, BC, EN, ... WA, WS, WW
+	applications.sort((a, b) =>
+		((a.ApplicationDetails?.subSector.abbreviation || '') >
+		(b.ApplicationDetails?.subSector.abbreviation || '')
+			? 1
+			: -1)
+	);
+
 	response.send(mapApplicationsWithSectorAndSubSector(applications));
 };

--- a/apps/api/src/server/applications/case-officer/case-officer.controller.js
+++ b/apps/api/src/server/applications/case-officer/case-officer.controller.js
@@ -21,5 +21,13 @@ const mapApplicationsWithSectorAndSubSector = (applications) => {
 export const getApplications = async (request, response) => {
 	const applications = await caseRepository.getAll();
 
+	// sort ascending order of subsector abbreviation, BC, EN, ... WA, WS, WW
+	applications.sort((a, b) =>
+		((a.ApplicationDetails?.subSector.abbreviation || '') >
+		(b.ApplicationDetails?.subSector.abbreviation || '')
+			? 1
+			: -1)
+	);
+
 	response.send(mapApplicationsWithSectorAndSubSector(applications));
 };

--- a/apps/api/src/server/applications/inspector/inspector.controller.js
+++ b/apps/api/src/server/applications/inspector/inspector.controller.js
@@ -21,5 +21,13 @@ const mapApplicationsWithSectorAndSubSector = (applications) => {
 export const getApplications = async (request, response) => {
 	const applications = await caseRepository.getAll();
 
+	// sort ascending order of subsector abbreviation, BC, EN, ... WA, WS, WW
+	applications.sort((a, b) =>
+		((a.ApplicationDetails?.subSector.abbreviation || '') >
+		(b.ApplicationDetails?.subSector.abbreviation || '')
+			? 1
+			: -1)
+	);
+
 	response.send(mapApplicationsWithSectorAndSubSector(applications));
 };

--- a/apps/api/src/server/applications/sector/sector.controller.js
+++ b/apps/api/src/server/applications/sector/sector.controller.js
@@ -25,5 +25,8 @@ export const getSectors = async (request, response) => {
 		? await sectorRepository.getAll()
 		: await subSectorRepository.getBySector({ name: request.query.sectorName?.toString() });
 
+	// sort ascending order of subsector abbreviation, BC, EN, ... WA, WS, WW
+	sectors.sort((a, b) => (a.abbreviation > b.abbreviation ? 1 : -1));
+
 	response.send(mapSectors(sectors));
 };


### PR DESCRIPTION
## Describe your changes

- change the getApplications apis used by Case Officer, CAO, and Inspector Dashboards, to display the sectors in the correct order (which is alphabetical order of abbreviation - eg BC, EN, . . . WA, WS, WW)
- also updated the getSectors api to return the list in the correct order too

## BOAS-180 Dashboard Sector Names Ordering

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
