### PR TITLE
feat(api): return startedAt field in the /appeals/:appealId endpoint

### DIFF
--- a/apps/api/prisma/schema.d.ts
+++ b/apps/api/prisma/schema.d.ts
@@ -69,6 +69,7 @@ export interface Appeal extends schema.Appeal {
 	reference: string;
 	reviewQuestionnaire?: schema.ReviewQuestionnaire[];
 	siteVisit?: SiteVisit;
+	startedAt: Date;
 	validationDecision?: ValidationDecision[];
 }
 

--- a/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
@@ -37,9 +37,6 @@ const appeal = {
 		siteVisibleFromPublicLand: true,
 		healthAndSafetyIssues: false
 	},
-	siteVisit: {
-		visitType: 'unaccompanied'
-	},
 	inspectorDecision: {
 		outcome: 'Not issued yet'
 	}
@@ -218,8 +215,6 @@ describe('Appeals', () => {
 				appellantName: appeal.appellant.name,
 				caseProcedure: 'Written',
 				decision: appeal.inspectorDecision.outcome,
-				developmentType: 'Minor Dwellings',
-				eventType: 'Site Visit',
 				linkedAppeal: {
 					appealId: 1,
 					appealReference: 'APP/Q9999/D/21/725284'
@@ -232,7 +227,7 @@ describe('Appeals', () => {
 					}
 				],
 				planningApplicationReference: appeal.planningApplicationReference,
-				visitType: appeal.siteVisit.visitType
+				startedAt: appeal.startedAt.toISOString()
 			});
 		});
 

--- a/apps/api/src/server/appeals/appeals/appeals.formatter.js
+++ b/apps/api/src/server/appeals/appeals/appeals.formatter.js
@@ -7,7 +7,7 @@ const appealFormatter = {
 	 * 	 appealId: number,
 	 * 	 appealReference: string,
 	 * 	 appealSite: { addressLine1?: string, addressLine2?: string, town?: string, county?: string, postCode?: string | null },
-	 * 	 appealStatus: string
+	 * 	 appealStatus: string,
 	 * 	 appealType: string,
 	 * 	 createdAt: Date,
 	 * 	 localPlanningDepartment: string,
@@ -30,18 +30,16 @@ const appealFormatter = {
 	 *   appealId: number,
 	 *   appealReference: string,
 	 *   appealSite: { addressLine1?: string, addressLine2?: string, town?: string, county?: string, postCode?: string | null },
-	 *   appealStatus: string
+	 *   appealStatus: string,
 	 *   appealType: string,
 	 *   appellantName?: string,
 	 *   caseProcedure: string,
 	 *   decision?: string,
-	 *   developmentType: string,
-	 *   eventType: string,
-	 *   linkedAppeal: { appealId: number | null, appealReference: string | null }
+	 *   linkedAppeal: { appealId: number | null, appealReference: string | null },
 	 *   localPlanningDepartment: string,
-	 *   otherAppeals: [{ appealId: number | null, appealReference: string | null }]
+	 *   otherAppeals: [{ appealId: number | null, appealReference: string | null }],
 	 *   planningApplicationReference: string,
-	 *   visitType?: string,
+	 * 	 startedAt: Date | null,
 	 * }}}
 	 */
 	formatAppeal(appeal) {
@@ -56,8 +54,6 @@ const appealFormatter = {
 			appellantName: appeal.appellant?.name,
 			caseProcedure: 'Written',
 			decision: appeal.inspectorDecision?.outcome,
-			developmentType: 'Minor Dwellings',
-			eventType: 'Site Visit',
 			linkedAppeal: {
 				appealId: 1,
 				appealReference: 'APP/Q9999/D/21/725284'
@@ -70,7 +66,7 @@ const appealFormatter = {
 				}
 			],
 			planningApplicationReference: appeal.planningApplicationReference,
-			visitType: appeal.siteVisit?.visitType
+			startedAt: appeal.startedAt
 		};
 	}
 };

--- a/apps/api/src/server/appeals/appeals/appeals.validators.js
+++ b/apps/api/src/server/appeals/appeals/appeals.validators.js
@@ -17,9 +17,9 @@ const isGreaterThanZero = (value) => Number(value) >= 1;
 /**
  * @param {string} pageNumber
  * @param {string} pageSize
- * @returns {string}
+ * @returns {boolean}
  */
-const hasPageNumberAndPageSize = (pageNumber, pageSize) => pageNumber && pageSize;
+const hasPageNumberAndPageSize = (pageNumber, pageSize) => !!(pageNumber && pageSize);
 
 /**
  * @param {string} parameterName

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -3427,14 +3427,6 @@
 					"type": "string",
 					"example": "Not issued yet"
 				},
-				"developmentType": {
-					"type": "string",
-					"example": "Minor Dwellings"
-				},
-				"eventType": {
-					"type": "string",
-					"example": "Site Visit"
-				},
 				"linkedAppeal": {
 					"type": "object",
 					"properties": {
@@ -3472,9 +3464,9 @@
 					"type": "string",
 					"example": "48269/APP/2021/1482"
 				},
-				"visitType": {
+				"startedAt": {
 					"type": "string",
-					"example": "unaccompanied"
+					"example": "2022-05-17T23:00:00.000Z"
 				}
 			}
 		},

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -516,8 +516,6 @@ const document = {
 			appellantOwnsWholeSite: true,
 			caseProcedure: 'Written',
 			decision: 'Not issued yet',
-			developmentType: 'Minor Dwellings',
-			eventType: 'Site Visit',
 			linkedAppeal: {
 				appealId: 1,
 				appealReference: 'APP/Q9999/D/21/725284'
@@ -530,7 +528,7 @@ const document = {
 				}
 			],
 			planningApplicationReference: '48269/APP/2021/1482',
-			visitType: 'unaccompanied'
+			startedAt: '2022-05-17T23:00:00.000Z'
 		},
 		AppealsForCaseOfficer: {
 			$AppealId: 1,


### PR DESCRIPTION
## Describe your changes

Updated the `/appeals/:appealId` endpoint to return the `startedAt` date field

Also:

- Removed some fields (`developmentType`, `eventType` and `visitType`) from the same endpoint that are no longer displayed in the Case View page
- Updated `hasPageNumberAndSize` validation function to return a boolean rather than a string

Also updated the tests and swagger docs

## Issue ticket number and link

https://pins-ds.atlassian.net/jira/software/projects/BOAT/boards/207?selectedIssue=BOAT-98

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
