### PR TITLE
chore(api): run prettier after swagger-autogen

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,7 @@
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
     "clean": "rimraf .turbo node_modules dist",
-    "swagger-autogen": "node ./src/server/swagger.js",
+    "swagger-autogen": "node ./src/server/swagger.js && npx prettier ./src/server/swagger-output.json --write",
     "db:migrate": "npx prisma migrate dev",
     "db:migrate:prod": "npx prisma migrate deploy",
     "db:push": "npx prisma db push --accept-data-loss",


### PR DESCRIPTION
## Describe your changes

Previously it appeared after running swagger-autogen that I had lots of changes, but they get removed when prettier runs via lint-staged. Now the `swagger-autogen` script also runs prettier so the output is as expected.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
