### PR TITLE
feature/boas 731 remove documents from queue

### DIFF
--- a/apps/api/prisma/migrations/20230421140434_documentversion_publishedstatusprev/migration.sql
+++ b/apps/api/prisma/migrations/20230421140434_documentversion_publishedstatusprev/migration.sql
@@ -1,0 +1,19 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[DocumentVersion] ADD [publishedStatusPrev] NVARCHAR(1000);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -428,6 +428,7 @@ model DocumentVersion {
   examinationRefNo       String?
   filter2                String?
   publishedStatus        String?   @default("awaiting_upload")
+  publishedStatusPrev    String?
   redactedStatus         String?
   redacted               Boolean   @default(false)
   documentURI            String?

--- a/apps/api/src/server/applications/application/documents/__tests__/update-document-status.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/update-document-status.test.js
@@ -411,6 +411,19 @@ describe('Update document statuses and redacted statuses', () => {
 				}
 			},
 			{
+				name: 'no document version',
+				guid: 'document-guid',
+				document: {},
+				documentVersion: null,
+				want: {
+					status: 404,
+					body: {
+						errors: 'No document found'
+					},
+					update: false
+				}
+			},
+			{
 				name: 'no previous status',
 				guid: 'document-guid',
 				document: {},

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -167,22 +167,20 @@ export const revertDocumentPublishedStatus = async ({ params: { guid } }, respon
 		throw new BackOfficeAppError(`No document found`, 404);
 	}
 
-	let publishedStatus;
-
 	if (
-		typeof documentVersion.publishedStatusPrev !== 'undefined' &&
-		documentVersion.publishedStatusPrev !== null
+		typeof documentVersion.publishedStatusPrev === 'undefined' ||
+		documentVersion.publishedStatusPrev === null
 	) {
-		publishedStatus = documentVersion.publishedStatusPrev;
-	} else {
 		throw new BackOfficeAppError(`No previous published status to revert to`, 412);
 	}
 
+	const publishedStatusToRevertTo = documentVersion.publishedStatusPrev;
+
 	logger.info(
-		`updating document version ${guid} to previous publishedStatus: '${publishedStatus}'`
+		`updating document version ${guid} to previous publishedStatus: '${publishedStatusToRevertTo}'`
 	);
 	await documentVersionRepository.update(guid, {
-		publishedStatus,
+		publishedStatus: publishedStatusToRevertTo,
 		publishedStatusPrev: null
 	});
 	response.sendStatus(200);

--- a/apps/api/src/server/applications/application/documents/document.routes.js
+++ b/apps/api/src/server/applications/application/documents/document.routes.js
@@ -8,6 +8,7 @@ import {
 	getDocumentProperties,
 	getReadyToPublishDocuments,
 	provideDocumentUploadURLs,
+	revertDocumentPublishedStatus,
 	storeDocumentVersion,
 	updateDocuments
 } from './document.controller.js';
@@ -133,6 +134,32 @@ router.get(
         }
     */
 	asyncHandler(getDocumentProperties)
+);
+
+router.post(
+	'/:id/documents/:guid/revert-published-status',
+	/*
+        #swagger.tags = ['Applications']
+        #swagger.path = '/applications/{id}/documents/{guid}/revert-published-status'
+        #swagger.description = 'Reverts the published status of a document to the previous status'
+        #swagger.parameters['id'] = {
+            in: 'path',
+			description: 'Application ID here',
+			required: true,
+			type: 'integer'
+		}
+		#swagger.parameters['guid'] = {
+            in: 'path',
+			description: 'guid of the document',
+			required: true,
+			type: 'string'
+		}
+        #swagger.responses[200] = {
+            description: 'OK'
+        }
+    */
+	validateApplicationId,
+	asyncHandler(revertDocumentPublishedStatus)
 );
 
 router.post(

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -6,11 +6,11 @@ import {
 } from '../../common/services/session.service.js';
 import {
 	deleteCaseDocumentationFile,
-	deleteCaseDocumentationPublishinQueue,
 	getCaseDocumentationFileInfo,
 	getCaseDocumentationFilesInFolder,
 	getCaseDocumentationReadyToPublish,
 	getCaseFolders,
+	removeCaseDocumentationPublishingQueue,
 	updateCaseDocumentationFiles
 } from './applications-documentation.service.js';
 import {
@@ -200,7 +200,7 @@ export async function viewApplicationsCaseDocumentationPublishingQueue(request, 
 export async function removeApplicationsCaseDocumentationPublishingQueue(request, response) {
 	const { caseId, documentGuid } = request.params;
 
-	await deleteCaseDocumentationPublishinQueue(caseId, documentGuid);
+	await removeCaseDocumentationPublishingQueue(caseId, documentGuid);
 
 	return response.redirect(url('documents-queue', { caseId }));
 }

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.service.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.service.js
@@ -128,14 +128,20 @@ export const deleteCaseDocumentationFile = async (caseId, documentGuid, fileName
  * @param {string} documentGuid
  * @returns {Promise<{isDeleted?: boolean, errors?: ValidationErrors}>}
  */
-export const deleteCaseDocumentationPublishinQueue = async (caseId, documentGuid) => {
+export const removeCaseDocumentationPublishingQueue = async (caseId, documentGuid) => {
 	let response;
 
 	try {
-		response = await post(`applications/${caseId}/documents/${documentGuid}/delete`);
+		response = await post(
+			`applications/${caseId}/documents/${documentGuid}/revert-published-status`
+		);
 	} catch {
 		response = new Promise((resolve) => {
-			resolve({ errors: { msg: `The document could not be deleted, please try again.` } });
+			resolve({
+				errors: {
+					msg: `The document could not be removed from the publishing queue, please try again.`
+				}
+			});
 		});
 	}
 


### PR DESCRIPTION
## Describe your changes

1. Changes to a documents published status now save the previous status to the database.
2. A new API endpoint for reverting the published status has been added
3. The front-end calls revert status when a user clicks "Remove" from the publishing queue.

## Issue ticket number and link

BOAS-731
https://pins-ds.atlassian.net/jira/software/projects/BOAS/boards/172?selectedIssue=BOAS-731

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
