### PR TITLE
fix(api/applications): add truncatetable as deletemany fails on 2100 records (BOAS-852)

### DIFF
--- a/apps/api/prisma/prisma.truncate.js
+++ b/apps/api/prisma/prisma.truncate.js
@@ -1,0 +1,13 @@
+import { databaseConnector } from '../src/server/utils/database-connector.js';
+
+/**
+ * Truncates a table in the DB, removing all data.
+ * Useful as DeleteMany cannot delete > 2100 rows.
+ * Azure MS SQL version
+ *
+ * @param {string} tableName
+ * @returns {Promise<any>}
+ */
+export const truncateTable = async (tableName) => {
+	await databaseConnector.$queryRawUnsafe(`TRUNCATE TABLE "${tableName}";`);
+};

--- a/apps/api/prisma/seed-production.js
+++ b/apps/api/prisma/seed-production.js
@@ -12,7 +12,7 @@ import {
 // create reference data only, no test data, as delivering to production DB
 
 /**
- * Upserts data for sectors, sub-sectors, regions, and zoom levels into the database.
+ * Upserts data for sectors, sub-sectors, regions, zoom levels, and examination timetable types into the database.
  *
  * @throws {Error} If any database operation fails.
  * @returns {Promise<void>}

--- a/apps/api/prisma/seed.js
+++ b/apps/api/prisma/seed.js
@@ -1,6 +1,7 @@
 import { createFolders } from '../src/server/repositories/folder.repository.js';
 import { databaseConnector } from '../src/server/utils/database-connector.js';
 import logger from '../src/server/utils/logger.js';
+import { truncateTable } from './prisma.truncate.js';
 import {
 	addressesList,
 	appealDetailsFromAppellantList,
@@ -654,8 +655,6 @@ const deleteAllRecords = async () => {
 	const deleteRegions = databaseConnector.region.deleteMany();
 	const deleteZoomLevels = databaseConnector.zoomLevel.deleteMany();
 	const deleteExaminationTimetables = databaseConnector.examinationTimetableType.deleteMany();
-	const deleteRegionsOnApplicationDetails =
-		databaseConnector.regionsOnApplicationDetails.deleteMany();
 	const deleteAppeals = databaseConnector.appeal.deleteMany();
 	const deleteUsers = databaseConnector.user.deleteMany();
 	const deleteAppealTypes = databaseConnector.appealType.deleteMany();
@@ -677,12 +676,18 @@ const deleteAllRecords = async () => {
 	const deleteRepresentationContact = databaseConnector.representationContact.deleteMany();
 	const deleteRepresentation = databaseConnector.representation.deleteMany();
 
+	// Truncate calls
+	const deleteRegionsOnApplicationDetails = truncateTable('RegionsOnApplicationDetails');
+
 	await deleteRepresentationContact;
 	await deleteRepresentation;
 
 	// delete document versions, documents, and THEN the folders.  Has to be in this order for integrity constraints
 	await deleteDocumentsVersions;
 	await deleteDocuments;
+
+	// truncate table
+	await deleteRegionsOnApplicationDetails;
 
 	await deleteLowestFolders();
 	await deleteLowestFolders();
@@ -693,7 +698,6 @@ const deleteAllRecords = async () => {
 	await databaseConnector.$transaction([
 		deleteGridReference,
 		deleteServiceCustomers,
-		deleteRegionsOnApplicationDetails,
 		deleteApplicationDetails,
 		deleteCaseStatuses,
 		deleteCases,


### PR DESCRIPTION
## Describe your changes

Prisma DeleteMany fails on more than 2100 records.  This causes seeding to fail when clearing the 
RegionsOnApplicationDetails table.  Added a simple truncateTable fn to call raw SQL to TRUNCATE TABLE.

This issue meant that seeding failed in Test, giving rise to the error of no exam timetable items in the dropdown

## BOAS-852 No dropdown list for Timetable item type
https://pins-ds.atlassian.net/browse/BOAS-852

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
