### PR TITLE
chore(tooling): add main entry point to fix node dep0151 warning

### DIFF
--- a/packages/event-client/package.json
+++ b/packages/event-client/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.0",
     "type": "module",
     "private": true,
+    "main": "index.js",
     "engines": {
         "node": ">=16.14.0"
     },


### PR DESCRIPTION
## Describe your changes

`packages/event-client` was missing a main entry in the package definition, resulting in a Node deprecated warning ([DEP0151](https://nodejs.org/api/deprecations.html#DEP0151)). A main entry has been added.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
