### PR TITLE
fix(api/applications): case create allow non-mandatory (BOAS-363)

### DIFF
--- a/apps/api/src/server/applications/application/application.validators.js
+++ b/apps/api/src/server/applications/application/application.validators.js
@@ -107,22 +107,37 @@ export const validateCreateUpdateApplication = composeMiddleware(
 		.custom(validateExistingRegions)
 		.optional({ nullable: true }),
 	body('applicants.*.email')
-		.isEmail()
+		.isEmail({
+			allow_display_name: false,
+			require_tld: true,
+			allow_ip_domain: false
+		})
 		.withMessage('Email must be a valid email')
-		.optional({ nullable: true }),
+		.optional({ nullable: true, checkFalsy: true }),
 	body('applicants.*.phoneNumber')
 		.trim()
-		.matches(/^\+?(?:\d\s?){10,12}$/g)
+		.matches(/^\+?(?:\d\s?){10,12}$/)
 		.withMessage('Phone Number must be a valid UK number')
-		.optional({ nullable: true }),
+		.optional({ nullable: true, checkFalsy: true }),
 	body('applicants.*.address.postcode')
 		.isPostalCode('GB')
 		.withMessage('Postcode must be a valid UK postcode')
 		.optional({ nullable: true }),
-	body('applicant.*.website')
-		.isURL()
+	// regex check added to website, to exclude @ signs, which for some reason are valid in isUrl
+	body('applicants.*.website')
+		.trim()
+		.matches(/^[^@]*$/)
 		.withMessage('Website must be a valid website')
-		.optional({ nullable: true }),
+		.isURL({
+			require_tld: true,
+			require_port: false,
+			allow_trailing_dot: false,
+			allow_protocol_relative_urls: false,
+			allow_query_components: false,
+			allow_fragments: false
+		})
+		.withMessage('Website must be a valid website')
+		.optional({ nullable: true, checkFalsy: true }),
 	body('keyDates.submissionDateInternal')
 		.customSanitizer(timestampToDate)
 		.custom(validateFutureDate)


### PR DESCRIPTION
## Describe your changes

- fixed bug that stopped Save and Continue in the draft case create journey, for non mandatory fields:
phone number, email.  And website
- there was a typo in the API validation that meant website not being validated at the API side, fixing this meant that this issue would also occur for website. Fixed.
- ensured that the validation checks for phone number, email and website are the same as the checks performed on the web app - eg the special case where the express-validator IsUrl fn allows a @ in the url - which is not correct.

## BOAS-363 Allow blank non-mandatory fields on case create
https://pins-ds.atlassian.net/browse/BOAS-363

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
