### PR TITLE
fix(web/applications): map zoom level spelling (BOAS-357)

### DIFF
--- a/apps/web/src/server/applications/pages/create/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
+++ b/apps/web/src/server/applications/pages/create/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
@@ -64,7 +64,7 @@ exports[`applications create applicant GET /check-your-answers should render the
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
-                            <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Map zoom Level</td>
+                            <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Map zoom level</td>
                             <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/123/zoom-level\\">Change</a>
                             </td>
@@ -258,7 +258,7 @@ exports[`applications create applicant POST /check-your-answers should display e
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
-                            <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Map zoom Level</td>
+                            <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Map zoom level</td>
                             <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/123/zoom-level\\">Change</a>
                             </td>

--- a/apps/web/src/server/views/applications/create/check-your-answers.njk
+++ b/apps/web/src/server/views/applications/create/check-your-answers.njk
@@ -72,7 +72,7 @@
 	{% set rows = rows | concat([row]) %}
 
 	{% set row = [] %}
-	{% set row = row | concat({ text: 'Map zoom Level', classes: 'font-weight--700 pins-table__cell--s' }) %}
+	{% set row = row | concat({ text: 'Map zoom level', classes: 'font-weight--700 pins-table__cell--s' }) %}
 	{% set row = row | concat({ text: values['case.zoomLevel'], classes: 'pins-table__cell--s' }) %}
 	{% set row = row | concat({ html: '<a class="govuk-link" href="' + baseUrl + '/zoom-level">' + 'Change' + '</a>', classes: 'text-align--right pins-table__cell--s' }) %}
 	{% set rows = rows | concat([row]) %}


### PR DESCRIPTION
## Describe your changes

Map zoom level label should have a lower case l

## BOAS-357 Capitalisation of Map zoom level

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
