### PR TITLE
fix(api/applications): correct spelling other docuents folder (BOAS-771)

### DIFF
--- a/apps/api/src/server/repositories/folder.repository.js
+++ b/apps/api/src/server/repositories/folder.repository.js
@@ -241,7 +241,7 @@ const defaultCaseFolders = [
 							{ displayNameEn: 'Compulsory acquisition information', displayOrder: 200 },
 							{ displayNameEn: 'DCO documents', displayOrder: 300 },
 							{ displayNameEn: 'Environmental statement', displayOrder: 400 },
-							{ displayNameEn: 'Other docuents', displayOrder: 500 },
+							{ displayNameEn: 'Other documents', displayOrder: 500 },
 							{ displayNameEn: 'Plans', displayOrder: 600 },
 							{ displayNameEn: 'Reports', displayOrder: 700 },
 							{ displayNameEn: 'Additional Reg 6 information', displayOrder: 800 }


### PR DESCRIPTION
## Describe your changes

Small fix to correct spelling mistake: Other docuents folder.  Note that this will only apply to applications made from now on, not existing applications.

## BOAS-771 Incorrect spelling under Application Documents Folder
https://pins-ds.atlassian.net/browse/BOAS-771

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
