### PR TITLE
Feature/boas 626 file size and type in document table

### DIFF
--- a/apps/api/prisma/migrations/20221223122013_add_file_size_and_type_to_document_table/migration.sql
+++ b/apps/api/prisma/migrations/20221223122013_add_file_size_and_type_to_document_table/migration.sql
@@ -1,0 +1,20 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Document] ADD [fileSize] INT NOT NULL CONSTRAINT [Document_fileSize_df] DEFAULT 0,
+[fileType] NVARCHAR(1000);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -315,6 +315,8 @@ model Document {
   status               String  		@default("awaiting_upload")
 	redacted						 Boolean 		@default(false)
 	createdAt						 DateTime  	@default(now())
+	fileSize						 Int				@default(0)
+	fileType						 String?
 
   @@unique([name, folderId])
 }

--- a/apps/api/src/server/applications/application/documents/__tests__/provide-document-upload-urls.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/provide-document-upload-urls.test.js
@@ -24,7 +24,7 @@ const upsertDocumentStub = sinon.stub();
 
 upsertDocumentStub
 	.withArgs({
-		create: { name: 'test doc', folderId: 1, fileType: 'DOC', fileSize: 1024 },
+		create: { name: 'test doc', folderId: 1, fileType: 'application/pdf', fileSize: 1024 },
 		where: { name_folderId: { name: 'test doc', folderId: 1 } },
 		update: {}
 	})
@@ -84,7 +84,9 @@ test.before('set up mocks', () => {
 test('saves documents information and returns upload URL', async (t) => {
 	const response = await request
 		.post('/applications/1/documents')
-		.send([{ folderId: 1, documentName: 'test doc', documentType: 'DOC', documentSize: 1024 }]);
+		.send([
+			{ folderId: 1, documentName: 'test doc', documentType: 'application/pdf', documentSize: 1024 }
+		]);
 
 	t.is(response.status, 200);
 	t.deepEqual(response.body, {
@@ -112,7 +114,9 @@ test('saves documents information and returns upload URL', async (t) => {
 test('throws error if folder id does not belong to case', async (t) => {
 	const response = await request
 		.post('/applications/1/documents')
-		.send([{ folderId: 2, documentName: 'test doc', documentType: 'DOC', documentSize: 1024 }]);
+		.send([
+			{ folderId: 2, documentName: 'test doc', documentType: 'application/pdf', documentSize: 1024 }
+		]);
 
 	t.is(response.status, 400);
 	t.deepEqual(response.body, {

--- a/apps/api/src/server/applications/application/documents/__tests__/provide-document-upload-urls.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/provide-document-upload-urls.test.js
@@ -24,7 +24,7 @@ const upsertDocumentStub = sinon.stub();
 
 upsertDocumentStub
 	.withArgs({
-		create: { name: 'test doc', folderId: 1 },
+		create: { name: 'test doc', folderId: 1, fileType: 'DOC', fileSize: 1024 },
 		where: { name_folderId: { name: 'test doc', folderId: 1 } },
 		update: {}
 	})
@@ -84,7 +84,7 @@ test.before('set up mocks', () => {
 test('saves documents information and returns upload URL', async (t) => {
 	const response = await request
 		.post('/applications/1/documents')
-		.send([{ folderId: 1, documentName: 'test doc' }]);
+		.send([{ folderId: 1, documentName: 'test doc', documentType: 'DOC', documentSize: 1024 }]);
 
 	t.is(response.status, 200);
 	t.deepEqual(response.body, {
@@ -112,7 +112,7 @@ test('saves documents information and returns upload URL', async (t) => {
 test('throws error if folder id does not belong to case', async (t) => {
 	const response = await request
 		.post('/applications/1/documents')
-		.send([{ folderId: 2, documentName: 'test doc' }]);
+		.send([{ folderId: 2, documentName: 'test doc', documentType: 'DOC', documentSize: 1024 }]);
 
 	t.is(response.status, 400);
 	t.deepEqual(response.body, {
@@ -129,6 +129,8 @@ test('throws error if not all document details provided', async (t) => {
 	t.deepEqual(response.body, {
 		errors: {
 			'[0].documentName': 'Must provide a document name',
+			'[0].documentSize': 'Must provide a document size',
+			'[0].documentType': 'Must provide a document type',
 			'[0].folderId': 'Must provide a folder id'
 		}
 	});

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -13,14 +13,23 @@ export const provideDocumentUploadURLs = async ({ params, body }, response) => {
 	const caseFromDatabase = await caseRepository.getById(params.id, {});
 
 	const documentsToSendToDatabase = documents.map(
-		(/** @type {{ documentName: any; folderId: any; }} */ document) => {
-			return { name: document.documentName, folderId: document.folderId };
+		(
+			/** @type {{ documentName: any; folderId: any; documentType: string; documentSize: number }} */ document
+		) => {
+			return {
+				name: document.documentName,
+				folderId: document.folderId,
+				fileType: document.documentType,
+				fileSize: document.documentSize
+			};
 		}
 	);
 
 	const documentsFromDatabase = await Promise.all(
 		documentsToSendToDatabase.map(
-			(/** @type {{ name: string; folderId: number; }} */ documentToDatabase) => {
+			(
+				/** @type {{ name: string; folderId: number; fileType: string; fileSize: number }} */ documentToDatabase
+			) => {
 				return documentRepository.upsert(documentToDatabase);
 			}
 		)

--- a/apps/api/src/server/applications/application/documents/document.validators.js
+++ b/apps/api/src/server/applications/application/documents/document.validators.js
@@ -31,6 +31,8 @@ const validateAllDocumentsExist = async (documentGuids) => {
 export const validateDocumentsToUploadProvided = composeMiddleware(
 	body('[]').notEmpty().withMessage('Must provide documents to upload'),
 	body('*.documentName').exists().withMessage('Must provide a document name'),
+	body('*.documentType').exists().withMessage('Must provide a document type'),
+	body('*.documentSize').exists().withMessage('Must provide a document size'),
 	body('*.folderId').exists().withMessage('Must provide a folder id'),
 	validationErrorHandler
 );

--- a/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
+++ b/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
@@ -72,7 +72,7 @@ const documents = [
 		blobStoragePath: null,
 		redacted: false,
 		createdAt: new Date(1_658_486_313_000),
-		fileType: 'PDF',
+		fileType: 'application/pdf',
 		fileSize: 1024
 	}
 ];
@@ -237,7 +237,7 @@ test('returns documents in a folder on a case', async (t) => {
 				from: '',
 				receivedDate: 1_658_486_313,
 				size: 1024,
-				type: 'PDF',
+				type: 'application/pdf',
 				redacted: false,
 				status: 'not_user_checked'
 			}

--- a/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
+++ b/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
@@ -71,7 +71,9 @@ const documents = [
 		blobStorageContainer: null,
 		blobStoragePath: null,
 		redacted: false,
-		createdAt: new Date(1_658_486_313_000)
+		createdAt: new Date(1_658_486_313_000),
+		fileType: 'PDF',
+		fileSize: 1024
 	}
 ];
 
@@ -234,8 +236,8 @@ test('returns documents in a folder on a case', async (t) => {
 				documentUrl: null,
 				from: '',
 				receivedDate: 1_658_486_313,
-				size: 0,
-				type: '',
+				size: 1024,
+				type: 'PDF',
 				redacted: false,
 				status: 'not_user_checked'
 			}

--- a/apps/api/src/server/applications/application/file-folders/folders.routes.js
+++ b/apps/api/src/server/applications/application/file-folders/folders.routes.js
@@ -143,8 +143,8 @@ router.post(
 			required: true
 		}
         #swagger.responses[200] = {
-            description: 'An array of updated document guids',
-            type: string[]
+            description: 'An paginated data set of documents',
+            schema: { $ref: '#/definitions/PaginatedDocumentDetails' }
         }
     */
 	validateApplicationId,

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -755,7 +755,14 @@
 						"required": true
 					}
 				],
-				"responses": {}
+				"responses": {
+					"200": {
+						"description": "An paginated data set of documents",
+						"schema": {
+							"$ref": "#/definitions/PaginatedDocumentDetails"
+						}
+					}
+				}
 			}
 		},
 		"/applications": {
@@ -1880,9 +1887,12 @@
 								},
 								"documentName": {
 									"type": "string",
-									"example": "Document Name 1"
+									"example": "document_name_1.pdf"
 								},
-								"documentUrl": {},
+								"documentUrl": {
+									"type": "string",
+									"example": "/some/path/document_name_1.pdf"
+								},
 								"from": {
 									"type": "string",
 									"example": ""
@@ -1893,11 +1903,11 @@
 								},
 								"size": {
 									"type": "number",
-									"example": 0
+									"example": 1024
 								},
 								"type": {
 									"type": "string",
-									"example": "PDF"
+									"example": "application/pdf"
 								},
 								"redacted": {
 									"type": "boolean",
@@ -1905,7 +1915,7 @@
 								},
 								"status": {
 									"type": "string",
-									"example": "unchecked"
+									"example": "not_user_checked"
 								}
 							}
 						}

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -1161,6 +1161,14 @@
 					"folderId": {
 						"type": "number",
 						"example": 123
+					},
+					"documentType": {
+						"type": "string",
+						"example": "PDF"
+					},
+					"documentSize": {
+						"type": "number",
+						"example": 1024
 					}
 				}
 			}

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -1164,7 +1164,7 @@
 					},
 					"documentType": {
 						"type": "string",
-						"example": "PDF"
+						"example": "application/pdf"
 					},
 					"documentSize": {
 						"type": "number",

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -252,14 +252,14 @@ const document = {
 				items: [
 					{
 						guid: '0fab253b-2c0c-4c55-94c0-f3f81ffc589c',
-						documentName: 'Document Name 1',
-						documentUrl: null,
+						documentName: 'document_name_1.pdf',
+						documentUrl: '/some/path/document_name_1.pdf',
 						from: '',
 						receivedDate: 1_658_486_313,
-						size: 0,
-						type: 'PDF',
+						size: 1024,
+						type: 'application/pdf',
 						redacted: false,
-						status: 'unchecked'
+						status: 'not_user_checked'
 					}
 				]
 			}

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -35,7 +35,9 @@ const document = {
 		documentsToSave: [
 			{
 				documentName: 'document.pdf',
-				folderId: 123
+				folderId: 123,
+				documentType: 'PDF',
+				documentSize: 1024
 			}
 		],
 		documentsToUpdateRequestBody: {

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -36,7 +36,7 @@ const document = {
 			{
 				documentName: 'document.pdf',
 				folderId: 123,
-				documentType: 'PDF',
+				documentType: 'application/pdf',
 				documentSize: 1024
 			}
 		],

--- a/apps/api/src/server/utils/mapping/map-document-details.js
+++ b/apps/api/src/server/utils/mapping/map-document-details.js
@@ -16,8 +16,8 @@ export const mapSingleDocumentDetails = (documentDetails) => {
 		documentUrl: documentDetails.blobStoragePath,
 		from: '',
 		receivedDate: mapDateStringToUnixTimestamp(documentDetails.createdAt.toString()),
-		size: 0,
-		type: '',
+		size: documentDetails.fileSize,
+		type: documentDetails.fileType ?? '',
 		redacted: documentDetails.redacted,
 		status: documentDetails.status
 	};

--- a/apps/web/src/client/components/file-uploader/_server-actions.js
+++ b/apps/web/src/client/components/file-uploader/_server-actions.js
@@ -24,6 +24,8 @@ const serverActions = (uploadForm) => {
 		const { folderId, caseId } = uploadForm.dataset;
 		const payload = [...fileList].map((file) => ({
 			documentName: file.name,
+			documentSize: file.size,
+			documentType: file.type,
 			caseId,
 			folderId,
 			fileRowId: file.fileRowId

--- a/apps/web/src/server/lib/nunjucks-filters/index.js
+++ b/apps/web/src/server/lib/nunjucks-filters/index.js
@@ -28,6 +28,7 @@ export { url } from './url.js';
 export { fileSize } from './file-size.js';
 export { userTypeMap } from './user-type-map.js';
 export { MIME } from './mime-type.js';
+export { fileType } from './mime-type.js';
 export { statusName } from './status-name.js';
 export { default as stripQueryParamsDev } from './strip-query-parameters.js';
 

--- a/apps/web/src/server/lib/nunjucks-filters/mime-type.js
+++ b/apps/web/src/server/lib/nunjucks-filters/mime-type.js
@@ -1,3 +1,23 @@
+/** @type {Record<string, string>} */
+const MIMEs = {
+	pdf: 'application/pdf',
+	doc: 'application/msword',
+	docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	ppt: 'application/vnd.ms-powerpoint',
+	pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+	xls: 'application/vnd.ms-excel',
+	xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+	jpg: 'image/jpeg',
+	jpeg: 'image/jpeg',
+	mpeg: 'video/mpeg',
+	mp3: 'audio/mpeg',
+	mp4: 'video/mp4',
+	mov: 'video/quicktime',
+	png: 'image/png',
+	tiff: 'image/tiff',
+	tif: 'image/tiff'
+};
+
 /**
  * Returns MIME type from extension
  *
@@ -5,25 +25,20 @@
  * @returns {string}
  */
 export const MIME = (extension) => {
-	/** @type {Record<string, string>} */
-	const MIMEs = {
-		pdf: 'application/pdf',
-		doc: 'application/msword',
-		docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-		ppt: 'application/vnd.ms-powerpoint',
-		pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-		xls: 'application/vnd.ms-excel',
-		xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-		jpg: 'image/jpeg',
-		jpeg: 'image/jpeg',
-		mpeg: 'video/mpeg',
-		mp3: 'audio/mpeg',
-		mp4: 'video/mp4',
-		mov: 'video/quicktime',
-		png: 'image/png',
-		tiff: 'image/tiff',
-		tif: 'image/tiff'
-	};
-
 	return `.${extension}${MIMEs[extension] ? `,${MIMEs[extension]}` : ''},`;
+};
+
+/**
+ * Returns extension from MIME type
+ *
+ * @param {string} mime
+ * @returns {string}
+ */
+export const fileType = (mime) => {
+	const MIMEList = Object.values(MIMEs);
+	const mimeIndex = MIMEList.indexOf(mime);
+
+	if (mimeIndex < 0) return '';
+
+	return Object.keys(MIMEs)[mimeIndex].toUpperCase();
 };

--- a/apps/web/src/server/views/applications/case-documentation/documentation-folder.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-folder.njk
@@ -197,9 +197,7 @@
 											}) }}
 										</td>
 										<td class="govuk-table__cell">
-											{# TODO: still uncertain how the API will return the types
-											so probably a literal == will need to be changed later #}
-											{% if documentationFile.type === 'PDF' or documentationFile.type === 'JPEG' or documentationFile.type === 'JPG' or documentationFile.type === 'PNG' %}
+											{% if documentationFile.type === 'application/pdf' or documentationFile.type === 'image/jpeg' or documentationFile.type === 'image/png' %}
 												<a class="govuk-link govuk-body-s govuk-!-font-weight-bold"
 												   href="{{ documentationFile.url }}">
 													{{ documentationFile.documentName }}
@@ -213,7 +211,7 @@
 												From: {{ documentationFile.from }}
 											</p>
 											<p class="file-info colour--secondary">
-												File type and size: {{ documentationFile.type }},
+												File type and size: {{ documentationFile.type|fileType }},
 												{{ documentationFile.size|fileSize }}
 											</p>
 										</td>

--- a/apps/web/testing/applications/factory/documentation-file.js
+++ b/apps/web/testing/applications/factory/documentation-file.js
@@ -32,7 +32,9 @@ export function createDocumentationFile({
 		wordsNumber: 1,
 		startOffset: createUniqueRandomNumberFromSeed(5, 20, uniqueSeed)
 	})}`;
-	const type = ['DOC', 'PDF', 'JPG', 'MP3'][createUniqueRandomNumberFromSeed(0, 4, uniqueSeed)];
+	const type = ['application/msword', 'application/pdf', 'image/jpeg', 'audio/mpeg'][
+		createUniqueRandomNumberFromSeed(0, 4, uniqueSeed)
+	];
 	const status = [
 		'user_checked',
 		'not_user_checked',


### PR DESCRIPTION
## Describe your changes

change the Document table to store 2 new fields:
fileType - mime type string eg  application/pdf
fileSize - file size in bytes.

update associated apis to store / return this data.
Front end updated to pass this data to the api on upload.

## BOAS-626 Display File Type and File Size of docs in folder view page
https://pins-ds.atlassian.net/browse/BOAS-626
(raised against BOAS-584)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-626]: https://pins-ds.atlassian.net/browse/BOAS-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BOAS-626]: https://pins-ds.atlassian.net/browse/BOAS-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BOAS-584]: https://pins-ds.atlassian.net/browse/BOAS-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ