### PR TITLE
chore(tooling): allow longer commit body line lengths

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -26,6 +26,7 @@ const scopes = [
 module.exports = {
 	extends: ['@commitlint/config-conventional'],
 	rules: {
+		'body-max-line-length': [2,	'always', 120], // dependabot needs longer lines, the value is somewhat arbitrary
 		'scope-enums': [
 			2,
 			'always',


### PR DESCRIPTION
## Describe your changes

Follow on from https://github.com/Planning-Inspectorate/back-office/pull/1008 to allow more dependabot commits through. The body line length is fairly arbitrary anyway.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
