### PR TITLE
fix(api/applications): error setting no document type (BOAS-830)

### DIFF
--- a/apps/api/prisma/migrations/20230420095018_documentversion_documenttype_nullable/migration.sql
+++ b/apps/api/prisma/migrations/20230420095018_documentversion_documenttype_nullable/migration.sql
@@ -1,0 +1,20 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[DocumentVersion] DROP CONSTRAINT [DocumentVersion_documentType_df];
+ALTER TABLE [dbo].[DocumentVersion] ALTER COLUMN [documentType] NVARCHAR(1000) NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -332,7 +332,7 @@ model DocumentVersion {
   documentGuid           String
   version                Int       @default(1)
   lastModified           DateTime?
-  documentType           String    @default("")
+  documentType           String?
   published              Boolean   @default(false)
   sourceSystem           String    @default("back-office")
   origin                 String?

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -17,7 +17,7 @@ import {
 import {
 	fetchDocumentByGuidAndCaseId,
 	getRedactionStatus,
-	validateDocumentVersionMetatdataBody,
+	validateDocumentVersionMetadataBody,
 	verifyMovingToReadyToPublish
 } from './document.validators.js';
 
@@ -172,7 +172,7 @@ export const storeDocumentVersion = async (request, response) => {
 
 	// Validate the request body and extract the document version metadata
 	/** @type {DocumentVersion} */
-	const documentVersionMetadataBody = validateDocumentVersionMetatdataBody(request.body);
+	const documentVersionMetadataBody = validateDocumentVersionMetadataBody(request.body);
 
 	// Retrieve the document from the database using the provided guid and caseId
 	const document = await fetchDocumentByGuidAndCaseId(guid, +caseId);

--- a/apps/api/src/server/applications/application/documents/document.validators.js
+++ b/apps/api/src/server/applications/application/documents/document.validators.js
@@ -83,7 +83,7 @@ export const validateDocumentVersionMetatdataBody = (documentVersonEventBody) =>
 		dateCreated: joi.date().iso().optional(),
 		datePublished: joi.date().iso().optional(),
 		lastModified: joi.date().iso().optional(),
-		documentType: joi.string().allow('').optional(),
+		documentType: joi.string().allow(null).optional(),
 		documentName: joi.string().optional(),
 		fileName: joi.string().optional(),
 		documentId: joi.string().optional(),

--- a/apps/api/src/server/applications/application/documents/document.validators.js
+++ b/apps/api/src/server/applications/application/documents/document.validators.js
@@ -76,7 +76,7 @@ export const fetchDocumentByGuidAndCaseId = async (
  * @param {DocumentVersion} documentVersonEventBody - the event body for document metadata to validate
  * @returns {DocumentVersion} - the validated document metadata event body
  */
-export const validateDocumentVersionMetatdataBody = (documentVersonEventBody) => {
+export const validateDocumentVersionMetadataBody = (documentVersonEventBody) => {
 	// Define the schema for the document version
 	const documentVersionSchema = joi.object({
 		version: joi.number().positive().optional(),
@@ -131,13 +131,13 @@ export const validateDocumentVersionMetatdataBody = (documentVersonEventBody) =>
 	if (error) {
 		const errorMessage = error?.message || 'there was an error validating request body';
 
-		logger.error(`[validateDocumentVersionMetatdataBody] ${errorMessage}`);
+		logger.error(`[validateDocumentVersionMetadataBody] ${errorMessage}`);
 		throw new BackOfficeAppError(errorMessage, 400);
 	}
 
 	// If there were no errors, log a message and return the validated document version event body
 	logger.info(
-		'[validateDocumentVersionMetatdataBody] Successfully validated document version event body'
+		'[validateDocumentVersionMetadataBody] Successfully validated document version event body'
 	);
 	return documentVersonEventBody;
 };

--- a/apps/api/src/server/applications/application/documents/document.validators.js
+++ b/apps/api/src/server/applications/application/documents/document.validators.js
@@ -83,7 +83,7 @@ export const validateDocumentVersionMetatdataBody = (documentVersonEventBody) =>
 		dateCreated: joi.date().iso().optional(),
 		datePublished: joi.date().iso().optional(),
 		lastModified: joi.date().iso().optional(),
-		documentType: joi.string().optional(),
+		documentType: joi.string().allow('').optional(),
 		documentName: joi.string().optional(),
 		fileName: joi.string().optional(),
 		documentId: joi.string().optional(),

--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
@@ -116,6 +116,10 @@ export async function updateDocumentationMetaData(request, response) {
 
 		newMetaData = { [fieldName]: new Date(newValue) };
 	}
+	// special case for documentType "No document type" - we need to send null to the api
+	if (metaDataName === 'type' && newMetaData.documentType === '') {
+		newMetaData.documentType = null;
+	}
 
 	const { errors: apiErrors } = await updateDocumentMetaData(caseId, documentGuid, newMetaData);
 


### PR DESCRIPTION
## Describe your changes

Fix error when trying to set No Document Type on a document.

This fix changes the DB structure of DocumentVersion to allow documentType to be nullable.  This should NOT be a breaking change.  DB migrate will have to be performed to update local dev etc.

The change also now changes Web as well as API.

## BOAS-830 No Document Type Error (BOAS-757)
https://pins-ds.atlassian.net/browse/BOAS-830


## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
