### PR TITLE
feat(web/applications): move backlink, button and breadcrumbs (BOAS-391)

### DIFF
--- a/apps/web/src/server/applications/pages/create/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
+++ b/apps/web/src/server/applications/pages/create/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
@@ -162,8 +162,8 @@ exports[`applications create applicant GET /check-your-answers should render the
             </div>
         </div>
         <div class=\\"govuk-grid-row\\">
-            <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/123/key-dates/\\">Back</a>
-                <button                 class=\\"govuk-button\\" data-module=\\"govuk-button\\">I accept - Confirm creation of a new case</button>
+            <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
+                <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">I accept - Confirm creation of a new case</button>
             </div>
         </div>
     </form>
@@ -356,8 +356,8 @@ exports[`applications create applicant POST /check-your-answers should display e
             </div>
         </div>
         <div class=\\"govuk-grid-row\\">
-            <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/123/key-dates/\\">Back</a>
-                <button                 class=\\"govuk-button\\" data-module=\\"govuk-button\\">I accept - Confirm creation of a new case</button>
+            <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
+                <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">I accept - Confirm creation of a new case</button>
             </div>
         </div>
     </form>

--- a/apps/web/src/server/views/applications/create/check-your-answers.njk
+++ b/apps/web/src/server/views/applications/create/check-your-answers.njk
@@ -5,15 +5,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block beforeContent %}
-	{{ govukBreadcrumbs({
+	{% set backLink = 'applications-create'|url({applicationId:applicationId, step: 'key-dates'}) %}
+	{{ govukBackLink({
 		classes: 'govuk-!-margin-top-3',
-		items: [
-			{ text: 'Applications', href: 'dashboard'|url({domainType:domainType}) },
-			{ text: 'Case information', href: 'applications-create'|url({applicationId: applicationId})},
-			{ text: 'Applicant Information', href: 'applications-create'|url({applicationId: applicationId, step: 'applicant-organisation-name'})},
-			{ text: 'Key dates', href: 'applications-create'|url({applicationId: applicationId, step: 'key-dates'})},
-			{ text: 'Check your answers'}
-		]
+		text: "Back",
+		href: backLink
 	}) }}
 {% endblock %}
 
@@ -192,8 +188,6 @@
 		</div>
 		<div class="govuk-grid-row">
 			<div class="govuk-button-group pins-button-group govuk-grid-column-one-half">
-				{% set backLink = 'applications-create'|url({applicationId:applicationId, step: 'key-dates'}) %}
-				<a class="govuk-link" href="{{ backLink }}">Back</a>
 				{{ govukButton({ text: 'I accept - Confirm creation of a new case' }) }}
 			</div>
 		</div>


### PR DESCRIPTION
## Describe your changes

On case creation journey, no breadcrumbs wanted.  Back link should be on top left, not bottom left.  
Continue / save button should now be bottom left.
Only the check-your-answers page needed updating, all others are already correct.

## BOAS-391 Move backlink, and button and remove breadcrumbs

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
