### PR TITLE
fix(web): BOAT-156 - fix status tag colours

### DIFF
--- a/apps/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/apps/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -144,13 +144,13 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     </dd>
                                 </div>
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> LPA questionnaire</dt>
-                                    <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--grey single-line\\">Overdue</strong>
+                                    <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--red single-line\\">Overdue</strong>
                                     </dd>
                                     <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Review<span class=\\"govuk-visually-hidden\\"> LPA questionnaire</span></a>
                                     </dd>
                                 </div>
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Statement and Proofs</dt>
-                                    <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--grey single-line\\">Incomplete</strong>
+                                    <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--yellow single-line\\">Incomplete</strong>
                                     </dd>
                                     <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Review<span class=\\"govuk-visually-hidden\\"> Statement and Proofs</span></a>
                                     </dd>
@@ -162,7 +162,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     </dd>
                                 </div>
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Final comments</dt>
-                                    <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--grey single-line\\">Overdue</strong>
+                                    <dd class=\\"govuk-summary-list__value\\"><strong class=\\"govuk-tag govuk-tag--red single-line\\">Overdue</strong>
                                     </dd>
                                     <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Review<span class=\\"govuk-visually-hidden\\"> Final comments</span></a>
                                     </dd>

--- a/apps/web/src/server/views/appeals/components/status-tag.njk
+++ b/apps/web/src/server/views/appeals/components/status-tag.njk
@@ -21,6 +21,10 @@
 			{%- set statusTagColor = 'pink' -%}
 		{%- case 'complete' -%}
 			{%- set statusTagColor = 'green' -%}
+		{%- case 'overdue' -%}
+			{%- set statusTagColor = 'red' -%}
+		{%- case 'incomplete' -%}
+			{%- set statusTagColor = 'yellow' -%}
 	{%- endswitch -%}
 	<strong class="govuk-tag govuk-tag--{{statusTagColor}} single-line">{{ statusLabel | replace("_", " ") }}</strong>
 {%- endmacro -%}


### PR DESCRIPTION
## Describe your changes

Fix for incorrect status tag colours for case documentation on appeal-details page

## Issue ticket number and link

BOAT-156

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
