### PR TITLE
fix(web/applications): slash in url stops some pages working (BOAS-525)

### DIFF
--- a/apps/web/src/server/applications/__tests__/__snapshots__/applications.test.js.snap
+++ b/apps/web/src/server/applications/__tests__/__snapshots__/applications.test.js.snap
@@ -25,7 +25,7 @@ exports[`applications GET /case-admin-officer should render a placeholder when t
         <div class=\\"govuk-grid-column-one-half\\">
             <div class=\\"pins-dashboard-box\\">
                 <h3 class=\\"govuk-heading-l pins-dashboard-box--title\\">Create new case</h3><a class=\\"govuk-button govuk-button--secondary pins-dashboard-box--btn\\"
-                href=\\"/applications-service/create-new-case/\\">Create new case here</a>
+                href=\\"/applications-service/create-new-case//\\">Create new case here</a>
             </div>
         </div>
     </div>
@@ -61,7 +61,7 @@ exports[`applications GET /case-admin-officer should render the open application
         <div class=\\"govuk-grid-column-one-half\\">
             <div class=\\"pins-dashboard-box\\">
                 <h3 class=\\"govuk-heading-l pins-dashboard-box--title\\">Create new case</h3><a class=\\"govuk-button govuk-button--secondary pins-dashboard-box--btn\\"
-                href=\\"/applications-service/create-new-case/\\">Create new case here</a>
+                href=\\"/applications-service/create-new-case//\\">Create new case here</a>
             </div>
         </div>
     </div>
@@ -229,7 +229,7 @@ exports[`applications GET /case-officer should render a placeholder when there a
         <div class=\\"govuk-grid-column-one-half\\">
             <div class=\\"pins-dashboard-box\\">
                 <h3 class=\\"govuk-heading-l pins-dashboard-box--title\\">Create new case</h3><a class=\\"govuk-button govuk-button--secondary pins-dashboard-box--btn\\"
-                href=\\"/applications-service/create-new-case/\\">Create new case here</a>
+                href=\\"/applications-service/create-new-case//\\">Create new case here</a>
             </div>
         </div>
     </div>
@@ -265,7 +265,7 @@ exports[`applications GET /case-officer should render the open applications belo
         <div class=\\"govuk-grid-column-one-half\\">
             <div class=\\"pins-dashboard-box\\">
                 <h3 class=\\"govuk-heading-l pins-dashboard-box--title\\">Create new case</h3><a class=\\"govuk-button govuk-button--secondary pins-dashboard-box--btn\\"
-                href=\\"/applications-service/create-new-case/\\">Create new case here</a>
+                href=\\"/applications-service/create-new-case//\\">Create new case here</a>
             </div>
         </div>
     </div>

--- a/apps/web/src/server/applications/pages/case/__tests__/__snapshots__/applications-case.test.js.snap
+++ b/apps/web/src/server/applications/pages/case/__tests__/__snapshots__/applications-case.test.js.snap
@@ -22,15 +22,15 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
                     <ul class=\\"gov-list pins-list-menu\\">
                         <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/4/\\"> Overview</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-information/\\"> Project information</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-information\\"> Project information</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/key-dates/\\"> Key dates</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/key-dates\\"> Key dates</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-team/\\"> Project team</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-team\\"> Project team</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/fees/\\"> Fees</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/fees\\"> Fees</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-documentation/\\"> Project documentation</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-documentation\\"> Project documentation</a>
                         </li>
                     </ul>
                 </nav>
@@ -64,7 +64,7 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
                     <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--grey\\">NOT PUBLISHED</strong>
                     </dd>
                 </div>
-            </dl><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/project-information/\\"> Update project information</a>
+            </dl><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/project-information\\"> Update project information</a>
             <hr             class=\\"govuk-section-break govuk-section-break--l govuk-section-break--visible\\">
                 <h2 class=\\"govuk-heading-m\\">Project team</h2>
                 <p class=\\"govuk-body\\">No project members have been added yet</p>
@@ -95,15 +95,15 @@ exports[`applications view case summary GET /case/123/project-information should
                     <ul class=\\"gov-list pins-list-menu\\">
                         <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/\\"> Overview</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/4/project-information/\\"> Project information</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/4/project-information\\"> Project information</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/key-dates/\\"> Key dates</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/key-dates\\"> Key dates</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-team/\\"> Project team</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-team\\"> Project team</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/fees/\\"> Fees</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/fees\\"> Fees</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-documentation/\\"> Project documentation</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-documentation\\"> Project documentation</a>
                         </li>
                     </ul>
                 </nav>
@@ -137,25 +137,25 @@ exports[`applications view case summary GET /case/123/project-information should
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project name</th>
                                     <td class=\\"govuk-table__cell\\">Case with no sector</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/name/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project description</th>
                                     <td class=\\"govuk-table__cell\\">Case with no sector description</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/description/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/description\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project email address</th>
                                     <td class=\\"govuk-table__cell\\"></td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/team-email/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/team-email\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project location</th>
                                     <td class=\\"govuk-table__cell\\"></td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/project-location/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/project-location\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
@@ -163,19 +163,19 @@ exports[`applications view case summary GET /case/123/project-information should
                                     <td class=\\"govuk-table__cell\\">
                                         <br>
                                     </td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/grid-references/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/grid-references\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Regions(s)</th>
                                     <td class=\\"govuk-table__cell\\"></td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/regions/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/regions\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Map zoom level</th>
                                     <td class=\\"govuk-table__cell\\"></td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/zoom-level/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/zoom-level\\"> Change</a>
                                     </td>
                                 </tr>
                             </tbody>
@@ -192,37 +192,37 @@ exports[`applications view case summary GET /case/123/project-information should
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Organisation name</th>
                                     <td class=\\"govuk-table__cell\\">Org name</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-organisation-name/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-organisation-name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Contact name</th>
                                     <td class=\\"govuk-table__cell\\">Lorem Ipsum</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-full-name/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-full-name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Address</th>
                                     <td class=\\"govuk-table__cell\\">Applicant address, ABC123, London</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-address/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-address\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Website</th>
                                     <td class=\\"govuk-table__cell\\">website.web</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-website/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-website\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Email address</th>
                                     <td class=\\"govuk-table__cell\\">email@email.co</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-email/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-email\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Telephone number</th>
                                     <td class=\\"govuk-table__cell\\">001</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-telephone-number/\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-telephone-number\\"> Change</a>
                                     </td>
                                 </tr>
                             </tbody>

--- a/apps/web/src/server/applications/pages/search-results/__tests/__snapshots__/applications-search.test.js.snap
+++ b/apps/web/src/server/applications/pages/search-results/__tests/__snapshots__/applications-search.test.js.snap
@@ -88,7 +88,7 @@ exports[`applications search POST /applications-service/search-results should re
             </thead>
             <tbody class=\\"govuk-table__body\\">
                 <tr class=\\"govuk-table__row\\">
-                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/76/check-your-answers/\\"> Title</a>
+                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/76/check-your-answers\\"> Title</a>
                     </td>
                     <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Draft</strong>
                     </td>

--- a/apps/web/src/server/applications/pages/search-results/__tests/applications-search.test.js
+++ b/apps/web/src/server/applications/pages/search-results/__tests/applications-search.test.js
@@ -54,7 +54,7 @@ describe('applications search', () => {
 
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain(
-				'<a class="govuk-body" href="/applications-service/create-new-case/76/check-your-answers/"> Title</a>'
+				'<a class="govuk-body" href="/applications-service/create-new-case/76/check-your-answers"> Title</a>'
 			);
 		});
 

--- a/apps/web/src/server/lib/nunjucks-filters/url.js
+++ b/apps/web/src/server/lib/nunjucks-filters/url.js
@@ -21,7 +21,7 @@ import slugify from 'slugify';
 const getArgument = (argumentName, filterArguments) => {
 	const argument = filterArguments[argumentName];
 
-	return argument ? `${argument}/` : '';
+	return argument ? `${argument}` : '';
 };
 
 // TODO: handle subfolders
@@ -57,17 +57,17 @@ export const url = (key, filterArguments = {}) => {
 
 	switch (key) {
 		case 'case-create':
-			return `${domainUrl}/create-new-case/${caseId}${step}`;
+			return `${domainUrl}/create-new-case/${caseId}/${step}`;
 		case 'case-edit':
-			return `${domainUrl}/case/${caseId}edit/${step}`;
+			return `${domainUrl}/case/${caseId}/edit/${step}`;
 		case 'dashboard':
 			return `${domainUrl}/${domainType}`;
 		case 'document-category':
-			return `${domainUrl}/case/${caseId}project-documentation/${documentationCategory}`;
+			return `${domainUrl}/case/${caseId}/project-documentation/${documentationCategory}`;
 		case 'search-results':
 			return `${domainUrl}/search-results/${step}?q=${query}`;
 		case 'case-view':
-			return `${domainUrl}/case/${caseId}${step}`;
+			return `${domainUrl}/case/${caseId}/${step}`;
 		default:
 			return 'app/404';
 	}


### PR DESCRIPTION
## Describe your changes

a trailing slash in some url links stops further pages working - particularly when returning to dashboard after visiting search or display case pages, the backlink adds a slash eg case-officer/ and further searches etc do not work

## BOAS-525 Trailing Slash in url stops some pages working
https://pins-ds.atlassian.net/browse/BOAS-525

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
