### PR TITLE
fix(api/applications): search applications only return valid status

### DIFF
--- a/apps/api/src/server/applications/search/__tests__/case-search.test.js
+++ b/apps/api/src/server/applications/search/__tests__/case-search.test.js
@@ -143,7 +143,11 @@ const expectedSearchParameters = (skip, take, query) => {
 					}
 				}
 			},
-			CaseStatus: true
+			CaseStatus: {
+				where: {
+					valid: true
+				}
+			}
 		}
 	};
 };

--- a/apps/api/src/server/repositories/case.repository.js
+++ b/apps/api/src/server/repositories/case.repository.js
@@ -106,7 +106,11 @@ export const getBySearchCriteria = (query, skipValue, pageSize) => {
 					}
 				}
 			},
-			CaseStatus: true
+			CaseStatus: {
+				where: {
+					valid: true
+				}
+			}
 		}
 	});
 };


### PR DESCRIPTION
## Describe your changes

amend the api - Search Applications By Criteria - used by search applications - to only include status data for valid statuses.  It was returning all historic statuses, which caused an error on front end searching.
Unit tests updated.

## BOAS-360 - Search Applications API only returns valid statuses 
(raised against BOAS-197)
https://pins-ds.atlassian.net/browse/BOAS-360

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
