### PR TITLE
feat(api): add /appeals route for returning appeals list data (BOAT-40)

### DIFF
--- a/apps/api/prisma/schema.d.ts
+++ b/apps/api/prisma/schema.d.ts
@@ -53,17 +53,21 @@ export interface ServiceCustomer extends schema.ServiceCustomer {
 }
 
 export interface Appeal extends schema.Appeal {
+	address?: schema.Address;
+	appealDetailsFromAppellant?: schema.AppealDetailsFromAppellant;
 	appealStatus: AppealStatus[];
 	appealType: AppealType;
-	address?: schema.Address;
 	appellant?: schema.Appellant;
-	appealDetailsFromAppellant?: schema.AppealDetailsFromAppellant;
-	validationDecision?: ValidationDecision[];
-	reviewQuestionnaire?: schema.ReviewQuestionnaire[];
-	lpaQuestionnaire?: schema.LPAQuestionnaire;
-	inspectorDecision?: InspectorDecision;
-	siteVisit?: SiteVisit;
+	createdAt: Date;
 	documents?: AppealDocument[];
+	id: number;
+	inspectorDecision?: InspectorDecision;
+	localPlanningDepartment: string;
+	lpaQuestionnaire?: schema.LPAQuestionnaire;
+	reference: string;
+	reviewQuestionnaire?: schema.ReviewQuestionnaire[];
+	siteVisit?: SiteVisit;
+	validationDecision?: ValidationDecision[];
 }
 
 export interface AppealDocument {
@@ -80,6 +84,7 @@ export interface AppealStatus extends schema.AppealStatus {
 
 export interface AppealType extends schema.AppealType {
 	shorthand: AppealTypeCode;
+	type: string;
 }
 
 export type AppealTypeCode = 'HAS' | 'FPA';

--- a/apps/api/src/server/appeals/appeals.routes.js
+++ b/apps/api/src/server/appeals/appeals.routes.js
@@ -1,9 +1,12 @@
 import { Router as createRouter } from 'express';
+import { appealsRoutes } from './appeals/appeals.routes.js';
 import { caseOfficerRoutes } from './case-officer/case-officer.routes.js';
 import { inspectorRoutes } from './inspector/inspector.routes.js';
 import { validationRoutes } from './validation/validation.routes.js';
 
 const router = createRouter();
+
+router.use('/', appealsRoutes);
 
 router.use('/validation', validationRoutes);
 

--- a/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
@@ -1,0 +1,63 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+
+const request = supertest(app);
+
+const appeal = {
+	id: 1,
+	reference: 'APP/Q9999/D/21/1345264',
+	appealStatus: [
+		{
+			status: 'awaiting_lpa_questionnaire',
+			valid: true
+		}
+	],
+	createdAt: new Date(2022, 1, 23),
+	addressId: 1,
+	localPlanningDepartment: 'Maidstone Borough Council',
+	planningApplicationReference: '48269/APP/2021/1482',
+	appellant: {
+		name: 'Lee Thornton'
+	},
+	startedAt: new Date(2022, 4, 18),
+	address: {
+		addressLine1: '96 The Avenue',
+		town: 'Maidstone',
+		county: 'Kent',
+		postcode: 'MD21 5XY'
+	},
+	appealType: {
+		id: 2,
+		type: 'household',
+		shorthand: 'HAS'
+	}
+};
+
+const appealResponse = [
+	{
+		appealId: 1,
+		appealReference: 'APP/Q9999/D/21/1345264',
+		appealSite: {
+			addressLine1: '96 The Avenue',
+			town: 'Maidstone',
+			county: 'Kent',
+			postCode: 'MD21 5XY'
+		},
+		appealStatus: 'awaiting_lpa_questionnaire',
+		appealType: 'household',
+		createdAt: new Date(2022, 1, 23).toISOString(),
+		localPlanningDepartment: 'Maidstone Borough Council'
+	}
+];
+
+describe('Appeals', () => {
+	test('gets all appeals', async () => {
+		databaseConnector.appeal.findMany.mockResolvedValue([appeal]);
+
+		const response = await request.get('/appeals');
+
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual(appealResponse);
+	});
+});

--- a/apps/api/src/server/appeals/appeals/appeals-formatter.js
+++ b/apps/api/src/server/appeals/appeals/appeals-formatter.js
@@ -1,0 +1,27 @@
+import formatAddress from '../../utils/address-block-formtter.js';
+
+const appealFormatter = {
+	/**
+	 * @param {import('@pins/api').Schema.Appeal} appeal
+	 * @returns {{
+	 * 	 appealId: number,
+	 * 	 appealReference: string,
+	 * 	 appealSite: {addressLine1?: string, addressLine2?: string, town?: string, county?: string, postCode?: string | null},
+	 * 	 appealStatus: string
+	 * 	 appealType: string,
+	 * 	 createdAt: Date,
+	 * 	 localPlanningDepartment: string,
+	 * }}}
+	 */
+	formatAppeals: (appeal) => ({
+		appealId: appeal.id,
+		appealReference: appeal.reference,
+		appealSite: formatAddress(appeal.address),
+		appealStatus: appeal.appealStatus[0].status,
+		appealType: appeal.appealType.type,
+		createdAt: appeal.createdAt,
+		localPlanningDepartment: appeal.localPlanningDepartment
+	})
+};
+
+export default appealFormatter;

--- a/apps/api/src/server/appeals/appeals/appeals.controller.js
+++ b/apps/api/src/server/appeals/appeals/appeals.controller.js
@@ -1,0 +1,18 @@
+// @ts-check
+
+import appealRepository from '../../repositories/appeal.repository.js';
+import appealFormatter from './appeals-formatter.js';
+
+/** @typedef {import('./appeals.routes.js').AppealParams} AppealParams */
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+const getAppeals = async (req, res) => {
+	const appeals = await appealRepository.getAll();
+	const formattedAppeals = appeals.map((appeal) => appealFormatter.formatAppeals(appeal));
+
+	res.send(formattedAppeals);
+};
+
+export { getAppeals };

--- a/apps/api/src/server/appeals/appeals/appeals.routes.js
+++ b/apps/api/src/server/appeals/appeals/appeals.routes.js
@@ -1,0 +1,26 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getAppeals } from './appeals.controller.js';
+
+/**
+ * @typedef {object} AppealParams
+ * @property {number} appealId
+ */
+
+const router = createRouter();
+
+router.get(
+	'/',
+	/*
+		#swagger.tags = ['Appeals']
+		#swagger.path = '/appeals'
+		#swagger.description = 'Gets all appeals'
+		#swagger.responses[200] = {
+			description: 'Gets all appeals',
+			schema: { $ref: '#/definitions/AllAppeals' }
+		}
+	 */
+	asyncHandler(getAppeals)
+);
+
+export { router as appealsRoutes };

--- a/apps/api/src/server/repositories/appeal.repository.js
+++ b/apps/api/src/server/repositories/appeal.repository.js
@@ -56,6 +56,30 @@ const appealRepository = (function () {
 	return {
 		/**
 		 *
+		 * @returns {Promise<import('@pins/api').Schema.Appeal[]>}
+		 */
+		getAll() {
+			return databaseConnector.appeal.findMany({
+				where: {
+					appealStatus: {
+						some: {
+							valid: true
+						}
+					}
+				},
+				include: {
+					address: true,
+					appealType: true,
+					appealStatus: {
+						where: {
+							valid: true
+						}
+					}
+				}
+			});
+		},
+		/**
+		 *
 		 * @param {{statuses: string[], includeAddress: boolean, includeAppellant: boolean, includeLPAQuestionnaire: boolean, includeAppealDetailsFromAppellant: boolean}} param0
 		 * @returns {Promise<import('@pins/api').Schema.Appeal[]>}
 		 */

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -16,6 +16,21 @@
 	"schemes": [],
 	"securityDefinitions": {},
 	"paths": {
+		"/appeals": {
+			"get": {
+				"tags": ["Appeals"],
+				"description": "Gets all appeals",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Gets all appeals",
+						"schema": {
+							"$ref": "#/definitions/AllAppeals"
+						}
+					}
+				}
+			}
+		},
 		"/appeals/validation/": {
 			"get": {
 				"tags": ["Appeals"],
@@ -511,6 +526,513 @@
 				}
 			}
 		},
+		"/applications": {
+			"post": {
+				"tags": ["Applications"],
+				"description": "Creates new application",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"description": "Application Details",
+						"schema": {
+							"$ref": "#/definitions/CreateApplication"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "ID of application",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "number",
+									"example": 1
+								},
+								"applicantIds": {
+									"type": "array",
+									"example": [2],
+									"items": {
+										"type": "number"
+									}
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/applications/{id}/start": {
+			"post": {
+				"tags": ["Applications"],
+				"description": "Moves application from Draft state to Pre-Application state",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Application Details",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "number",
+									"example": 1
+								},
+								"reference": {
+									"type": "string",
+									"example": "AB0110203"
+								},
+								"status": {
+									"type": "string",
+									"example": "Pre-Application"
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/applications/{id}": {
+			"get": {
+				"tags": ["Applications"],
+				"description": "Gets all of the application details",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID here"
+					},
+					{
+						"name": "query",
+						"in": "query",
+						"description": "Application details",
+						"example": "{ &ldquo;title&rdquo;:true, &ldquo;description&rdquo;:true, &ldquo;reference&rdquo;:true, &ldquo;status&rdquo;:true, &ldquo;caseEmail&rdquo;:true, &ldquo;sector&rdquo;:true, &ldquo;subSector&rdquo;:true, &ldquo;applicants&rdquo;:true, &ldquo;geographicalInformation&rdquo;:true, &ldquo;keyDates&rdquo;:true }",
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "IDs of application",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "number",
+									"example": 1
+								},
+								"reference": {
+									"type": "string",
+									"example": "BC010001"
+								},
+								"title": {
+									"type": "string",
+									"example": "Office Use Test Application 1"
+								},
+								"description": {
+									"type": "string",
+									"example": "A description of test case 1 which is a case of subsector type Office Use"
+								},
+								"status": {
+									"type": "string",
+									"example": "Withdrawn"
+								},
+								"caseEmail": {
+									"type": "string",
+									"example": "caseemail@gmail.com"
+								},
+								"sector": {
+									"type": "object",
+									"properties": {}
+								},
+								"subSector": {
+									"type": "object",
+									"properties": {
+										"name": {
+											"type": "string",
+											"example": "office_use"
+										},
+										"abbreviation": {
+											"type": "string",
+											"example": "BC01"
+										},
+										"displayNameEn": {
+											"type": "string",
+											"example": "Office Use"
+										},
+										"displayNameCy": {
+											"type": "string",
+											"example": "Office Use"
+										}
+									}
+								},
+								"applicants": {
+									"type": "array",
+									"example": [],
+									"items": {}
+								},
+								"geographicalInformation": {
+									"type": "object",
+									"properties": {
+										"mapZoomLevel": {
+											"type": "object",
+											"properties": {
+												"id": {
+													"type": "number",
+													"example": 5
+												},
+												"name": {
+													"type": "string",
+													"example": "district"
+												},
+												"displayNameEn": {
+													"type": "string",
+													"example": "District"
+												},
+												"displayNameCy": {
+													"type": "string",
+													"example": "District"
+												}
+											}
+										}
+									}
+								},
+								"locationDescription": {
+									"type": "string",
+									"example": "location description"
+								},
+								"gridReference": {
+									"type": "object",
+									"properties": {}
+								},
+								"regions": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {}
+									}
+								},
+								"keyDates": {
+									"type": "object",
+									"properties": {}
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			},
+			"patch": {
+				"tags": ["Applications"],
+				"description": "Updates application",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"description": "Application Details",
+						"schema": {
+							"$ref": "#/definitions/UpdateApplication"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "ID of application",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "number",
+									"example": 1
+								},
+								"applicantIds": {
+									"type": "array",
+									"example": [2],
+									"items": {
+										"type": "number"
+									}
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/applications/{id}/representations": {
+			"get": {
+				"tags": ["Applications"],
+				"description": "Gets list of representations on a case",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					},
+					{
+						"name": "page",
+						"in": "query",
+						"description": "Page to show",
+						"required": false,
+						"type": "integer",
+						"example": 1,
+						"minimum": 1
+					},
+					{
+						"name": "pageSize",
+						"in": "query",
+						"description": "Page size",
+						"required": false,
+						"type": "integer",
+						"example": 25,
+						"minimum": 1,
+						"maximun": 100
+					},
+					{
+						"name": "searchTerm",
+						"in": "query",
+						"description": "Search Term",
+						"required": false,
+						"type": "string"
+					},
+					{
+						"name": "status",
+						"in": "query",
+						"description": "Filter by status",
+						"required": false,
+						"schema": {
+							"type": "array",
+							"example": [""],
+							"items": {
+								"type": "string"
+							}
+						},
+						"style": "form",
+						"explode": true
+					},
+					{
+						"name": "under18",
+						"in": "query",
+						"description": "Filter by under18",
+						"required": false,
+						"type": "boolean"
+					},
+					{
+						"name": "sortBy",
+						"in": "query",
+						"description": "Sory by field. +field for ASC, -field for DESC",
+						"required": false,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Representations",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"page": {
+									"type": "number",
+									"example": 1
+								},
+								"pageSize": {
+									"type": "number",
+									"example": 25
+								},
+								"pageCount": {
+									"type": "number",
+									"example": 1
+								},
+								"itemCount": {
+									"type": "number",
+									"example": 100
+								},
+								"items": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"id": {
+												"type": "number",
+												"example": 1
+											},
+											"reference": {
+												"type": "string",
+												"example": "BC0110001-2"
+											},
+											"status": {
+												"type": "string",
+												"example": "VALID"
+											},
+											"redacted": {
+												"type": "boolean",
+												"example": true
+											},
+											"received": {
+												"type": "string",
+												"example": "2023-03-14T14:28:25.704Z"
+											},
+											"firstName": {
+												"type": "string",
+												"example": "James"
+											},
+											"lastName": {
+												"type": "string",
+												"example": "Bond"
+											},
+											"organisationName": {
+												"type": "string",
+												"example": "MI6"
+											}
+										}
+									}
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/applications/{id}/representations/{repId}": {
+			"get": {
+				"tags": ["Applications"],
+				"description": "Gets a representation on a case",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					},
+					{
+						"name": "repId",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Representation ID"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Representation",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "number",
+									"example": 1
+								},
+								"reference": {
+									"type": "string",
+									"example": "BC0110001-2"
+								},
+								"status": {
+									"type": "string",
+									"example": "VALID"
+								},
+								"redacted": {
+									"type": "boolean",
+									"example": true
+								},
+								"received": {
+									"type": "string",
+									"example": "2023-03-14T14:28:25.704Z"
+								},
+								"originalRepresentation": {
+									"type": "string",
+									"example": ""
+								},
+								"redactedRepresentation": {
+									"type": "string",
+									"example": ""
+								},
+								"redactedBy": {
+									"type": "object",
+									"properties": {}
+								},
+								"contacts": {
+									"type": "array",
+									"example": [],
+									"items": {}
+								},
+								"attachments": {
+									"type": "array",
+									"example": [],
+									"items": {}
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/applications/{id}/publish": {
+			"patch": {
+				"tags": ["Applications"],
+				"description": "publish application",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "response will have the date that the case was published as a timestamp",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"publishedDate": {
+									"type": "number",
+									"example": 1673873105
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/applications/{id}/documents/{guid}/metadata": {
 			"post": {
 				"tags": ["Applications"],
@@ -922,46 +1444,6 @@
 				}
 			}
 		},
-		"/applications": {
-			"post": {
-				"tags": ["Applications"],
-				"description": "Creates new application",
-				"parameters": [
-					{
-						"name": "body",
-						"in": "body",
-						"description": "Application Details",
-						"schema": {
-							"$ref": "#/definitions/CreateApplication"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "ID of application",
-						"schema": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "number",
-									"example": 1
-								},
-								"applicantIds": {
-									"type": "array",
-									"example": [2],
-									"items": {
-										"type": "number"
-									}
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
-						}
-					}
-				}
-			}
-		},
 		"/applications/documents/{documentGUID}/status": {
 			"patch": {
 				"tags": ["Applications"],
@@ -1006,473 +1488,6 @@
 								"status": {
 									"type": "string",
 									"example": "awaiting_virus_check"
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/applications/{id}": {
-			"patch": {
-				"tags": ["Applications"],
-				"description": "Updates application",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"required": true,
-						"type": "integer",
-						"description": "Application ID"
-					},
-					{
-						"name": "body",
-						"in": "body",
-						"description": "Application Details",
-						"schema": {
-							"$ref": "#/definitions/UpdateApplication"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "ID of application",
-						"schema": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "number",
-									"example": 1
-								},
-								"applicantIds": {
-									"type": "array",
-									"example": [2],
-									"items": {
-										"type": "number"
-									}
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
-						}
-					}
-				}
-			},
-			"get": {
-				"tags": ["Applications"],
-				"description": "Gets all of the application details",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"required": true,
-						"type": "integer",
-						"description": "Application ID here"
-					},
-					{
-						"name": "query",
-						"in": "query",
-						"description": "Application details",
-						"example": "{ &ldquo;title&rdquo;:true, &ldquo;description&rdquo;:true, &ldquo;reference&rdquo;:true, &ldquo;status&rdquo;:true, &ldquo;caseEmail&rdquo;:true, &ldquo;sector&rdquo;:true, &ldquo;subSector&rdquo;:true, &ldquo;applicants&rdquo;:true, &ldquo;geographicalInformation&rdquo;:true, &ldquo;keyDates&rdquo;:true }",
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "IDs of application",
-						"schema": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "number",
-									"example": 1
-								},
-								"reference": {
-									"type": "string",
-									"example": "BC010001"
-								},
-								"title": {
-									"type": "string",
-									"example": "Office Use Test Application 1"
-								},
-								"description": {
-									"type": "string",
-									"example": "A description of test case 1 which is a case of subsector type Office Use"
-								},
-								"status": {
-									"type": "string",
-									"example": "Withdrawn"
-								},
-								"caseEmail": {
-									"type": "string",
-									"example": "caseemail@gmail.com"
-								},
-								"sector": {
-									"type": "object",
-									"properties": {}
-								},
-								"subSector": {
-									"type": "object",
-									"properties": {
-										"name": {
-											"type": "string",
-											"example": "office_use"
-										},
-										"abbreviation": {
-											"type": "string",
-											"example": "BC01"
-										},
-										"displayNameEn": {
-											"type": "string",
-											"example": "Office Use"
-										},
-										"displayNameCy": {
-											"type": "string",
-											"example": "Office Use"
-										}
-									}
-								},
-								"applicants": {
-									"type": "array",
-									"example": [],
-									"items": {}
-								},
-								"geographicalInformation": {
-									"type": "object",
-									"properties": {
-										"mapZoomLevel": {
-											"type": "object",
-											"properties": {
-												"id": {
-													"type": "number",
-													"example": 5
-												},
-												"name": {
-													"type": "string",
-													"example": "district"
-												},
-												"displayNameEn": {
-													"type": "string",
-													"example": "District"
-												},
-												"displayNameCy": {
-													"type": "string",
-													"example": "District"
-												}
-											}
-										}
-									}
-								},
-								"locationDescription": {
-									"type": "string",
-									"example": "location description"
-								},
-								"gridReference": {
-									"type": "object",
-									"properties": {}
-								},
-								"regions": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {}
-									}
-								},
-								"keyDates": {
-									"type": "object",
-									"properties": {}
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/applications/{id}/start": {
-			"post": {
-				"tags": ["Applications"],
-				"description": "Moves application from Draft state to Pre-Application state",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"required": true,
-						"type": "integer",
-						"description": "Application ID"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Application Details",
-						"schema": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "number",
-									"example": 1
-								},
-								"reference": {
-									"type": "string",
-									"example": "AB0110203"
-								},
-								"status": {
-									"type": "string",
-									"example": "Pre-Application"
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/applications/{id}/representations": {
-			"get": {
-				"tags": ["Applications"],
-				"description": "Gets list of representations on a case",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"required": true,
-						"type": "integer",
-						"description": "Application ID"
-					},
-					{
-						"name": "page",
-						"in": "query",
-						"description": "Page to show",
-						"required": false,
-						"type": "integer",
-						"example": 1,
-						"minimum": 1
-					},
-					{
-						"name": "pageSize",
-						"in": "query",
-						"description": "Page size",
-						"required": false,
-						"type": "integer",
-						"example": 25,
-						"minimum": 1,
-						"maximun": 100
-					},
-					{
-						"name": "searchTerm",
-						"in": "query",
-						"description": "Search Term",
-						"required": false,
-						"type": "string"
-					},
-					{
-						"name": "status",
-						"in": "query",
-						"description": "Filter by status",
-						"required": false,
-						"schema": {
-							"type": "array",
-							"example": [""],
-							"items": {
-								"type": "string"
-							}
-						},
-						"style": "form",
-						"explode": true
-					},
-					{
-						"name": "under18",
-						"in": "query",
-						"description": "Filter by under18",
-						"required": false,
-						"type": "boolean"
-					},
-					{
-						"name": "sortBy",
-						"in": "query",
-						"description": "Sory by field. +field for ASC, -field for DESC",
-						"required": false,
-						"type": "string"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Representations",
-						"schema": {
-							"type": "object",
-							"properties": {
-								"page": {
-									"type": "number",
-									"example": 1
-								},
-								"pageSize": {
-									"type": "number",
-									"example": 25
-								},
-								"pageCount": {
-									"type": "number",
-									"example": 1
-								},
-								"itemCount": {
-									"type": "number",
-									"example": 100
-								},
-								"items": {
-									"type": "array",
-									"items": {
-										"type": "object",
-										"properties": {
-											"id": {
-												"type": "number",
-												"example": 1
-											},
-											"reference": {
-												"type": "string",
-												"example": "BC0110001-2"
-											},
-											"status": {
-												"type": "string",
-												"example": "VALID"
-											},
-											"redacted": {
-												"type": "boolean",
-												"example": true
-											},
-											"received": {
-												"type": "string",
-												"example": "2023-03-14T14:28:25.704Z"
-											},
-											"firstName": {
-												"type": "string",
-												"example": "James"
-											},
-											"lastName": {
-												"type": "string",
-												"example": "Bond"
-											},
-											"organisationName": {
-												"type": "string",
-												"example": "MI6"
-											}
-										}
-									}
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/applications/{id}/representations/{repId}": {
-			"get": {
-				"tags": ["Applications"],
-				"description": "Gets a representation on a case",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"required": true,
-						"type": "integer",
-						"description": "Application ID"
-					},
-					{
-						"name": "repId",
-						"in": "path",
-						"required": true,
-						"type": "integer",
-						"description": "Representation ID"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Representation",
-						"schema": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "number",
-									"example": 1
-								},
-								"reference": {
-									"type": "string",
-									"example": "BC0110001-2"
-								},
-								"status": {
-									"type": "string",
-									"example": "VALID"
-								},
-								"redacted": {
-									"type": "boolean",
-									"example": true
-								},
-								"received": {
-									"type": "string",
-									"example": "2023-03-14T14:28:25.704Z"
-								},
-								"originalRepresentation": {
-									"type": "string",
-									"example": ""
-								},
-								"redactedRepresentation": {
-									"type": "string",
-									"example": ""
-								},
-								"redactedBy": {
-									"type": "object",
-									"properties": {}
-								},
-								"contacts": {
-									"type": "array",
-									"example": [],
-									"items": {}
-								},
-								"attachments": {
-									"type": "array",
-									"example": [],
-									"items": {}
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/applications/{id}/publish": {
-			"patch": {
-				"tags": ["Applications"],
-				"description": "publish application",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"required": true,
-						"type": "integer",
-						"description": "Application ID"
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "response will have the date that the case was published as a timestamp",
-						"schema": {
-							"type": "object",
-							"properties": {
-								"publishedDate": {
-									"type": "number",
-									"example": 1673873105
 								}
 							},
 							"xml": {
@@ -3187,6 +3202,55 @@
 				"acceptingFinalComments": {
 					"type": "boolean",
 					"example": true
+				}
+			}
+		},
+		"AllAppeals": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"appealId": {
+						"type": "number",
+						"example": 1
+					},
+					"appealReference": {
+						"type": "string",
+						"example": "APP/Q9999/D/21/235348"
+					},
+					"appealSite": {
+						"type": "object",
+						"properties": {
+							"addressLine1": {
+								"type": "string",
+								"example": "19 Beauchamp Road"
+							},
+							"town": {
+								"type": "string",
+								"example": "Bristol"
+							},
+							"postCode": {
+								"type": "string",
+								"example": "BS7 8LQ"
+							}
+						}
+					},
+					"appealStatus": {
+						"type": "string",
+						"example": "awaiting_lpa_questionnaire"
+					},
+					"appealType": {
+						"type": "string",
+						"example": "household"
+					},
+					"createdAt": {
+						"type": "string",
+						"example": "2023-02-16T11:43:27.096Z"
+					},
+					"localPlanningDepartment": {
+						"type": "string",
+						"example": "Wiltshire Council"
+					}
 				}
 			}
 		},

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -476,6 +476,21 @@ const document = {
 			acceptingStatements: false,
 			acceptingFinalComments: true
 		},
+		AllAppeals: [
+			{
+				appealId: 1,
+				appealReference: 'APP/Q9999/D/21/235348',
+				appealSite: {
+					addressLine1: '19 Beauchamp Road',
+					town: 'Bristol',
+					postCode: 'BS7 8LQ'
+				},
+				appealStatus: 'awaiting_lpa_questionnaire',
+				appealType: 'household',
+				createdAt: '2023-02-16T11:43:27.096Z',
+				localPlanningDepartment: 'Wiltshire Council'
+			}
+		],
 		AppealsForCaseOfficer: {
 			$AppealId: 1,
 			$AppealReference: '',

--- a/apps/api/src/server/utils/address-block-formtter.js
+++ b/apps/api/src/server/utils/address-block-formtter.js
@@ -1,0 +1,18 @@
+/**
+ * @param {import('@pins/api').Schema.Address | undefined} address
+ * @returns {{addressLine1?: string, addressLine2?: string, town?: string, county?: string, postCode?: string | null}}
+ */
+function formatAddress(address) {
+	if (typeof address !== 'undefined') {
+		return {
+			...(address.addressLine1 && { addressLine1: address.addressLine1 }),
+			...(address.addressLine2 && { addressLine2: address.addressLine2 }),
+			...(address.town && { town: address.town }),
+			...(address.county && { county: address.county }),
+			postCode: address.postcode
+		};
+	}
+	return {};
+}
+
+export default formatAddress;


### PR DESCRIPTION
## Describe your changes

Added `/appeals` route for returning data for the Appeals List page.

Also added swagger docs and tests

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-40

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
