### PR TITLE
fix(api): fix display order for the examination timetable subfolders

### DIFF
--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
@@ -56,7 +56,7 @@ export const createExaminationTimetableItem = async (_request, response) => {
 		examinationTimetableItem.name
 	}`;
 
-	const displayOrder = +format(new Date(examinationTimetableItem.date), 'ddMMyyyy');
+	const displayOrder = +format(new Date(examinationTimetableItem.date), 'yyyyMMdd');
 
 	const folder = {
 		displayNameEn: folderName?.trim(),

--- a/apps/api/src/server/repositories/folder.repository.js
+++ b/apps/api/src/server/repositories/folder.repository.js
@@ -310,9 +310,9 @@ const defaultCaseFolders = [
 					displayNameEn: 'Examination timetable',
 					displayOrder: 300,
 					childFolders: {
-						// for examination timetable we storing date in ddmmyyyy(31122023) format for display order.
+						// for examination timetable we storing date in yyyyMMdd(20231230) format for display order.
 						// To display other in the end we need to put other in highest possible order.
-						create: [{ displayNameEn: 'Other', displayOrder: 20000000 }]
+						create: [{ displayNameEn: 'Other', displayOrder: 30000000 }]
 					}
 				},
 				{ displayNameEn: 'Procedural decisions', displayOrder: 400 },


### PR DESCRIPTION
## Describe your changes

- fix display order for the examination timetable subfolders

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[BOAS-949](https://pins-ds.atlassian.net.mcas.ms/browse/BOAS-949)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-949]: https://pins-ds.atlassian.net/browse/BOAS-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ