### PR TITLE
feat(api/applications): api to return blob file uri info (BOAS-695)

### DIFF
--- a/apps/api/src/server/applications/application/documents/__tests__/document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document.test.js
@@ -21,8 +21,8 @@ findUniqueDocumentStub.withArgs({ where: { guid: '1111-2222-3333' } }).returns({
 	guid: '1111-2222-3333',
 	name: 'my doc.doc',
 	folderId: 1,
-	blobStorageContainer: null,
-	blobStoragePath: null,
+	blobStorageContainer: 'document-service-uploads',
+	blobStoragePath: '/application/BC010001/1111-2222-3333/my doc.doc',
 	status: 'awaiting_upload',
 	createdAt: '2022-12-12 17:12:25.9610000',
 	redacted: true
@@ -91,6 +91,27 @@ test('checks invalid case id', async (t) => {
 	const response = await request
 		.patch('/applications/2/documents/update')
 		.send([{ status: 'not_user_checked', items: [{ guid: 'xxxxx' }] }]);
+
+	t.is(response.status, 404);
+	t.deepEqual(response.body, {
+		errors: {
+			id: 'Must be an existing application'
+		}
+	});
+});
+
+test('returns a Blob Storage URI info for a single document on a case', async (t) => {
+	const response = await request.get('/applications/1/documents/1111-2222-3333');
+
+	t.is(response.status, 200);
+	t.deepEqual(response.body, {
+		blobStorageContainer: 'document-service-uploads',
+		blobStoragePath: '/application/BC010001/1111-2222-3333/my doc.doc'
+	});
+});
+
+test('checks invalid case id on Blob Storage URI call', async (t) => {
+	const response = await request.get('/applications/999999/documents/1111-2222-3333');
 
 	t.is(response.status, 404);
 	t.deepEqual(response.body, {

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -82,3 +82,28 @@ export const updateDocuments = async ({ body }, response) => {
 	}
 	response.send(items);
 };
+
+/**
+ * Gets the blob storage uri components for a single document
+ * blobStorageContainer and blobStoragePath
+ *
+ * @type {import('express').RequestHandler<{guid: string}, ?, ?, any>}
+ */
+export const getDocumentUri = async ({ params }, response) => {
+	let /** @type { import('apps/api/prisma/schema.js').Document |null} */ document = null;
+
+	try {
+		document = await documentRepository.getById(params.guid);
+
+		if (document === null || typeof document === 'undefined') {
+			throw new Error(`Unknown document guid ${params.guid}`);
+		}
+	} catch {
+		throw new Error(`Unknown document guid ${params.guid}`);
+	}
+
+	response.send({
+		blobStorageContainer: document.blobStorageContainer,
+		blobStoragePath: document.blobStoragePath
+	});
+};

--- a/apps/api/src/server/applications/application/documents/document.routes.js
+++ b/apps/api/src/server/applications/application/documents/document.routes.js
@@ -1,7 +1,10 @@
 import { Router as createRouter } from 'express';
 import { asyncHandler } from '../../../middleware/async-handler.js';
 import { trimUnexpectedRequestParameters } from '../../../middleware/trim-unexpected-request-parameters.js';
-import { validateApplicationId } from '../../application/application.validators.js';
+import {
+	validateApplicationId,
+	validateFolderIds
+} from '../../application/application.validators.js';
 import {
 	getDocumentUri,
 	provideDocumentUploadURLs,
@@ -39,6 +42,7 @@ router.post(
 	 */
 	validateApplicationId,
 	validateDocumentsToUploadProvided,
+	validateFolderIds,
 	trimUnexpectedRequestParameters,
 	asyncHandler(provideDocumentUploadURLs)
 );

--- a/apps/api/src/server/applications/application/documents/document.routes.js
+++ b/apps/api/src/server/applications/application/documents/document.routes.js
@@ -1,11 +1,12 @@
 import { Router as createRouter } from 'express';
 import { asyncHandler } from '../../../middleware/async-handler.js';
 import { trimUnexpectedRequestParameters } from '../../../middleware/trim-unexpected-request-parameters.js';
+import { validateApplicationId } from '../../application/application.validators.js';
 import {
-	validateApplicationId,
-	validateFolderIds
-} from '../../application/application.validators.js';
-import { provideDocumentUploadURLs, updateDocuments } from './document.controller.js';
+	getDocumentUri,
+	provideDocumentUploadURLs,
+	updateDocuments
+} from './document.controller.js';
 import {
 	validateDocumentIds,
 	validateDocumentsToUpdateProvided,
@@ -38,7 +39,6 @@ router.post(
 	 */
 	validateApplicationId,
 	validateDocumentsToUploadProvided,
-	validateFolderIds,
 	trimUnexpectedRequestParameters,
 	asyncHandler(provideDocumentUploadURLs)
 );
@@ -71,6 +71,33 @@ router.patch(
 	validateDocumentIds,
 	trimUnexpectedRequestParameters,
 	asyncHandler(updateDocuments)
+);
+
+router.get(
+	'/:id/documents/:guid',
+	/*
+        #swagger.tags = ['Applications']
+        #swagger.path = '/applications/{id}/documents/{guid}'
+        #swagger.description = 'Gets the blob storage uri for a single file on a case'
+        #swagger.parameters['id'] = {
+            in: 'path',
+			description: 'Application ID here',
+			required: true,
+			type: 'integer'
+		}
+		#swagger.parameters['guid'] = {
+            in: 'path',
+			description: 'guid of the required document here',
+			required: true,
+			type: 'string'
+		}
+        #swagger.responses[200] = {
+            description: 'Blob Storage uri',
+            schema: { blobStorageContainer: 'document-service-uploads', blobStoragePath: '/application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/screenshot 2.png' }
+        }
+    */
+	validateApplicationId,
+	asyncHandler(getDocumentUri)
 );
 
 export { router as documentRoutes };

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -586,6 +586,49 @@
 				}
 			}
 		},
+		"/applications/{id}/documents/{guid}": {
+			"get": {
+				"tags": ["Applications"],
+				"description": "Gets the blob storage uri for a single file on a case",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID here"
+					},
+					{
+						"name": "guid",
+						"in": "path",
+						"required": true,
+						"type": "string",
+						"description": "guid of the required document here"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Blob Storage uri",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"blobStorageContainer": {
+									"type": "string",
+									"example": "document-service-uploads"
+								},
+								"blobStoragePath": {
+									"type": "string",
+									"example": "/application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/screenshot 2.png"
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/applications/{id}/folders": {
 			"get": {
 				"tags": ["Applications"],


### PR DESCRIPTION
## Describe your changes

New api to return the blob storage info for a single document on a case, eg
GET /applications/{caseId}/documents/{guid}
to return
{
      "blobStorageContainer": "document-service-uploads",
      "blobStoragePath": "application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/screenshot 2.png"
}

## BOAS-695 API to return file URI
https://pins-ds.atlassian.net/browse/BOAS-695
(part of ticket BOAS-694)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
