### PR TITLE
Fix/boas 403 inspector access to case details page

### DIFF
--- a/apps/web/src/server/applications/applications.router.js
+++ b/apps/web/src/server/applications/applications.router.js
@@ -4,7 +4,6 @@ import * as filters from './applications.filters.js';
 import * as guards from './applications.guards.js';
 import * as locals from './applications.locals.js';
 import applicationsCaseRouter from './pages/case/applications-case.router.js';
-import applicationsEditRouter from './pages/case/edit/applications-edit.router.js';
 import applicationsCreateRouter from './pages/create/applications-create.router.js';
 import applicationsSearchRouter from './pages/search/applications-search.router.js';
 
@@ -36,8 +35,6 @@ router.use(locals.registerLocals);
 router.use('/search-results', guards.assertDomainTypeExists, applicationsSearchRouter);
 
 router.use('/create-new-case', guards.assertDomainTypeExists, applicationsCreateRouter);
-
-router.use('/case', guards.assertDomainTypeExists, applicationsEditRouter);
 
 router.use('/case', guards.assertDomainTypeExists, applicationsCaseRouter);
 

--- a/apps/web/src/server/views/applications/case/key-dates.njk
+++ b/apps/web/src/server/views/applications/case/key-dates.njk
@@ -7,20 +7,5 @@
 
 	<p class="govuk-body">Not yet implemented</p>
 
-	<h4>Case</h4>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'name'})}}">Name</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'description'})}}">Description</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'project-location'})}}">Project location</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'grid-references'})}}">Grid references</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'team-email'})}}">Team email</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'regions'})}}">Regions</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'zoom-level'})}}">Zoom Level</a>
-	<h4>Applicant</h4>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'applicant-full-name'})}}">Applicant full name</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'applicant-organisation-name'})}}">Applicant organisation name</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'applicant-website'})}}">Applicant website</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'applicant-email'})}}">Applicant email</a>
-	<a href="{{ 'applications-edit'|url({applicationId: applicationId, step: 'applicant-address'})}}">Applicant address</a>
-
 	<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 {% endblock %}


### PR DESCRIPTION
## Describe your changes

correct routing to allow the Inspector role to access the view Case Details pages.
also removed unwanted set of links on the key-dates page.

## BOAS-403 Inspector unable to Navigate to the Case details Overview page (raised against BOAS-312)
https://pins-ds.atlassian.net/browse/BOAS-403

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
