### PR TITLE
feat(web/applications): handle draft guard for new-case pages (boas-586)

### DIFF
--- a/apps/web/.env.test
+++ b/apps/web/.env.test
@@ -64,7 +64,7 @@ LOG_LEVEL_FILE=debug
 
 # The logging level for the stdout.
 # Options: trace, debug, info, warn, error, fatal, silent
-LOG_LEVEL_STDOUT=debug
+LOG_LEVEL_STDOUT=fatal
 
 ## SERVICE COMMON  ####################################################################
 

--- a/apps/web/.env.test
+++ b/apps/web/.env.test
@@ -64,7 +64,7 @@ LOG_LEVEL_FILE=debug
 
 # The logging level for the stdout.
 # Options: trace, debug, info, warn, error, fatal, silent
-LOG_LEVEL_STDOUT=fatal
+LOG_LEVEL_STDOUT=debug
 
 ## SERVICE COMMON  ####################################################################
 

--- a/apps/web/src/server/applications/__tests__/__snapshots__/applications.test.js.snap
+++ b/apps/web/src/server/applications/__tests__/__snapshots__/applications.test.js.snap
@@ -65,6 +65,53 @@ exports[`applications GET /case-admin-officer should render the open application
             </div>
         </div>
     </div>
+    <div class=\\"pins-dashboard-list--drafts\\">
+        <h2 class=\\"govuk-heading-l\\">Draft cases</h2>
+        <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"\\">
+            <div class=\\"govuk-accordion__section \\">
+                <div class=\\"govuk-accordion__section-header\\">
+                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-1\\"></span></h2>
+                </div>
+                <div id=\\"-content-1\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-1\\">
+                    <table class=\\"govuk-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header pins-table__cell--s\\">Created</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/1/check-your-answers\\"> Title CASE/01</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Title CASE/03</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Title CASE/02</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">31/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/4/check-your-answers\\"> Case with no sector</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"></td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/5/check-your-answers\\"> Case with no subsector</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class=\\"pins-dashboard-list--open\\">
         <h2 class=\\"govuk-heading-l\\">All cases</h2>
         <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"\\">
@@ -86,7 +133,7 @@ exports[`applications GET /case-admin-officer should render the open application
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/1/\\"> CASE/01 - Title CASE/01</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/6/\\"> CASE/06 - Title CASE/06</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                                         </td>
@@ -108,89 +155,9 @@ exports[`applications GET /case-admin-officer should render the open application
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/2/\\"> CASE/02 - Title CASE/02</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/7/\\"> CASE/07 - Title CASE/07</a>
                                         </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Status 2000</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> undefined undefined</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/5/\\"> CASE/05 - Case with no subsector</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            <div class=\\"govuk-accordion__section \\">
-                <div class=\\"govuk-accordion__section-header\\">
-                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-2\\"> Waste EN</span></h2>
-                </div>
-                <div id=\\"-content-2\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-2\\">
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> ENE Energy EN</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/3/\\"> CASE/03 - Title CASE/03</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Status 3000</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            <div class=\\"govuk-accordion__section \\">
-                <div class=\\"govuk-accordion__section-header\\">
-                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-3\\"></span></h2>
-                </div>
-                <div id=\\"-content-3\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-3\\">
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> undefined undefined</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/4/\\"> CASE/04 - Case with no sector</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
+                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Pre-application</strong>
                                         </td>
                                     </tr>
                                 </tbody>
@@ -269,6 +236,53 @@ exports[`applications GET /case-officer should render the open applications belo
             </div>
         </div>
     </div>
+    <div class=\\"pins-dashboard-list--drafts\\">
+        <h2 class=\\"govuk-heading-l\\">Draft cases</h2>
+        <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"\\">
+            <div class=\\"govuk-accordion__section \\">
+                <div class=\\"govuk-accordion__section-header\\">
+                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-1\\"></span></h2>
+                </div>
+                <div id=\\"-content-1\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-1\\">
+                    <table class=\\"govuk-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header pins-table__cell--s\\">Created</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/1/check-your-answers\\"> Title CASE/01</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Title CASE/03</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Title CASE/02</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">31/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/4/check-your-answers\\"> Case with no sector</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"></td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/5/check-your-answers\\"> Case with no subsector</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class=\\"pins-dashboard-list--open\\">
         <h2 class=\\"govuk-heading-l\\">All cases</h2>
         <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"\\">
@@ -290,7 +304,7 @@ exports[`applications GET /case-officer should render the open applications belo
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/1/\\"> CASE/01 - Title CASE/01</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/6/\\"> CASE/06 - Title CASE/06</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                                         </td>
@@ -312,89 +326,9 @@ exports[`applications GET /case-officer should render the open applications belo
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/2/\\"> CASE/02 - Title CASE/02</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/7/\\"> CASE/07 - Title CASE/07</a>
                                         </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Status 2000</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> undefined undefined</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/5/\\"> CASE/05 - Case with no subsector</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            <div class=\\"govuk-accordion__section \\">
-                <div class=\\"govuk-accordion__section-header\\">
-                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-2\\"> Waste EN</span></h2>
-                </div>
-                <div id=\\"-content-2\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-2\\">
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> ENE Energy EN</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/3/\\"> CASE/03 - Title CASE/03</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Status 3000</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            <div class=\\"govuk-accordion__section \\">
-                <div class=\\"govuk-accordion__section-header\\">
-                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-3\\"></span></h2>
-                </div>
-                <div id=\\"-content-3\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-3\\">
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> undefined undefined</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/4/\\"> CASE/04 - Case with no sector</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
+                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Pre-application</strong>
                                         </td>
                                     </tr>
                                 </tbody>
@@ -461,6 +395,53 @@ exports[`applications GET /inspector should render the open applications belongi
             </div>
         </div>
     </div>
+    <div class=\\"pins-dashboard-list--drafts\\">
+        <h2 class=\\"govuk-heading-l\\">Draft cases</h2>
+        <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"\\">
+            <div class=\\"govuk-accordion__section \\">
+                <div class=\\"govuk-accordion__section-header\\">
+                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-1\\"></span></h2>
+                </div>
+                <div id=\\"-content-1\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-1\\">
+                    <table class=\\"govuk-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header pins-table__cell--s\\">Created</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/1/check-your-answers\\"> Title CASE/01</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Title CASE/03</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Title CASE/02</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">31/01/2022</td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/4/check-your-answers\\"> Case with no sector</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"></td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/5/check-your-answers\\"> Case with no subsector</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class=\\"pins-dashboard-list--open\\">
         <h2 class=\\"govuk-heading-l\\">All cases</h2>
         <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"\\">
@@ -482,7 +463,7 @@ exports[`applications GET /inspector should render the open applications belongi
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/1/\\"> CASE/01 - Title CASE/01</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/6/\\"> CASE/06 - Title CASE/06</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                                         </td>
@@ -504,89 +485,9 @@ exports[`applications GET /inspector should render the open applications belongi
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/2/\\"> CASE/02 - Title CASE/02</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/7/\\"> CASE/07 - Title CASE/07</a>
                                         </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Status 2000</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> undefined undefined</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/5/\\"> CASE/05 - Case with no subsector</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            <div class=\\"govuk-accordion__section \\">
-                <div class=\\"govuk-accordion__section-header\\">
-                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-2\\"> Waste EN</span></h2>
-                </div>
-                <div id=\\"-content-2\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-2\\">
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> ENE Energy EN</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/3/\\"> CASE/03 - Title CASE/03</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Status 3000</strong>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </details>
-                </div>
-            </div>
-            <div class=\\"govuk-accordion__section \\">
-                <div class=\\"govuk-accordion__section-header\\">
-                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"-heading-3\\"></span></h2>
-                </div>
-                <div id=\\"-content-3\\" class=\\"govuk-accordion__section-content\\" aria-labelledby=\\"-heading-3\\">
-                    <details class=\\"govuk-details\\" data-module=\\"govuk-details\\">
-                        <summary class=\\"govuk-details__summary\\"><span class=\\"govuk-details__summary-text\\"> undefined undefined</span>
-                        </summary>
-                        <div class=\\"govuk-details__text\\">
-                            <table class=\\"govuk-table pins-table--fixed pins-table--bordered\\">
-                                <thead class=\\"govuk-table__head\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Name</th>
-                                        <th scope=\\"col\\" class=\\"govuk-table__header govuk-!-width-one-quarter text-align--right\\">Stage</th>
-                                    </tr>
-                                </thead>
-                                <tbody class=\\"govuk-table__body\\">
-                                    <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/4/\\"> CASE/04 - Case with no sector</a>
-                                        </td>
-                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
+                                        <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Pre-application</strong>
                                         </td>
                                     </tr>
                                 </tbody>

--- a/apps/web/src/server/applications/__tests__/__snapshots__/applications.test.js.snap
+++ b/apps/web/src/server/applications/__tests__/__snapshots__/applications.test.js.snap
@@ -87,22 +87,12 @@ exports[`applications GET /case-admin-officer should render the open application
                                 <td class=\\"govuk-table__cell\\">01/01/2022</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Title CASE/03</a>
-                                </td>
-                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Title CASE/02</a>
-                                </td>
-                                <td class=\\"govuk-table__cell\\">31/01/2022</td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/4/check-your-answers\\"> Case with no sector</a>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Case with no subsector</a>
                                 </td>
                                 <td class=\\"govuk-table__cell\\"></td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/5/check-your-answers\\"> Case with no subsector</a>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Case with no sector</a>
                                 </td>
                                 <td class=\\"govuk-table__cell\\"></td>
                             </tr>
@@ -133,7 +123,7 @@ exports[`applications GET /case-admin-officer should render the open application
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/6/\\"> CASE/06 - Title CASE/06</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/4/\\"> CASE/04 - Title CASE/04</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                                         </td>
@@ -155,7 +145,7 @@ exports[`applications GET /case-admin-officer should render the open application
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/7/\\"> CASE/07 - Title CASE/07</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/5/\\"> CASE/05 - Title CASE/05</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Pre-application</strong>
                                         </td>
@@ -258,22 +248,12 @@ exports[`applications GET /case-officer should render the open applications belo
                                 <td class=\\"govuk-table__cell\\">01/01/2022</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Title CASE/03</a>
-                                </td>
-                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Title CASE/02</a>
-                                </td>
-                                <td class=\\"govuk-table__cell\\">31/01/2022</td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/4/check-your-answers\\"> Case with no sector</a>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Case with no subsector</a>
                                 </td>
                                 <td class=\\"govuk-table__cell\\"></td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/5/check-your-answers\\"> Case with no subsector</a>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Case with no sector</a>
                                 </td>
                                 <td class=\\"govuk-table__cell\\"></td>
                             </tr>
@@ -304,7 +284,7 @@ exports[`applications GET /case-officer should render the open applications belo
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/6/\\"> CASE/06 - Title CASE/06</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/4/\\"> CASE/04 - Title CASE/04</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                                         </td>
@@ -326,7 +306,7 @@ exports[`applications GET /case-officer should render the open applications belo
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/7/\\"> CASE/07 - Title CASE/07</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/5/\\"> CASE/05 - Title CASE/05</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Pre-application</strong>
                                         </td>
@@ -417,22 +397,12 @@ exports[`applications GET /inspector should render the open applications belongi
                                 <td class=\\"govuk-table__cell\\">01/01/2022</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Title CASE/03</a>
-                                </td>
-                                <td class=\\"govuk-table__cell\\">01/01/2022</td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Title CASE/02</a>
-                                </td>
-                                <td class=\\"govuk-table__cell\\">31/01/2022</td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/4/check-your-answers\\"> Case with no sector</a>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/2/check-your-answers\\"> Case with no subsector</a>
                                 </td>
                                 <td class=\\"govuk-table__cell\\"></td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/5/check-your-answers\\"> Case with no subsector</a>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/create-new-case/3/check-your-answers\\"> Case with no sector</a>
                                 </td>
                                 <td class=\\"govuk-table__cell\\"></td>
                             </tr>
@@ -463,7 +433,7 @@ exports[`applications GET /inspector should render the open applications belongi
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/6/\\"> CASE/06 - Title CASE/06</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/4/\\"> CASE/04 - Title CASE/04</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                                         </td>
@@ -485,7 +455,7 @@ exports[`applications GET /inspector should render the open applications belongi
                                 </thead>
                                 <tbody class=\\"govuk-table__body\\">
                                     <tr class=\\"govuk-table__row\\">
-                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/7/\\"> CASE/07 - Title CASE/07</a>
+                                        <td class=\\"govuk-table__cell\\"><a class=\\"govuk-body\\" href=\\"/applications-service/case/5/\\"> CASE/05 - Title CASE/05</a>
                                         </td>
                                         <td class=\\"govuk-table__cell govuk-!-width-one-quarter text-align--right\\"><strong class=\\"govuk-tag govuk-tag--\\">Pre-application</strong>
                                         </td>

--- a/apps/web/src/server/applications/applications.locals.js
+++ b/apps/web/src/server/applications/applications.locals.js
@@ -2,6 +2,7 @@ import {
 	getSessionApplicationsDomainType,
 	setSessionApplicationsDomainType
 } from './applications-session.service.js';
+import { getCase } from './lib/services/case.service.js';
 
 /** @typedef {import('./applications.router').DomainParams} DomainParams */
 /** @typedef {import('./applications.types').DomainType} DomainType */
@@ -42,4 +43,34 @@ export const registerDomainLocals = ({ params, session }, response, next) => {
 	setSessionApplicationsDomainType(session, params.domainType);
 
 	next();
+};
+
+/**
+ *
+ * @param {string[]|null} query
+ * @param {boolean} shouldBeDraft
+ * @returns {(request: *, response:*, next:*) => void}
+ */
+export const registerCaseWithQuery = (query, shouldBeDraft = false) => {
+	return async (request, response, next) => {
+		const { caseId } = response.locals;
+		const fullQuery = !query ? null : [...query, 'status'];
+
+		const currentCase = caseId
+			? await getCase(caseId, fullQuery)
+			: { title: '', description: '', status: 'Draft' };
+
+		const isDraft = currentCase.status === 'Draft';
+
+		if ((isDraft && !shouldBeDraft) || (currentCase.status !== 'Draft' && shouldBeDraft)) {
+			throw new Error(
+				`Trying to load a ${isDraft ? 'draft' : 'non-draft'} when it should${
+					shouldBeDraft ? ' ' : ' not '
+				}be`
+			);
+		}
+
+		response.locals.currentCase = currentCase;
+		next();
+	};
 };

--- a/apps/web/src/server/applications/applications.locals.js
+++ b/apps/web/src/server/applications/applications.locals.js
@@ -64,9 +64,9 @@ export const registerCaseWithQuery = (query, shouldBeDraft = false) => {
 
 		if ((isDraft && !shouldBeDraft) || (currentCase.status !== 'Draft' && shouldBeDraft)) {
 			throw new Error(
-				`Trying to load a ${isDraft ? 'draft' : 'non-draft'} when it should${
-					shouldBeDraft ? ' ' : ' not '
-				}be`
+				`Trying to load a ${shouldBeDraft ? '' : 'non-'}draft page for a ${
+					isDraft ? '' : 'non-'
+				}draft case`
 			);
 		}
 

--- a/apps/web/src/server/applications/components/form/form-applicant-components.controller.js
+++ b/apps/web/src/server/applications/components/form/form-applicant-components.controller.js
@@ -21,9 +21,9 @@ import { updateCase } from '../../lib/services/case.service.js';
  * @returns {Promise<ApplicationsCreateApplicantOrganisationNameProps>}
  */
 export async function applicantOrganisationNameData(request, locals) {
-	const { caseId, applicantId } = locals;
+	const { currentCase, applicantId } = locals;
 
-	const applicant = await getApplicantById(caseId, applicantId, ['applicants']);
+	const applicant = await getApplicantById(currentCase, applicantId);
 	const values = {
 		'applicant.organisationName': applicant?.organisationName
 	};
@@ -65,9 +65,9 @@ export async function applicantOrganisationNameDataUpdate({ body }, locals) {
  * @returns {Promise<ApplicationsCreateApplicantFullNameProps>}
  */
 export async function applicantFullNameData(request, locals) {
-	const { caseId, applicantId } = locals;
+	const { currentCase, applicantId } = locals;
 
-	const applicant = await getApplicantById(caseId, applicantId, ['applicants']);
+	const applicant = await getApplicantById(currentCase, applicantId);
 	const values = {
 		'applicant.firstName': applicant?.firstName,
 		'applicant.middleName': applicant?.middleName,
@@ -110,9 +110,9 @@ export async function applicantFullNameDataUpdate({ body }, locals) {
  * @returns {Promise<ApplicationsCreateApplicantEmailProps>}
  */
 export async function applicantEmailData(request, locals) {
-	const { caseId, applicantId } = locals;
+	const { currentCase, applicantId } = locals;
 
-	const applicant = await getApplicantById(caseId, applicantId, ['applicants']);
+	const applicant = await getApplicantById(currentCase, applicantId);
 	const values = {
 		'applicant.email': applicant?.email
 	};
@@ -150,15 +150,12 @@ export async function applicantEmailDataUpdate({ errors: validationErrors, body 
  */
 export async function applicantAddressData({ query }, locals) {
 	const { postcode: queryPostcode } = query;
-	const { caseId, applicantId } = locals;
+	const { currentCase, applicantId } = locals;
 
-	const applicant = await getApplicantById(caseId, applicantId, [
-		'applicants',
-		'applicantsAddress'
-	]);
+	const applicant = await getApplicantById(currentCase, applicantId);
 	const singlePostcode = queryPostcode ? `${queryPostcode}` : null;
 	const trimAddressPart = (/** @type {string | undefined} */ addressPart) =>
-		(addressPart ? `${addressPart.trim()}, ` : '');
+		addressPart ? `${addressPart.trim()}, ` : '';
 
 	let applicantAddress = '';
 
@@ -262,9 +259,9 @@ export async function applicantAddressDataUpdate({ errors: validationErrors, bod
  * @returns {Promise<ApplicationsCreateApplicantWebsiteProps>}
  */
 export async function applicantWebsiteData(request, locals) {
-	const { caseId, applicantId } = locals;
+	const { currentCase, applicantId } = locals;
 
-	const applicant = await getApplicantById(caseId, applicantId, ['applicants']);
+	const applicant = await getApplicantById(currentCase, applicantId);
 	const values = {
 		'applicant.website': applicant?.website
 	};
@@ -307,9 +304,9 @@ export async function applicantWebsiteDataUpdate({ body, errors: validationError
  * @returns {Promise<ApplicationsCreateApplicantTelephoneNumberProps>}
  */
 export async function applicantTelephoneNumberData(request, locals) {
-	const { caseId, applicantId } = locals;
+	const { currentCase, applicantId } = locals;
 
-	const applicant = await getApplicantById(caseId, applicantId, ['applicants']);
+	const applicant = await getApplicantById(currentCase, applicantId);
 	const values = {
 		'applicant.phoneNumber': applicant?.phoneNumber
 	};

--- a/apps/web/src/server/applications/components/form/form-applicant-components.controller.js
+++ b/apps/web/src/server/applications/components/form/form-applicant-components.controller.js
@@ -155,7 +155,7 @@ export async function applicantAddressData({ query }, locals) {
 	const applicant = await getApplicantById(currentCase, applicantId);
 	const singlePostcode = queryPostcode ? `${queryPostcode}` : null;
 	const trimAddressPart = (/** @type {string | undefined} */ addressPart) =>
-		addressPart ? `${addressPart.trim()}, ` : '';
+		(addressPart ? `${addressPart.trim()}, ` : '');
 
 	let applicantAddress = '';
 

--- a/apps/web/src/server/applications/components/form/form-case-components.controller.js
+++ b/apps/web/src/server/applications/components/form/form-case-components.controller.js
@@ -8,6 +8,7 @@ import {
 } from '../../lib/services/entities.service.js';
 import { getSessionCaseSectorName } from '../../lib/services/session.service.js';
 
+/** @typedef {import('../../applications.types').Region} Region */
 /** @typedef {import('../../pages/create-new-case/case/applications-create-case.types').ApplicationsCreateCaseNameProps} ApplicationsCreateCaseNameProps */
 /** @typedef {import('../../pages/create-new-case/case/applications-create-case.types').ApplicationsCreateCaseSectorProps} ApplicationsCreateCaseSectorProps */
 /** @typedef {import('../../pages/create-new-case/case/applications-create-case.types').ApplicationsCreateCaseZoomLevelProps} ApplicationsCreateCaseZoomLevelProps */
@@ -24,10 +25,8 @@ import { getSessionCaseSectorName } from '../../lib/services/session.service.js'
  * @returns {Promise<ApplicationsCreateCaseNameProps>}
  */
 export async function caseNameAndDescriptionData(request, locals) {
-	const { caseId } = locals || {};
-	const { title, description } = caseId
-		? await getCase(caseId, ['title', 'description'])
-		: { title: '', description: '' };
+	const { currentCase } = locals || {};
+	const { title, description } = currentCase;
 
 	return { values: { title, description } };
 }
@@ -66,10 +65,10 @@ export async function caseNameAndDescriptionDataUpdate(
  * @returns {Promise<ApplicationsCreateCaseSectorProps>}
  */
 export async function caseSectorData({ session }, locals) {
-	const { caseId } = locals;
+	const { currentCase } = locals;
 	const allSectors = await getAllSectors();
 
-	const { sector } = await getCase(caseId, ['sector']);
+	const { sector } = currentCase;
 	const selectedSectorName = getSessionCaseSectorName(session) || sector?.name;
 
 	const values = { sectorName: selectedSectorName || '' };
@@ -105,11 +104,11 @@ export async function caseSectorDataUpdate({ errors, body }) {
  *
  * @param {import('express').Request} request
  * @param {Record<string, any>} locals
- * @returns {Promise<ApplicationsCreateCaseGeographicalInformationProps>}
+ * @returns {ApplicationsCreateCaseGeographicalInformationProps}
  */
-export async function caseGeographicalInformationData(request, locals) {
-	const { caseId } = locals;
-	const { geographicalInformation } = await getCase(caseId, ['geographicalInformation']);
+export function caseGeographicalInformationData(request, locals) {
+	const { currentCase } = locals;
+	const { geographicalInformation } = currentCase;
 	const { locationDescription, gridReference } = geographicalInformation || {};
 
 	const values = {
@@ -159,8 +158,8 @@ export async function caseGeographicalInformationDataUpdate(
  * @returns {Promise<{properties?: ApplicationsCreateCaseSubSectorProps, redirectToSector: boolean}>}
  */
 export async function caseSubSectorData({ session }, locals) {
-	const { caseId } = locals;
-	const { sector, subSector } = await getCase(caseId, ['subSector', 'sector']);
+	const { currentCase } = locals;
+	const { sector, subSector } = currentCase;
 	const selectedSectorName = getSessionCaseSectorName(session) || sector?.name;
 
 	if (!selectedSectorName) {
@@ -219,12 +218,12 @@ export async function caseSubSectorDataUpdate({ session, errors: validationError
  * @returns {Promise<ApplicationsCreateCaseRegionsProps>}
  */
 export async function caseRegionsData(request, locals) {
-	const { caseId } = locals;
+	const { currentCase } = locals;
 	const allRegions = await getAllRegions();
-	const { geographicalInformation } = await getCase(caseId, ['geographicalInformation']);
-	const selectedRegionNames = new Set(
-		(geographicalInformation?.regions || []).map((region) => region?.name)
-	);
+	const { geographicalInformation } = currentCase;
+	/** @type {Region[]} */
+	const regions = geographicalInformation?.regions || [];
+	const selectedRegionNames = new Set(regions.map((region) => region?.name));
 
 	const checkBoxRegions = allRegions.map((region) => ({
 		text: region.displayNameEn,
@@ -276,8 +275,8 @@ export async function caseRegionsDataUpdate({ errors: validationErrors, body }, 
  * @returns {Promise<ApplicationsCreateCaseZoomLevelProps>}
  */
 export async function caseZoomLevelData(request, locals) {
-	const { caseId } = locals;
-	const { geographicalInformation } = await getCase(caseId, ['geographicalInformation']);
+	const { currentCase } = locals;
+	const { geographicalInformation } = currentCase;
 	const allZoomLevels = await getAllZoomLevels();
 	const values = {
 		'geographicalInformation.mapZoomLevelName':
@@ -328,8 +327,8 @@ export async function caseZoomLevelDataUpdate({ body }, locals) {
  * @returns {Promise<ApplicationsCreateCaseTeamEmailProps>}
  */
 export async function caseTeamEmailData(request, locals) {
-	const { caseId } = locals;
-	const { caseEmail } = await getCase(caseId, ['caseEmail']);
+	const { currentCase } = locals;
+	const { caseEmail } = currentCase;
 
 	return { values: { caseEmail } };
 }

--- a/apps/web/src/server/applications/components/form/form-key-dates-components.controller.js
+++ b/apps/web/src/server/applications/components/form/form-key-dates-components.controller.js
@@ -1,4 +1,4 @@
-import { getCase, updateCase } from '../../lib/services/case.service.js';
+import { updateCase } from '../../lib/services/case.service.js';
 
 /** @typedef {import('../../pages/create-new-case/key-dates/applications-create-key-dates.types').ApplicationsCreateKeyDatesProps} ApplicationsCreateKeyDatesProps */
 
@@ -8,11 +8,11 @@ import { getCase, updateCase } from '../../lib/services/case.service.js';
  *
  * @param {import('express').Request} request
  * @param {Record<string, any>} locals
- * @returns {Promise<ApplicationsCreateKeyDatesProps>}
+ * @returns {ApplicationsCreateKeyDatesProps}
  */
-export async function keyDatesData(request, locals) {
-	const { caseId } = locals;
-	const { keyDates } = await getCase(caseId, ['keyDates']);
+export function keyDatesData(request, locals) {
+	const { currentCase } = locals;
+	const { keyDates } = currentCase;
 	const { submissionDatePublished, submissionDateInternal } = keyDates || {};
 
 	const values = {

--- a/apps/web/src/server/applications/lib/services/applicant.service.js
+++ b/apps/web/src/server/applications/lib/services/applicant.service.js
@@ -1,22 +1,17 @@
-import { getCase } from './case.service.js';
-
 /** @typedef {import('../../applications.types.js').Applicant} Applicant */
+/** @typedef {import('../../applications.types.js').Case} Case */
 
 /**
  * Returns the applicant matching id of a draft case
  *
- * @param {number} caseId
+ * @param {Case} currentCase
  * @param {number} applicantId
- * @param { string[] | null } query
- * @returns {Promise<Applicant|null>}
+ * @returns {Promise<Applicant|undefined>}
  */
-export async function getApplicantById(caseId, applicantId, query = null) {
-	const { applicants } = await getCase(caseId, query);
+export async function getApplicantById(currentCase, applicantId) {
+	const { applicants } = currentCase;
+	/** @type {Applicant[] } */
+	const allApplicants = applicants ?? [];
 
-	let applicant;
-
-	if (applicants && applicants.length > 0) {
-		applicant = applicants.find((apps) => apps.id === applicantId);
-	}
-	return applicant || null;
+	return allApplicants.find((applicant) => applicant.id === applicantId);
 }

--- a/apps/web/src/server/applications/pages/case/__tests__/__snapshots__/applications-case.test.js.snap
+++ b/apps/web/src/server/applications/pages/case/__tests__/__snapshots__/applications-case.test.js.snap
@@ -4,12 +4,12 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary\\">
         <div class=\\"govuk-grid-column-full\\">
-            <h4 class=\\"govuk-heading-m\\"> CASE/04 </h4>
-            <h1 class=\\"govuk-heading-xl\\">Case with no sector</h1>
+            <h4 class=\\"govuk-heading-m\\"> CASE/06 </h4>
+            <h1 class=\\"govuk-heading-xl\\">Title CASE/06</h1>
             <div class=\\"govuk-grid-row\\">
-                <div class=\\"govuk-grid-column-full govuk-body\\">,
+                <div class=\\"govuk-grid-column-full govuk-body\\">Transport EN, Highways EN
                     <br>
-                    <br><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
+                    <br><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                 </div>
             </div>
         </div>
@@ -20,17 +20,17 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
                 <nav>
                     <h3 class=\\"govuk-visually-hidden\\">Case Details Menu</h3>
                     <ul class=\\"gov-list pins-list-menu\\">
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/4/\\"> Overview</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/6/\\"> Overview</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-information\\"> Project information</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-information\\"> Project information</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/key-dates\\"> Key dates</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/key-dates\\"> Key dates</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-team\\"> Project team</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-team\\"> Project team</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/fees\\"> Fees</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/fees\\"> Fees</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-documentation\\"> Project documentation</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-documentation\\"> Project documentation</a>
                         </li>
                     </ul>
                 </nav>
@@ -46,7 +46,7 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
             <h2 class=\\"govuk-heading-m\\">Summary information</h2>
             <dl class=\\"govuk-summary-list govuk-summary-list--no-border\\">
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case reference</dt>
-                    <dd class=\\"govuk-summary-list__value\\">CASE/04</dd>
+                    <dd class=\\"govuk-summary-list__value\\">CASE/06</dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Applicant Information</dt>
                     <dd class=\\"govuk-summary-list__value\\">Org name
@@ -58,13 +58,13 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
                     </dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Project email</dt>
-                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                    <dd class=\\"govuk-summary-list__value\\">another@ema.il</dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Project page</dt>
                     <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--grey\\">NOT PUBLISHED</strong>
                     </dd>
                 </div>
-            </dl><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/project-information\\"> Update project information</a>
+            </dl><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/project-information\\"> Update project information</a>
             <hr             class=\\"govuk-section-break govuk-section-break--l govuk-section-break--visible\\">
                 <h2 class=\\"govuk-heading-m\\">Project team</h2>
                 <p class=\\"govuk-body\\">No project members have been added yet</p>
@@ -77,12 +77,12 @@ exports[`applications view case summary GET /case/123/project-information should
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary\\">
         <div class=\\"govuk-grid-column-full\\">
-            <h4 class=\\"govuk-heading-m\\"> CASE/04 </h4>
-            <h1 class=\\"govuk-heading-xl\\">Case with no sector</h1>
+            <h4 class=\\"govuk-heading-m\\"> CASE/06 </h4>
+            <h1 class=\\"govuk-heading-xl\\">Title CASE/06</h1>
             <div class=\\"govuk-grid-row\\">
-                <div class=\\"govuk-grid-column-full govuk-body\\">,
+                <div class=\\"govuk-grid-column-full govuk-body\\">Transport EN, Highways EN
                     <br>
-                    <br><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
+                    <br><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                 </div>
             </div>
         </div>
@@ -93,17 +93,17 @@ exports[`applications view case summary GET /case/123/project-information should
                 <nav>
                     <h3 class=\\"govuk-visually-hidden\\">Case Details Menu</h3>
                     <ul class=\\"gov-list pins-list-menu\\">
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/\\"> Overview</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/\\"> Overview</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/4/project-information\\"> Project information</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/6/project-information\\"> Project information</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/key-dates\\"> Key dates</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/key-dates\\"> Key dates</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-team\\"> Project team</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-team\\"> Project team</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/fees\\"> Fees</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/fees\\"> Fees</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-documentation\\"> Project documentation</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-documentation\\"> Project documentation</a>
                         </li>
                     </ul>
                 </nav>
@@ -117,13 +117,13 @@ exports[`applications view case summary GET /case/123/project-information should
                     </dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case reference number</dt>
-                    <dd class=\\"govuk-summary-list__value\\">CASE/04</dd>
+                    <dd class=\\"govuk-summary-list__value\\">CASE/06</dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Sector</dt>
-                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                    <dd class=\\"govuk-summary-list__value\\">Transport EN</dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Subsector</dt>
-                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                    <dd class=\\"govuk-summary-list__value\\">Highways EN</dd>
                 </div>
             </dl>
             <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"\\">
@@ -136,46 +136,47 @@ exports[`applications view case summary GET /case/123/project-information should
                             <tbody class=\\"govuk-table__body\\">
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project name</th>
-                                    <td class=\\"govuk-table__cell\\">Case with no sector</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/name\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">Title CASE/06</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project description</th>
-                                    <td class=\\"govuk-table__cell\\">Case with no sector description</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/description\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">Adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna
+                                        aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris
+                                        nisi ut aliquip ex ea commodo consequat</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/description\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project email address</th>
-                                    <td class=\\"govuk-table__cell\\"></td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/team-email\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">another@ema.il</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/team-email\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project location</th>
-                                    <td class=\\"govuk-table__cell\\"></td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/project-location\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">Bristol</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/project-location\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Grid references</th>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <br>
-                                    </td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/grid-references\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">654321 (Easting)
+                                        <br>456789 (Northing)</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/grid-references\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Regions(s)</th>
-                                    <td class=\\"govuk-table__cell\\"></td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/regions\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">East EN,North EN</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/regions\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Map zoom level</th>
-                                    <td class=\\"govuk-table__cell\\"></td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/zoom-level\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">Junction EN</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/zoom-level\\"> Change</a>
                                     </td>
                                 </tr>
                             </tbody>
@@ -192,37 +193,37 @@ exports[`applications view case summary GET /case/123/project-information should
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Organisation name</th>
                                     <td class=\\"govuk-table__cell\\">Org name</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-organisation-name\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-organisation-name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Contact name</th>
-                                    <td class=\\"govuk-table__cell\\">Lorem Ipsum</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-full-name\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">John Smith</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-full-name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Address</th>
                                     <td class=\\"govuk-table__cell\\">Applicant address, ABC123, London</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-address\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-address\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Website</th>
                                     <td class=\\"govuk-table__cell\\">website.web</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-website\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-website\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Email address</th>
                                     <td class=\\"govuk-table__cell\\">email@email.co</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-email\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-email\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Telephone number</th>
                                     <td class=\\"govuk-table__cell\\">001</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-telephone-number\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-telephone-number\\"> Change</a>
                                     </td>
                                 </tr>
                             </tbody>

--- a/apps/web/src/server/applications/pages/case/__tests__/__snapshots__/applications-case.test.js.snap
+++ b/apps/web/src/server/applications/pages/case/__tests__/__snapshots__/applications-case.test.js.snap
@@ -4,8 +4,8 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary\\">
         <div class=\\"govuk-grid-column-full\\">
-            <h4 class=\\"govuk-heading-m\\"> CASE/06 </h4>
-            <h1 class=\\"govuk-heading-xl\\">Title CASE/06</h1>
+            <h4 class=\\"govuk-heading-m\\"> CASE/04 </h4>
+            <h1 class=\\"govuk-heading-xl\\">Title CASE/04</h1>
             <div class=\\"govuk-grid-row\\">
                 <div class=\\"govuk-grid-column-full govuk-body\\">Transport EN, Highways EN
                     <br>
@@ -20,17 +20,17 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
                 <nav>
                     <h3 class=\\"govuk-visually-hidden\\">Case Details Menu</h3>
                     <ul class=\\"gov-list pins-list-menu\\">
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/6/\\"> Overview</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/4/\\"> Overview</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-information\\"> Project information</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-information\\"> Project information</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/key-dates\\"> Key dates</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/key-dates\\"> Key dates</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-team\\"> Project team</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-team\\"> Project team</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/fees\\"> Fees</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/fees\\"> Fees</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-documentation\\"> Project documentation</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-documentation\\"> Project documentation</a>
                         </li>
                     </ul>
                 </nav>
@@ -46,7 +46,7 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
             <h2 class=\\"govuk-heading-m\\">Summary information</h2>
             <dl class=\\"govuk-summary-list govuk-summary-list--no-border\\">
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case reference</dt>
-                    <dd class=\\"govuk-summary-list__value\\">CASE/06</dd>
+                    <dd class=\\"govuk-summary-list__value\\">CASE/04</dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Applicant Information</dt>
                     <dd class=\\"govuk-summary-list__value\\">Org name
@@ -58,13 +58,13 @@ exports[`applications view case summary GET /case/123 should render the page 1`]
                     </dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Project email</dt>
-                    <dd class=\\"govuk-summary-list__value\\">another@ema.il</dd>
+                    <dd class=\\"govuk-summary-list__value\\">some@ema.il</dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Project page</dt>
                     <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--grey\\">NOT PUBLISHED</strong>
                     </dd>
                 </div>
-            </dl><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/project-information\\"> Update project information</a>
+            </dl><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/project-information\\"> Update project information</a>
             <hr             class=\\"govuk-section-break govuk-section-break--l govuk-section-break--visible\\">
                 <h2 class=\\"govuk-heading-m\\">Project team</h2>
                 <p class=\\"govuk-body\\">No project members have been added yet</p>
@@ -77,8 +77,8 @@ exports[`applications view case summary GET /case/123/project-information should
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary\\">
         <div class=\\"govuk-grid-column-full\\">
-            <h4 class=\\"govuk-heading-m\\"> CASE/06 </h4>
-            <h1 class=\\"govuk-heading-xl\\">Title CASE/06</h1>
+            <h4 class=\\"govuk-heading-m\\"> CASE/04 </h4>
+            <h1 class=\\"govuk-heading-xl\\">Title CASE/04</h1>
             <div class=\\"govuk-grid-row\\">
                 <div class=\\"govuk-grid-column-full govuk-body\\">Transport EN, Highways EN
                     <br>
@@ -93,17 +93,17 @@ exports[`applications view case summary GET /case/123/project-information should
                 <nav>
                     <h3 class=\\"govuk-visually-hidden\\">Case Details Menu</h3>
                     <ul class=\\"gov-list pins-list-menu\\">
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/\\"> Overview</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/\\"> Overview</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/6/project-information\\"> Project information</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link pins-selected-item\\" href=\\"/applications-service/case/4/project-information\\"> Project information</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/key-dates\\"> Key dates</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/key-dates\\"> Key dates</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-team\\"> Project team</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-team\\"> Project team</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/fees\\"> Fees</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/fees\\"> Fees</a>
                         </li>
-                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/6/project-documentation\\"> Project documentation</a>
+                        <li class=\\"govuk-heading-s\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/4/project-documentation\\"> Project documentation</a>
                         </li>
                     </ul>
                 </nav>
@@ -117,7 +117,7 @@ exports[`applications view case summary GET /case/123/project-information should
                     </dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case reference number</dt>
-                    <dd class=\\"govuk-summary-list__value\\">CASE/06</dd>
+                    <dd class=\\"govuk-summary-list__value\\">CASE/04</dd>
                 </div>
                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Sector</dt>
                     <dd class=\\"govuk-summary-list__value\\">Transport EN</dd>
@@ -136,47 +136,47 @@ exports[`applications view case summary GET /case/123/project-information should
                             <tbody class=\\"govuk-table__body\\">
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project name</th>
-                                    <td class=\\"govuk-table__cell\\">Title CASE/06</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/name\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">Title CASE/04</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project description</th>
-                                    <td class=\\"govuk-table__cell\\">Adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna
-                                        aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris
-                                        nisi ut aliquip ex ea commodo consequat</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/description\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">Amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore
+                                        et dolore magna aliqua Ut enim ad minim veniam quis nostrud exercitation
+                                        ullamco laboris nisi ut aliquip ex ea commodo consequat</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/description\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project email address</th>
-                                    <td class=\\"govuk-table__cell\\">another@ema.il</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/team-email\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">some@ema.il</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/team-email\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Project location</th>
-                                    <td class=\\"govuk-table__cell\\">Bristol</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/project-location\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">London</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/project-location\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Grid references</th>
-                                    <td class=\\"govuk-table__cell\\">654321 (Easting)
-                                        <br>456789 (Northing)</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/grid-references\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">123456 (Easting)
+                                        <br>987654 (Northing)</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/grid-references\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Regions(s)</th>
-                                    <td class=\\"govuk-table__cell\\">East EN,North EN</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/regions\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">London EN,Yorkshire EN</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/regions\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Map zoom level</th>
-                                    <td class=\\"govuk-table__cell\\">Junction EN</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/zoom-level\\"> Change</a>
+                                    <td class=\\"govuk-table__cell\\">City EN</td>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/zoom-level\\"> Change</a>
                                     </td>
                                 </tr>
                             </tbody>
@@ -193,37 +193,37 @@ exports[`applications view case summary GET /case/123/project-information should
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Organisation name</th>
                                     <td class=\\"govuk-table__cell\\">Org name</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-organisation-name\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-organisation-name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Contact name</th>
                                     <td class=\\"govuk-table__cell\\">John Smith</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-full-name\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-full-name\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Address</th>
                                     <td class=\\"govuk-table__cell\\">Applicant address, ABC123, London</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-address\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-address\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Website</th>
                                     <td class=\\"govuk-table__cell\\">website.web</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-website\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-website\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Email address</th>
                                     <td class=\\"govuk-table__cell\\">email@email.co</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-email\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-email\\"> Change</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
                                     <th scope=\\"row\\" class=\\"govuk-table__header\\">Telephone number</th>
                                     <td class=\\"govuk-table__cell\\">001</td>
-                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/6/edit/applicant-telephone-number\\"> Change</a>
+                                    <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/4/edit/applicant-telephone-number\\"> Change</a>
                                     </td>
                                 </tr>
                             </tbody>

--- a/apps/web/src/server/applications/pages/case/__tests__/applications-case.test.js
+++ b/apps/web/src/server/applications/pages/case/__tests__/applications-case.test.js
@@ -9,7 +9,7 @@ const request = supertest(app);
 
 const nocks = () => {
 	nock('http://test/').get('/applications/case-officer').reply(200, {});
-	nock('http://test/').get('/applications/123').reply(200, fixtureCases[5]);
+	nock('http://test/').get('/applications/123').reply(200, fixtureCases[3]);
 };
 
 describe('applications view case summary', () => {

--- a/apps/web/src/server/applications/pages/case/__tests__/applications-case.test.js
+++ b/apps/web/src/server/applications/pages/case/__tests__/applications-case.test.js
@@ -8,9 +8,8 @@ const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 
 const nocks = () => {
-	nock('http://test/').get('/applications/case-officer').reply(200, []);
-
-	nock('http://test/').get('/applications/123').reply(200, fixtureCases[3]);
+	nock('http://test/').get('/applications/case-officer').reply(200, {});
+	nock('http://test/').get('/applications/123').reply(200, fixtureCases[5]);
 };
 
 describe('applications view case summary', () => {

--- a/apps/web/src/server/applications/pages/case/applications-case.locals.js
+++ b/apps/web/src/server/applications/pages/case/applications-case.locals.js
@@ -28,6 +28,10 @@ export const registerCase = async (request, response, next) => {
 	response.locals.caseId = Number(request.params.caseId);
 	response.locals.case = await getCase(response.locals.caseId);
 
+	if (response.locals.case.status === 'Draft') {
+		throw new Error(`Trying to load a non-draft page for a draft case`);
+	}
+
 	next();
 };
 

--- a/apps/web/src/server/applications/pages/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/pages/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -4,8 +4,8 @@ exports[`applications documentation GET /case/123/project-documentation should r
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary\\">
         <div class=\\"govuk-grid-column-full\\">
-            <h4 class=\\"govuk-heading-m\\"> CASE/06 </h4>
-            <h1 class=\\"govuk-heading-xl\\">Title CASE/06</h1>
+            <h4 class=\\"govuk-heading-m\\"> CASE/04 </h4>
+            <h1 class=\\"govuk-heading-xl\\">Title CASE/04</h1>
             <div class=\\"govuk-grid-row\\">
                 <div class=\\"govuk-grid-column-full govuk-body\\">Transport EN, Highways EN
                     <br>
@@ -30,8 +30,8 @@ exports[`applications documentation GET /case/123/project-documentation/21/sub-f
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary\\">
         <div class=\\"govuk-grid-column-full\\">
-            <h4 class=\\"govuk-heading-m\\"> CASE/06 </h4>
-            <h1 class=\\"govuk-heading-xl\\">Title CASE/06</h1>
+            <h4 class=\\"govuk-heading-m\\"> CASE/04 </h4>
+            <h1 class=\\"govuk-heading-xl\\">Title CASE/04</h1>
             <div class=\\"govuk-grid-row\\">
                 <div class=\\"govuk-grid-column-full govuk-body\\">Transport EN, Highways EN
                     <br>

--- a/apps/web/src/server/applications/pages/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/pages/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -4,12 +4,12 @@ exports[`applications documentation GET /case/123/project-documentation should r
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary\\">
         <div class=\\"govuk-grid-column-full\\">
-            <h4 class=\\"govuk-heading-m\\"> CASE/04 </h4>
-            <h1 class=\\"govuk-heading-xl\\">Case with no sector</h1>
+            <h4 class=\\"govuk-heading-m\\"> CASE/06 </h4>
+            <h1 class=\\"govuk-heading-xl\\">Title CASE/06</h1>
             <div class=\\"govuk-grid-row\\">
-                <div class=\\"govuk-grid-column-full govuk-body\\">,
+                <div class=\\"govuk-grid-column-full govuk-body\\">Transport EN, Highways EN
                     <br>
-                    <br><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
+                    <br><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                 </div>
             </div>
         </div>
@@ -30,12 +30,12 @@ exports[`applications documentation GET /case/123/project-documentation/21/sub-f
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary\\">
         <div class=\\"govuk-grid-column-full\\">
-            <h4 class=\\"govuk-heading-m\\"> CASE/04 </h4>
-            <h1 class=\\"govuk-heading-xl\\">Case with no sector</h1>
+            <h4 class=\\"govuk-heading-m\\"> CASE/06 </h4>
+            <h1 class=\\"govuk-heading-xl\\">Title CASE/06</h1>
             <div class=\\"govuk-grid-row\\">
-                <div class=\\"govuk-grid-column-full govuk-body\\">,
+                <div class=\\"govuk-grid-column-full govuk-body\\">Transport EN, Highways EN
                     <br>
-                    <br><strong class=\\"govuk-tag govuk-tag--\\">draft</strong>
+                    <br><strong class=\\"govuk-tag govuk-tag--green\\">Pre-Application</strong>
                 </div>
             </div>
         </div>

--- a/apps/web/src/server/applications/pages/case/documentation/__tests__/applications-documentation.test.js
+++ b/apps/web/src/server/applications/pages/case/documentation/__tests__/applications-documentation.test.js
@@ -14,8 +14,8 @@ const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 
 const nocks = () => {
-	nock('http://test/').get('/applications/case-officer').reply(200, []);
-	nock('http://test/').get('/applications/123').reply(200, fixtureCases[3]);
+	nock('http://test/').get('/applications/case-officer').reply(200, {});
+	nock('http://test/').get('/applications/123').reply(200, fixtureCases[5]);
 
 	nock('http://test/')
 		.get('/applications/123/folders')

--- a/apps/web/src/server/applications/pages/case/documentation/__tests__/applications-documentation.test.js
+++ b/apps/web/src/server/applications/pages/case/documentation/__tests__/applications-documentation.test.js
@@ -15,7 +15,7 @@ const request = supertest(app);
 
 const nocks = () => {
 	nock('http://test/').get('/applications/case-officer').reply(200, {});
-	nock('http://test/').get('/applications/123').reply(200, fixtureCases[5]);
+	nock('http://test/').get('/applications/123').reply(200, fixtureCases[3]);
 
 	nock('http://test/')
 		.get('/applications/123/folders')

--- a/apps/web/src/server/applications/pages/case/edit/applicant/__tests__/__snapshots__/applications-edit-applicant.test.js.snap
+++ b/apps/web/src/server/applications/pages/case/edit/applicant/__tests__/__snapshots__/applications-edit-applicant.test.js.snap
@@ -32,7 +32,7 @@ exports[`applications create applicant GET edit/applicant-address should render 
                 <div class=\\"govuk-grid-column-one-third\\">
                     <div class=\\"govuk-grid-row govuk-button-group\\">
                         <p class='govuk-body govuk-grid-column-one-half'>ABC123</p>
-                        <div class=\\"govuk-grid-column-one-half\\"><a class=\\"govuk-link \\" href=\\"./new\\">Change</a>
+                        <div class=\\"govuk-grid-column-one-half\\"><a class=\\"govuk-link \\" href=\\"/applications-service/case/123/edit/applicant-address/new\\">Change</a>
                         </div>
                     </div>
                 </div>
@@ -90,12 +90,12 @@ exports[`applications create applicant GET edit/applicant-full-name should rende
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"applicant.firstName\\">First name</label>
             <input class=\\"govuk-input govuk-!-width-one-third\\" id=\\"applicant.firstName\\"
-            name=\\"applicant.firstName\\" type=\\"text\\" value=\\"Lorem\\">
+            name=\\"applicant.firstName\\" type=\\"text\\" value=\\"John\\">
         </div>
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"applicant.lastName\\">Last name</label>
             <input class=\\"govuk-input govuk-!-width-one-third\\" id=\\"applicant.lastName\\"
-            name=\\"applicant.lastName\\" type=\\"text\\" value=\\"Ipsum\\">
+            name=\\"applicant.lastName\\" type=\\"text\\" value=\\"Smith\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">

--- a/apps/web/src/server/applications/pages/case/edit/applicant/__tests__/applications-edit-applicant.test.js
+++ b/apps/web/src/server/applications/pages/case/edit/applicant/__tests__/applications-edit-applicant.test.js
@@ -11,12 +11,12 @@ const nocks = () => {
 	nock('http://test/').get('/applications/case-officer').reply(200, {});
 	nock('http://test/')
 		.get(/\/applications\/123(.*)/g)
-		.times(5)
-		.reply(200, fixtureCases[5]);
+		.times(2)
+		.reply(200, fixtureCases[3]);
 	nock('http://test/')
 		.get(/\/applications\/456(.*)/g)
 		.times(2)
-		.reply(200, fixtureCases[6]);
+		.reply(200, fixtureCases[4]);
 };
 
 describe('applications create applicant', () => {

--- a/apps/web/src/server/applications/pages/case/edit/applicant/__tests__/applications-edit-applicant.test.js
+++ b/apps/web/src/server/applications/pages/case/edit/applicant/__tests__/applications-edit-applicant.test.js
@@ -8,11 +8,15 @@ const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
 
 const nocks = () => {
-	nock('http://test/').get('/applications/case-officer').reply(200, []);
+	nock('http://test/').get('/applications/case-officer').reply(200, {});
 	nock('http://test/')
 		.get(/\/applications\/123(.*)/g)
+		.times(5)
+		.reply(200, fixtureCases[5]);
+	nock('http://test/')
+		.get(/\/applications\/456(.*)/g)
 		.times(2)
-		.reply(200, fixtureCases[3]);
+		.reply(200, fixtureCases[6]);
 };
 
 describe('applications create applicant', () => {
@@ -125,11 +129,6 @@ describe('applications create applicant', () => {
 
 		it('should render the read only page without the address', async () => {
 			const baseUrl = '/applications-service/case/456/edit/applicant-address';
-
-			nock('http://test/')
-				.get(/\/applications\/456(.*)/g)
-				.times(2)
-				.reply(200, fixtureCases[0]);
 
 			const response = await request.get(baseUrl);
 			const element = parseHtml(response.text);

--- a/apps/web/src/server/applications/pages/case/edit/applicant/applications-edit-applicant.router.js
+++ b/apps/web/src/server/applications/pages/case/edit/applicant/applications-edit-applicant.router.js
@@ -1,5 +1,6 @@
 import { Router as createRouter } from 'express';
 import asyncRoute from '../../../../../lib/async-route.js';
+import { registerCaseWithQuery } from '../../../../applications.locals.js';
 import { registerApplicantId } from '../../../create-new-case/applicant/applications-create-applicant.locals.js';
 import * as validators from '../../../create-new-case/applicant/applications-create-applicant.validators.js';
 import * as controller from './applications-edit-applicant.controller.js';
@@ -10,17 +11,26 @@ applicationsEditApplicantRouter.use(registerApplicantId);
 
 applicationsEditApplicantRouter
 	.route('/applicant-organisation-name')
-	.get(asyncRoute(controller.viewApplicationsEditApplicantOrganisationName))
+	.get(
+		registerCaseWithQuery(['applicants']),
+		asyncRoute(controller.viewApplicationsEditApplicantOrganisationName)
+	)
 	.post(asyncRoute(controller.updateApplicationsEditApplicantOrganisationName));
 
 applicationsEditApplicantRouter
 	.route('/applicant-full-name')
-	.get(asyncRoute(controller.viewApplicationsEditApplicantFullName))
+	.get(
+		registerCaseWithQuery(['applicants']),
+		asyncRoute(controller.viewApplicationsEditApplicantFullName)
+	)
 	.post(asyncRoute(controller.updateApplicationsEditApplicantFullName));
 
 applicationsEditApplicantRouter
 	.route('/applicant-address')
-	.get(asyncRoute(controller.viewApplicationsEditApplicantAddressReadyOnly))
+	.get(
+		registerCaseWithQuery(['applicants', 'applicantsAddress']),
+		asyncRoute(controller.viewApplicationsEditApplicantAddressReadyOnly)
+	)
 	.post(
 		validators.validateApplicationsCreateApplicantPostCode,
 		asyncRoute(controller.updateApplicationsEditApplicantAddress)
@@ -28,7 +38,10 @@ applicationsEditApplicantRouter
 
 applicationsEditApplicantRouter
 	.route('/applicant-address/new')
-	.get(asyncRoute(controller.viewApplicationsEditApplicantAddress))
+	.get(
+		registerCaseWithQuery(['applicants', 'applicantsAddress']),
+		asyncRoute(controller.viewApplicationsEditApplicantAddress)
+	)
 	.post(
 		validators.validateApplicationsCreateApplicantPostCode,
 		asyncRoute(controller.updateApplicationsEditApplicantAddress)
@@ -36,7 +49,10 @@ applicationsEditApplicantRouter
 
 applicationsEditApplicantRouter
 	.route('/applicant-website')
-	.get(asyncRoute(controller.viewApplicationsEditApplicantWebsite))
+	.get(
+		registerCaseWithQuery(['applicants']),
+		asyncRoute(controller.viewApplicationsEditApplicantWebsite)
+	)
 	.post(
 		validators.validateApplicationsCreateApplicantWebsite,
 		asyncRoute(controller.updateApplicationsEditApplicantWebsite)
@@ -44,7 +60,10 @@ applicationsEditApplicantRouter
 
 applicationsEditApplicantRouter
 	.route('/applicant-email')
-	.get(asyncRoute(controller.viewApplicationsEditApplicantEmail))
+	.get(
+		registerCaseWithQuery(['applicants']),
+		asyncRoute(controller.viewApplicationsEditApplicantEmail)
+	)
 	.post(
 		validators.validateApplicationsCreateApplicantEmail,
 		asyncRoute(controller.updateApplicationsEditApplicantEmail)
@@ -52,7 +71,10 @@ applicationsEditApplicantRouter
 
 applicationsEditApplicantRouter
 	.route('/applicant-telephone-number')
-	.get(asyncRoute(controller.viewApplicationsEditApplicantTelephoneNumber))
+	.get(
+		registerCaseWithQuery(['applicants']),
+		asyncRoute(controller.viewApplicationsEditApplicantTelephoneNumber)
+	)
 	.post(
 		validators.validateApplicationsCreateApplicantTelephoneNumber,
 		asyncRoute(controller.updateApplicationsEditApplicantTelephoneNumber)

--- a/apps/web/src/server/applications/pages/case/edit/case/__tests__/__snapshots__/applications-edit-case.test.js.snap
+++ b/apps/web/src/server/applications/pages/case/edit/case/__tests__/__snapshots__/applications-edit-case.test.js.snap
@@ -9,9 +9,9 @@ exports[`applications edit Description GET edit/description should render page w
             <div id=\\"description-hint\\" class=\\"govuk-hint\\">for example, An offshore wind generating station of capacity up to 285
                 MW</div>
             <textarea class=\\"govuk-textarea govuk-!-width-three-quarters\\" id=\\"description\\"
-            name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\">Adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna
-                aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris
-                nisi ut aliquip ex ea commodo consequat</textarea>
+            name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\">Amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore
+                et dolore magna aliqua Ut enim ad minim veniam quis nostrud exercitation
+                ullamco laboris nisi ut aliquip ex ea commodo consequat</textarea>
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -32,7 +32,7 @@ exports[`applications edit Grid references GET /edit/:caseId/project-location sh
             class=\\"govuk-hint\\">for example, 345678</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
             id=\\"geographicalInformation.gridReference.easting\\" name=\\"geographicalInformation.gridReference.easting\\"
-            type=\\"text\\" value=\\"654321\\" aria-describedby=\\"geographicalInformation.gridReference.easting-hint\\">
+            type=\\"text\\" value=\\"123456\\" aria-describedby=\\"geographicalInformation.gridReference.easting-hint\\">
         </div>
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"geographicalInformation.gridReference.northing\\">Grid reference Northing</label>
@@ -40,7 +40,7 @@ exports[`applications edit Grid references GET /edit/:caseId/project-location sh
             class=\\"govuk-hint\\">for example, 345678</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
             id=\\"geographicalInformation.gridReference.northing\\" name=\\"geographicalInformation.gridReference.northing\\"
-            type=\\"text\\" value=\\"456789\\" aria-describedby=\\"geographicalInformation.gridReference.northing-hint\\">
+            type=\\"text\\" value=\\"987654\\" aria-describedby=\\"geographicalInformation.gridReference.northing-hint\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -59,7 +59,7 @@ exports[`applications edit Name GET /edit/name When role is: Case officer should
             <label class=\\"govuk-label font-weight--700\\" for=\\"title\\">Name of the project</label>
             <div id=\\"title-hint\\" class=\\"govuk-hint\\">for example, Bridge over a very long canyon</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
-            id=\\"title\\" name=\\"title\\" type=\\"text\\" value=\\"Title CASE/06\\" aria-describedby=\\"title-hint\\">
+            id=\\"title\\" name=\\"title\\" type=\\"text\\" value=\\"Title CASE/04\\" aria-describedby=\\"title-hint\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -104,7 +104,7 @@ exports[`applications edit Name GET /edit/name When status is Non-draft: should 
             <label class=\\"govuk-label font-weight--700\\" for=\\"title\\">Name of the project</label>
             <div id=\\"title-hint\\" class=\\"govuk-hint\\">for example, Bridge over a very long canyon</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
-            id=\\"title\\" name=\\"title\\" type=\\"text\\" value=\\"Title CASE/06\\" aria-describedby=\\"title-hint\\">
+            id=\\"title\\" name=\\"title\\" type=\\"text\\" value=\\"Title CASE/04\\" aria-describedby=\\"title-hint\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -124,7 +124,7 @@ exports[`applications edit Project location GET /edit/:caseId/project-location s
                 Thanet Offshore Wind Farm</div>
             <textarea class=\\"govuk-textarea govuk-!-width-three-quarters\\"
             id=\\"geographicalInformation.locationDescription\\" name=\\"geographicalInformation.locationDescription\\"
-            rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescription-hint\\">Bristol</textarea>
+            rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescription-hint\\">London</textarea>
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -143,61 +143,14 @@ exports[`applications edit Regions GET /edit/regions should render the page with
             <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
                 <div class=\\"govuk-checkboxes__item\\">
                     <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"london\\">
+                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"london\\"
+                    checked>
                     <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames\\">London EN</label>
                 </div>
                 <div class=\\"govuk-checkboxes__item\\">
                     <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-2\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"yorkshire\\">
-                    <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-2\\">Yorkshire EN</label>
-                </div>
-                <div class=\\"govuk-checkboxes__item\\">
-                    <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-3\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"east\\"
+                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"yorkshire\\"
                     checked>
-                    <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-3\\">East EN</label>
-                </div>
-                <div class=\\"govuk-checkboxes__item\\">
-                    <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-4\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"north\\"
-                    checked>
-                    <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-4\\">North EN</label>
-                </div>
-                <div class=\\"govuk-checkboxes__item\\">
-                    <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-5\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"south\\">
-                    <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-5\\">South EN</label>
-                </div>
-                <div class=\\"govuk-checkboxes__item\\">
-                    <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-6\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"west\\">
-                    <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-6\\">West EN</label>
-                </div>
-            </div>
-        </div>
-        <div class=\\"govuk-grid-row\\">
-            <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
-                <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save changes</button>
-            </div>
-        </div>
-    </form>
-</main>"
-`;
-
-exports[`applications edit Regions GET /edit/regions should render the page without checked options 1`] = `
-"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h2 class=\\"govuk-heading-l\\"> Choose one or multiple regions</h2>
-    <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
-        <div class=\\"govuk-form-group\\">
-            <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                <div class=\\"govuk-checkboxes__item\\">
-                    <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"london\\">
-                    <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames\\">London EN</label>
-                </div>
-                <div class=\\"govuk-checkboxes__item\\">
-                    <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-2\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"yorkshire\\">
                     <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-2\\">Yorkshire EN</label>
                 </div>
                 <div class=\\"govuk-checkboxes__item\\">
@@ -256,55 +209,7 @@ exports[`applications edit Team email GET /edit/team-email should render the pag
         <div class=\\"govuk-form-group\\">
             <div id=\\"caseEmail-hint\\" class=\\"govuk-hint\\">for example, NIEnquiries@planninginspectorate.gsi.gov.uk</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
-            id=\\"caseEmail\\" name=\\"caseEmail\\" type=\\"text\\" value=\\"another@ema.il\\" aria-describedby=\\"caseEmail-hint\\">
-        </div>
-        <div class=\\"govuk-grid-row\\">
-            <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
-                <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save changes</button>
-            </div>
-        </div>
-    </form>
-</main>"
-`;
-
-exports[`applications edit Zoom Level GET edit/zoom-level should render the page with None checked if the api does not return resumed data 1`] = `
-"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h2 class=\\"govuk-heading-l\\"> Choose map zoom level</h2>
-    <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
-        <div class=\\"govuk-form-group\\">
-            <div class=\\"govuk-radios\\" data-module=\\"govuk-radios\\">
-                <div class=\\"govuk-radios__item\\">
-                    <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"none\\"
-                    checked>
-                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName\\">None EN</label>
-                </div>
-                <div class=\\"govuk-radios__item\\">
-                    <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-2\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"region\\">
-                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-2\\">Region EN</label>
-                </div>
-                <div class=\\"govuk-radios__item\\">
-                    <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-3\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"country\\">
-                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-3\\">Country EN</label>
-                </div>
-                <div class=\\"govuk-radios__item\\">
-                    <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-4\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"junction\\">
-                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-4\\">Junction EN</label>
-                </div>
-                <div class=\\"govuk-radios__item\\">
-                    <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-5\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"county\\">
-                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-5\\">County EN</label>
-                </div>
-                <div class=\\"govuk-radios__item\\">
-                    <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-6\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"city\\">
-                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-6\\">City EN</label>
-                </div>
-            </div>
+            id=\\"caseEmail\\" name=\\"caseEmail\\" type=\\"text\\" value=\\"some@ema.il\\" aria-describedby=\\"caseEmail-hint\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -338,8 +243,7 @@ exports[`applications edit Zoom Level GET edit/zoom-level should render the page
                 </div>
                 <div class=\\"govuk-radios__item\\">
                     <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-4\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"junction\\"
-                    checked>
+                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"junction\\">
                     <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-4\\">Junction EN</label>
                 </div>
                 <div class=\\"govuk-radios__item\\">
@@ -349,7 +253,8 @@ exports[`applications edit Zoom Level GET edit/zoom-level should render the page
                 </div>
                 <div class=\\"govuk-radios__item\\">
                     <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-6\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"city\\">
+                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"city\\"
+                    checked>
                     <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-6\\">City EN</label>
                 </div>
             </div>

--- a/apps/web/src/server/applications/pages/case/edit/case/__tests__/__snapshots__/applications-edit-case.test.js.snap
+++ b/apps/web/src/server/applications/pages/case/edit/case/__tests__/__snapshots__/applications-edit-case.test.js.snap
@@ -9,9 +9,9 @@ exports[`applications edit Description GET edit/description should render page w
             <div id=\\"description-hint\\" class=\\"govuk-hint\\">for example, An offshore wind generating station of capacity up to 285
                 MW</div>
             <textarea class=\\"govuk-textarea govuk-!-width-three-quarters\\" id=\\"description\\"
-            name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\">Ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor
-                incididunt ut labore et dolore magna aliqua Ut enim ad minim veniam quis
-                nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</textarea>
+            name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\">Adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna
+                aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris
+                nisi ut aliquip ex ea commodo consequat</textarea>
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -32,7 +32,7 @@ exports[`applications edit Grid references GET /edit/:caseId/project-location sh
             class=\\"govuk-hint\\">for example, 345678</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
             id=\\"geographicalInformation.gridReference.easting\\" name=\\"geographicalInformation.gridReference.easting\\"
-            type=\\"text\\" value=\\"123456\\" aria-describedby=\\"geographicalInformation.gridReference.easting-hint\\">
+            type=\\"text\\" value=\\"654321\\" aria-describedby=\\"geographicalInformation.gridReference.easting-hint\\">
         </div>
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"geographicalInformation.gridReference.northing\\">Grid reference Northing</label>
@@ -40,7 +40,7 @@ exports[`applications edit Grid references GET /edit/:caseId/project-location sh
             class=\\"govuk-hint\\">for example, 345678</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
             id=\\"geographicalInformation.gridReference.northing\\" name=\\"geographicalInformation.gridReference.northing\\"
-            type=\\"text\\" value=\\"987654\\" aria-describedby=\\"geographicalInformation.gridReference.northing-hint\\">
+            type=\\"text\\" value=\\"456789\\" aria-describedby=\\"geographicalInformation.gridReference.northing-hint\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -59,7 +59,7 @@ exports[`applications edit Name GET /edit/name When role is: Case officer should
             <label class=\\"govuk-label font-weight--700\\" for=\\"title\\">Name of the project</label>
             <div id=\\"title-hint\\" class=\\"govuk-hint\\">for example, Bridge over a very long canyon</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
-            id=\\"title\\" name=\\"title\\" type=\\"text\\" value=\\"Title CASE/01\\" aria-describedby=\\"title-hint\\">
+            id=\\"title\\" name=\\"title\\" type=\\"text\\" value=\\"Title CASE/06\\" aria-describedby=\\"title-hint\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -83,7 +83,20 @@ exports[`applications edit Name GET /edit/name When role is: Inspector should NO
 </main>"
 `;
 
-exports[`applications edit Name GET edit/name should render page with resumed data 1`] = `
+exports[`applications edit Name GET /edit/name When status is Draft: should not render the page 1`] = `
+"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
+    <div class=\\"govuk-grid-row\\">
+        <div class=\\"govuk-grid-column-two-thirds\\">
+            <h1 class=\\"govuk-heading-xl\\">Sorry, there is a problem with the service</h1>
+            <p class=\\"govuk-body\\">Try again later.</p>
+            <p class=\\"govuk-body\\"><a href=\\"https://has-appeal.herokuapp.com/help/contact\\" class=\\"govuk-link\\">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists.</p>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`applications edit Name GET /edit/name When status is Non-draft: should render the page with resumed data 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <h2 class=\\"govuk-heading-l\\"> Enter project name</h2>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
@@ -91,7 +104,7 @@ exports[`applications edit Name GET edit/name should render page with resumed da
             <label class=\\"govuk-label font-weight--700\\" for=\\"title\\">Name of the project</label>
             <div id=\\"title-hint\\" class=\\"govuk-hint\\">for example, Bridge over a very long canyon</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
-            id=\\"title\\" name=\\"title\\" type=\\"text\\" value=\\"Title CASE/01\\" aria-describedby=\\"title-hint\\">
+            id=\\"title\\" name=\\"title\\" type=\\"text\\" value=\\"Title CASE/06\\" aria-describedby=\\"title-hint\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -111,7 +124,7 @@ exports[`applications edit Project location GET /edit/:caseId/project-location s
                 Thanet Offshore Wind Farm</div>
             <textarea class=\\"govuk-textarea govuk-!-width-three-quarters\\"
             id=\\"geographicalInformation.locationDescription\\" name=\\"geographicalInformation.locationDescription\\"
-            rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescription-hint\\">London</textarea>
+            rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescription-hint\\">Bristol</textarea>
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -130,24 +143,24 @@ exports[`applications edit Regions GET /edit/regions should render the page with
             <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
                 <div class=\\"govuk-checkboxes__item\\">
                     <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"london\\"
-                    checked>
+                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"london\\">
                     <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames\\">London EN</label>
                 </div>
                 <div class=\\"govuk-checkboxes__item\\">
                     <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-2\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"yorkshire\\"
-                    checked>
+                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"yorkshire\\">
                     <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-2\\">Yorkshire EN</label>
                 </div>
                 <div class=\\"govuk-checkboxes__item\\">
                     <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-3\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"east\\">
+                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"east\\"
+                    checked>
                     <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-3\\">East EN</label>
                 </div>
                 <div class=\\"govuk-checkboxes__item\\">
                     <input class=\\"govuk-checkboxes__input\\" id=\\"geographicalInformation.regionNames-4\\"
-                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"north\\">
+                    name=\\"geographicalInformation.regionNames[]\\" type=\\"checkbox\\" value=\\"north\\"
+                    checked>
                     <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"geographicalInformation.regionNames-4\\">North EN</label>
                 </div>
                 <div class=\\"govuk-checkboxes__item\\">
@@ -243,7 +256,7 @@ exports[`applications edit Team email GET /edit/team-email should render the pag
         <div class=\\"govuk-form-group\\">
             <div id=\\"caseEmail-hint\\" class=\\"govuk-hint\\">for example, NIEnquiries@planninginspectorate.gsi.gov.uk</div>
             <input class=\\"govuk-input govuk-!-width-one-third\\"
-            id=\\"caseEmail\\" name=\\"caseEmail\\" type=\\"text\\" value=\\"some@ema.il\\" aria-describedby=\\"caseEmail-hint\\">
+            id=\\"caseEmail\\" name=\\"caseEmail\\" type=\\"text\\" value=\\"another@ema.il\\" aria-describedby=\\"caseEmail-hint\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -325,7 +338,8 @@ exports[`applications edit Zoom Level GET edit/zoom-level should render the page
                 </div>
                 <div class=\\"govuk-radios__item\\">
                     <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-4\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"junction\\">
+                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"junction\\"
+                    checked>
                     <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-4\\">Junction EN</label>
                 </div>
                 <div class=\\"govuk-radios__item\\">
@@ -335,8 +349,7 @@ exports[`applications edit Zoom Level GET edit/zoom-level should render the page
                 </div>
                 <div class=\\"govuk-radios__item\\">
                     <input class=\\"govuk-radios__input\\" id=\\"geographicalInformation.mapZoomLevelName-6\\"
-                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"city\\"
-                    checked>
+                    name=\\"geographicalInformation.mapZoomLevelName\\" type=\\"radio\\" value=\\"city\\">
                     <label class=\\"govuk-label govuk-radios__label\\" for=\\"geographicalInformation.mapZoomLevelName-6\\">City EN</label>
                 </div>
             </div>

--- a/apps/web/src/server/applications/pages/case/edit/case/__tests__/applications-edit-case.test.js
+++ b/apps/web/src/server/applications/pages/case/edit/case/__tests__/applications-edit-case.test.js
@@ -17,11 +17,11 @@ const nocks = () => {
 	nock('http://test/').get('/applications/case-officer').reply(200, {});
 	nock('http://test/').get('/applications/sector').reply(200, fixtureSectors);
 	nock('http://test/')
-		.get(/\/applications\/6(.*)/g)
-		.reply(200, fixtureCases[5]);
+		.get(/\/applications\/3(.*)/g)
+		.reply(200, fixtureCases[3]);
 	nock('http://test/')
-		.get(/\/applications\/7(.*)/g)
-		.reply(200, fixtureCases[6]);
+		.get(/\/applications\/4(.*)/g)
+		.reply(200, fixtureCases[4]);
 	nock('http://test/')
 		.get('/applications/sector?sectorName=transport')
 		.reply(200, fixtureSubSectors);
@@ -36,7 +36,7 @@ describe('applications edit', () => {
 	});
 
 	describe('Name', () => {
-		const baseUrl = '/applications-service/case/6/edit/name';
+		const baseUrl = '/applications-service/case/3/edit/name';
 
 		describe('GET /edit/name', () => {
 			describe('When role is:', () => {
@@ -79,7 +79,7 @@ describe('applications edit', () => {
 						const element = parseHtml(response.text);
 
 						expect(element.innerHTML).toMatchSnapshot();
-						expect(element.innerHTML).toContain(fixtureCases[5].title.slice(0, 20));
+						expect(element.innerHTML).toContain(fixtureCases[3].title.slice(0, 20));
 					});
 				});
 				describe('Draft:', () => {
@@ -97,7 +97,7 @@ describe('applications edit', () => {
 
 	describe('Description', () => {
 		describe('GET edit/description', () => {
-			const baseUrl = '/applications-service/case/6/edit/description';
+			const baseUrl = '/applications-service/case/3/edit/description';
 
 			beforeEach(async () => {
 				await request.get('/applications-service/case-officer');
@@ -109,13 +109,13 @@ describe('applications edit', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain(fixtureCases[5].description.slice(0, 20));
+				expect(element.innerHTML).toContain(fixtureCases[3].description.slice(0, 20));
 			});
 		});
 	});
 
 	describe('Project location', () => {
-		const baseUrl = `/applications-service/case/6/edit/project-location`;
+		const baseUrl = `/applications-service/case/3/edit/project-location`;
 
 		beforeEach(async () => {
 			await request.get('/applications-service/case-officer');
@@ -128,13 +128,13 @@ describe('applications edit', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('Bristol');
+				expect(element.innerHTML).toContain('London');
 			});
 		});
 	});
 
 	describe('Grid references', () => {
-		const baseUrl = `/applications-service/case/6/edit/grid-references`;
+		const baseUrl = `/applications-service/case/3/edit/grid-references`;
 
 		beforeEach(async () => {
 			await request.get('/applications-service/case-officer');
@@ -147,7 +147,7 @@ describe('applications edit', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('654321');
+				expect(element.innerHTML).toContain('123456');
 			});
 		});
 	});
@@ -164,20 +164,12 @@ describe('applications edit', () => {
 
 		describe('GET /edit/regions', () => {
 			it('should render the page with checked options if the api returns something', async () => {
-				const response = await request.get(baseUrl('6'));
+				const response = await request.get(baseUrl('3'));
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('value="east"\n                    checked');
-				expect(element.innerHTML).toContain('value="north"\n                    checked');
-			});
-
-			it('should render the page without checked options', async () => {
-				const response = await request.get(baseUrl('7'));
-				const element = parseHtml(response.text);
-
-				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).not.toContain('checked');
+				expect(element.innerHTML).toContain('value="london"\n                    checked');
+				expect(element.innerHTML).toContain('value="yorkshire"\n                    checked');
 			});
 		});
 	});
@@ -193,20 +185,12 @@ describe('applications edit', () => {
 		});
 
 		describe('GET edit/zoom-level', () => {
-			it('should render the page with None checked if the api does not return resumed data', async () => {
-				const response = await request.get(baseUrl('7'));
-				const element = parseHtml(response.text);
-
-				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('value="none"\n                    checked');
-			});
-
 			it('should render the page with the checked option from the resumed data', async () => {
-				const response = await request.get(baseUrl('6'));
+				const response = await request.get(baseUrl('3'));
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('value="junction"\n                    checked');
+				expect(element.innerHTML).toContain('value="city"\n                    checked');
 			});
 		});
 	});
@@ -223,15 +207,15 @@ describe('applications edit', () => {
 
 		describe('GET /edit/team-email', () => {
 			it('should render the page with the resumed data if the api returns something', async () => {
-				const response = await request.get(baseUrl('6'));
+				const response = await request.get(baseUrl('3'));
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('another@ema.il');
+				expect(element.innerHTML).toContain('some@ema.il');
 			});
 
 			it('should render the page with no value inside the text input if api does not return resumed data', async () => {
-				const response = await request.get(baseUrl('7'));
+				const response = await request.get(baseUrl('4'));
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();

--- a/apps/web/src/server/applications/pages/case/edit/case/applications-edit-case.router.js
+++ b/apps/web/src/server/applications/pages/case/edit/case/applications-edit-case.router.js
@@ -1,5 +1,6 @@
 import { Router as createRouter } from 'express';
 import asyncRoute from '../../../../../lib/async-route.js';
+import { registerCaseWithQuery } from '../../../../applications.locals.js';
 import * as validators from '../../../create-new-case/case/applications-create-case.validators.js';
 import * as controller from './applications-edit-case.controller.js';
 
@@ -7,7 +8,7 @@ const applicationsEditCaseRouter = createRouter();
 
 applicationsEditCaseRouter
 	.route('/name')
-	.get(asyncRoute(controller.viewApplicationsEditCaseName))
+	.get(registerCaseWithQuery(['title']), asyncRoute(controller.viewApplicationsEditCaseName))
 	.post(
 		[validators.validateApplicationsCreateCaseName],
 		asyncRoute(controller.updateApplicationsEditCaseNameAndDescription)
@@ -15,7 +16,10 @@ applicationsEditCaseRouter
 
 applicationsEditCaseRouter
 	.route('/description')
-	.get(asyncRoute(controller.viewApplicationsEditCaseDescription))
+	.get(
+		registerCaseWithQuery(['description']),
+		asyncRoute(controller.viewApplicationsEditCaseDescription)
+	)
 	.post(
 		[validators.validateApplicationsCreateCaseDescription],
 		asyncRoute(controller.updateApplicationsEditCaseNameAndDescription)
@@ -23,7 +27,10 @@ applicationsEditCaseRouter
 
 applicationsEditCaseRouter
 	.route('/team-email')
-	.get(asyncRoute(controller.viewApplicationsEditCaseTeamEmail))
+	.get(
+		registerCaseWithQuery(['caseEmail']),
+		asyncRoute(controller.viewApplicationsEditCaseTeamEmail)
+	)
 	.post(
 		validators.validateApplicationsTeamEmail,
 		asyncRoute(controller.updateApplicationsEditCaseTeamEmail)
@@ -31,7 +38,10 @@ applicationsEditCaseRouter
 
 applicationsEditCaseRouter
 	.route('/project-location')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseLocation))
+	.get(
+		registerCaseWithQuery(['geographicalInformation']),
+		asyncRoute(controller.viewApplicationsCreateCaseLocation)
+	)
 	.post(
 		validators.validateApplicationsCreateCaseLocation,
 		asyncRoute(controller.updateApplicationsEditCaseGeographicalInformation)
@@ -39,7 +49,10 @@ applicationsEditCaseRouter
 
 applicationsEditCaseRouter
 	.route('/grid-references')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseGridReferences))
+	.get(
+		registerCaseWithQuery(['geographicalInformation']),
+		asyncRoute(controller.viewApplicationsCreateCaseGridReferences)
+	)
 	.post(
 		[
 			validators.validateApplicationsCreateCaseEasting,
@@ -50,7 +63,10 @@ applicationsEditCaseRouter
 
 applicationsEditCaseRouter
 	.route('/regions')
-	.get(asyncRoute(controller.viewApplicationsEditCaseRegions))
+	.get(
+		registerCaseWithQuery(['geographicalInformation']),
+		asyncRoute(controller.viewApplicationsEditCaseRegions)
+	)
 	.post(
 		validators.validateApplicationsCreateCaseRegions,
 		asyncRoute(controller.updateApplicationsEditCaseRegions)
@@ -58,7 +74,10 @@ applicationsEditCaseRouter
 
 applicationsEditCaseRouter
 	.route('/zoom-level')
-	.get(asyncRoute(controller.viewApplicationsEditCaseZoomLevel))
+	.get(
+		registerCaseWithQuery(['geographicalInformation']),
+		asyncRoute(controller.viewApplicationsEditCaseZoomLevel)
+	)
 	.post(asyncRoute(controller.updateApplicationsEditCaseZoomLevel));
 
 export default applicationsEditCaseRouter;

--- a/apps/web/src/server/applications/pages/create-new-case/applicant/__tests__/__snapshots__/applications-create-applicant.test.js.snap
+++ b/apps/web/src/server/applications/pages/create-new-case/applicant/__tests__/__snapshots__/applications-create-applicant.test.js.snap
@@ -255,12 +255,12 @@ exports[`applications create applicant GET /applicant-full-name should render th
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"applicant.firstName\\">First name</label>
             <input class=\\"govuk-input govuk-!-width-one-third\\" id=\\"applicant.firstName\\"
-            name=\\"applicant.firstName\\" type=\\"text\\" value=\\"Lorem\\">
+            name=\\"applicant.firstName\\" type=\\"text\\" value=\\"John\\">
         </div>
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"applicant.lastName\\">Last name</label>
             <input class=\\"govuk-input govuk-!-width-one-third\\" id=\\"applicant.lastName\\"
-            name=\\"applicant.lastName\\" type=\\"text\\" value=\\"Ipsum\\">
+            name=\\"applicant.lastName\\" type=\\"text\\" value=\\"Smith\\">
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">

--- a/apps/web/src/server/applications/pages/create-new-case/applicant/__tests__/applications-create-applicant.test.js
+++ b/apps/web/src/server/applications/pages/create-new-case/applicant/__tests__/applications-create-applicant.test.js
@@ -15,7 +15,7 @@ const nocks = () => {
 	nock('http://test/')
 		.get(/\/applications\/123(.*)/g)
 		.times(2)
-		.reply(200, fixtureCases[3]);
+		.reply(200, fixtureCases[0]);
 };
 
 describe('applications create applicant', () => {

--- a/apps/web/src/server/applications/pages/create-new-case/applicant/applications-create-applicant.router.js
+++ b/apps/web/src/server/applications/pages/create-new-case/applicant/applications-create-applicant.router.js
@@ -1,5 +1,6 @@
 import { Router as createRouter } from 'express';
 import asyncRoute from '../../../../lib/async-route.js';
+import { registerCaseWithQuery } from '../../../applications.locals.js';
 import * as controller from './applications-create-applicant.controller.js';
 import * as guards from './applications-create-applicant.guards.js';
 import * as locals from './applications-create-applicant.locals.js';
@@ -7,7 +8,7 @@ import * as validators from './applications-create-applicant.validators.js';
 
 const applicationsCreateApplicantRouter = createRouter();
 
-applicationsCreateApplicantRouter.use([locals.registerBackPath, locals.registerApplicantId]);
+applicationsCreateApplicantRouter.use(locals.registerApplicantId);
 
 applicationsCreateApplicantRouter
 	.route('/applicant-information-types')
@@ -18,18 +19,27 @@ applicationsCreateApplicantRouter
 	.route('/applicant-organisation-name')
 	.get(
 		guards.assertStepIsAllowed,
+		registerCaseWithQuery(['applicants'], true),
 		asyncRoute(controller.viewApplicationsCreateApplicantOrganisationName)
 	)
 	.post(asyncRoute(controller.updateApplicationsCreateApplicantOrganisationName));
 
 applicationsCreateApplicantRouter
 	.route('/applicant-full-name')
-	.get(guards.assertStepIsAllowed, asyncRoute(controller.viewApplicationsCreateApplicantFullName))
+	.get(
+		guards.assertStepIsAllowed,
+		registerCaseWithQuery(['applicants'], true),
+		asyncRoute(controller.viewApplicationsCreateApplicantFullName)
+	)
 	.post(asyncRoute(controller.updateApplicationsCreateApplicantFullName));
 
 applicationsCreateApplicantRouter
 	.route('/applicant-address')
-	.get(guards.assertStepIsAllowed, asyncRoute(controller.viewApplicationsCreateApplicantAddress))
+	.get(
+		guards.assertStepIsAllowed,
+		registerCaseWithQuery(['applicants', 'applicantsAddress'], true),
+		asyncRoute(controller.viewApplicationsCreateApplicantAddress)
+	)
 	.post(
 		validators.validateApplicationsCreateApplicantPostCode,
 		asyncRoute(controller.updateApplicationsCreateApplicantAddress)
@@ -37,7 +47,11 @@ applicationsCreateApplicantRouter
 
 applicationsCreateApplicantRouter
 	.route('/applicant-website')
-	.get(guards.assertStepIsAllowed, asyncRoute(controller.viewApplicationsCreateApplicantWebsite))
+	.get(
+		guards.assertStepIsAllowed,
+		registerCaseWithQuery(['applicants'], true),
+		asyncRoute(controller.viewApplicationsCreateApplicantWebsite)
+	)
 	.post(
 		validators.validateApplicationsCreateApplicantWebsite,
 		asyncRoute(controller.updateApplicationsCreateApplicantWebsite)
@@ -45,7 +59,11 @@ applicationsCreateApplicantRouter
 
 applicationsCreateApplicantRouter
 	.route('/applicant-email')
-	.get(guards.assertStepIsAllowed, asyncRoute(controller.viewApplicationsCreateApplicantEmail))
+	.get(
+		guards.assertStepIsAllowed,
+		registerCaseWithQuery(['applicants'], true),
+		asyncRoute(controller.viewApplicationsCreateApplicantEmail)
+	)
 	.post(
 		validators.validateApplicationsCreateApplicantEmail,
 		asyncRoute(controller.updateApplicationsCreateApplicantEmail)
@@ -55,6 +73,7 @@ applicationsCreateApplicantRouter
 	.route('/applicant-telephone-number')
 	.get(
 		guards.assertStepIsAllowed,
+		registerCaseWithQuery(['applicants'], true),
 		asyncRoute(controller.viewApplicationsCreateApplicantTelephoneNumber)
 	)
 	.post(

--- a/apps/web/src/server/applications/pages/create-new-case/applications-create.router.js
+++ b/apps/web/src/server/applications/pages/create-new-case/applications-create.router.js
@@ -14,11 +14,12 @@ applicationsCreateRouter.use(guards.assertDomainTypeIsNotInspector);
 applicationsCreateRouter.use('/:caseId?', applicationsCreateResumedRouter);
 applicationsCreateResumedRouter.use(locals.registerCaseId);
 
+// do not change the order of the routers
 applicationsCreateResumedRouter.use('/', [
 	applicationsCreateCaseRouter,
-	applicationsCreateApplicantRouter,
+	applicationsCreateCheckYourAnswersRouter,
 	applicationsCreateKeyDatesRouter,
-	applicationsCreateCheckYourAnswersRouter
+	applicationsCreateApplicantRouter
 ]);
 
 export default applicationsCreateRouter;

--- a/apps/web/src/server/applications/pages/create-new-case/case/__tests__/__snapshots__/applications-create-case.test.js.snap
+++ b/apps/web/src/server/applications/pages/create-new-case/case/__tests__/__snapshots__/applications-create-case.test.js.snap
@@ -342,6 +342,19 @@ exports[`applications create Name and description GET /create-new-case When role
 </main>"
 `;
 
+exports[`applications create Name and description GET /create-new-case/1 should not render the page when case is not Draft 1`] = `
+"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
+    <div class=\\"govuk-grid-row\\">
+        <div class=\\"govuk-grid-column-two-thirds\\">
+            <h1 class=\\"govuk-heading-xl\\">Sorry, there is a problem with the service</h1>
+            <p class=\\"govuk-body\\">Try again later.</p>
+            <p class=\\"govuk-body\\"><a href=\\"https://has-appeal.herokuapp.com/help/contact\\" class=\\"govuk-link\\">Contact the Planning Inspectorate Customer Support</a> if
+                the problem persists.</p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`applications create Name and description GET /create-new-case/1 should render page with resumed data 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <h2 class=\\"govuk-heading-l\\"> Enter name and description</h2>

--- a/apps/web/src/server/applications/pages/create-new-case/case/__tests__/applications-create-case.test.js
+++ b/apps/web/src/server/applications/pages/create-new-case/case/__tests__/applications-create-case.test.js
@@ -23,19 +23,10 @@ const nocks = () => {
 		.reply(200, fixtureCases[0]);
 	nock('http://test/')
 		.get(/\/applications\/2(.*)/g)
-		.reply(200, fixtureCases[1]);
-	nock('http://test/')
-		.get(/\/applications\/3(.*)/g)
-		.reply(200, fixtureCases[2]);
-	nock('http://test/')
-		.get(/\/applications\/4(.*)/g)
-		.reply(200, fixtureCases[3]);
-	nock('http://test/')
-		.get(/\/applications\/5(.*)/g)
 		.reply(200, fixtureCases[4]);
 	nock('http://test/')
-		.get(/\/applications\/6(.*)/g)
-		.reply(200, fixtureCases[5]);
+		.get(/\/applications\/3(.*)/g)
+		.reply(200, fixtureCases[3]);
 	nock('http://test/')
 		.get('/applications/sector?sectorName=transport')
 		.reply(200, fixtureSubSectors);
@@ -217,7 +208,7 @@ describe('applications create', () => {
 					});
 
 					it('should not display a _checked_ option if the API does NOT return a resumed value', async () => {
-						const response = await request.get(baseUrl('4'));
+						const response = await request.get(baseUrl('3'));
 						const element = parseHtml(response.text);
 
 						expect(element.innerHTML).toMatchSnapshot();
@@ -268,9 +259,9 @@ describe('applications create', () => {
 
 		describe('GET /create-new-case/:caseId/sub-sector', () => {
 			it('should redirect to sector page if the sectorName is null', async () => {
-				const response = await request.get(baseUrl('4'));
+				const response = await request.get(baseUrl('3'));
 
-				expect(response?.headers?.location).toContain('4/sector');
+				expect(response?.headers?.location).toContain('3/sector');
 			});
 
 			it('should render subsectors matching with the sectorName in the session', async () => {
@@ -294,7 +285,7 @@ describe('applications create', () => {
 			});
 
 			it('should not display a _checked_ option if the API does NOT return a resumed value', async () => {
-				const response = await request.get(baseUrl('5'));
+				const response = await request.get(baseUrl('2'));
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
@@ -553,7 +544,7 @@ describe('applications create', () => {
 
 		describe('GET /create-new-case/:caseId/zoom-level', () => {
 			it('should render the page with None checked if the api does not return resumed data', async () => {
-				const response = await request.get(baseUrl('3'));
+				const response = await request.get(baseUrl('2'));
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
@@ -620,7 +611,7 @@ describe('applications create', () => {
 			});
 
 			it('should render the page with no value inside the text input if api does not return resumed data', async () => {
-				const response = await request.get(baseUrl('3'));
+				const response = await request.get(baseUrl('2'));
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();

--- a/apps/web/src/server/applications/pages/create-new-case/case/__tests__/applications-create-case.test.js
+++ b/apps/web/src/server/applications/pages/create-new-case/case/__tests__/applications-create-case.test.js
@@ -15,29 +15,27 @@ const request = supertest(app);
 const successResponse = { id: 1, applicantIds: [1] };
 
 const nocks = () => {
-	nock('http://test/').get('/applications/case-officer').times(4).reply(200, {});
+	nock('http://test/').get('/applications/case-officer').reply(200, {});
 	nock('http://test/').get('/applications/sector').reply(200, fixtureSectors);
 	nock('http://test/')
-		.get(/\/applications\/1\?(.*)/g)
-		.times(4)
+		.get(/\/applications\/1(.*)/g)
+		.times(2)
 		.reply(200, fixtureCases[0]);
 	nock('http://test/')
-		.get(/\/applications\/2\?(.*)/g)
-		.times(4)
+		.get(/\/applications\/2(.*)/g)
 		.reply(200, fixtureCases[1]);
 	nock('http://test/')
-		.get(/\/applications\/3\?(.*)/g)
-		.times(4)
+		.get(/\/applications\/3(.*)/g)
 		.reply(200, fixtureCases[2]);
 	nock('http://test/')
-		.get(/\/applications\/4\?(.*)/g)
-		.times(4)
+		.get(/\/applications\/4(.*)/g)
 		.reply(200, fixtureCases[3]);
 	nock('http://test/')
-		.get(/\/applications\/5\?(.*)/g)
-		.times(4)
+		.get(/\/applications\/5(.*)/g)
 		.reply(200, fixtureCases[4]);
-	nock('http://test/').get('/applications/').times(4).reply(404);
+	nock('http://test/')
+		.get(/\/applications\/6(.*)/g)
+		.reply(200, fixtureCases[5]);
 	nock('http://test/')
 		.get('/applications/sector?sectorName=transport')
 		.reply(200, fixtureSubSectors);
@@ -106,6 +104,14 @@ describe('applications create', () => {
 
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain(fixtureCases[0].description.slice(0, 20));
+			});
+
+			it('should not render the page when case is not Draft', async () => {
+				const response = await request.get('/applications-service/create-new-case/6');
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).not.toContain('Save and continue');
 			});
 		});
 

--- a/apps/web/src/server/applications/pages/create-new-case/case/__tests__/applications-create-case.test.js
+++ b/apps/web/src/server/applications/pages/create-new-case/case/__tests__/applications-create-case.test.js
@@ -21,12 +21,14 @@ const nocks = () => {
 		.get(/\/applications\/1(.*)/g)
 		.times(2)
 		.reply(200, fixtureCases[0]);
+
 	nock('http://test/')
 		.get(/\/applications\/2(.*)/g)
-		.reply(200, fixtureCases[4]);
+		.reply(200, fixtureCases[1]);
+
 	nock('http://test/')
 		.get(/\/applications\/3(.*)/g)
-		.reply(200, fixtureCases[3]);
+		.reply(200, fixtureCases[2]);
 	nock('http://test/')
 		.get('/applications/sector?sectorName=transport')
 		.reply(200, fixtureSubSectors);

--- a/apps/web/src/server/applications/pages/create-new-case/case/applications-create-case.router.js
+++ b/apps/web/src/server/applications/pages/create-new-case/case/applications-create-case.router.js
@@ -1,5 +1,6 @@
 import { Router as createRouter } from 'express';
 import asyncRoute from '../../../../lib/async-route.js';
+import { registerCaseWithQuery } from '../../../applications.locals.js';
 import * as controller from './applications-create-case.controller.js';
 import * as validators from './applications-create-case.validators.js';
 
@@ -7,7 +8,10 @@ const applicationsCreateCaseRouter = createRouter();
 
 applicationsCreateCaseRouter
 	.route('/')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseName))
+	.get(
+		registerCaseWithQuery(['title', 'description'], true),
+		asyncRoute(controller.viewApplicationsCreateCaseName)
+	)
 	.post(
 		[
 			validators.validateApplicationsCreateCaseName,
@@ -18,7 +22,10 @@ applicationsCreateCaseRouter
 
 applicationsCreateCaseRouter
 	.route('/sector')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseSector))
+	.get(
+		registerCaseWithQuery(['sector'], true),
+		asyncRoute(controller.viewApplicationsCreateCaseSector)
+	)
 	.post(
 		validators.validateApplicationsCreateCaseSector,
 		asyncRoute(controller.updateApplicationsCreateCaseSector)
@@ -26,7 +33,10 @@ applicationsCreateCaseRouter
 
 applicationsCreateCaseRouter
 	.route('/sub-sector')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseSubSector))
+	.get(
+		registerCaseWithQuery(['subSector', 'sector'], true),
+		asyncRoute(controller.viewApplicationsCreateCaseSubSector)
+	)
 	.post(
 		validators.validateApplicationsCreateCaseSubSector,
 		asyncRoute(controller.updateApplicationsCreateCaseSubSector)
@@ -34,7 +44,10 @@ applicationsCreateCaseRouter
 
 applicationsCreateCaseRouter
 	.route('/geographical-information')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseGeographicalInformation))
+	.get(
+		registerCaseWithQuery(['geographicalInformation'], true),
+		asyncRoute(controller.viewApplicationsCreateCaseGeographicalInformation)
+	)
 	.post(
 		[
 			validators.validateApplicationsCreateCaseLocation,
@@ -46,7 +59,10 @@ applicationsCreateCaseRouter
 
 applicationsCreateCaseRouter
 	.route('/regions')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseRegions))
+	.get(
+		registerCaseWithQuery(['geographicalInformation'], true),
+		asyncRoute(controller.viewApplicationsCreateCaseRegions)
+	)
 	.post(
 		validators.validateApplicationsCreateCaseRegions,
 		asyncRoute(controller.updateApplicationsCreateCaseRegions)
@@ -54,12 +70,18 @@ applicationsCreateCaseRouter
 
 applicationsCreateCaseRouter
 	.route('/zoom-level')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseZoomLevel))
+	.get(
+		registerCaseWithQuery(['geographicalInformation'], true),
+		asyncRoute(controller.viewApplicationsCreateCaseZoomLevel)
+	)
 	.post(asyncRoute(controller.updateApplicationsCreateCaseZoomLevel));
 
 applicationsCreateCaseRouter
 	.route('/team-email')
-	.get(asyncRoute(controller.viewApplicationsCreateCaseTeamEmail))
+	.get(
+		registerCaseWithQuery(['caseEmail'], true),
+		asyncRoute(controller.viewApplicationsCreateCaseTeamEmail)
+	)
 	.post(
 		validators.validateApplicationsTeamEmail,
 		asyncRoute(controller.updateApplicationsCreateCaseTeamEmail)

--- a/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
+++ b/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
@@ -7,7 +7,7 @@ exports[`applications create: check your answers Case created should render the 
             <div class=\\"govuk-panel govuk-panel--confirmation\\">
                 <h1 class=\\"govuk-panel__title\\"> New case has been created</h1>
                 <div class=\\"govuk-panel__body\\">The case reference number
-                    <br><strong>CASE/07</strong>
+                    <br><strong>CASE/04</strong>
                 </div>
             </div>
         </div>
@@ -35,61 +35,63 @@ exports[`applications create: check your answers Check your answers GET /check-y
                     <tbody class=\\"govuk-table__body\\">
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Project name</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Case with no sector</td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Title CASE/01</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"name\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Project description</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Case with no sector description</td>
-                            <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"description\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/\\">Change</a>
-                            </td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua Ut enim ad minim veniam quis
+                                nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</td>
+                            <td                             class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"description\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/\\">Change</a>
+                                </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Sector</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Transport EN</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"sector\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/sector\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Subsector</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Highways EN</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"subSector\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/sub-sector\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Project location</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">London</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"projectLocation\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/geographical-information\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Grid reference Easting</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">123456</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"gridReferenceEasting\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/geographical-information\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Grid reference Northing</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">987654</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"gridReferenceNorthing\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/geographical-information\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Region(s)</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">London EN,Yorkshire EN</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"regions\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/regions\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Map zoom level</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">City EN</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/zoom-level\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Project email</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">some@ema.il</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/team-email\\">Change</a>
                             </td>
                         </tr>
@@ -112,7 +114,7 @@ exports[`applications create: check your answers Check your answers GET /check-y
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Contact name</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Lorem Ipsum</td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">John Smith</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/applicant-full-name\\">Change</a>
                             </td>
                         </tr>
@@ -222,61 +224,63 @@ exports[`applications create: check your answers Check your answers POST /check-
                     <tbody class=\\"govuk-table__body\\">
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Project name</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Case with no sector</td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Title CASE/01</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"name\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Project description</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Case with no sector description</td>
-                            <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"description\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/\\">Change</a>
-                            </td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor
+                                incididunt ut labore et dolore magna aliqua Ut enim ad minim veniam quis
+                                nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat</td>
+                            <td                             class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"description\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/\\">Change</a>
+                                </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Sector</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Transport EN</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"sector\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/sector\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Subsector</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Highways EN</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"subSector\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/sub-sector\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Project location</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">London</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"projectLocation\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/geographical-information\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Grid reference Easting</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">123456</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"gridReferenceEasting\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/geographical-information\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Grid reference Northing</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">987654</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"gridReferenceNorthing\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/geographical-information\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Region(s)</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">London EN,Yorkshire EN</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a id=\\"regions\\" class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/regions\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Map zoom level</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">City EN</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/zoom-level\\">Change</a>
                             </td>
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Project email</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\"></td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">some@ema.il</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/team-email\\">Change</a>
                             </td>
                         </tr>
@@ -299,7 +303,7 @@ exports[`applications create: check your answers Check your answers POST /check-
                         </tr>
                         <tr class=\\"govuk-table__row\\">
                             <td class=\\"govuk-table__cell font-weight--700 pins-table__cell--s\\">Contact name</td>
-                            <td class=\\"govuk-table__cell pins-table__cell--s\\">Lorem Ipsum</td>
+                            <td class=\\"govuk-table__cell pins-table__cell--s\\">John Smith</td>
                             <td class=\\"govuk-table__cell text-align--right pins-table__cell--s\\"><a class=\\"govuk-link\\" href=\\"/applications-service/create-new-case/1/applicant-full-name\\">Change</a>
                             </td>
                         </tr>

--- a/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
+++ b/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`applications create applicant GET /check-your-answers should render the page 1`] = `
+exports[`applications create: check your answers Case created should render the page 1`] = `
+"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
+    <div class=\\"govuk-grid-row\\">
+        <div class=\\"govuk-grid-column-two-thirds\\">
+            <div class=\\"govuk-panel govuk-panel--confirmation\\">
+                <h1 class=\\"govuk-panel__title\\"> New case has been created</h1>
+                <div class=\\"govuk-panel__body\\">The case reference number
+                    <br><strong></strong>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div>
+        <br><a class=\\"govuk-link\\" href=\\"/applications-service/case-officer\\">Go back to main Applications homepage</a>
+    </div>
+</main>"
+`;
+
+exports[`applications create: check your answers Check your answers GET /check-your-answers should render the page 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <h2 class=\\"govuk-heading-l\\"><div class=\\"govuk-grid-row\\"><div class=\\"govuk-grid-column-full\\"> Check your answers before creating a new project</div></div></h2>
     <form method=\\"post\\" action=\\"\\">
@@ -163,7 +181,7 @@ exports[`applications create applicant GET /check-your-answers should render the
 </main>"
 `;
 
-exports[`applications create applicant POST /check-your-answers should display errors if fields are missing 1`] = `
+exports[`applications create: check your answers Check your answers POST /check-your-answers should display errors if fields are missing 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row\\">
         <div class=\\"govuk-grid-column-two-thirds\\">

--- a/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
+++ b/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
@@ -7,7 +7,7 @@ exports[`applications create: check your answers Case created should render the 
             <div class=\\"govuk-panel govuk-panel--confirmation\\">
                 <h1 class=\\"govuk-panel__title\\"> New case has been created</h1>
                 <div class=\\"govuk-panel__body\\">The case reference number
-                    <br><strong></strong>
+                    <br><strong>CASE/07</strong>
                 </div>
             </div>
         </div>

--- a/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/applications-create-check-your-answers.test.js
+++ b/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/applications-create-check-your-answers.test.js
@@ -21,11 +21,11 @@ const nocks = () => {
 	nock('http://test/').get('/applications/case-officer').reply(200, {});
 	nock('http://test/')
 		.get(/\/applications\/1(.*)/g)
-		.reply(200, fixtureCases[3]);
+		.reply(200, fixtureCases[0]);
 
 	nock('http://test/')
 		.get(/\/applications\/2(.*)/g)
-		.reply(200, fixtureCases[6]);
+		.reply(200, fixtureCases[3]);
 };
 
 describe('applications create: check your answers', () => {
@@ -68,6 +68,9 @@ describe('applications create: check your answers', () => {
 				nock('http://test/').post('/applications/1/start').reply(200, fixtureCases[0]);
 
 				const response = await request.post(baseUrl);
+
+				/* const element = parseHtml(response.text);
+				expect(element.innerHTML).toMatchSnapshot(); */
 
 				expect(response?.headers?.location).toContain(
 					'/applications-service/create-new-case/1/case-created'

--- a/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/applications-create-check-your-answers.test.js
+++ b/apps/web/src/server/applications/pages/create-new-case/check-your-answers/__tests__/applications-create-check-your-answers.test.js
@@ -18,14 +18,17 @@ const errorPostResponse = {
 };
 
 const nocks = () => {
-	nock('http://test/').get('/applications/case-officer').reply(200, []);
+	nock('http://test/').get('/applications/case-officer').reply(200, {});
 	nock('http://test/')
 		.get(/\/applications\/1(.*)/g)
-		.times(2)
 		.reply(200, fixtureCases[3]);
+
+	nock('http://test/')
+		.get(/\/applications\/2(.*)/g)
+		.reply(200, fixtureCases[6]);
 };
 
-describe('applications create applicant', () => {
+describe('applications create: check your answers', () => {
 	beforeEach(installMockApi);
 	afterEach(teardown);
 
@@ -37,50 +40,70 @@ describe('applications create applicant', () => {
 		await request.get('/applications-service/case-officer');
 	});
 
-	const baseUrl = '/applications-service/create-new-case/1/check-your-answers';
+	describe('Check your answers', () => {
+		describe('GET /check-your-answers', () => {
+			beforeEach(async () => {
+				nocks();
+			});
 
-	describe('GET /check-your-answers', () => {
+			const baseUrl = '/applications-service/create-new-case/1/check-your-answers';
+
+			it('should render the page', async () => {
+				const response = await request.get(baseUrl);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('I accept - confirm creation of a new case');
+			});
+		});
+
+		describe('POST /check-your-answers', () => {
+			beforeEach(async () => {
+				nocks();
+			});
+
+			const baseUrl = '/applications-service/create-new-case/1/check-your-answers';
+
+			it('should confirm status if no fields are missing', async () => {
+				nock('http://test/').post('/applications/1/start').reply(200, fixtureCases[0]);
+
+				const response = await request.post(baseUrl);
+
+				expect(response?.headers?.location).toContain(
+					'/applications-service/create-new-case/1/case-created'
+				);
+			});
+
+			it('should display errors if fields are missing', async () => {
+				nock('http://test/').post('/applications/1/start').reply(200, errorPostResponse);
+
+				const response = await request.post(baseUrl);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Enter the project location');
+				expect(element.innerHTML).toContain('Choose the subsector of the project');
+				expect(element.innerHTML).toContain('Choose the sector of the project');
+				expect(element.innerHTML).toContain('Choose at least one region');
+				expect(element.innerHTML).toContain('Enter the Grid reference Easting');
+				expect(element.innerHTML).toContain('Enter the Grid reference Northing');
+			});
+		});
+	});
+
+	describe('Case created', () => {
 		beforeEach(async () => {
 			nocks();
 		});
+
+		const baseUrl = '/applications-service/create-new-case/2/case-created';
 
 		it('should render the page', async () => {
 			const response = await request.get(baseUrl);
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('I accept - confirm creation of a new case');
-		});
-	});
-
-	describe('POST /check-your-answers', () => {
-		beforeEach(async () => {
-			nocks();
-		});
-
-		it('should confirm status if no fields are missing', async () => {
-			nock('http://test/').post('/applications/1/start').reply(200, fixtureCases[0]);
-
-			const response = await request.post(baseUrl);
-
-			expect(response?.headers?.location).toContain(
-				'/applications-service/create-new-case/1/case-created'
-			);
-		});
-
-		it('should display errors if fields are missing', async () => {
-			nock('http://test/').post('/applications/1/start').reply(200, errorPostResponse);
-
-			const response = await request.post(baseUrl);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Enter the project location');
-			expect(element.innerHTML).toContain('Choose the subsector of the project');
-			expect(element.innerHTML).toContain('Choose the sector of the project');
-			expect(element.innerHTML).toContain('Choose at least one region');
-			expect(element.innerHTML).toContain('Enter the Grid reference Easting');
-			expect(element.innerHTML).toContain('Enter the Grid reference Northing');
+			expect(element.innerHTML).toContain('New case has been created');
 		});
 	});
 });

--- a/apps/web/src/server/applications/pages/create-new-case/check-your-answers/applications-create-check-your-answers.controller.js
+++ b/apps/web/src/server/applications/pages/create-new-case/check-your-answers/applications-create-check-your-answers.controller.js
@@ -14,8 +14,8 @@ import * as applicationsCreateCheckYourAnswersService from './applications-creat
  * {}, {}, {}, {}>}
  */
 export async function viewApplicationsCreateConfirmation(req, response) {
-	const { caseId } = response.locals;
-	const { reference } = await getCase(caseId, ['reference']);
+	const { currentCase, caseId } = response.locals;
+	const { reference } = currentCase;
 
 	if (!reference) {
 		pino.warn(`[WEB] reference number for case ${caseId} is not defined`);
@@ -33,13 +33,11 @@ export async function viewApplicationsCreateConfirmation(req, response) {
  * {}, {}, {}, {}>}
  */
 export async function viewApplicationsCreateCheckYourAnswers(req, response) {
-	const { caseId } = response.locals;
+	const { currentCase } = response.locals;
 
 	destroySessionCaseHasNeverBeenResumed(req.session);
 
-	const caseData = await getCase(caseId);
-
-	const { values } = applicationsCreateCheckYourAnswersService.mapCaseData(caseData);
+	const { values } = applicationsCreateCheckYourAnswersService.mapCaseData(currentCase);
 
 	return response.render('applications/create-new-case/check-your-answers', { values });
 }

--- a/apps/web/src/server/applications/pages/create-new-case/check-your-answers/applications-create-check-your-answers.router.js
+++ b/apps/web/src/server/applications/pages/create-new-case/check-your-answers/applications-create-check-your-answers.router.js
@@ -1,16 +1,23 @@
 import { Router as createRouter } from 'express';
 import asyncRoute from '../../../../lib/async-route.js';
+import { registerCaseWithQuery } from '../../../applications.locals.js';
 import * as controller from './applications-create-check-your-answers.controller.js';
 
 const applicationsCreateCheckYourAnswersRouter = createRouter();
 
 applicationsCreateCheckYourAnswersRouter
-	.route('/case-created')
-	.get(asyncRoute(controller.viewApplicationsCreateConfirmation));
+	.route('/check-your-answers')
+	.get(
+		registerCaseWithQuery(null, true),
+		asyncRoute(controller.viewApplicationsCreateCheckYourAnswers)
+	)
+	.post(asyncRoute(controller.confirmCreateCase));
 
 applicationsCreateCheckYourAnswersRouter
-	.route('/check-your-answers')
-	.get(asyncRoute(controller.viewApplicationsCreateCheckYourAnswers))
-	.post(asyncRoute(controller.confirmCreateCase));
+	.route('/case-created')
+	.get(
+		registerCaseWithQuery(['reference']),
+		asyncRoute(controller.viewApplicationsCreateConfirmation)
+	);
 
 export default applicationsCreateCheckYourAnswersRouter;

--- a/apps/web/src/server/applications/pages/create-new-case/key-dates/__tests__/applications-create-key-dates.test.js
+++ b/apps/web/src/server/applications/pages/create-new-case/key-dates/__tests__/applications-create-key-dates.test.js
@@ -13,7 +13,7 @@ const nocks = () => {
 	nock('http://test/').patch('/applications/123').reply(200, successPatchPostResponse);
 	nock('http://test/')
 		.get(/\/applications\/123(.*)/g)
-		.reply(200, fixtureCases[3]);
+		.reply(200, fixtureCases[0]);
 };
 
 describe('Applications create key dates', () => {

--- a/apps/web/src/server/applications/pages/create-new-case/key-dates/__tests__/applications-create-key-dates.test.js
+++ b/apps/web/src/server/applications/pages/create-new-case/key-dates/__tests__/applications-create-key-dates.test.js
@@ -13,7 +13,6 @@ const nocks = () => {
 	nock('http://test/').patch('/applications/123').reply(200, successPatchPostResponse);
 	nock('http://test/')
 		.get(/\/applications\/123(.*)/g)
-		.times(2)
 		.reply(200, fixtureCases[3]);
 };
 

--- a/apps/web/src/server/applications/pages/create-new-case/key-dates/applications-create-key-dates.router.js
+++ b/apps/web/src/server/applications/pages/create-new-case/key-dates/applications-create-key-dates.router.js
@@ -1,13 +1,20 @@
 import { Router as createRouter } from 'express';
 import asyncRoute from '../../../../lib/async-route.js';
+import { registerCaseWithQuery } from '../../../applications.locals.js';
+import * as locals from '../applicant/applications-create-applicant.locals.js';
 import * as controller from './applications-create-key-dates.controller.js';
 import * as validators from './applications-create-key-dates.validators.js';
 
 const applicationsCreateKeyDatesRouter = createRouter();
 
+applicationsCreateKeyDatesRouter.use(locals.registerBackPath);
+
 applicationsCreateKeyDatesRouter
 	.route('/key-dates')
-	.get(asyncRoute(controller.viewApplicationsCreateKeyDates))
+	.get(
+		registerCaseWithQuery(['keyDates'], true),
+		asyncRoute(controller.viewApplicationsCreateKeyDates)
+	)
 	.post(
 		validators.validateApplicationsCreateKeyDates,
 		asyncRoute(controller.updateApplicationsCreateKeyDates)

--- a/apps/web/src/server/views/applications/components/case-form/applicant/address-view.njk
+++ b/apps/web/src/server/views/applications/components/case-form/applicant/address-view.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% macro addressView(postcode, applicantAddress) %}
+{% macro addressView(postcode, applicantAddress, caseId) %}
 	{% if applicantAddress.length < 1 %}
 		<input type="hidden" name='currentFormStage' value="searchPostcode">
 		<div class="govuk-form-group">
@@ -25,7 +25,7 @@
 					<div class="govuk-grid-row govuk-button-group">
 						<p class='govuk-body govuk-grid-column-one-half'>{{ postcode | upper }}</p>
 						<div class="govuk-grid-column-one-half">
-							<a class="govuk-link " href="./new">Change</a>
+							<a class="govuk-link " href="{{ 'case-edit'|url({caseId: caseId, step: 'applicant-address/new'}) }}">Change</a>
 						</div>
 					</div>
 				</div>

--- a/apps/web/src/server/views/applications/components/case-form/case-form-layout.njk
+++ b/apps/web/src/server/views/applications/components/case-form/case-form-layout.njk
@@ -99,7 +99,7 @@
 		{% elif componentName == 'address' %}
 		{{ address(formStage, postcode, errors, addressList) }}
 		{% elif componentName == 'address-view' %}
-		{{ addressView(postcode, applicantAddress) }}
+		{{ addressView(postcode, applicantAddress, caseId) }}
 		{% elif componentName == 'date-internal' %}
 		{{ dateInternal(values, errors) }}
 		{% elif componentName == 'date-published' %}

--- a/apps/web/testing/applications/factory/application.js
+++ b/apps/web/testing/applications/factory/application.js
@@ -38,7 +38,8 @@ export const createCase = ({
 	sector = createOptionsItem(),
 	subSector = createOptionsItem(),
 	status = `Status ${id}000`,
-	applicants = [createApplicant(true)]
+	applicants = [createApplicant(true)],
+	caseEmail
 } = {}) => {
 	return {
 		id,
@@ -51,14 +52,14 @@ export const createCase = ({
 		subSector,
 		applicants,
 		geographicalInformation: {
-			locationDescription: 'Bristol',
+			locationDescription: 'London',
 			gridReference: {
-				easting: '654321',
-				northing: '456789'
+				easting: '123456',
+				northing: '987654'
 			},
-			regions: [fixtureRegions[2], fixtureRegions[3]],
-			mapZoomLevel: fixtureZoomLevels[2]
+			regions: [fixtureRegions[0], fixtureRegions[1]],
+			mapZoomLevel: fixtureZoomLevels[0]
 		},
-		caseEmail: 'another@ema.il'
+		caseEmail
 	};
 };

--- a/apps/web/testing/applications/factory/application.js
+++ b/apps/web/testing/applications/factory/application.js
@@ -1,23 +1,45 @@
 import { fake } from '@pins/platform';
 import sub from 'date-fns/sub/index.js';
 import { random } from 'lodash-es';
+import { fixtureRegions, fixtureZoomLevels } from '../fixtures/options-item.js';
 import { createOptionsItem } from './options-item.js';
 import { createCaseReference, createRandomDescription } from './util.js';
 
 /** @typedef {import('../../../src/server/applications/applications.types').Case} Case */
+/** @typedef {import('../../../src/server/applications/applications.types').Applicant} Applicant */
+
+/**
+ * @param {boolean} showAddress
+ * @returns {Applicant}
+ */
+export const createApplicant = (showAddress = false) => {
+	return {
+		id: 2,
+		organisationName: 'Org name',
+		firstName: 'John',
+		lastName: 'Smith',
+		website: 'website.web',
+		email: 'email@email.co',
+		phoneNumber: '001',
+		...(showAddress
+			? { address: { addressLine1: 'Applicant address', postCode: 'ABC123', town: 'London' } }
+			: {})
+	};
+};
 
 /**
  * @param {Partial<Case>} [options={}]
  * @returns {Case}
  */
-export function createCase({
+export const createCase = ({
 	id = fake.createUniqueId(),
 	modifiedDate = `${sub(new Date(), { weeks: random(1, 6) }).getTime() / 1000}`,
 	reference = createCaseReference(),
 	sector = createOptionsItem(),
 	subSector = createOptionsItem(),
-	status = `Status ${id}000`
-} = {}) {
+	status = `Status ${id}000`,
+	applicants = [createApplicant(true)]
+} = {}) => {
 	return {
 		id,
 		reference,
@@ -27,16 +49,16 @@ export function createCase({
 		modifiedDate,
 		sector,
 		subSector,
-		applicants: [
-			{
-				id: 2,
-				organisationName: 'Org name',
-				firstName: 'John',
-				lastName: 'Smith',
-				website: 'website.web',
-				email: 'email@email.co',
-				phoneNumber: '001'
-			}
-		]
+		applicants,
+		geographicalInformation: {
+			locationDescription: 'Bristol',
+			gridReference: {
+				easting: '654321',
+				northing: '456789'
+			},
+			regions: [fixtureRegions[2], fixtureRegions[3]],
+			mapZoomLevel: fixtureZoomLevels[2]
+		},
+		caseEmail: 'another@ema.il'
 	};
-}
+};

--- a/apps/web/testing/applications/fixtures/cases.js
+++ b/apps/web/testing/applications/fixtures/cases.js
@@ -17,7 +17,7 @@ export const fixtureCases = [
 			reference: 'CASE/01',
 			sector: fixtureSectors[0],
 			subSector: fixtureSubSectors[0],
-			status: 'Pre-Application'
+			status: 'Draft'
 		}),
 		geographicalInformation: {
 			locationDescription: 'London',
@@ -35,21 +35,23 @@ export const fixtureCases = [
 		modifiedDate: `${new Date(2022, 0, 31).getTime() / 1000}`,
 		reference: 'CASE/02',
 		sector: fixtureSectors[0],
-		subSector: fixtureSectors[1]
+		subSector: fixtureSectors[1],
+		status: 'Draft'
 	}),
 	createCase({
 		id: 3,
 		modifiedDate: `${new Date(2022, 0, 1).getTime() / 1000}`,
 		reference: 'CASE/03',
 		sector: fixtureSectors[2],
-		subSector: fixtureSectors[3]
+		subSector: fixtureSectors[3],
+		status: 'Draft'
 	}),
 	{
 		id: 4,
 		reference: 'CASE/04',
 		title: `Case with no sector`,
 		description: 'Case with no sector description',
-		status: 'draft',
+		status: 'Draft',
 		applicants: [
 			{
 				id: 2,
@@ -69,6 +71,14 @@ export const fixtureCases = [
 		title: `Case with no subsector`,
 		description: 'Case with no subsector description',
 		sector: fixtureSectors[0],
-		status: 'draft'
-	}
+		status: 'Draft'
+	},
+	createCase({
+		id: 6,
+		modifiedDate: `${new Date(2022, 0, 31).getTime() / 1000}`,
+		reference: 'CASE/06',
+		sector: fixtureSectors[0],
+		subSector: fixtureSectors[1],
+		status: 'Pre-Application'
+	})
 ];

--- a/apps/web/testing/applications/fixtures/cases.js
+++ b/apps/web/testing/applications/fixtures/cases.js
@@ -1,35 +1,18 @@
-import { createCase } from '../factory/application.js';
-import {
-	fixtureRegions,
-	fixtureSectors,
-	fixtureSubSectors,
-	fixtureZoomLevels
-} from './options-item.js';
+import { createApplicant, createCase } from '../factory/application.js';
+import { fixtureSectors, fixtureSubSectors } from './options-item.js';
 
 /** @typedef {import('../../../src/server/applications/applications.types').Case} Case */
 
 /** @type {Case[]} */
 export const fixtureCases = [
-	{
-		...createCase({
-			id: 1,
-			modifiedDate: `${new Date(2022, 0, 1).getTime() / 1000}`,
-			reference: 'CASE/01',
-			sector: fixtureSectors[0],
-			subSector: fixtureSubSectors[0],
-			status: 'Draft'
-		}),
-		geographicalInformation: {
-			locationDescription: 'London',
-			gridReference: {
-				easting: '123456',
-				northing: '987654'
-			},
-			regions: [fixtureRegions[0], fixtureRegions[1]],
-			mapZoomLevel: fixtureZoomLevels[0]
-		},
-		caseEmail: 'some@ema.il'
-	},
+	createCase({
+		id: 1,
+		modifiedDate: `${new Date(2022, 0, 1).getTime() / 1000}`,
+		reference: 'CASE/01',
+		sector: fixtureSectors[0],
+		subSector: fixtureSubSectors[0],
+		status: 'Draft'
+	}),
 	createCase({
 		id: 2,
 		modifiedDate: `${new Date(2022, 0, 31).getTime() / 1000}`,
@@ -51,19 +34,7 @@ export const fixtureCases = [
 		reference: 'CASE/04',
 		title: `Case with no sector`,
 		description: 'Case with no sector description',
-		status: 'Draft',
-		applicants: [
-			{
-				id: 2,
-				organisationName: 'Org name',
-				firstName: 'Lorem',
-				lastName: 'Ipsum',
-				website: 'website.web',
-				email: 'email@email.co',
-				phoneNumber: '001',
-				address: { addressLine1: 'Applicant address', postCode: 'ABC123', town: 'London' }
-			}
-		]
+		status: 'Draft'
 	},
 	{
 		id: 5,
@@ -75,10 +46,19 @@ export const fixtureCases = [
 	},
 	createCase({
 		id: 6,
-		modifiedDate: `${new Date(2022, 0, 31).getTime() / 1000}`,
+		modifiedDate: `${new Date(2022, 0, 1).getTime() / 1000}`,
 		reference: 'CASE/06',
 		sector: fixtureSectors[0],
-		subSector: fixtureSectors[1],
+		subSector: fixtureSubSectors[0],
 		status: 'Pre-Application'
+	}),
+	createCase({
+		id: 7,
+		modifiedDate: `${new Date(2022, 0, 31).getTime() / 1000}`,
+		reference: 'CASE/07',
+		sector: fixtureSectors[0],
+		subSector: fixtureSectors[1],
+		status: 'Pre-application',
+		applicants: [createApplicant(false)]
 	})
 ];

--- a/apps/web/testing/applications/fixtures/cases.js
+++ b/apps/web/testing/applications/fixtures/cases.js
@@ -11,51 +11,37 @@ export const fixtureCases = [
 		reference: 'CASE/01',
 		sector: fixtureSectors[0],
 		subSector: fixtureSubSectors[0],
-		status: 'Draft'
+		status: 'Draft',
+		caseEmail: 'some@ema.il'
 	}),
-	createCase({
+	{
 		id: 2,
-		modifiedDate: `${new Date(2022, 0, 31).getTime() / 1000}`,
 		reference: 'CASE/02',
-		sector: fixtureSectors[0],
-		subSector: fixtureSectors[1],
-		status: 'Draft'
-	}),
-	createCase({
-		id: 3,
-		modifiedDate: `${new Date(2022, 0, 1).getTime() / 1000}`,
-		reference: 'CASE/03',
-		sector: fixtureSectors[2],
-		subSector: fixtureSectors[3],
-		status: 'Draft'
-	}),
-	{
-		id: 4,
-		reference: 'CASE/04',
-		title: `Case with no sector`,
-		description: 'Case with no sector description',
-		status: 'Draft'
-	},
-	{
-		id: 5,
-		reference: 'CASE/05',
 		title: `Case with no subsector`,
 		description: 'Case with no subsector description',
 		sector: fixtureSectors[0],
 		status: 'Draft'
 	},
+	{
+		id: 3,
+		reference: 'CASE/03',
+		title: `Case with no sector`,
+		description: 'Case with no sector description',
+		status: 'Draft'
+	},
 	createCase({
-		id: 6,
+		id: 4,
 		modifiedDate: `${new Date(2022, 0, 1).getTime() / 1000}`,
-		reference: 'CASE/06',
+		reference: 'CASE/04',
 		sector: fixtureSectors[0],
 		subSector: fixtureSubSectors[0],
-		status: 'Pre-Application'
+		status: 'Pre-Application',
+		caseEmail: 'some@ema.il'
 	}),
 	createCase({
-		id: 7,
+		id: 5,
 		modifiedDate: `${new Date(2022, 0, 31).getTime() / 1000}`,
-		reference: 'CASE/07',
+		reference: 'CASE/05',
 		sector: fixtureSectors[0],
 		subSector: fixtureSectors[1],
 		status: 'Pre-application',


### PR DESCRIPTION
## Describe your changes

Add a middleware that queries the Case with the correct filters and 
1. throw and error in case user is trying to access a non-draft page with a draft case or viceversa.
2. in case the status is ok, put the case into a local variable and retrieve from there in the controller rather than doing 2 separates requests

also: Fixed all the tests to use non-draft cases for non-draft pages and draft-cases for draft-pages.

## Issue ticket number and link
https://pins-ds.atlassian.net/jira/software/projects/BOAS/boards/172?selectedIssue=BOAS-586
## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
