### PR TITLE
feat(api): add patch route for /appeals/:appealId for saving appeal data

### DIFF
--- a/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
@@ -1,7 +1,15 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-const { databaseConnector } = await import('../../../utils/database-connector.js');
+import {
+	ERROR_FAILED_TO_SAVE_DATA,
+	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
+	ERROR_MUST_BE_GREATER_THAN_ZERO,
+	ERROR_MUST_BE_NUMBER,
+	ERROR_NOT_FOUND,
+	ERROR_PAGENUMBER_AND_PAGESIZE_ARE_REQUIRED
+} from '../../constants.js';
 
+const { databaseConnector } = await import('../../../utils/database-connector.js');
 const request = supertest(app);
 const appeal = {
 	id: 1,
@@ -146,7 +154,7 @@ describe('Appeals', () => {
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					pageNumber: 'Both pageNumber and pageSize are required for pagination'
+					pageNumber: ERROR_PAGENUMBER_AND_PAGESIZE_ARE_REQUIRED
 				}
 			});
 		});
@@ -157,7 +165,7 @@ describe('Appeals', () => {
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					pageSize: 'Both pageNumber and pageSize are required for pagination'
+					pageSize: ERROR_PAGENUMBER_AND_PAGESIZE_ARE_REQUIRED
 				}
 			});
 		});
@@ -168,7 +176,7 @@ describe('Appeals', () => {
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					pageNumber: 'Must be a number'
+					pageNumber: ERROR_MUST_BE_NUMBER
 				}
 			});
 		});
@@ -179,7 +187,7 @@ describe('Appeals', () => {
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					pageNumber: 'Must be greater than 0'
+					pageNumber: ERROR_MUST_BE_GREATER_THAN_ZERO
 				}
 			});
 		});
@@ -190,7 +198,7 @@ describe('Appeals', () => {
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					pageSize: 'Must be a number'
+					pageSize: ERROR_MUST_BE_NUMBER
 				}
 			});
 		});
@@ -201,7 +209,7 @@ describe('Appeals', () => {
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					pageSize: 'Must be greater than 0'
+					pageSize: ERROR_MUST_BE_GREATER_THAN_ZERO
 				}
 			});
 		});
@@ -253,7 +261,7 @@ describe('Appeals', () => {
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					appealId: 'Appeal id must be a number'
+					appealId: ERROR_MUST_BE_NUMBER
 				}
 			});
 		});
@@ -267,9 +275,96 @@ describe('Appeals', () => {
 			expect(response.status).toEqual(404);
 			expect(response.body).toEqual({
 				errors: {
-					appealId: `Appeal with id ${appeal.id} not found`
+					appealId: ERROR_NOT_FOUND
 				}
 			});
+		});
+
+		test('updates an appeal', async () => {
+			const response = await request.patch(`/appeals/${appeal.id}`).send({
+				startedAt: '2023-05-05'
+			});
+
+			expect(databaseConnector.appeal.update).toBeCalledWith({
+				data: {
+					startedAt: '2023-05-05T00:00:00.000Z',
+					updatedAt: expect.any(Date)
+				},
+				where: {
+					id: appeal.id
+				}
+			});
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual({
+				startedAt: '2023-05-05T00:00:00.000Z'
+			});
+		});
+
+		test('returns an error if startedAt is not in the correct format', async () => {
+			const response = await request.patch(`/appeals/${appeal.id}`).send({
+				startedAt: '05/05/2023'
+			});
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					startedAt: ERROR_MUST_BE_CORRECT_DATE_FORMAT
+				}
+			});
+		});
+
+		test('returns an error if startedAt does not contain leading zeros', async () => {
+			const response = await request.patch(`/appeals/${appeal.id}`).send({
+				startedAt: '2023-5-5'
+			});
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					startedAt: ERROR_MUST_BE_CORRECT_DATE_FORMAT
+				}
+			});
+		});
+
+		test('returns an error if startedAt is not a valid date', async () => {
+			const response = await request.patch(`/appeals/${appeal.id}`).send({
+				startedAt: '2023-02-30'
+			});
+
+			expect(response.status).toEqual(400);
+			expect(response.body).toEqual({
+				errors: {
+					startedAt: ERROR_MUST_BE_CORRECT_DATE_FORMAT
+				}
+			});
+		});
+
+		test('returns an error if given an incorrect field name', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.update.mockImplementation(() => {
+				throw new Error(ERROR_FAILED_TO_SAVE_DATA);
+			});
+
+			const response = await request.patch(`/appeals/${appeal.id}`).send({
+				startedAtDate: '2023-02-10'
+			});
+
+			expect(response.status).toEqual(500);
+			expect(response.body).toEqual({
+				errors: {
+					body: ERROR_FAILED_TO_SAVE_DATA
+				}
+			});
+		});
+
+		test('does not throw an error if given an empty body', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.update.mockResolvedValue(true);
+
+			const response = await request.patch(`/appeals/${appeal.id}`).send({});
+
+			expect(response.status).toEqual(200);
+			expect(response.body).toEqual({});
 		});
 	});
 });

--- a/apps/api/src/server/appeals/appeals/appeals.controller.js
+++ b/apps/api/src/server/appeals/appeals/appeals.controller.js
@@ -1,6 +1,11 @@
 import appealRepository from '../../repositories/appeal.repository.js';
 import { getPageCount } from '../../utils/database-pagination.js';
-import { DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE } from '../constants.js';
+import {
+	DEFAULT_PAGE_NUMBER,
+	DEFAULT_PAGE_SIZE,
+	ERROR_FAILED_TO_SAVE_DATA,
+	ERROR_NOT_FOUND
+} from '../constants.js';
 import appealFormatter from './appeals.formatter.js';
 
 /** @typedef {import('./appeals.routes.js').AppealParams} AppealParams */
@@ -36,7 +41,7 @@ const getAppealById = async (req, res) => {
 	const appeal = await appealRepository.getById(Number(appealId));
 
 	if (!appeal) {
-		return res.status(404).send({ errors: { appealId: `Appeal with id ${appealId} not found` } });
+		return res.status(404).send({ errors: { appealId: ERROR_NOT_FOUND } });
 	}
 
 	const formattedAppeal = appealFormatter.formatAppeal(appeal);
@@ -44,4 +49,25 @@ const getAppealById = async (req, res) => {
 	return res.send(formattedAppeal);
 };
 
-export { getAppealById, getAppeals };
+/**
+ * @type {import('express').RequestHandler}
+ * @returns {Promise<object>}
+ */
+const updateAppealById = async (req, res) => {
+	const {
+		body,
+		params: { appealId }
+	} = req;
+
+	try {
+		await appealRepository.updateById(Number(appealId), body);
+	} catch (error) {
+		if (error) {
+			return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
+		}
+	}
+
+	return res.send(body);
+};
+
+export { getAppealById, getAppeals, updateAppealById };

--- a/apps/api/src/server/appeals/appeals/appeals.routes.js
+++ b/apps/api/src/server/appeals/appeals/appeals.routes.js
@@ -1,7 +1,11 @@
 import { Router as createRouter } from 'express';
 import { asyncHandler } from '../../middleware/async-handler.js';
-import { getAppealById, getAppeals } from './appeals.controller.js';
-import { validateAppealId, validatePaginationParameters } from './appeals.validators.js';
+import { getAppealById, getAppeals, updateAppealById } from './appeals.controller.js';
+import {
+	validateAppealId,
+	validateAppealUpdate,
+	validatePaginationParameters
+} from './appeals.validators.js';
 
 /**
  * @typedef {object} AppealParams
@@ -51,6 +55,26 @@ router.get(
 	 */
 	validateAppealId,
 	asyncHandler(getAppealById)
+);
+
+router.patch(
+	'/:appealId',
+	/*
+		#swagger.tags = ['Appeals']
+		#swagger.path = '/appeals/{appealId}'
+		#swagger.description = 'Updates a single appeal by id'
+		#swagger.parameters['body'] = {
+			in: 'body',
+			description: 'Appeal details to update',
+			schema: { $ref: '#/definitions/UpdateAppeal' },
+			required: true
+		}
+		#swagger.responses[200] = {}
+		#swagger.responses[400] = {}
+		#swagger.responses[500] = {}
+	 */
+	validateAppealUpdate,
+	asyncHandler(updateAppealById)
 );
 
 export { router as appealsRoutes };

--- a/apps/api/src/server/appeals/constants.js
+++ b/apps/api/src/server/appeals/constants.js
@@ -1,2 +1,11 @@
 export const DEFAULT_PAGE_NUMBER = 1;
 export const DEFAULT_PAGE_SIZE = 30;
+
+export const ERROR_FAILED_TO_SAVE_DATA = 'Failed to save data - check field names are correct';
+export const ERROR_MUST_BE_CORRECT_DATE_FORMAT =
+	'Must be a valid date and in the format yyyy-mm-dd';
+export const ERROR_MUST_BE_GREATER_THAN_ZERO = 'Must be greater than 0';
+export const ERROR_MUST_BE_NUMBER = 'Must be a number';
+export const ERROR_NOT_FOUND = 'Not found';
+export const ERROR_PAGENUMBER_AND_PAGESIZE_ARE_REQUIRED =
+	'Both pageNumber and pageSize are required for pagination';

--- a/apps/api/src/server/repositories/appeal.repository.js
+++ b/apps/api/src/server/repositories/appeal.repository.js
@@ -175,6 +175,25 @@ const appealRepository = (function () {
 				this.createNewStatuses(id, appealStatesToCreate)
 			]);
 		},
+		/**
+		 * @param {number} id
+		 * @param {{
+		 *	startedAt?: string;
+		 * }} data
+		 * @returns {Prisma.PrismaPromise<{
+		 * 	id: number,
+		 *	reference: string,
+		 *	createdAt: Date,
+		 *	updatedAt: Date,
+		 *	addressId: number | null,
+		 *	localPlanningDepartment: string,
+		 *	planningApplicationReference: string,
+		 *	startedAt: Date | null,
+		 *	userId: number | null,
+		 *	appellantId: number | null,
+		 *	appealTypeId: number | null,
+		 * }>}
+		 */
 		updateById(id, data) {
 			const updatedAt = new Date();
 

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -570,6 +570,38 @@
 						"description": "Not Found"
 					}
 				}
+			},
+			"patch": {
+				"tags": ["Appeals"],
+				"description": "Updates a single appeal by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"description": "Appeal details to update",
+						"schema": {
+							"$ref": "#/definitions/UpdateAppeal"
+						},
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK"
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
 			}
 		},
 		"/applications": {
@@ -3488,6 +3520,15 @@
 				"startedAt": {
 					"type": "string",
 					"example": "2022-05-17T23:00:00.000Z"
+				}
+			}
+		},
+		"UpdateAppeal": {
+			"type": "object",
+			"properties": {
+				"startedAt": {
+					"type": "string",
+					"example": "2023-05-09"
 				}
 			}
 		},

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -536,6 +536,9 @@ const document = {
 			planningApplicationReference: '48269/APP/2021/1482',
 			startedAt: '2022-05-17T23:00:00.000Z'
 		},
+		UpdateAppeal: {
+			startedAt: '2023-05-09'
+		},
 		AppealsForCaseOfficer: {
 			$AppealId: 1,
 			$AppealReference: '',


### PR DESCRIPTION
## Describe your changes

Added a `PATCH` route for `/appeals/:appealId` for saving appeal data. Currently this will be used for saving the start date with the following request body:

```
{
  "startedAt": "2023-05-09"
}
```
Also added validation to ensure that if a date is given: 
- It’s in the correct format
- It's a valid date
- It contains leading zeros

Also added tests and updated swagger docs

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-101

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
