### PR TITLE
fix(api): set base reference number if one doesn't exist

### DIFF
--- a/apps/api/src/server/applications/application/__tests__/start-case.test.js
+++ b/apps/api/src/server/applications/application/__tests__/start-case.test.js
@@ -8,9 +8,6 @@ const { databaseConnector } = await import('../../../utils/database-connector.js
 
 const request = supertest(app);
 
-const referenceSettingSqlQuery =
-	'declare @sub_sector_abbreviation nchar(4), @max_reference int, @reference_number int;declare @minimum_new_reference int = 10001;declare @id int = 1;select @sub_sector_abbreviation = sub_sector_table.abbreviation FROM [dbo].[Case] as case_table     join [dbo].[ApplicationDetails] as application_details_table     on case_table.id = application_details_table.caseId     join [dbo].[SubSector] as sub_sector_table     on application_details_table.subSectorId = sub_sector_table.id where case_table.id = @id; SELECT @max_reference = max(cast(SUBSTRING(case_table.reference, 5, len(case_table.reference)) as int)) FROM [dbo].[Case] as case_table     join [dbo].[ApplicationDetails] as application_details_table     on case_table.id = application_details_table.caseId     join [dbo].[SubSector] as sub_sector_table     on application_details_table.subSectorId = sub_sector_table.id         and sub_sector_table.abbreviation = @sub_sector_abbreviation; if(@max_reference < @minimum_new_reference) select @reference_number = @minimum_new_reference else select @reference_number = @max_reference + 1;update [dbo].[Case]     set reference = @sub_sector_abbreviation + cast(@reference_number as nchar(5))     where id = @id;';
-
 const applicationReadyToStart = applicationFactoryForTests({
 	id: 1,
 	title: 'Title',
@@ -85,7 +82,7 @@ describe('Start case', () => {
 
 		expect(databaseConnector.case.update).not.toHaveBeenCalled();
 
-		expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledWith(referenceSettingSqlQuery);
+		expect(databaseConnector.$executeRawUnsafe).toHaveBeenCalledTimes(1);
 
 		// test 1st top level folder and its sub folders
 		expect(databaseConnector.folder.create).toHaveBeenCalledWith({

--- a/apps/api/src/server/repositories/raw_sql_queries/update-application-reference.sql
+++ b/apps/api/src/server/repositories/raw_sql_queries/update-application-reference.sql
@@ -3,24 +3,24 @@ declare @sub_sector_abbreviation nchar(4), @max_reference int, @reference_number
 declare @minimum_new_reference int = 10001;
 declare @id int = CASE_ID;
 
-select @sub_sector_abbreviation = sub_sector_table.abbreviation 
-FROM [dbo].[Case] as case_table 
-    join [dbo].[ApplicationDetails] as application_details_table 
-    on case_table.id = application_details_table.caseId 
-    join [dbo].[SubSector] as sub_sector_table 
-    on application_details_table.subSectorId = sub_sector_table.id 
-where case_table.id = @id; 
+select @sub_sector_abbreviation = sub_sector_table.abbreviation
+FROM [dbo].[Case] as case_table
+    join [dbo].[ApplicationDetails] as application_details_table
+    on case_table.id = application_details_table.caseId
+    join [dbo].[SubSector] as sub_sector_table
+    on application_details_table.subSectorId = sub_sector_table.id
+where case_table.id = @id;
 
-SELECT @max_reference = max(cast(SUBSTRING(case_table.reference, 5, len(case_table.reference)) as int)) 
-FROM [dbo].[Case] as case_table 
-    join [dbo].[ApplicationDetails] as application_details_table 
-    on case_table.id = application_details_table.caseId 
-    join [dbo].[SubSector] as sub_sector_table 
-    on application_details_table.subSectorId = sub_sector_table.id 
-        and sub_sector_table.abbreviation = @sub_sector_abbreviation; 
+SELECT @max_reference = max(cast(SUBSTRING(case_table.reference, 5, len(case_table.reference)) as int))
+FROM [dbo].[Case] as case_table
+    join [dbo].[ApplicationDetails] as application_details_table
+    on case_table.id = application_details_table.caseId
+    join [dbo].[SubSector] as sub_sector_table
+    on application_details_table.subSectorId = sub_sector_table.id
+        and sub_sector_table.abbreviation = @sub_sector_abbreviation;
 
-if(@max_reference < @minimum_new_reference) select @reference_number = @minimum_new_reference else select @reference_number = @max_reference + 1;
+if(@max_reference < @minimum_new_reference OR @max_reference IS NULL) select @reference_number = @minimum_new_reference else select @reference_number = @max_reference + 1;
 
-update [dbo].[Case] 
-    set reference = @sub_sector_abbreviation + cast(@reference_number as nchar(5)) 
+update [dbo].[Case]
+    set reference = CONCAT(@sub_sector_abbreviation, cast(@reference_number as nchar(5)))
     where id = @id;


### PR DESCRIPTION
## Describe your changes

Fixed some expressions containing NULL where they shouldn't. If this is the first case of its kind, the expression evaluating against the minimum reference number will return falsy (because NULL < Number is false), and then @reference_number becomes NULL (because NULL + 1 = NULL).

Then eventually, the entire string concatenation (with pluses) will return NULL even if the left operand is a string, because NULLs are the wild west in MSSQL.

In future I think we should move this logic out of SQL and into the codebase, that way we can test it and get better observability on it too. I understand why it's in SQL, but I think we'd get equal value from just putting a UNIQUE constraint on the reference column and allowing it to fail in race conditions (there's almost no chance we'll be creating two cases at the same time, never-mind two cases of the exact same sub-type, so I think an explicit failure is fine as long as the entire request is atomic)

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/BOAS-834

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
