### PR TITLE
feat(api): update appeal pagination results to include item and page count

### DIFF
--- a/apps/api/setup-tests.js
+++ b/apps/api/setup-tests.js
@@ -17,6 +17,7 @@ const mockAppealUpdate = jest.fn().mockResolvedValue({});
 const mockValidationDecisionCreate = jest.fn().mockResolvedValue({});
 const mockAppealStatusCreateMany = jest.fn().mockResolvedValue({});
 const mockAppealFindMany = jest.fn().mockResolvedValue({});
+const mockAppealCount = jest.fn().mockResolvedValue(0);
 const mockReviewQuestionnaireCreate = jest.fn().mockResolvedValue({});
 const mockCaseCreate = jest.fn().mockResolvedValue({});
 const mockFolderCreate = jest.fn().mockResolvedValue({});
@@ -57,7 +58,8 @@ class MockPrismaClient {
 		return {
 			findUnique: mockAppealFindUnique,
 			update: mockAppealUpdate,
-			findMany: mockAppealFindMany
+			findMany: mockAppealFindMany,
+			count: mockAppealCount
 		};
 	}
 

--- a/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
@@ -50,6 +50,8 @@ describe('Appeals', () => {
 	describe('/appeals', () => {
 		test('gets appeals when not given pagination params', async () => {
 			// @ts-ignore
+			databaseConnector.appeal.count.mockResolvedValue(5);
+			// @ts-ignore
 			databaseConnector.appeal.findMany.mockResolvedValue([appeal, appealTwo]);
 
 			const response = await request.get('/appeals');
@@ -61,39 +63,47 @@ describe('Appeals', () => {
 				})
 			);
 			expect(response.status).toEqual(200);
-			expect(response.body).toEqual([
-				{
-					appealId: appeal.id,
-					appealReference: appeal.reference,
-					appealSite: {
-						addressLine1: appeal.address.addressLine1,
-						town: appeal.address.town,
-						county: appeal.address.county,
-						postCode: appeal.address.postcode
+			expect(response.body).toEqual({
+				itemCount: 5,
+				items: [
+					{
+						appealId: appeal.id,
+						appealReference: appeal.reference,
+						appealSite: {
+							addressLine1: appeal.address.addressLine1,
+							town: appeal.address.town,
+							county: appeal.address.county,
+							postCode: appeal.address.postcode
+						},
+						appealStatus: appeal.appealStatus[0].status,
+						appealType: appeal.appealType.type,
+						createdAt: appeal.createdAt.toISOString(),
+						localPlanningDepartment: appeal.localPlanningDepartment
 					},
-					appealStatus: appeal.appealStatus[0].status,
-					appealType: appeal.appealType.type,
-					createdAt: appeal.createdAt.toISOString(),
-					localPlanningDepartment: appeal.localPlanningDepartment
-				},
-				{
-					appealId: appealTwo.id,
-					appealReference: appeal.reference,
-					appealSite: {
-						addressLine1: appeal.address.addressLine1,
-						town: appeal.address.town,
-						county: appeal.address.county,
-						postCode: appeal.address.postcode
-					},
-					appealStatus: appeal.appealStatus[0].status,
-					appealType: appeal.appealType.type,
-					createdAt: appeal.createdAt.toISOString(),
-					localPlanningDepartment: appeal.localPlanningDepartment
-				}
-			]);
+					{
+						appealId: appealTwo.id,
+						appealReference: appeal.reference,
+						appealSite: {
+							addressLine1: appeal.address.addressLine1,
+							town: appeal.address.town,
+							county: appeal.address.county,
+							postCode: appeal.address.postcode
+						},
+						appealStatus: appeal.appealStatus[0].status,
+						appealType: appeal.appealType.type,
+						createdAt: appeal.createdAt.toISOString(),
+						localPlanningDepartment: appeal.localPlanningDepartment
+					}
+				],
+				page: 1,
+				pageCount: 1,
+				pageSize: 30
+			});
 		});
 
 		test('gets appeals when given pagination params', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.count.mockResolvedValue(5);
 			// @ts-ignore
 			databaseConnector.appeal.findMany.mockResolvedValue([appealTwo]);
 
@@ -106,22 +116,28 @@ describe('Appeals', () => {
 				})
 			);
 			expect(response.status).toEqual(200);
-			expect(response.body).toEqual([
-				{
-					appealId: appealTwo.id,
-					appealReference: appeal.reference,
-					appealSite: {
-						addressLine1: appeal.address.addressLine1,
-						town: appeal.address.town,
-						county: appeal.address.county,
-						postCode: appeal.address.postcode
-					},
-					appealStatus: appeal.appealStatus[0].status,
-					appealType: appeal.appealType.type,
-					createdAt: appeal.createdAt.toISOString(),
-					localPlanningDepartment: appeal.localPlanningDepartment
-				}
-			]);
+			expect(response.body).toEqual({
+				itemCount: 5,
+				items: [
+					{
+						appealId: appealTwo.id,
+						appealReference: appeal.reference,
+						appealSite: {
+							addressLine1: appeal.address.addressLine1,
+							town: appeal.address.town,
+							county: appeal.address.county,
+							postCode: appeal.address.postcode
+						},
+						appealStatus: appeal.appealStatus[0].status,
+						appealType: appeal.appealType.type,
+						createdAt: appeal.createdAt.toISOString(),
+						localPlanningDepartment: appeal.localPlanningDepartment
+					}
+				],
+				page: 2,
+				pageCount: 5,
+				pageSize: 1
+			});
 		});
 
 		test('returns an error if pageNumber is given and pageSize is not given', async () => {

--- a/apps/api/src/server/appeals/appeals/appeals.controller.js
+++ b/apps/api/src/server/appeals/appeals/appeals.controller.js
@@ -1,4 +1,5 @@
 import appealRepository from '../../repositories/appeal.repository.js';
+import { getPageCount } from '../../utils/database-pagination.js';
 import { DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE } from '../constants.js';
 import appealFormatter from './appeals.formatter.js';
 
@@ -12,10 +13,16 @@ const getAppeals = async (req, res) => {
 	const pageNumber = Number(req.query.pageNumber) || DEFAULT_PAGE_NUMBER;
 	const pageSize = Number(req.query.pageSize) || DEFAULT_PAGE_SIZE;
 
-	const appeals = await appealRepository.getAll(pageNumber, pageSize);
+	const [itemCount, appeals = []] = await appealRepository.getAll(pageNumber, pageSize);
 	const formattedAppeals = appeals.map((appeal) => appealFormatter.formatAppeals(appeal));
 
-	return res.send(formattedAppeals);
+	return res.send({
+		itemCount,
+		items: formattedAppeals,
+		page: pageNumber,
+		pageCount: getPageCount(itemCount, pageSize),
+		pageSize
+	});
 };
 
 /**

--- a/apps/api/src/server/repositories/appeal.repository.js
+++ b/apps/api/src/server/repositories/appeal.repository.js
@@ -59,29 +59,36 @@ const appealRepository = (function () {
 		/**
 		 * @param {number} pageNumber
 		 * @param {number} pageSize
-		 * @returns {Prisma.PrismaPromise<import('@pins/api').Schema.Appeal[]>}
+		 * @returns {Prisma.PrismaPromise<[number, import('@pins/api').Schema.Appeal[]]>}
 		 */
 		getAll(pageNumber, pageSize) {
-			return databaseConnector.appeal.findMany({
-				where: {
-					appealStatus: {
-						some: {
-							valid: true
-						}
+			const where = {
+				appealStatus: {
+					some: {
+						valid: true
 					}
-				},
-				include: {
-					address: true,
-					appealType: true,
-					appealStatus: {
-						where: {
-							valid: true
+				}
+			};
+
+			return databaseConnector.$transaction([
+				databaseConnector.appeal.count({
+					where
+				}),
+				databaseConnector.appeal.findMany({
+					where,
+					include: {
+						address: true,
+						appealType: true,
+						appealStatus: {
+							where: {
+								valid: true
+							}
 						}
-					}
-				},
-				skip: getSkipValue(pageNumber, pageSize),
-				take: pageSize
-			});
+					},
+					skip: getSkipValue(pageNumber, pageSize),
+					take: pageSize
+				})
+			]);
 		},
 		/**
 		 *

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -3322,51 +3322,72 @@
 			}
 		},
 		"AllAppeals": {
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"appealId": {
-						"type": "number",
-						"example": 1
-					},
-					"appealReference": {
-						"type": "string",
-						"example": "APP/Q9999/D/21/235348"
-					},
-					"appealSite": {
+			"type": "object",
+			"properties": {
+				"itemCount": {
+					"type": "number",
+					"example": 57
+				},
+				"items": {
+					"type": "array",
+					"items": {
 						"type": "object",
 						"properties": {
-							"addressLine1": {
-								"type": "string",
-								"example": "19 Beauchamp Road"
+							"appealId": {
+								"type": "number",
+								"example": 1
 							},
-							"town": {
+							"appealReference": {
 								"type": "string",
-								"example": "Bristol"
+								"example": "APP/Q9999/D/21/235348"
 							},
-							"postCode": {
+							"appealSite": {
+								"type": "object",
+								"properties": {
+									"addressLine1": {
+										"type": "string",
+										"example": "19 Beauchamp Road"
+									},
+									"town": {
+										"type": "string",
+										"example": "Bristol"
+									},
+									"postCode": {
+										"type": "string",
+										"example": "BS7 8LQ"
+									}
+								}
+							},
+							"appealStatus": {
 								"type": "string",
-								"example": "BS7 8LQ"
+								"example": "awaiting_lpa_questionnaire"
+							},
+							"appealType": {
+								"type": "string",
+								"example": "household"
+							},
+							"createdAt": {
+								"type": "string",
+								"example": "2023-02-16T11:43:27.096Z"
+							},
+							"localPlanningDepartment": {
+								"type": "string",
+								"example": "Wiltshire Council"
 							}
 						}
-					},
-					"appealStatus": {
-						"type": "string",
-						"example": "awaiting_lpa_questionnaire"
-					},
-					"appealType": {
-						"type": "string",
-						"example": "household"
-					},
-					"createdAt": {
-						"type": "string",
-						"example": "2023-02-16T11:43:27.096Z"
-					},
-					"localPlanningDepartment": {
-						"type": "string",
-						"example": "Wiltshire Council"
 					}
+				},
+				"page": {
+					"type": "number",
+					"example": 1
+				},
+				"pageCount": {
+					"type": "number",
+					"example": 27
+				},
+				"pageSize": {
+					"type": "number",
+					"example": 30
 				}
 			}
 		},

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -485,21 +485,27 @@ const document = {
 			acceptingStatements: false,
 			acceptingFinalComments: true
 		},
-		AllAppeals: [
-			{
-				appealId: 1,
-				appealReference: 'APP/Q9999/D/21/235348',
-				appealSite: {
-					addressLine1: '19 Beauchamp Road',
-					town: 'Bristol',
-					postCode: 'BS7 8LQ'
-				},
-				appealStatus: 'awaiting_lpa_questionnaire',
-				appealType: 'household',
-				createdAt: '2023-02-16T11:43:27.096Z',
-				localPlanningDepartment: 'Wiltshire Council'
-			}
-		],
+		AllAppeals: {
+			itemCount: 57,
+			items: [
+				{
+					appealId: 1,
+					appealReference: 'APP/Q9999/D/21/235348',
+					appealSite: {
+						addressLine1: '19 Beauchamp Road',
+						town: 'Bristol',
+						postCode: 'BS7 8LQ'
+					},
+					appealStatus: 'awaiting_lpa_questionnaire',
+					appealType: 'household',
+					createdAt: '2023-02-16T11:43:27.096Z',
+					localPlanningDepartment: 'Wiltshire Council'
+				}
+			],
+			page: 1,
+			pageCount: 27,
+			pageSize: 30
+		},
 		SingleAppeal: {
 			agentName: null,
 			allocationDetails: 'F / General Allocation',


### PR DESCRIPTION
## Describe your changes

Updated the pagination response to include `itemCount`, `page`, `pageCount` and `pageSize`, following the naming convention used in Applications.

For example:

```
{
    "itemCount": 57,
    "items": [
        {
            "appealId": 1,
            "appealReference": "APP/Q9999/D/21/235348",
            "appealSite": {
                "addressLine1": "19 Beauchamp Road",
                "town": "Bristol",
                "postCode": "BS7 8LQ"
            },
            "appealStatus": "awaiting_lpa_questionnaire",
            "appealType": "household",
            "createdAt": "2023-02-16T11:43:27.096Z",
            "localPlanningDepartment": "Wiltshire Council"
        }
    ],
    "page": 1
    "pageCount": 29,
    "pagaeSize": 30
}
```
Also updated test and swagger docs.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
