### PR TITLE
fix(api/applications): fix seeded cases display error (BOAS-704)

### DIFF
--- a/apps/api/prisma/seed.js
+++ b/apps/api/prisma/seed.js
@@ -38,14 +38,14 @@ function generateAppealReference() {
 	return `APP/Q9999/D/21/${number}`;
 }
 
-// Application reference should be in the format (subSector)(4 digit sequential_number) eg EN010001
+// Application reference should be in the format (subSector)(5 digit sequential_number with leading 1) eg EN0110001
 /**
  * @param {{abbreviation: string}} subSector
  * @param {number} referenceNumber
  * @returns {string}
  */
 function generateApplicationReference(subSector, referenceNumber) {
-	const formattedReferenceNumber = `000${referenceNumber}`.slice(-4);
+	const formattedReferenceNumber = `1000${referenceNumber}`.slice(-5);
 
 	return `${subSector.abbreviation}${formattedReferenceNumber}`;
 }
@@ -710,9 +710,10 @@ const deleteAllRecords = async () => {
  * @param {number} index
  */
 const createApplication = async (subSector, index) => {
-	const reference = generateApplicationReference(subSector, index);
 	const title = `${subSector.displayNameEn} Test Application ${index}`;
 	const caseStatus = pickRandom(caseStatusNames).name;
+	// Draft cases do not have a reference assigned to them yet
+	const reference = caseStatus === 'draft' ? null : generateApplicationReference(subSector, index);
 
 	const newCase = await databaseConnector.case.create({
 		data: {
@@ -751,6 +752,9 @@ const createApplication = async (subSector, index) => {
 						status: caseStatus
 					}
 				]
+			},
+			serviceCustomer: {
+				create: [{}]
 			}
 		}
 	});


### PR DESCRIPTION
## Describe your changes

These are fixes to the seeding script, and therefore only affect local, dev, and test environments, not Production.
1. This fixes seeding case not displaying correctly - both in draft, and for started cases, when trying to amend Application Info details.  
2. all seeded cases are assigned a caseReference eg EN010001.  This should not be the case for Draft cases, as cases are assigned a caseReference when they progress from Draft to Pre-application.  Code amended to set caseReference to NULL for Draft seeded cases.
3. case references have changed from a 4 digit number to include a leading ‘1' to separate these cases from existing Horizon case references. eg EN010001 should be EN0110001.  Seed code still generates 8 char ref codes, needs to change to 9 to include the '1’ after the SubSector code - ie EN01 +1. 

**Note that `npm run db:seed ` will need to be run after this has been delivered for these changes to take affect**

## BOAS-704 Seeded Draft Application cases cannot display
https://pins-ds.atlassian.net/browse/BOAS-704

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
