### PR TITLE
feat(api/applications): extend document properties returned (BOAS-726)

### DIFF
--- a/apps/api/prisma/schema.d.ts
+++ b/apps/api/prisma/schema.d.ts
@@ -1,6 +1,7 @@
 import * as schema from '@prisma/client';
 import { ZoomLevel } from '@prisma/client';
 import { GridReference } from 'packages/applications';
+import { string_to_uuid } from 'rhea/typings/util';
 
 export {
 	Address,
@@ -188,11 +189,19 @@ export type CaseStatusNameType =
 export interface DocumentDetails {
 	guid: string;
 	documentName: string;
-	documentUrl: string | null;
+	blobStorageContainer: string | null;
+	blobStoragePath: string | null;
 	from: string;
 	receivedDate: number | null;
 	size: number;
 	type: string;
 	redacted: boolean;
 	status: string;
+	description: string;
+	documentReferenceNumber: string;
+	version: number;
+	agent: string;
+	caseStage: string;
+	webFilter: string;
+	documentType: string;
 }

--- a/apps/api/src/server/applications/application/documents/__tests__/document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document.test.js
@@ -19,13 +19,15 @@ findUniqueStub.withArgs({ where: { id: 1 } }).returns(application);
 
 findUniqueDocumentStub.withArgs({ where: { guid: '1111-2222-3333' } }).returns({
 	guid: '1111-2222-3333',
-	name: 'my doc.doc',
+	name: 'my doc.pdf',
 	folderId: 1,
 	blobStorageContainer: 'document-service-uploads',
-	blobStoragePath: '/application/BC010001/1111-2222-3333/my doc.doc',
+	blobStoragePath: '/application/BC010001/1111-2222-3333/my doc.pdf',
 	status: 'awaiting_upload',
 	createdAt: '2022-12-12 17:12:25.9610000',
-	redacted: true
+	redacted: true,
+	fileSize: 1024,
+	fileType: 'application/pdf'
 });
 
 test.before('set up mocks', () => {
@@ -100,19 +102,21 @@ test('checks invalid case id', async (t) => {
 	});
 });
 
-test('returns a Blob Storage URI info for a single document on a case', async (t) => {
+test('returns document properties for a single document on a case', async (t) => {
 	const response = await request.get('/applications/1/documents/1111-2222-3333');
 
 	t.is(response.status, 200);
 	t.deepEqual(response.body, {
 		guid: '1111-2222-3333',
-		name: 'my doc.doc',
-		folderId: 1,
+		documentName: 'my doc.pdf',
 		blobStorageContainer: 'document-service-uploads',
-		blobStoragePath: '/application/BC010001/1111-2222-3333/my doc.doc',
-		status: 'awaiting_upload',
-		createdAt: '2022-12-12 17:12:25.9610000',
+		blobStoragePath: '/application/BC010001/1111-2222-3333/my doc.pdf',
+		from: '',
+		receivedDate: 1_670_865_145,
+		size: 1024,
+		type: 'application/pdf',
 		redacted: true,
+		status: 'awaiting_upload',
 		description: '',
 		documentReferenceNumber: '',
 		version: 1,

--- a/apps/api/src/server/applications/application/documents/__tests__/document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document.test.js
@@ -105,8 +105,21 @@ test('returns a Blob Storage URI info for a single document on a case', async (t
 
 	t.is(response.status, 200);
 	t.deepEqual(response.body, {
+		guid: '1111-2222-3333',
+		name: 'my doc.doc',
+		folderId: 1,
 		blobStorageContainer: 'document-service-uploads',
-		blobStoragePath: '/application/BC010001/1111-2222-3333/my doc.doc'
+		blobStoragePath: '/application/BC010001/1111-2222-3333/my doc.doc',
+		status: 'awaiting_upload',
+		createdAt: '2022-12-12 17:12:25.9610000',
+		redacted: true,
+		description: '',
+		documentReferenceNumber: '',
+		version: 1,
+		agent: '',
+		caseStage: '',
+		webFilter: '',
+		documentType: ''
 	});
 });
 

--- a/apps/api/src/server/applications/application/documents/__tests__/document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document.test.js
@@ -127,7 +127,7 @@ test('returns document properties for a single document on a case', async (t) =>
 	});
 });
 
-test('checks invalid case id on Blob Storage URI call', async (t) => {
+test('checks invalid case id on document properties call', async (t) => {
 	const response = await request.get('/applications/999999/documents/1111-2222-3333');
 
 	t.is(response.status, 404);

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -2,6 +2,12 @@ import { pick } from 'lodash-es';
 import * as caseRepository from '../../../repositories/case.repository.js';
 import * as documentRepository from '../../../repositories/document.repository.js';
 import { getStorageLocation } from '../../../utils/document-storage-api-client.js';
+import { mapSingleDocumentDetails } from '../../../utils/mapping/map-document-details.js';
+
+/**
+ * @typedef {import('apps/api/prisma/schema.js').Document} Document
+ * @typedef {import('apps/api/prisma/schema.js').DocumentDetails} DocumentDetails
+ */
 
 /**
  *
@@ -84,13 +90,13 @@ export const updateDocuments = async ({ body }, response) => {
 };
 
 /**
- * Gets the blob storage uri components for a single document
- * blobStorageContainer and blobStoragePath
+ * Gets the properties for a single document
  *
  * @type {import('express').RequestHandler<{guid: string}, ?, ?, any>}
  */
-export const getDocumentUri = async ({ params }, response) => {
-	let /** @type { import('apps/api/prisma/schema.js').Document |null} */ document = null;
+export const getDocumentProperties = async ({ params }, response) => {
+	let /** @type { Document |null} */ document = null;
+	let /** @type { DocumentDetails |null} */ documentDetails = null;
 
 	try {
 		document = await documentRepository.getById(params.guid);
@@ -98,12 +104,10 @@ export const getDocumentUri = async ({ params }, response) => {
 		if (document === null || typeof document === 'undefined') {
 			throw new Error(`Unknown document guid ${params.guid}`);
 		}
+		documentDetails = mapSingleDocumentDetails(document);
 	} catch {
 		throw new Error(`Unknown document guid ${params.guid}`);
 	}
 
-	response.send({
-		blobStorageContainer: document.blobStorageContainer,
-		blobStoragePath: document.blobStoragePath
-	});
+	response.send(documentDetails);
 };

--- a/apps/api/src/server/applications/application/documents/document.routes.js
+++ b/apps/api/src/server/applications/application/documents/document.routes.js
@@ -5,7 +5,7 @@ import { validateApplicationId } from '../../application/application.validators.
 import { validateFolderIds } from '../../documents/documents.validators.js';
 import { publishCase } from '../application.controller.js';
 import {
-	getDocumentUri,
+	getDocumentProperties,
 	provideDocumentUploadURLs,
 	updateDocuments
 } from './document.controller.js';
@@ -81,7 +81,7 @@ router.get(
 	/*
         #swagger.tags = ['Applications']
         #swagger.path = '/applications/{id}/documents/{guid}'
-        #swagger.description = 'Gets the blob storage uri for a single file on a case'
+        #swagger.description = 'Gets the properties of a single file on a case'
         #swagger.parameters['id'] = {
             in: 'path',
 			description: 'Application ID here',
@@ -95,12 +95,12 @@ router.get(
 			type: 'string'
 		}
         #swagger.responses[200] = {
-            description: 'Blob Storage uri',
-            schema: { blobStorageContainer: 'document-service-uploads', blobStoragePath: '/application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/screenshot 2.png' }
+            description: 'Document properties',
+            schema: { $ref: '#/definitions/DocumentDetails' }
         }
     */
 	validateApplicationId,
-	asyncHandler(getDocumentUri)
+	asyncHandler(getDocumentProperties)
 );
 
 router.patch(

--- a/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
+++ b/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
@@ -233,13 +233,21 @@ test('returns documents in a folder on a case', async (t) => {
 			{
 				guid: '1111-2222-3333',
 				documentName: 'Document 1',
-				documentUrl: null,
+				blobStorageContainer: null,
+				blobStoragePath: null,
 				from: '',
 				receivedDate: 1_658_486_313,
 				size: 1024,
 				type: 'application/pdf',
 				redacted: false,
-				status: 'not_user_checked'
+				status: 'not_user_checked',
+				agent: '',
+				caseStage: '',
+				description: '',
+				documentReferenceNumber: '',
+				documentType: '',
+				version: 1,
+				webFilter: ''
 			}
 		]
 	});

--- a/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
+++ b/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
@@ -241,13 +241,13 @@ test('returns documents in a folder on a case', async (t) => {
 				type: 'application/pdf',
 				redacted: false,
 				status: 'not_user_checked',
-				agent: '',
-				caseStage: '',
 				description: '',
 				documentReferenceNumber: '',
-				documentType: '',
 				version: 1,
-				webFilter: ''
+				agent: '',
+				caseStage: '',
+				webFilter: '',
+				documentType: ''
 			}
 		]
 	});

--- a/apps/api/src/server/applications/application/file-folders/folders.routes.js
+++ b/apps/api/src/server/applications/application/file-folders/folders.routes.js
@@ -143,7 +143,7 @@ router.post(
 			required: true
 		}
         #swagger.responses[200] = {
-            description: 'An paginated data set of documents',
+            description: 'An paginated data set of documents and their properties',
             schema: { $ref: '#/definitions/PaginatedDocumentDetails' }
         }
     */

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -589,7 +589,7 @@
 		"/applications/{id}/documents/{guid}": {
 			"get": {
 				"tags": ["Applications"],
-				"description": "Gets the blob storage uri for a single file on a case",
+				"description": "Gets the properties of a single file on a case",
 				"parameters": [
 					{
 						"name": "id",
@@ -608,22 +608,9 @@
 				],
 				"responses": {
 					"200": {
-						"description": "Blob Storage uri",
+						"description": "Document properties",
 						"schema": {
-							"type": "object",
-							"properties": {
-								"blobStorageContainer": {
-									"type": "string",
-									"example": "document-service-uploads"
-								},
-								"blobStoragePath": {
-									"type": "string",
-									"example": "/application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/screenshot 2.png"
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
+							"$ref": "#/definitions/DocumentDetails"
 						}
 					}
 				}
@@ -832,7 +819,7 @@
 				],
 				"responses": {
 					"200": {
-						"description": "An paginated data set of documents",
+						"description": "An paginated data set of documents and their properties",
 						"schema": {
 							"$ref": "#/definitions/PaginatedDocumentDetails"
 						}
@@ -1157,11 +1144,11 @@
 		"/applications/case-admin-officer": {
 			"get": {
 				"tags": ["Applications"],
-				"description": "Gets all applications associated with case officer admin",
+				"description": "Gets all applications associated with case team admin",
 				"parameters": [],
 				"responses": {
 					"200": {
-						"description": "List of applications assigned to case officer",
+						"description": "List of applications assigned to case team",
 						"schema": {
 							"$ref": "#/definitions/ApplicationsForCaseAdminOfficer"
 						}
@@ -1172,11 +1159,11 @@
 		"/applications/inspector": {
 			"get": {
 				"tags": ["Applications"],
-				"description": "Gets all applications associated with case officer admin",
+				"description": "Gets all applications associated with case team admin",
 				"parameters": [],
 				"responses": {
 					"200": {
-						"description": "List of applications assigned to case officer",
+						"description": "List of applications assigned to case team",
 						"schema": {
 							"$ref": "#/definitions/ApplicationsForInspector"
 						}
@@ -1970,6 +1957,79 @@
 				}
 			}
 		},
+		"DocumentDetails": {
+			"type": "object",
+			"properties": {
+				"guid": {
+					"type": "string",
+					"example": "0fab253b-2c0c-4c55-94c0-f3f81ffc589c"
+				},
+				"documentName": {
+					"type": "string",
+					"example": "document_name_1.pdf"
+				},
+				"blobStorageContainer": {
+					"type": "string",
+					"example": "document-service-uploads"
+				},
+				"blobStoragePath": {
+					"type": "string",
+					"example": "/application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/document_name_1.pdf"
+				},
+				"from": {
+					"type": "string",
+					"example": "TBD"
+				},
+				"receivedDate": {
+					"type": "number",
+					"example": 1658486313
+				},
+				"size": {
+					"type": "number",
+					"example": 1024
+				},
+				"type": {
+					"type": "string",
+					"example": "application/pdf"
+				},
+				"redacted": {
+					"type": "boolean",
+					"example": false
+				},
+				"status": {
+					"type": "string",
+					"example": "not_user_checked"
+				},
+				"description": {
+					"type": "string",
+					"example": "TBD"
+				},
+				"documentReferenceNumber": {
+					"type": "string",
+					"example": "TBD"
+				},
+				"version": {
+					"type": "number",
+					"example": 1
+				},
+				"agent": {
+					"type": "string",
+					"example": "Mr S King"
+				},
+				"caseStage": {
+					"type": "string",
+					"example": "Examination"
+				},
+				"webFilter": {
+					"type": "string",
+					"example": "TBD"
+				},
+				"documentType": {
+					"type": "string",
+					"example": "TBD"
+				}
+			}
+		},
 		"PaginatedDocumentDetails": {
 			"type": "array",
 			"items": {
@@ -2004,13 +2064,17 @@
 									"type": "string",
 									"example": "document_name_1.pdf"
 								},
-								"documentUrl": {
+								"blobStorageContainer": {
 									"type": "string",
-									"example": "/some/path/document_name_1.pdf"
+									"example": "document-service-uploads"
+								},
+								"blobStoragePath": {
+									"type": "string",
+									"example": "/application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/document_name_1.pdf"
 								},
 								"from": {
 									"type": "string",
-									"example": ""
+									"example": "TBD"
 								},
 								"receivedDate": {
 									"type": "number",
@@ -2031,6 +2095,34 @@
 								"status": {
 									"type": "string",
 									"example": "not_user_checked"
+								},
+								"description": {
+									"type": "string",
+									"example": "TBD"
+								},
+								"documentReferenceNumber": {
+									"type": "string",
+									"example": "TBD"
+								},
+								"version": {
+									"type": "number",
+									"example": 1
+								},
+								"agent": {
+									"type": "string",
+									"example": "Mr S King"
+								},
+								"caseStage": {
+									"type": "string",
+									"example": "Examination"
+								},
+								"webFilter": {
+									"type": "string",
+									"example": "TBD"
+								},
+								"documentType": {
+									"type": "string",
+									"example": "TBD"
 								}
 							}
 						}

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -243,6 +243,26 @@ const document = {
 			pageNumber: 1,
 			pageSize: 1
 		},
+		DocumentDetails: {
+			guid: '0fab253b-2c0c-4c55-94c0-f3f81ffc589c',
+			documentName: 'document_name_1.pdf',
+			blobStorageContainer: 'document-service-uploads',
+			blobStoragePath:
+				'/application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/document_name_1.pdf',
+			from: 'TBD',
+			receivedDate: 1_658_486_313,
+			size: 1024,
+			type: 'application/pdf',
+			redacted: false,
+			status: 'not_user_checked',
+			description: 'TBD',
+			documentReferenceNumber: 'TBD',
+			version: 1,
+			agent: 'Mr S King',
+			caseStage: 'Examination',
+			webFilter: 'TBD',
+			documentType: 'TBD'
+		},
 		PaginatedDocumentDetails: [
 			{
 				page: 1,
@@ -253,13 +273,22 @@ const document = {
 					{
 						guid: '0fab253b-2c0c-4c55-94c0-f3f81ffc589c',
 						documentName: 'document_name_1.pdf',
-						documentUrl: '/some/path/document_name_1.pdf',
-						from: '',
+						blobStorageContainer: 'document-service-uploads',
+						blobStoragePath:
+							'/application/TR010002/d38ef007-98d8-4d89-b7bb-34160d97e84e/document_name_1.pdf',
+						from: 'TBD',
 						receivedDate: 1_658_486_313,
 						size: 1024,
 						type: 'application/pdf',
 						redacted: false,
-						status: 'not_user_checked'
+						status: 'not_user_checked',
+						description: 'TBD',
+						documentReferenceNumber: 'TBD',
+						version: 1,
+						agent: 'Mr S King',
+						caseStage: 'Examination',
+						webFilter: 'TBD',
+						documentType: 'TBD'
 					}
 				]
 			}

--- a/apps/api/src/server/utils/mapping/map-document-details.js
+++ b/apps/api/src/server/utils/mapping/map-document-details.js
@@ -13,13 +13,21 @@ export const mapSingleDocumentDetails = (documentDetails) => {
 	return {
 		guid: documentDetails.guid,
 		documentName: documentDetails.name,
-		documentUrl: documentDetails.blobStoragePath,
+		blobStorageContainer: documentDetails.blobStorageContainer,
+		blobStoragePath: documentDetails.blobStoragePath,
 		from: '',
 		receivedDate: mapDateStringToUnixTimestamp(documentDetails.createdAt.toString()),
 		size: documentDetails.fileSize,
 		type: documentDetails.fileType ?? '',
 		redacted: documentDetails.redacted,
-		status: documentDetails.status
+		status: documentDetails.status,
+		description: '',
+		documentReferenceNumber: '',
+		version: 1,
+		agent: '',
+		caseStage: '',
+		webFilter: '',
+		documentType: ''
 	};
 };
 


### PR DESCRIPTION
## Describe your changes

- modify the get document by guid endpoint to return all document properties required (extending this from just returning the 2 blob uri values)
**GET /applications/{caseId}/documents/{guid}**
- modify the get documents in folder endpoint to return the same document properties in the items[] array
**GET /applications/{caseId}/folders/{folderId}/documents**

## BOAS-726 Document Properties API  (subticket of BOAS-595)
https://pins-ds.atlassian.net/browse/BOAS-726

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
