### PR TITLE
fix(document-storage): fix use of cross-env

### DIFF
--- a/apps/document-storage/package.json
+++ b/apps/document-storage/package.json
@@ -9,8 +9,8 @@
     "type": "module",
     "scripts": {
         "dev": "nodemon -e js ./src/server.js",
-        "test": "NODE_ENV=test cross-env NODE_OPTIONS=--experimental-vm-modules npx jest",
-        "coverage": "NODE_ENV=test cross-env NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",
+        "test": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest",
+        "coverage": "cross-env NODE_ENV=test cross-env NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",
         "lint:js": "eslint .",
         "lint:js:fix": "eslint . --fix",
         "swagger-autogen": "node ./src/server/swagger.js"


### PR DESCRIPTION
## Describe your changes

`cross-env` was not correctly used so `test` for `document-storage` wouldn't work on Windows.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
