### PR TITLE
feat(api): add message schema for representations

### DIFF
--- a/apps/api/src/message-schemas/events/interested-party.schema.json
+++ b/apps/api/src/message-schemas/events/interested-party.schema.json
@@ -4,7 +4,7 @@
 	"title": "interested-party",
 	"description": "Subset of Pins Data Model [Service User]",
 	"type": "object",
-	"required": ["id", "interestedPartyNo"],
+	"required": ["id"],
 	"properties": {
 		"id": {
 			"type": "number",
@@ -22,12 +22,27 @@
 			"type": "string",
 			"examples": ["Turing"]
 		},
-		"name": {
+		"under18": {
+			"type": "boolean"
+		},
+		"organisationName": {
 			"title": "Name",
 			"type": "string",
 			"default": "",
 			"examples": ["National Highways"],
 			"pattern": "^.*$"
+		},
+		"contactMethod": {
+			"type": "string",
+			"enum": ["email", "post"]
+		},
+		"emailAddress": {
+			"type": "string",
+			"examples": ["alan.turing@planninginspectorate.gov.uk"]
+		},
+		"telephone": {
+			"type": "string",
+			"examples": ["0137732432"]
 		},
 		"address": {
 			"title": "Address",

--- a/apps/api/src/message-schemas/events/representation.schema.json
+++ b/apps/api/src/message-schemas/events/representation.schema.json
@@ -3,16 +3,116 @@
 	"$id": "representation.schema.json",
 	"title": "Representation",
 	"type": "object",
-	"required": ["id", "representation", "interestedParty"],
+	"required": [
+		"caseRef",
+		"representationId",
+		"represented",
+		"originalRepresentation",
+		"dateReceived"
+	],
 	"properties": {
-		"id": {
+		"representationId": {
 			"type": "string"
 		},
-		"interestedPartyNo": {
+		"referenceId": {
+			"examples": ["TR043003-000010"],
 			"type": "string"
 		},
-		"representation": {
+		"examinationLibraryRef": {
+			"examples": ["RR-0001"],
 			"type": "string"
+		},
+		"caseRef": {
+			"type": "string"
+		},
+		"status": {
+			"type": "string",
+			"enum": ["awaiting_review", "referred", "valid", "invalid", "published", "archived"]
+		},
+		"originalRepresentation": {
+			"type": "string"
+		},
+		"redacted": {
+			"type": "boolean"
+		},
+		"redactedRepresentation": {
+			"type": "string"
+		},
+		"redactedBy": {
+			"type": "string",
+			"examples": ["Joe Blogs"]
+		},
+		"redactedNotes": {
+			"type": "string",
+			"examples": ["Removed names of family members"]
+		},
+		"representationFrom": {
+			"type": "string",
+			"enum": ["Myself", "Organisation", "Agent"]
+		},
+		"represented": {
+			"$ref": "interested-party.schema.json",
+			"description": "Person or organisation being represented"
+		},
+		"representative": {
+			"$ref": "interested-party.schema.json",
+			"description": "Person or organisation submitting representation in the case of Agent representationFrom"
+		},
+		"registerFor": {
+			"type": "string",
+			"enum": ["person", "organisation", "family_group"]
+		},
+		"representationType": {
+			"type": "string",
+			"enum": [
+				"Local Authorities",
+				"Parish Councils",
+				"Members of the Public/Businesses",
+				"Public & Businesses",
+				"Statutory Consultees",
+				"Non-Statutory Organisations",
+				"Another Individual"
+			]
+		},
+		"dateReceived": {
+			"format": "date-time",
+			"examples": ["2023-03-26T00:00:00.000"]
+		},
+		"attachments": {
+			"type": "array",
+			"items": {
+				"$ref": "#/$defs/attachment"
+			}
+		}
+	},
+	"$defs": {
+		"attachment": {
+			"type": "object",
+			"required": ["documentId", "filename", "size", "documentURI"],
+			"properties": {
+				"documentId": {
+					"type": "string",
+					"examples": ["ID23343453"],
+					"description": "The unique identifier for the file"
+				},
+				"filename": {
+					"type": "string",
+					"examples": ["filename.pdf"],
+					"description": "Current stored filename of the file"
+				},
+				"size": {
+					"type": "number",
+					"examples": [23452]
+				},
+				"mime": {
+					"type": "string",
+					"examples": ["application/pdf"]
+				},
+				"documentURI": {
+					"type": "string",
+					"examples": ["blob:https://published/en010120/filename.pdf"]
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Describe your changes

This change adds the Representation message schema to support:

- registering interest in a case from front office;
- the relevant representations workflow in back office;
- and the publishing of relevant representations to front office

Some points to note for the schema:
- The schema supports the entire workflow FO (register)-> BO (operations)-> (publish) FO.   This could be split in the future. 
- The schema supports the concept of the representation submitted by an agent (representative) for a person/organisation (represented).
- Both representative and represented use the interested-party.schema.json to capture the personal details
- Some changes have been made to the interested-party.schema.json to include some additional fields used in this domain, eg under18 and contactMethod.
- interestedPartyNo is no longer mandatory to support the business workflow in that IP number is only created when the representation is accepted. 

Schema is tested for validity under the test script schema-test-utils.js

## [Issue ticket number and link](https://pins-ds.atlassian.net/browse/ASB-1266)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
