### PR TITLE
fix(web/applications): negate smooth scroll on table sort

### DIFF
--- a/apps/web/src/styles/_shame.scss
+++ b/apps/web/src/styles/_shame.scss
@@ -4,3 +4,6 @@
   top: 0;
 }
 
+html:has(#rr-table) {
+  scroll-behavior: unset;
+}


### PR DESCRIPTION
-negate smooth scrolling on chrome based browsers that made the previous fix less impactful. Scoped only to the relevant representations table/page

## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
