### PR TITLE
fix(api/applications): fix sql error on case creation (BOAS-866)

### DIFF
--- a/apps/api/src/server/repositories/case.repository.js
+++ b/apps/api/src/server/repositories/case.repository.js
@@ -562,7 +562,9 @@ const replaceValueInString = (inputString, keysToReplace) => {
 const assignApplicationReference = (id) => {
 	const sqlQueryAbsolutePath = getSqlQuery('update-application-reference');
 
-	const data = fs.readFileSync(sqlQueryAbsolutePath, 'utf8').replace(/\r|\n/g, '');
+	// remove new lines from the sql script - but replace with a space.
+	// otherwise, if there are not spaces on the end of each line, then the wordswillallruntogether
+	const data = fs.readFileSync(sqlQueryAbsolutePath, 'utf8').replace(/\r|\n/g, ' ');
 
 	const formattedSqlQuery = replaceValueInString(data, { CASE_ID: id.toString() });
 

--- a/apps/api/src/server/repositories/raw_sql_queries/update-application-reference.sql
+++ b/apps/api/src/server/repositories/raw_sql_queries/update-application-reference.sql
@@ -19,7 +19,7 @@ FROM [dbo].[Case] as case_table
     on application_details_table.subSectorId = sub_sector_table.id
         and sub_sector_table.abbreviation = @sub_sector_abbreviation;
 
-if(@max_reference < @minimum_new_reference OR @max_reference IS NULL) select @reference_number = @minimum_new_reference else select @reference_number = @max_reference + 1;
+if(@max_reference < @minimum_new_reference OR @max_reference IS NULL) select @reference_number = @minimum_new_reference else select @reference_number = @max_reference + 1;
 
 update [dbo].[Case]
     set reference = CONCAT(@sub_sector_abbreviation, cast(@reference_number as nchar(5)))


### PR DESCRIPTION
## Describe your changes

SQL script to create case used to have a space on the end of each line, this was inadvertently cleaned up on the last update, however when the sql script file is read, it removes all CR and LF chars, replacing them with ''.
With the removal of spaces, therefor the wordsallruntogether.  eg SELECT  * FROM ApplicationDetailsWHERE ...
Fix was to replace the new lines with a space, to avoid having to remember to add a space to each line.

## BOAS-866 Error on Case Creation
https://pins-ds.atlassian.net/browse/BOAS-866

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
