### PR TITLE
fix(web/appeals): accordion should not save state between appeals

### DIFF
--- a/apps/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/apps/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -42,13 +42,13 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     <dd                     class=\\"govuk-summary-list__value\\">Wiltshire Council</dd>
                 </div>
                 </dl>
-                <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-default\\">
+                <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-default-1\\">
                     <div class=\\"govuk-accordion__section \\">
                         <div class=\\"govuk-accordion__section-header\\">
-                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-heading-1\\"> Case overview</span></h2>
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-1-heading-1\\"> Case overview</span></h2>
                         </div>
-                        <div id=\\"accordion-default-content-1\\" class=\\"govuk-accordion__section-content\\"
-                        aria-labelledby=\\"accordion-default-heading-1\\">
+                        <div id=\\"accordion-default-1-content-1\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-1-heading-1\\">
                             <dl class=\\"govuk-summary-list\\">
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Appeal type</dt>
                                     <dd class=\\"govuk-summary-list__value\\">household</dd>
@@ -102,10 +102,10 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     </div>
                     <div class=\\"govuk-accordion__section \\">
                         <div class=\\"govuk-accordion__section-header\\">
-                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-heading-2\\"> Case timetable</span></h2>
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-1-heading-2\\"> Case timetable</span></h2>
                         </div>
-                        <div id=\\"accordion-default-content-2\\" class=\\"govuk-accordion__section-content\\"
-                        aria-labelledby=\\"accordion-default-heading-2\\">
+                        <div id=\\"accordion-default-1-content-2\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-1-heading-2\\">
                             <div class=\\"govuk-inset-text govuk-!-margin-top-0\\">
                                 <p>Case not started</p><a href=\\"/appeals-service/appeal-details/1/enter-start-date\\"
                                 class=\\"govuk-link\\">Add start date</a>
@@ -114,10 +114,10 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     </div>
                     <div class=\\"govuk-accordion__section \\">
                         <div class=\\"govuk-accordion__section-header\\">
-                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-heading-3\\"> Case documentation</span></h2>
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-1-heading-3\\"> Case documentation</span></h2>
                         </div>
-                        <div id=\\"accordion-default-content-3\\" class=\\"govuk-accordion__section-content\\"
-                        aria-labelledby=\\"accordion-default-heading-3\\">
+                        <div id=\\"accordion-default-1-content-3\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-1-heading-3\\">
                             <dl class=\\"govuk-summary-list\\">
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Appellant case</dt>
                                     <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--green single-line\\">Complete</strong>
@@ -166,10 +166,10 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                     </div>
                     <div class=\\"govuk-accordion__section \\">
                         <div class=\\"govuk-accordion__section-header\\">
-                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-heading-4\\"> Case team</span></h2>
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-1-heading-4\\"> Case team</span></h2>
                         </div>
-                        <div id=\\"accordion-default-content-4\\" class=\\"govuk-accordion__section-content\\"
-                        aria-labelledby=\\"accordion-default-heading-4\\">
+                        <div id=\\"accordion-default-1-content-4\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-1-heading-4\\">
                             <dl class=\\"govuk-summary-list\\">
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case officer</dt>
                                     <dd class=\\"govuk-summary-list__value\\">

--- a/apps/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/apps/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -18,7 +18,7 @@ describe('appeal-details', () => {
 
 			nock('http://test/').get(`/appeals/${appealId}`).reply(200, appealData);
 
-			const response = await request.get(`${baseUrl}/1`);
+			const response = await request.get(`${baseUrl}/${appealId}`);
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toMatchSnapshot();

--- a/apps/web/src/server/views/appeals/appeal/appeal-details.njk
+++ b/apps/web/src/server/views/appeals/appeal/appeal-details.njk
@@ -90,7 +90,7 @@
 	}}
 	{{
 		govukAccordion({
-			id: "accordion-default",
+			id: "accordion-default-" + appeal.id,
 			items: [{
 				heading: {
 					text: "Case overview"


### PR DESCRIPTION
## Describe your changes

The accordion state is stored in local storage by tag id. It now appends ID to make sure they are only stored by appeal and not for all appeals.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-132

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
