### PR TITLE
fix(web/applications): applicant tel number validation fix (BOAS-285)

### DIFF
--- a/apps/web/src/server/applications/create/applicant/applications-create-applicant.validators.js
+++ b/apps/web/src/server/applications/create/applicant/applications-create-applicant.validators.js
@@ -36,7 +36,7 @@ export const validateApplicationsCreateApplicantTelephoneNumber = createValidato
 	body('applicant.phoneNumber')
 		.optional({ checkFalsy: true })
 		.trim()
-		.matches(/^\+?(?:\d\s?){10,12}$/g)
+		.matches(/^\+?(?:\d\s?){10,12}$/)
 		.withMessage('Enter a phone number e.g. 01632 960 001, 07700 900 982 or +44 808 157 0192')
 );
 


### PR DESCRIPTION
## Describe your changes

Create Applicant - Applicant Telephone Number - validation bug fix - odd behaviour: not validating good input, and alternately validating and not-validating.  Issue was with /g in the regex, needed to be either removed, or set a separate 'g' parameter in the matches() fn call.

## BOAS-285:  BOAS 155 - Error on Applicants telephone number page for entering the e.g telephone no from error message without spaces
https://pins-ds.atlassian.net/browse/BOAS-285

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
