### PR TITLE
fix(api): update linked/other appeal fields to return data from the database

### DIFF
--- a/apps/api/src/database/migrations/20230530111714_add_linked_appeals/migration.sql
+++ b/apps/api/src/database/migrations/20230530111714_add_linked_appeals/migration.sql
@@ -1,0 +1,26 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Appeal] ADD [linkedAppealId] INT,
+[otherAppealId] INT;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[Appeal] ADD CONSTRAINT [Appeal_linkedAppealId_fkey] FOREIGN KEY ([linkedAppealId]) REFERENCES [dbo].[Appeal]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[Appeal] ADD CONSTRAINT [Appeal_otherAppealId_fkey] FOREIGN KEY ([otherAppealId]) REFERENCES [dbo].[Appeal]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/database/schema.d.ts
+++ b/apps/api/src/database/schema.d.ts
@@ -65,8 +65,10 @@ export interface Appeal extends schema.Appeal {
 	documents?: AppealDocument[];
 	id: number;
 	inspectorDecision?: InspectorDecision;
+	linkedAppealId?: number | null;
 	localPlanningDepartment: string;
 	lpaQuestionnaire?: schema.LPAQuestionnaire;
+	otherAppealId?: number | null;
 	planningApplicationReference: string;
 	reference: string;
 	reviewQuestionnaire?: schema.ReviewQuestionnaire[];
@@ -291,8 +293,8 @@ export interface LPAQuestionnaire extends schema.LPAQuestionnaire {
 	listedBuildingDetails: ListedBuildingDetails[] | null;
 	lpaNotificationMethods: LPANotificationMethod[] | null;
 	meetsOrExceedsThresholdOrCriteriaInColumn2: boolean | null;
-	procedureType: ProcedureType;
-	scheduleType: ScheduleType;
+	procedureType: ProcedureType | null;
+	scheduleType: ScheduleType | null;
 	sensitiveAreaDetails: string | null;
 	siteWithinGreenBelt: boolean | null;
 	statutoryConsulteesDetails?: string | null;
@@ -323,7 +325,7 @@ export interface LPANotificationMethod {
 	lpaNotificationMethod: LPANotificationMethodDetails;
 }
 
-export interface ListedBuildingDetails {
+export interface ListedBuildingDetails extends schema.ListedBuildingDetails {
 	grade: string;
 	description: string;
 	affectsListedBuilding: boolean;

--- a/apps/api/src/database/schema.prisma
+++ b/apps/api/src/database/schema.prisma
@@ -22,6 +22,8 @@ model Appeal {
   userId                       Int?
   appellantId                  Int?                        @unique
   appealTypeId                 Int?
+  linkedAppealId               Int?
+  otherAppealId                Int?
   address                      Address?                    @relation(fields: [addressId], references: [id])
   appealType                   AppealType?                 @relation(fields: [appealTypeId], references: [id])
   appellant                    Appellant?                  @relation(fields: [appellantId], references: [id])
@@ -34,6 +36,10 @@ model Appeal {
   siteVisit                    SiteVisit?
   validationDecision           ValidationDecision[]
   appealTimetable              AppealTimetable?
+  linkedAppeal                 Appeal?                     @relation("LinkedAppeals", fields: [linkedAppealId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  linkedAppeals                Appeal[]                    @relation("LinkedAppeals")
+  otherAppeal                  Appeal?                     @relation("OtherAppeals", fields: [otherAppealId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  otherAppeals                 Appeal[]                    @relation("OtherAppeals")
 }
 
 /// AppealType model

--- a/apps/api/src/server/appeals/appeals.d.ts
+++ b/apps/api/src/server/appeals/appeals.d.ts
@@ -65,8 +65,11 @@ interface RepositoryGetByIdResultItem {
 	createdAt: Date;
 	id: number;
 	inspectorDecision?: { outcome: string } | null;
+	linkedAppealId: number | null;
+	linkedAppeals: Appeal[];
 	localPlanningDepartment: string;
 	lpaQuestionnaire: import('@pins/api').Schema.LPAQuestionnaire | null;
+	otherAppeals: Appeal[];
 	planningApplicationReference: string;
 	reference: string;
 	siteVisit?: { visitDate: Date } | null;
@@ -148,9 +151,9 @@ interface SingleLPAQuestionnaireResponse {
 	otherAppeals: LinkedAppeal[];
 	procedureType?: string;
 	scheduleType?: string;
-	sensitiveAreaDetails?: string;
+	sensitiveAreaDetails?: string | null;
 	siteWithinGreenBelt?: boolean | null;
-	statutoryConsulteesDetails?: string;
+	statutoryConsulteesDetails?: string | null;
 }
 
 interface SingleAppealDetailsResponse {
@@ -163,13 +166,14 @@ interface SingleAppealDetailsResponse {
 	appealTimetable: AppealTimetable;
 	appealType?: string;
 	appellantName?: string;
-	caseProcedure: string;
 	decision?: string;
-	linkedAppeal: LinkedAppeal;
+	isParentAppeal: boolean | null;
+	linkedAppeals: LinkedAppeal[];
 	localPlanningDepartment: string;
 	lpaQuestionnaireId: number | null;
 	otherAppeals: LinkedAppeal[];
 	planningApplicationReference: string;
+	procedureType: string | null;
 	siteVisit: { visitDate?: Date | null };
 	startedAt: Date | null;
 	documentationSummary: DocumentationSummary;

--- a/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
@@ -134,7 +134,9 @@ const householdAppeal = {
 		scheduleTypeId: 1,
 		sentAt: '2023-05-24T10:34:09.286Z',
 		siteWithinGreenBelt: null
-	}
+	},
+	linkedAppealId: 1,
+	otherAppealId: 3
 };
 const fullPlanningAppeal = {
 	...householdAppeal,
@@ -143,8 +145,33 @@ const fullPlanningAppeal = {
 		id: 1,
 		type: 'full planning',
 		shorthand: 'FPA'
-	}
+	},
+	otherAppealId: null
 };
+const householdAppealTwo = {
+	...householdAppeal,
+	id: 3
+};
+const linkedAppeals = [
+	{
+		id: householdAppeal.id,
+		reference: householdAppeal.reference
+	},
+	{
+		id: fullPlanningAppeal.id,
+		reference: fullPlanningAppeal.reference
+	}
+];
+const otherAppeals = [
+	{
+		id: householdAppeal.id,
+		reference: householdAppeal.reference
+	},
+	{
+		id: householdAppealTwo.id,
+		reference: householdAppealTwo.reference
+	}
+];
 
 describe('Appeals', () => {
 	describe('/appeals', () => {
@@ -314,6 +341,10 @@ describe('Appeals', () => {
 			test('gets a single household appeal', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appeal.findMany
+					.mockResolvedValueOnce(linkedAppeals)
+					.mockResolvedValueOnce(otherAppeals);
 
 				const response = await request.get(`/appeals/${householdAppeal.id}`);
 
@@ -336,8 +367,14 @@ describe('Appeals', () => {
 					},
 					appealType: householdAppeal.appealType.type,
 					appellantName: householdAppeal.appellant.name,
-					caseProcedure: 'Written',
 					decision: householdAppeal.inspectorDecision.outcome,
+					isParentAppeal: true,
+					linkedAppeals: [
+						{
+							appealId: fullPlanningAppeal.id,
+							appealReference: fullPlanningAppeal.reference
+						}
+					],
 					documentationSummary: {
 						appellantCase: {
 							status: 'received',
@@ -348,19 +385,16 @@ describe('Appeals', () => {
 							status: 'received'
 						}
 					},
-					linkedAppeal: {
-						appealId: 1,
-						appealReference: 'APP/Q9999/D/21/725284'
-					},
 					localPlanningDepartment: householdAppeal.localPlanningDepartment,
 					lpaQuestionnaireId: householdAppeal.lpaQuestionnaire.id,
 					otherAppeals: [
 						{
-							appealId: 1,
-							appealReference: 'APP/Q9999/D/21/725284'
+							appealId: householdAppealTwo.id,
+							appealReference: householdAppealTwo.reference
 						}
 					],
 					planningApplicationReference: householdAppeal.planningApplicationReference,
+					procedureType: householdAppeal.lpaQuestionnaire.procedureType.name,
 					siteVisit: {
 						visitDate: householdAppeal.siteVisit.visitDate
 					},
@@ -371,6 +405,10 @@ describe('Appeals', () => {
 			test('gets a single full planning appeal', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(fullPlanningAppeal);
+				// @ts-ignore
+				databaseConnector.appeal.findMany
+					.mockResolvedValueOnce(linkedAppeals)
+					.mockResolvedValueOnce([]);
 
 				const response = await request.get(`/appeals/${fullPlanningAppeal.id}`);
 
@@ -396,8 +434,14 @@ describe('Appeals', () => {
 					},
 					appealType: fullPlanningAppeal.appealType.type,
 					appellantName: fullPlanningAppeal.appellant.name,
-					caseProcedure: 'Written',
 					decision: fullPlanningAppeal.inspectorDecision.outcome,
+					isParentAppeal: false,
+					linkedAppeals: [
+						{
+							appealId: householdAppeal.id,
+							appealReference: householdAppeal.reference
+						}
+					],
 					documentationSummary: {
 						appellantCase: {
 							status: 'received',
@@ -408,19 +452,11 @@ describe('Appeals', () => {
 							status: 'received'
 						}
 					},
-					linkedAppeal: {
-						appealId: 1,
-						appealReference: 'APP/Q9999/D/21/725284'
-					},
 					localPlanningDepartment: fullPlanningAppeal.localPlanningDepartment,
 					lpaQuestionnaireId: fullPlanningAppeal.lpaQuestionnaire.id,
-					otherAppeals: [
-						{
-							appealId: 1,
-							appealReference: 'APP/Q9999/D/21/725284'
-						}
-					],
+					otherAppeals: [],
 					planningApplicationReference: fullPlanningAppeal.planningApplicationReference,
+					procedureType: fullPlanningAppeal.lpaQuestionnaire.procedureType.name,
 					siteVisit: {
 						visitDate: fullPlanningAppeal.siteVisit.visitDate
 					},

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -3694,24 +3694,27 @@
 					"type": "boolean",
 					"example": true
 				},
-				"caseProcedure": {
-					"type": "string",
-					"example": "Written"
-				},
 				"decision": {
 					"type": "string",
 					"example": "Not issued yet"
 				},
-				"linkedAppeal": {
-					"type": "object",
-					"properties": {
-						"appealId": {
-							"type": "number",
-							"example": 1
-						},
-						"appealReference": {
-							"type": "string",
-							"example": "APP/Q9999/D/21/725284"
+				"isParentAppeal": {
+					"type": "boolean",
+					"example": true
+				},
+				"linkedAppeals": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"appealId": {
+								"type": "number",
+								"example": 1
+							},
+							"appealReference": {
+								"type": "string",
+								"example": "APP/Q9999/D/21/725284"
+							}
 						}
 					}
 				},
@@ -3742,6 +3745,10 @@
 				"planningApplicationReference": {
 					"type": "string",
 					"example": "48269/APP/2021/1482"
+				},
+				"procedureType": {
+					"type": "string",
+					"example": "Written"
 				},
 				"siteVisit": {
 					"type": "object",
@@ -3849,8 +3856,8 @@
 					}
 				},
 				"communityInfrastructureLevyAdoptionDate": {
-					"type": "boolean",
-					"example": true
+					"type": "string",
+					"example": "2023-05-09T01:00:00.000Z"
 				},
 				"designatedSites": {
 					"type": "array",
@@ -3869,8 +3876,8 @@
 					}
 				},
 				"developmentDescription": {
-					"type": "boolean",
-					"example": true
+					"type": "string",
+					"example": ""
 				},
 				"documents": {
 					"type": "object",

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -578,12 +578,14 @@ const document = {
 			appealType: 'household',
 			appellantName: 'Fiona Burgess',
 			appellantOwnsWholeSite: true,
-			caseProcedure: 'Written',
 			decision: 'Not issued yet',
-			linkedAppeal: {
-				appealId: 1,
-				appealReference: 'APP/Q9999/D/21/725284'
-			},
+			isParentAppeal: true,
+			linkedAppeals: [
+				{
+					appealId: 1,
+					appealReference: 'APP/Q9999/D/21/725284'
+				}
+			],
 			localPlanningDepartment: 'Wiltshire Council',
 			lpaQuestionnaireId: 1,
 			otherAppeals: [
@@ -593,6 +595,7 @@ const document = {
 				}
 			],
 			planningApplicationReference: '48269/APP/2021/1482',
+			procedureType: 'Written',
 			siteVisit: {
 				visitDate: '2022-03-31T12:00:00.000Z'
 			},

--- a/apps/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/apps/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -14,7 +14,7 @@ exports[`appeal-details GET /:appealId should render a page not found when the a
 </main>"
 `;
 
-exports[`appeal-details GET /:appealId should render the received appeal details for a valid appealId 1`] = `
+exports[`appeal-details GET /:appealId should render the received appeal details for a valid appealId with multiple linked/other appeals 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row\\">
         <div class=\\"govuk-grid-column-two-thirds\\">
@@ -56,7 +56,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     </dd>
                                 </div>
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case procedure</dt>
-                                    <dd class=\\"govuk-summary-list__value\\">Written</dd>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
                                     <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Case procedure</span></a>
                                     </dd>
                                 </div>
@@ -70,14 +70,26 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                     <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent name</span></a>
                                     </dd>
                                 </div>
-                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Linked appeal</dt>
-                                    <dd class=\\"govuk-summary-list__value\\"><a href=\\"/appeals-service/appeal-details/1\\">APP/Q9999/D/21/725284</a>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Linked appeals</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">
+                                        <ul class=\\"govuk-list\\">
+                                            <li><a href=\\"/appeals-service/appeal-details/1\\" class=\\"govuk-link\\">APP/Q9999/D/21/725284</a>
+                                            </li>
+                                            <li><a href=\\"/appeals-service/appeal-details/2\\" class=\\"govuk-link\\">APP/Q9999/D/21/123456</a>
+                                            </li>
+                                        </ul>
                                     </dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Linked appeal</span></a>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Linked appeals</span></a>
                                     </dd>
                                 </div>
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Other appeals</dt>
-                                    <dd class=\\"govuk-summary-list__value\\"><a href=\\"/appeals-service/appeal-details/1\\">APP/Q9999/D/21/725284</a>
+                                    <dd class=\\"govuk-summary-list__value\\">
+                                        <ul class=\\"govuk-list\\">
+                                            <li><a href=\\"/appeals-service/appeal-details/3\\" class=\\"govuk-link\\">APP/Q9999/D/21/765413</a>
+                                            </li>
+                                            <li><a href=\\"/appeals-service/appeal-details/4\\" class=\\"govuk-link\\">APP/Q9999/D/21/523467</a>
+                                            </li>
+                                        </ul>
                                     </dd>
                                     <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Other appeals</span></a>
                                     </dd>
@@ -170,6 +182,368 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                         </div>
                         <div id=\\"accordion-default-1-content-4\\" class=\\"govuk-accordion__section-content\\"
                         aria-labelledby=\\"accordion-default-1-heading-4\\">
+                            <dl class=\\"govuk-summary-list\\">
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case officer</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">
+                                        <p class=\\"govuk-!-margin-0\\">Robert Williams</p>
+                                        <p class=\\"govuk-!-margin-0\\">robert.williams@planninginspectorate.gov.uk</p>
+                                        <p class=\\"govuk-!-margin-0\\">0300 027 1289</p>
+                                    </dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Case officer</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Inspector</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">
+                                        <p class=\\"govuk-!-margin-0\\">No project members have been added yet</p>
+                                    </dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Add<span class=\\"govuk-visually-hidden\\"> Interested parties</span></a>
+                                    </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId should render the received appeal details for a valid appealId with no linked/other appeals 1`] = `
+"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
+    <div class=\\"govuk-grid-row\\">
+        <div class=\\"govuk-grid-column-two-thirds\\">
+            <div class=\\"govuk-notification-banner\\" role=\\"region\\" aria-labelledby=\\"govuk-notification-banner-title\\"
+            data-module=\\"govuk-notification-banner\\">
+                <div class=\\"govuk-notification-banner__header\\">
+                    <h3 class=\\"govuk-notification-banner__title\\" id=\\"govuk-notification-banner-title\\"> Important</h3>
+                </div>
+                <div class=\\"govuk-notification-banner__content\\">
+                    <p class=\\"govuk-notification-banner__heading\\">LPA questionnaire is ready for review
+                        <br><a class=\\"govuk-notification-banner__link\\" href=\\"#\\">Review project documentation</a>
+                    </p>
+                </div>
+            </div>
+            <div class=\\"govuk-grid-row\\">
+                <div class=\\"govuk-grid-column-full\\"><span class=\\"govuk-caption-l govuk-!-margin-bottom-3\\">Appeal 351062</span>
+                    <h1                     class=\\"govuk-heading-xl govuk-!-margin-bottom-3\\">Case details</h1>
+                </div>
+            </div><strong class=\\"govuk-tag govuk-tag--grey single-line\\">received appeal</strong>
+            <dl             class=\\"govuk-summary-list govuk-summary-list--no-border\\">
+                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Site address</dt>
+                    <dd class=\\"govuk-summary-list__value\\">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                </div>
+                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Local planning authority</dt>
+                    <dd                     class=\\"govuk-summary-list__value\\">Wiltshire Council</dd>
+                </div>
+                </dl>
+                <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-default-3\\">
+                    <div class=\\"govuk-accordion__section \\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-3-heading-1\\"> Case overview</span></h2>
+                        </div>
+                        <div id=\\"accordion-default-3-content-1\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-3-heading-1\\">
+                            <dl class=\\"govuk-summary-list\\">
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Appeal type</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">household</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Appeal type</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case procedure</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Case procedure</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Appellant name</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">Eva Sharma</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Appellant name</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent name</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">No agent for this appeal</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent name</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Linked appeals</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">No linked appeals</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Linked appeals</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Other appeals</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">No linked appeals</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Other appeals</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Allocation details</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">F / General Allocation</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Allocation details</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> LPA reference</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">48269/APP/2021/1482</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> LPA reference</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Decision</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">Not issued yet</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Decision</span></a>
+                                    </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
+                    <div class=\\"govuk-accordion__section \\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-3-heading-2\\"> Case timetable</span></h2>
+                        </div>
+                        <div id=\\"accordion-default-3-content-2\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-3-heading-2\\">
+                            <dl class=\\"govuk-summary-list\\">
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start date</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">23 May 2023</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Start date</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> LPA Questionnaire due</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> LPA Questionnaire due</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Final events due</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Final events due</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Site visit</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Site visit</span></a>
+                                    </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
+                    <div class=\\"govuk-accordion__section \\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-3-heading-3\\"> Case documentation</span></h2>
+                        </div>
+                        <div id=\\"accordion-default-3-content-3\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-3-heading-3\\">
+                            <table class=\\"govuk-table\\">
+                                <thead class=\\"govuk-table__head\\">
+                                    <tr class=\\"govuk-table__row\\">
+                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Documentation</th>
+                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Status</th>
+                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Due date</th>
+                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Action</th>
+                                    </tr>
+                                </thead>
+                                <tbody class=\\"govuk-table__body\\">
+                                    <tr class=\\"govuk-table__row\\">
+                                        <th scope=\\"row\\" class=\\"govuk-table__header\\">Appellant case</th>
+                                        <td class=\\"govuk-table__cell\\">Received</td>
+                                        <td class=\\"govuk-table__cell\\">23 May 2024</td>
+                                        <td class=\\"govuk-table__cell\\"><a href=\\"#\\" class=\\"govuk-link\\">Review</a>
+                                        </td>
+                                    </tr>
+                                    <tr class=\\"govuk-table__row\\">
+                                        <th scope=\\"row\\" class=\\"govuk-table__header\\">LPA Questionnaire</th>
+                                        <td class=\\"govuk-table__cell\\">Not received</td>
+                                        <td class=\\"govuk-table__cell\\">23 May 2024</td>
+                                        <td class=\\"govuk-table__cell\\"><a href=\\"#\\" class=\\"govuk-link\\">Review</a>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class=\\"govuk-accordion__section \\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-3-heading-4\\"> Case team</span></h2>
+                        </div>
+                        <div id=\\"accordion-default-3-content-4\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-3-heading-4\\">
+                            <dl class=\\"govuk-summary-list\\">
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case officer</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">
+                                        <p class=\\"govuk-!-margin-0\\">Robert Williams</p>
+                                        <p class=\\"govuk-!-margin-0\\">robert.williams@planninginspectorate.gov.uk</p>
+                                        <p class=\\"govuk-!-margin-0\\">0300 027 1289</p>
+                                    </dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Case officer</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Inspector</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">
+                                        <p class=\\"govuk-!-margin-0\\">No project members have been added yet</p>
+                                    </dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Add<span class=\\"govuk-visually-hidden\\"> Interested parties</span></a>
+                                    </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`appeal-details GET /:appealId should render the received appeal details for a valid appealId with single linked/other appeals 1`] = `
+"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
+    <div class=\\"govuk-grid-row\\">
+        <div class=\\"govuk-grid-column-two-thirds\\">
+            <div class=\\"govuk-notification-banner\\" role=\\"region\\" aria-labelledby=\\"govuk-notification-banner-title\\"
+            data-module=\\"govuk-notification-banner\\">
+                <div class=\\"govuk-notification-banner__header\\">
+                    <h3 class=\\"govuk-notification-banner__title\\" id=\\"govuk-notification-banner-title\\"> Important</h3>
+                </div>
+                <div class=\\"govuk-notification-banner__content\\">
+                    <p class=\\"govuk-notification-banner__heading\\">LPA questionnaire is ready for review
+                        <br><a class=\\"govuk-notification-banner__link\\" href=\\"#\\">Review project documentation</a>
+                    </p>
+                </div>
+            </div>
+            <div class=\\"govuk-grid-row\\">
+                <div class=\\"govuk-grid-column-full\\"><span class=\\"govuk-caption-l govuk-!-margin-bottom-3\\">Appeal 351062</span>
+                    <h1                     class=\\"govuk-heading-xl govuk-!-margin-bottom-3\\">Case details</h1>
+                </div>
+            </div><strong class=\\"govuk-tag govuk-tag--grey single-line\\">received appeal</strong>
+            <dl             class=\\"govuk-summary-list govuk-summary-list--no-border\\">
+                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Site address</dt>
+                    <dd class=\\"govuk-summary-list__value\\">21 The Pavement, Wandsworth, SW4 0HY</dd>
+                </div>
+                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Local planning authority</dt>
+                    <dd                     class=\\"govuk-summary-list__value\\">Wiltshire Council</dd>
+                </div>
+                </dl>
+                <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-default-2\\">
+                    <div class=\\"govuk-accordion__section \\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-2-heading-1\\"> Case overview</span></h2>
+                        </div>
+                        <div id=\\"accordion-default-2-content-1\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-2-heading-1\\">
+                            <dl class=\\"govuk-summary-list\\">
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Appeal type</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">household</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Appeal type</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case procedure</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Case procedure</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Appellant name</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">Eva Sharma</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Appellant name</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent name</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">No agent for this appeal</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent name</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Linked appeals</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"><a href=\\"/appeals-service/appeal-details/1\\" class=\\"govuk-link\\">APP/Q9999/D/21/725284</a>
+                                    </dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Linked appeals</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Other appeals</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"><a href=\\"/appeals-service/appeal-details/3\\" class=\\"govuk-link\\">APP/Q9999/D/21/765413</a>
+                                    </dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Other appeals</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Allocation details</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">F / General Allocation</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Allocation details</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> LPA reference</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">48269/APP/2021/1482</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> LPA reference</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Decision</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">Not issued yet</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Decision</span></a>
+                                    </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
+                    <div class=\\"govuk-accordion__section \\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-2-heading-2\\"> Case timetable</span></h2>
+                        </div>
+                        <div id=\\"accordion-default-2-content-2\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-2-heading-2\\">
+                            <dl class=\\"govuk-summary-list\\">
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start date</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">23 May 2023</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Start date</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> LPA Questionnaire due</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> LPA Questionnaire due</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Final events due</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Final events due</span></a>
+                                    </dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Site visit</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"#\\"> Change<span class=\\"govuk-visually-hidden\\"> Site visit</span></a>
+                                    </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
+                    <div class=\\"govuk-accordion__section \\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-2-heading-3\\"> Case documentation</span></h2>
+                        </div>
+                        <div id=\\"accordion-default-2-content-3\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-2-heading-3\\">
+                            <table class=\\"govuk-table\\">
+                                <thead class=\\"govuk-table__head\\">
+                                    <tr class=\\"govuk-table__row\\">
+                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Documentation</th>
+                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Status</th>
+                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Due date</th>
+                                        <th scope=\\"col\\" class=\\"govuk-table__header\\">Action</th>
+                                    </tr>
+                                </thead>
+                                <tbody class=\\"govuk-table__body\\">
+                                    <tr class=\\"govuk-table__row\\">
+                                        <th scope=\\"row\\" class=\\"govuk-table__header\\">Appellant case</th>
+                                        <td class=\\"govuk-table__cell\\">Received</td>
+                                        <td class=\\"govuk-table__cell\\">23 May 2024</td>
+                                        <td class=\\"govuk-table__cell\\"><a href=\\"#\\" class=\\"govuk-link\\">Review</a>
+                                        </td>
+                                    </tr>
+                                    <tr class=\\"govuk-table__row\\">
+                                        <th scope=\\"row\\" class=\\"govuk-table__header\\">LPA Questionnaire</th>
+                                        <td class=\\"govuk-table__cell\\">Not received</td>
+                                        <td class=\\"govuk-table__cell\\">23 May 2024</td>
+                                        <td class=\\"govuk-table__cell\\"><a href=\\"#\\" class=\\"govuk-link\\">Review</a>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class=\\"govuk-accordion__section \\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-default-2-heading-4\\"> Case team</span></h2>
+                        </div>
+                        <div id=\\"accordion-default-2-content-4\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-default-2-heading-4\\">
                             <dl class=\\"govuk-summary-list\\">
                                 <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case officer</dt>
                                     <dd class=\\"govuk-summary-list__value\\">

--- a/apps/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
+++ b/apps/web/src/server/appeals/appeal-details/__tests__/appeal-details.test.js
@@ -13,10 +13,56 @@ describe('appeal-details', () => {
 	afterEach(teardown);
 
 	describe('GET /:appealId', () => {
-		it('should render the received appeal details for a valid appealId', async () => {
+		it('should render the received appeal details for a valid appealId with multiple linked/other appeals', async () => {
 			const appealId = appealData.appealId.toString();
 
 			nock('http://test/').get(`/appeals/${appealId}`).reply(200, appealData);
+
+			const response = await request.get(`${baseUrl}/${appealId}`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+		});
+
+		it('should render the received appeal details for a valid appealId with single linked/other appeals', async () => {
+			const appealId = '2';
+
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, {
+					...appealData,
+					appealId,
+					linkedAppeals: [
+						{
+							appealId: 1,
+							appealReference: 'APP/Q9999/D/21/725284'
+						}
+					],
+					otherAppeals: [
+						{
+							appealId: 3,
+							appealReference: 'APP/Q9999/D/21/765413'
+						}
+					]
+				});
+
+			const response = await request.get(`${baseUrl}/${appealId}`);
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+		});
+
+		it('should render the received appeal details for a valid appealId with no linked/other appeals', async () => {
+			const appealId = '3';
+
+			nock('http://test/')
+				.get(`/appeals/${appealId}`)
+				.reply(200, {
+					...appealData,
+					appealId,
+					linkedAppeals: [],
+					otherAppeals: []
+				});
 
 			const response = await request.get(`${baseUrl}/${appealId}`);
 			const element = parseHtml(response.text);

--- a/apps/web/src/server/appeals/appeal-details/appeal-details.controller.js
+++ b/apps/web/src/server/appeals/appeal-details/appeal-details.controller.js
@@ -26,14 +26,9 @@ export const viewAppealDetails = async (request, response) => {
 			siteAddress: formattedSiteAddress ?? 'No site address for this appeal',
 			localPlanningAuthority: appealDetails?.localPlanningDepartment,
 			type: appealDetails?.appealType,
-			caseProcedure: appealDetails?.caseProcedure,
-			linkedAppeal: {
-				appealId: appealDetails?.linkedAppeal?.appealId,
-				appealReference: appealDetails?.linkedAppeal?.appealReference
-			} ?? { appealId: 'None', appealReference: 'No linked appeal' },
-			otherAppeals: appealDetails?.otherAppeals ?? [
-				{ appealId: 'None', appealReference: 'No linked appeal' }
-			],
+			procedureType: appealDetails?.procedureType,
+			linkedAppeals: appealDetails?.linkedAppeals,
+			otherAppeals: appealDetails?.otherAppeals,
 			allocationDetails:
 				appealDetails?.allocationDetails ?? 'No allocation details for this appeal',
 			lpaReference:

--- a/apps/web/src/server/appeals/appeal-details/appeal-details.types.d.ts
+++ b/apps/web/src/server/appeals/appeal-details/appeal-details.types.d.ts
@@ -8,13 +8,13 @@ export interface Appeal {
 	appealStatus: string;
 	appealType: string;
 	appellantName: string;
-	caseProcedure: string;
+	procedureType: string;
 	caseOfficer?: Contact;
 	inspector?: Contact;
 	developmentType: string;
 	decision?: string;
 	eventType: string;
-	linkedAppeal: AppealLink | null;
+	linkedAppeals: AppealLink[] | [];
 	localPlanningDepartment: string;
 	otherAppeals: [AppealLink] | [];
 	planningApplicationReference: string;

--- a/apps/web/src/server/views/appeals/appeal/appeal-details.njk
+++ b/apps/web/src/server/views/appeals/appeal/appeal-details.njk
@@ -21,15 +21,19 @@
 	</p>
 {%- endset -%}
 
-{%- set otherAppealsHtml -%}
-	{%- for otherAppeal in appeal.otherAppeals -%}
-		<a href="/appeals-service/appeal-details/{{ otherAppeal.appealId }}">{{ otherAppeal.appealReference }}</a>
-	{%- endfor -%}
-{%- endset -%}
-
-{%- set linkedAppealHtml -%}
-		<a href="/appeals-service/appeal-details/{{ appeal.linkedAppeal.appealId }}">{{ appeal.linkedAppeal.appealReference }}</a>
-{%- endset -%}
+{% macro linkedAppealsList(linkedAppeals) %}
+  {% if linkedAppeals | length > 1 %}
+    <ul class="govuk-list">
+      {% for linkedAppeal in linkedAppeals %}
+        <li><a href="/appeals-service/appeal-details/{{ linkedAppeal.appealId }}" class="govuk-link">{{ linkedAppeal.appealReference }}</a></li>
+      {% endfor %}
+    </ul>
+  {% elseif linkedAppeals | length === 1 %}
+    	<a href="/appeals-service/appeal-details/{{ linkedAppeals[0].appealId }}" class="govuk-link">{{ linkedAppeals[0].appealReference }}</a>
+  {% else %}
+		No linked appeals
+  {% endif %}
+{% endmacro %}
 
 {%- set caseTimetableHtml -%}
 	{%- if appeal.startedAt -%}
@@ -224,16 +228,16 @@
 							}
 						}, {
 							key: {
-								text: "Linked appeal"
+								text: "Linked appeals"
 							},
 							value: {
-								html: linkedAppealHtml
+								html: linkedAppealsList(appeal.linkedAppeals)
 							},
 							actions: {
 								items: [{
 									href: "#",
 									text: "Change",
-									visuallyHiddenText: "Linked appeal"
+									visuallyHiddenText: "Linked appeals"
 								}]
 							}
 						}, {
@@ -241,7 +245,7 @@
 								text: "Other appeals"
 							},
 							value: {
-								html: otherAppealsHtml
+								html: linkedAppealsList(appeal.otherAppeals)
 							},
 							actions: {
 								items: [{

--- a/apps/web/testing/app/fixtures/referencedata.js
+++ b/apps/web/testing/app/fixtures/referencedata.js
@@ -60,18 +60,28 @@ export const appealData = {
 	appealStatus: 'received_appeal',
 	appealType: 'household',
 	appellantName: 'Eva Sharma',
-	caseProcedure: 'Written',
+	procedureType: 'Written',
 	developmentType: 'Minor Dwellings',
 	eventType: 'Site Visit',
-	linkedAppeal: {
-		appealId: 1,
-		appealReference: 'APP/Q9999/D/21/725284'
-	},
-	localPlanningDepartment: 'Wiltshire Council',
-	otherAppeals: [
+	linkedAppeals: [
 		{
 			appealId: 1,
 			appealReference: 'APP/Q9999/D/21/725284'
+		},
+		{
+			appealId: 2,
+			appealReference: 'APP/Q9999/D/21/123456'
+		}
+	],
+	localPlanningDepartment: 'Wiltshire Council',
+	otherAppeals: [
+		{
+			appealId: 3,
+			appealReference: 'APP/Q9999/D/21/765413'
+		},
+		{
+			appealId: 4,
+			appealReference: 'APP/Q9999/D/21/523467'
 		}
 	],
 	planningApplicationReference: '48269/APP/2021/1482',


### PR DESCRIPTION
## Describe your changes

Add `linkedAppeals` and `otherAppeals` fields to the database to enable appeal linking.

Update the API with the following field changes:

- Rename `caseProcedure` to `procedureType`

- Rename `linkedAppeal` to `linkedAppeals`

- Change `linkedAppeals` to return multiple appeals

- Return additional `otherAppeals` field

- Return additional `isParentAppeal` field (only API as it’s not used in the UI right now)

Updated the Case Details page in the UI for the naming changes and to display the list of linked appeals and created a new macro to display the data for the linked/other appeals. 


## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-176

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
