### PR TITLE
feat(api): add pagination for /appeals route

### DIFF
--- a/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
@@ -3,7 +3,6 @@ import { app } from '../../../app-test.js';
 const { databaseConnector } = await import('../../../utils/database-connector.js');
 
 const request = supertest(app);
-
 const appeal = {
 	id: 1,
 	reference: 'APP/Q9999/D/21/1345264',
@@ -45,15 +44,25 @@ const appeal = {
 		outcome: 'Not issued yet'
 	}
 };
+const appealTwo = {
+	...appeal,
+	id: 2
+};
 
 describe('Appeals', () => {
 	describe('/appeals', () => {
-		test('get all appeals', async () => {
+		test('gets appeals when not given pagination params', async () => {
 			// @ts-ignore
-			databaseConnector.appeal.findMany.mockResolvedValue([appeal]);
+			databaseConnector.appeal.findMany.mockResolvedValue([appeal, appealTwo]);
 
 			const response = await request.get('/appeals');
 
+			expect(databaseConnector.appeal.findMany).toBeCalledWith(
+				expect.objectContaining({
+					skip: 0,
+					take: 30
+				})
+			);
 			expect(response.status).toEqual(200);
 			expect(response.body).toEqual([
 				{
@@ -69,13 +78,124 @@ describe('Appeals', () => {
 					appealType: appeal.appealType.type,
 					createdAt: appeal.createdAt.toISOString(),
 					localPlanningDepartment: appeal.localPlanningDepartment
+				},
+				{
+					appealId: appealTwo.id,
+					appealReference: appeal.reference,
+					appealSite: {
+						addressLine1: appeal.address.addressLine1,
+						town: appeal.address.town,
+						county: appeal.address.county,
+						postCode: appeal.address.postcode
+					},
+					appealStatus: appeal.appealStatus[0].status,
+					appealType: appeal.appealType.type,
+					createdAt: appeal.createdAt.toISOString(),
+					localPlanningDepartment: appeal.localPlanningDepartment
 				}
 			]);
+		});
+
+		test('gets appeals when given pagination params', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findMany.mockResolvedValue([appealTwo]);
+
+			const response = await request.get('/appeals?pageNumber=2&pageSize=1');
+
+			expect(databaseConnector.appeal.findMany).toBeCalledWith(
+				expect.objectContaining({
+					skip: 1,
+					take: 1
+				})
+			);
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual([
+				{
+					appealId: appealTwo.id,
+					appealReference: appeal.reference,
+					appealSite: {
+						addressLine1: appeal.address.addressLine1,
+						town: appeal.address.town,
+						county: appeal.address.county,
+						postCode: appeal.address.postcode
+					},
+					appealStatus: appeal.appealStatus[0].status,
+					appealType: appeal.appealType.type,
+					createdAt: appeal.createdAt.toISOString(),
+					localPlanningDepartment: appeal.localPlanningDepartment
+				}
+			]);
+		});
+
+		test('returns an error if pageNumber is given and pageSize is not given', async () => {
+			const response = await request.get('/appeals?pageNumber=1');
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					pageNumber: 'Both pageNumber and pageSize are required for pagination'
+				}
+			});
+		});
+
+		test('returns an error if pageSize is given and pageNumber is not given', async () => {
+			const response = await request.get('/appeals?pageSize=1');
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					pageSize: 'Both pageNumber and pageSize are required for pagination'
+				}
+			});
+		});
+
+		test('returns an error if pageNumber is not numeric', async () => {
+			const response = await request.get('/appeals?pageNumber=one&pageSize=1');
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					pageNumber: 'Must be a number'
+				}
+			});
+		});
+
+		test('returns an error if pageNumber is less than 1', async () => {
+			const response = await request.get('/appeals?pageNumber=-1&pageSize=1');
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					pageNumber: 'Must be greater than 0'
+				}
+			});
+		});
+
+		test('returns an error if pageSize is not numeric', async () => {
+			const response = await request.get('/appeals?pageNumber=1&pageSize=one');
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					pageSize: 'Must be a number'
+				}
+			});
+		});
+
+		test('returns an error if pageSize is less than 1', async () => {
+			const response = await request.get('/appeals?pageNumber=1&pageSize=-1');
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					pageSize: 'Must be greater than 0'
+				}
+			});
 		});
 	});
 
 	describe('/appeals/:appealId', () => {
-		test('get a single appeal', async () => {
+		test('gets a single appeal', async () => {
 			// @ts-ignore
 			databaseConnector.appeal.findUnique.mockResolvedValue(appeal);
 

--- a/apps/api/src/server/appeals/appeals/appeals.controller.js
+++ b/apps/api/src/server/appeals/appeals/appeals.controller.js
@@ -1,4 +1,5 @@
 import appealRepository from '../../repositories/appeal.repository.js';
+import { DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE } from '../constants.js';
 import appealFormatter from './appeals.formatter.js';
 
 /** @typedef {import('./appeals.routes.js').AppealParams} AppealParams */
@@ -8,7 +9,10 @@ import appealFormatter from './appeals.formatter.js';
  * @returns {Promise<object>}
  */
 const getAppeals = async (req, res) => {
-	const appeals = await appealRepository.getAll();
+	const pageNumber = Number(req.query.pageNumber) || DEFAULT_PAGE_NUMBER;
+	const pageSize = Number(req.query.pageSize) || DEFAULT_PAGE_SIZE;
+
+	const appeals = await appealRepository.getAll(pageNumber, pageSize);
 	const formattedAppeals = appeals.map((appeal) => appealFormatter.formatAppeals(appeal));
 
 	return res.send(formattedAppeals);

--- a/apps/api/src/server/appeals/appeals/appeals.routes.js
+++ b/apps/api/src/server/appeals/appeals/appeals.routes.js
@@ -1,7 +1,7 @@
 import { Router as createRouter } from 'express';
 import { asyncHandler } from '../../middleware/async-handler.js';
 import { getAppealById, getAppeals } from './appeals.controller.js';
-import { validateAppealId } from './appeals.validators.js';
+import { validateAppealId, validatePaginationParameters } from './appeals.validators.js';
 
 /**
  * @typedef {object} AppealParams
@@ -15,12 +15,24 @@ router.get(
 	/*
 		#swagger.tags = ['Appeals']
 		#swagger.path = '/appeals'
-		#swagger.description = 'Gets all appeals'
-		#swagger.responses[200] = {
-			description: 'Gets all appeals',
-			schema: { $ref: '#/definitions/AllAppeals' }
+		#swagger.description = 'Gets requested appeals, limited to the first 30 if no pagination params are given'
+		#swagger.parameters['pageNumber'] = {
+			in: 'query',
+			description: 'The pagination page number, required if pageSize is given',
+			example: 1,
 		}
+		#swagger.parameters['pageSize'] = {
+			in: 'query',
+			description: 'The pagination page size, required if pageNumber is given',
+			example: 30,
+		}
+		#swagger.responses[200] = {
+			description: 'Requested appeals',
+			schema: { $ref: '#/definitions/AllAppeals' },
+		}
+		#swagger.responses[400] = {}
 	 */
+	validatePaginationParameters,
 	asyncHandler(getAppeals)
 );
 
@@ -32,8 +44,10 @@ router.get(
 		#swagger.description = 'Gets a single appeal by id'
 		#swagger.responses[200] = {
 			description: 'Gets a single appeal by id',
-			schema: { $ref: '#/definitions/SingleAppeal' }
+			schema: { $ref: '#/definitions/SingleAppeal' },
 		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
 	 */
 	validateAppealId,
 	asyncHandler(getAppealById)

--- a/apps/api/src/server/appeals/appeals/appeals.validators.js
+++ b/apps/api/src/server/appeals/appeals/appeals.validators.js
@@ -1,10 +1,51 @@
 import { composeMiddleware } from '@pins/express';
-import { param } from 'express-validator';
+import { param, query } from 'express-validator';
 import { validationErrorHandler } from '../../middleware/error-handler.js';
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+const hasValue = (value) => !!value;
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+const isGreaterThanZero = (value) => Number(value) >= 1;
+
+/**
+ * @param {string} pageNumber
+ * @param {string} pageSize
+ * @returns {string}
+ */
+const hasPageNumberAndPageSize = (pageNumber, pageSize) => pageNumber && pageSize;
+
+/**
+ * @param {string} parameterName
+ * @returns {import('express-validator').ValidationChain}
+ */
+const validatePaginationParameter = (parameterName) =>
+	query(parameterName)
+		.if(hasValue)
+		.isInt()
+		.withMessage('Must be a number')
+		.custom(isGreaterThanZero)
+		.withMessage('Must be greater than 0')
+		.custom((value, { req }) =>
+			hasPageNumberAndPageSize(req.query?.pageNumber, req.query?.pageSize)
+		)
+		.withMessage('Both pageNumber and pageSize are required for pagination');
 
 const validateAppealId = composeMiddleware(
 	param('appealId').isInt().withMessage('Appeal id must be a number'),
 	validationErrorHandler
 );
 
-export { validateAppealId };
+const validatePaginationParameters = composeMiddleware(
+	validatePaginationParameter('pageNumber'),
+	validatePaginationParameter('pageSize'),
+	validationErrorHandler
+);
+
+export { validateAppealId, validatePaginationParameters };

--- a/apps/api/src/server/appeals/constants.js
+++ b/apps/api/src/server/appeals/constants.js
@@ -1,0 +1,2 @@
+export const DEFAULT_PAGE_NUMBER = 1;
+export const DEFAULT_PAGE_SIZE = 30;

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -514,14 +514,32 @@
 		"/appeals": {
 			"get": {
 				"tags": ["Appeals"],
-				"description": "Gets all appeals",
-				"parameters": [],
+				"description": "Gets requested appeals, limited to the first 30 if no pagination params are given",
+				"parameters": [
+					{
+						"name": "pageNumber",
+						"in": "query",
+						"description": "The pagination page number, required if pageSize is given",
+						"example": 1,
+						"type": "string"
+					},
+					{
+						"name": "pageSize",
+						"in": "query",
+						"description": "The pagination page size, required if pageNumber is given",
+						"example": 30,
+						"type": "string"
+					}
+				],
 				"responses": {
 					"200": {
-						"description": "Gets all appeals",
+						"description": "Requested appeals",
 						"schema": {
 							"$ref": "#/definitions/AllAppeals"
 						}
+					},
+					"400": {
+						"description": "Bad Request"
 					}
 				}
 			}
@@ -544,6 +562,12 @@
 						"schema": {
 							"$ref": "#/definitions/SingleAppeal"
 						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
 					}
 				}
 			}


### PR DESCRIPTION
## Describe your changes

Adds pagination for the `/appeals` route as query params.

For example `http://localhost:3000/appeals?pageNumber=1&pageSize=30`.

If no pagination params are given then the response is limited to the first 30 appeals.

If pagination params are given then:

- Both `pageNumber` and `pageSize` must be given
- Both `pageNumber` and `pageSize` must be numeric
- Both `pageNumber` and `pageSize` must be greater than 0

Also added tests for success and error states and updated swagger docs.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-41

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
