### PR TITLE
fix(web): boas-953 - no back to examination timetable link

### DIFF
--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
@@ -72,7 +72,7 @@ export async function viewApplicationsCaseExaminationTimeTable(request, response
 /**
  * View the preview page of the examination timetable for a single case
  *
- * @type {import('@pins/express').RenderHandler<{timetableItems: Array<Record<string, any>>}>}
+ * @type {import('@pins/express').RenderHandler<{timetableItems: Array<Record<string, any>>, backLink: string}>}
  */
 export async function previewApplicationsCaseExaminationTimeTable(_, response) {
 	const timetableItems = await getCaseTimetableItems(response.locals.caseId);
@@ -82,7 +82,8 @@ export async function previewApplicationsCaseExaminationTimeTable(_, response) {
 	);
 
 	response.render(`applications/case-timetable/timetable-preview.njk`, {
-		timetableItems: timetableItemsViewData
+		timetableItems: timetableItemsViewData,
+		backLink: `/applications-service/case/${response.locals.caseId}/examination-timetable`
 	});
 }
 

--- a/apps/web/src/server/views/applications/case-timetable/timetable-preview.njk
+++ b/apps/web/src/server/views/applications/case-timetable/timetable-preview.njk
@@ -1,6 +1,12 @@
 {% extends "./../layouts/applications.layout.njk" %}
 {% from "./components/timetable-items-list.component.njk" import timetableItemsList%}
 
+{% block beforeContent %}
+	<div class="govuk-width-container">
+		<a class="govuk-back-link" href="{{ backLink }}" >Back</a>
+	</div>
+{% endblock %}
+
 {% block pageContent %}
     <h1 class="govuk-heading-l">Publish examination timetable</h1>
     <p class="govuk-body">Check before publishing</p>

--- a/apps/web/src/server/views/applications/case-timetable/timetable-preview.njk
+++ b/apps/web/src/server/views/applications/case-timetable/timetable-preview.njk
@@ -3,7 +3,7 @@
 
 {% block beforeContent %}
 	<div class="govuk-width-container">
-		<a class="govuk-back-link" href="{{ backLink }}" >Back</a>
+		<a class="govuk-back-link" href="{{ backLink }}" >Back to examination timetable</a>
 	</div>
 {% endblock %}
 


### PR DESCRIPTION
## Describe your changes

Fix for: BOAS-953 - Within the Publish examination timetable page, there should be a 'Back to examination timetable' link.  This is not present

## Issue ticket number and link
https://pins-ds.atlassian.net.mcas.ms/browse/BOAS-953

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
