### PR TITLE
fix(web/appeals): appeal type names

### DIFF
--- a/apps/api/src/database/seed/data-static.js
+++ b/apps/api/src/database/seed/data-static.js
@@ -488,6 +488,15 @@ export const examinationTimetableTypes = [
 ];
 
 /**
+ * Appeal tyles
+ *
+ */
+export const appealTypes = [
+	{ shorthand: 'FPA', type: 'Full planning' },
+	{ shorthand: 'HAS', type: 'Householder' }
+];
+
+/**
  * Seed static data into the database. Does not disconnect from the database or handle errors.
  *
  * @param {import('@prisma/client').PrismaClient} databaseConnector
@@ -526,6 +535,13 @@ export async function seedStaticData(databaseConnector) {
 			create: examinationTimetableType,
 			where: { name: examinationTimetableType.name },
 			update: {}
+		});
+	}
+	for (const appealType of appealTypes) {
+		await databaseConnector.appealType.upsert({
+			create: appealType,
+			where: { shorthand: appealType.shorthand },
+			update: { type: appealType.type }
 		});
 	}
 }

--- a/apps/api/src/database/seed/data-test.js
+++ b/apps/api/src/database/seed/data-test.js
@@ -59,11 +59,6 @@ function pickRandom(list) {
 	return list[Math.floor(Math.random() * list.length)];
 }
 
-const appealTypes = {
-	HAS: 'household',
-	FPA: 'full planning'
-};
-
 /**
  *
  * @param {string} lpaQuestionnaireAndInspectorPickupState
@@ -451,12 +446,6 @@ const createApplication = async (databaseConnector, subSector, index) => {
  * @param {import('@prisma/client').PrismaClient} databaseConnector
  */
 export async function seedTestData(databaseConnector) {
-	await databaseConnector.appealType.createMany({
-		data: [
-			{ shorthand: 'FPA', type: appealTypes.FPA },
-			{ shorthand: 'HAS', type: appealTypes.HAS }
-		]
-	});
 	for (const appealData of appealsData) {
 		await databaseConnector.appeal.create({ data: appealData });
 	}


### PR DESCRIPTION
## Describe your changes

Changed the display name for appeal types, and moved the generation to `seedStaticData`.  

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-160

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
