### PR TITLE
chore: speed up tests

### DIFF
--- a/appeals/api/src/server/app-test.js
+++ b/appeals/api/src/server/app-test.js
@@ -1,6 +1,10 @@
 import { buildApp } from './build-app.js';
+import supertest from 'supertest';
 
 // This instance of the app will only ever be used by Jest fixtures, and has Swagger omitted.
 const app = buildApp();
 
-export { app };
+// init supertest once for all tests to use
+const request = supertest(app);
+
+export { app, request };

--- a/appeals/api/src/server/appeals/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/appeals/appeals/__tests__/appeals.test.js
@@ -1,5 +1,4 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import {
 	ERROR_FAILED_TO_SAVE_DATA,
 	ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS,
@@ -18,7 +17,6 @@ import {
 } from '../../tests/data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-const request = supertest(app);
 
 describe('appeals routes', () => {
 	describe('/appeals', () => {

--- a/appeals/api/src/server/appeals/appeals/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/appeals/appeals/__tests__/appellant-cases.test.js
@@ -20,6 +20,8 @@ import {
 	appellantCaseValidationOutcomes
 } from '../../tests/data.js';
 
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+
 describe('appellant cases routes', () => {
 	describe('/appeals/:appealId/appellant-cases/:appellantCaseId', () => {
 		describe('GET', () => {

--- a/appeals/api/src/server/appeals/appeals/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/appeals/appeals/__tests__/appellant-cases.test.js
@@ -1,5 +1,4 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import {
 	ERROR_INCOMPLETE_REASONS_ONLY_FOR_INCOMPLETE_OUTCOME,
 	ERROR_INVALID_REASONS_ONLY_FOR_INVALID_OUTCOME,
@@ -20,9 +19,6 @@ import {
 	householdAppeal,
 	appellantCaseValidationOutcomes
 } from '../../tests/data.js';
-
-const { databaseConnector } = await import('../../../utils/database-connector.js');
-const request = supertest(app);
 
 describe('appellant cases routes', () => {
 	describe('/appeals/:appealId/appellant-cases/:appellantCaseId', () => {

--- a/appeals/api/src/server/appeals/appeals/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/appeals/appeals/__tests__/lpa-questionnaires.test.js
@@ -1,5 +1,4 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import {
 	ERROR_FAILED_TO_SAVE_DATA,
 	ERROR_INCOMPLETE_REASONS_ONLY_FOR_INCOMPLETE_OUTCOME,
@@ -26,7 +25,6 @@ import {
 import { createManyToManyRelationData } from '../appeals.service.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-const request = supertest(app);
 
 describe('lpa questionnaires routes', () => {
 	describe('/appeals/:appealId/lpa-questionnaires/:lpaQuestionnaireId', () => {

--- a/apps/api/src/server/app-test.js
+++ b/apps/api/src/server/app-test.js
@@ -1,6 +1,10 @@
 import { buildApp } from './build-app.js';
+import supertest from 'supertest';
 
 // This instance of the app will only ever be used by Jest fixtures, and has Swagger omitted.
 const app = buildApp();
 
-export { app };
+// init supertest once for all tests to use
+const request = supertest(app);
+
+export { app, request };

--- a/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/appeals.test.js
@@ -1,5 +1,4 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import {
 	ERROR_FAILED_TO_SAVE_DATA,
 	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
@@ -17,7 +16,6 @@ import {
 } from '../../tests/data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-const request = supertest(app);
 
 describe('appeals routes', () => {
 	describe('/appeals', () => {

--- a/apps/api/src/server/appeals/appeals/__tests__/appellant-cases.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/appellant-cases.test.js
@@ -1,5 +1,4 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import {
 	ERROR_INCOMPLETE_REASONS_ONLY_FOR_INCOMPLETE_OUTCOME,
 	ERROR_INVALID_REASONS_ONLY_FOR_INVALID_OUTCOME,
@@ -22,7 +21,6 @@ import {
 } from '../../tests/data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-const request = supertest(app);
 
 describe('appellant cases routes', () => {
 	describe('/appeals/:appealId/appellant-cases/:appellantCaseId', () => {

--- a/apps/api/src/server/appeals/appeals/__tests__/lpa-questionnaires.test.js
+++ b/apps/api/src/server/appeals/appeals/__tests__/lpa-questionnaires.test.js
@@ -1,10 +1,8 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { ERROR_MUST_BE_NUMBER, ERROR_NOT_FOUND } from '../../constants.js';
 import { householdAppeal } from '../../tests/data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-const request = supertest(app);
 
 describe('lpa questionnaires routes', () => {
 	describe('/appeals/:appealId/lpa-questionnaires/:lpaQuestionnaireId', () => {

--- a/apps/api/src/server/appeals/appellant-case-incomplete-reasons/__tests__/appellant-case-incomplete-reasons.test.js
+++ b/apps/api/src/server/appeals/appellant-case-incomplete-reasons/__tests__/appellant-case-incomplete-reasons.test.js
@@ -1,10 +1,8 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { appellantCaseIncompleteReasons } from '../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-const request = supertest(app);
 
 describe('appellant case incomplete reasons routes', () => {
 	describe('/appeals/appellant-case-incomplete-reasons', () => {

--- a/apps/api/src/server/appeals/appellant-case-invalid-reasons/__tests__/appellant-case-invalid-reasons.test.js
+++ b/apps/api/src/server/appeals/appellant-case-invalid-reasons/__tests__/appellant-case-invalid-reasons.test.js
@@ -1,10 +1,8 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { appellantCaseInvalidReasons } from '../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-const request = supertest(app);
 
 describe('appellant case invalid reasons routes', () => {
 	describe('/appeals/appellant-case-invalid-reasons', () => {

--- a/apps/api/src/server/applications/application/__tests__/create-application.test.js
+++ b/apps/api/src/server/applications/application/__tests__/create-application.test.js
@@ -1,10 +1,7 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 const { eventClient } = await import('../../../infrastructure/event-client.js');
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const createdCase = { id: 1, serviceCustomer: [{ id: 4 }] };
 

--- a/apps/api/src/server/applications/application/__tests__/get-application-details.test.js
+++ b/apps/api/src/server/applications/application/__tests__/get-application-details.test.js
@@ -1,11 +1,9 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { applicationFactoryForTests } from '../../../utils/application-factory-for-tests.js';
 const { databaseConnector } = await import('../../../utils/database-connector.js');
 
 import { mapDateStringToUnixTimestamp } from '../../../utils/mapping/map-date-string-to-unix-timestamp.js';
 
-const request = supertest(app);
 const time = new Date();
 
 const application1 = applicationFactoryForTests({

--- a/apps/api/src/server/applications/application/__tests__/publish-application.test.js
+++ b/apps/api/src/server/applications/application/__tests__/publish-application.test.js
@@ -1,12 +1,9 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 const { eventClient } = await import('../../../infrastructure/event-client.js');
 const { databaseConnector } = await import('../../../utils/database-connector.js');
 
 import logger from '../../../utils/logger.js';
-
-const request = supertest(app);
 
 const now = 1_649_319_144_000;
 const mockDate = new Date(now);

--- a/apps/api/src/server/applications/application/__tests__/start-case.test.js
+++ b/apps/api/src/server/applications/application/__tests__/start-case.test.js
@@ -1,12 +1,9 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 const { eventClient } = await import('../../../infrastructure/event-client.js');
 
 import { applicationFactoryForTests } from '../../../utils/application-factory-for-tests.js';
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const applicationReadyToStart = applicationFactoryForTests({
 	id: 1,

--- a/apps/api/src/server/applications/application/__tests__/update-application.test.js
+++ b/apps/api/src/server/applications/application/__tests__/update-application.test.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
 
 /** @type {import('../application.js').NsipProjectPayload} */
 const expectedEventPayload = {
@@ -14,11 +13,9 @@ const expectedEventPayload = {
 	interestedPartyIds: []
 };
 
-const { app } = await import('../../../app-test.js');
+const { request } = await import('../../../app-test.js');
 const { databaseConnector } = await import('../../../utils/database-connector.js');
 const { eventClient } = await import('../../../infrastructure/event-client.js');
-
-const request = supertest(app);
 
 describe('Update application', () => {
 	test('update-application updates application with just title and first notified date', async () => {

--- a/apps/api/src/server/applications/application/documents/__tests__/delete-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/delete-document.test.js
@@ -1,11 +1,8 @@
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
 
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 import { applicationStates } from '../../../state-machine/application.machine.js';
-
-const request = supertest(app);
 
 describe('delete Document', () => {
 	beforeEach(() => {

--- a/apps/api/src/server/applications/application/documents/__tests__/document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document.test.js
@@ -1,10 +1,7 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
 const { default: got } = await import('got');
-
-const request = supertest(app);
 
 const application = {
 	id: 1,

--- a/apps/api/src/server/applications/application/documents/__tests__/provide-document-upload-urls.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/provide-document-upload-urls.test.js
@@ -1,10 +1,7 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
 const { default: got } = await import('got');
-
-const request = supertest(app);
 
 const application = {
 	id: 1,

--- a/apps/api/src/server/applications/application/documents/__tests__/publish-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/publish-document.test.js
@@ -1,9 +1,6 @@
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 import { applicationFactoryForTests } from '../../../../utils/application-factory-for-tests.js';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const application1 = applicationFactoryForTests({
 	id: 1,

--- a/apps/api/src/server/applications/application/documents/__tests__/store-document-metadata.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/store-document-metadata.test.js
@@ -1,11 +1,8 @@
 import { jest } from '@jest/globals';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
 
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 import { applicationStates } from '../../../state-machine/application.machine.js';
-
-const request = supertest(app);
 
 const generatesDocumentMetadataResponse = (
 	/** @type {Record<string, any>} */ updateResponseValues

--- a/apps/api/src/server/applications/application/documents/__tests__/update-document-status.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/update-document-status.test.js
@@ -1,8 +1,5 @@
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const document1 = {
 	caseId: 1,

--- a/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
+++ b/apps/api/src/server/applications/application/file-folders/__tests__/get-folder-details.test.js
@@ -1,9 +1,6 @@
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 import { applicationFactoryForTests } from '../../../../utils/application-factory-for-tests.js';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const application1 = applicationFactoryForTests({
 	id: 1,

--- a/apps/api/src/server/applications/application/representations/__tests__/create-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/create-representation.test.js
@@ -1,8 +1,5 @@
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const createdRepresentation = {
 	id: 1,

--- a/apps/api/src/server/applications/application/representations/__tests__/get-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/get-representation.test.js
@@ -1,8 +1,5 @@
-import supertest from 'supertest';
-import { app } from '../../../../app.js';
+import { request } from '../../../../app-test.js';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const existingRepresentations = [
 	{

--- a/apps/api/src/server/applications/application/representations/__tests__/get-representations.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/get-representations.test.js
@@ -1,8 +1,5 @@
-import supertest from 'supertest';
-import { app } from '../../../../app-test.js';
+import { request } from '../../../../app-test.js';
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const existingRepresentations = [
 	{

--- a/apps/api/src/server/applications/application/representations/__tests__/patch-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/patch-representation.test.js
@@ -1,9 +1,6 @@
-import supertest from 'supertest';
-import { app } from '../../../../app.js';
+import { request } from '../../../../app-test.js';
 
 const { databaseConnector } = await import('../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const existingRepresentations = [
 	{

--- a/apps/api/src/server/applications/application/representations/contacts/__tests___/delete-contact.test.js
+++ b/apps/api/src/server/applications/application/representations/contacts/__tests___/delete-contact.test.js
@@ -1,9 +1,6 @@
-import supertest from 'supertest';
-import { app } from '../../../../../app.js';
+import { request } from '../../../../../app-test.js';
 
 const { databaseConnector } = await import('../../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const existingRepresentations = [
 	{

--- a/apps/api/src/server/applications/application/representations/redact/__tests__/patch-redact.test.js
+++ b/apps/api/src/server/applications/application/representations/redact/__tests__/patch-redact.test.js
@@ -1,10 +1,7 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../../../app.js';
+import { request } from '../../../../../app-test.js';
 
 const { databaseConnector } = await import('../../../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const existingRepresentations = [
 	{

--- a/apps/api/src/server/applications/case-admin-officer/__tests__/get-applications.test.js
+++ b/apps/api/src/server/applications/case-admin-officer/__tests__/get-applications.test.js
@@ -1,9 +1,6 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { applicationFactoryForTests } from '../../../utils/application-factory-for-tests.js';
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const application = applicationFactoryForTests({
 	id: 1,

--- a/apps/api/src/server/applications/case-team/__tests__/get-applications.test.js
+++ b/apps/api/src/server/applications/case-team/__tests__/get-applications.test.js
@@ -1,9 +1,6 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { applicationFactoryForTests } from '../../../utils/application-factory-for-tests.js';
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const application = applicationFactoryForTests({
 	id: 1,

--- a/apps/api/src/server/applications/examination-timetable-items/__tests__/examination-timetable-items.test.js
+++ b/apps/api/src/server/applications/examination-timetable-items/__tests__/examination-timetable-items.test.js
@@ -1,10 +1,7 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const examinationTimetableItem = {
 	id: 1,

--- a/apps/api/src/server/applications/examination-timetable-type/__tests__/get-examination-timetable-type.test.js
+++ b/apps/api/src/server/applications/examination-timetable-type/__tests__/get-examination-timetable-type.test.js
@@ -1,11 +1,8 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { nodeCache, setCache } from '../../../utils/cache-data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const examinationTimetableTypes = {
 	id: 1,

--- a/apps/api/src/server/applications/inspector/__tests__/get-applications.test.js
+++ b/apps/api/src/server/applications/inspector/__tests__/get-applications.test.js
@@ -1,9 +1,6 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { applicationFactoryForTests } from '../../../utils/application-factory-for-tests.js';
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const application = applicationFactoryForTests({
 	id: 1,

--- a/apps/api/src/server/applications/region/__tests__/get-regions.test.js
+++ b/apps/api/src/server/applications/region/__tests__/get-regions.test.js
@@ -1,11 +1,8 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { nodeCache, setCache } from '../../../utils/cache-data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const region = {
 	id: 1,

--- a/apps/api/src/server/applications/search/__tests__/case-search.test.js
+++ b/apps/api/src/server/applications/search/__tests__/case-search.test.js
@@ -1,9 +1,6 @@
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { applicationFactoryForTests } from '../../../utils/application-factory-for-tests.js';
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const searchString = 'EN010003 - NI Case 3 Name';
 const notFoundSearchString = 'BCDEF';

--- a/apps/api/src/server/applications/sector/__tests__/get-sectors.test.js
+++ b/apps/api/src/server/applications/sector/__tests__/get-sectors.test.js
@@ -1,11 +1,8 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { nodeCache, setCache } from '../../../utils/cache-data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 /**
  * @type {import('@pins/api').Schema.Sector}

--- a/apps/api/src/server/applications/zoom-level/__tests__/get-zoom-map.test.js
+++ b/apps/api/src/server/applications/zoom-level/__tests__/get-zoom-map.test.js
@@ -1,11 +1,8 @@
 import { jest } from '@jest/globals';
-import supertest from 'supertest';
-import { app } from '../../../app-test.js';
+import { request } from '../../../app-test.js';
 import { nodeCache, setCache } from '../../../utils/cache-data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
-
-const request = supertest(app);
 
 const mapZoomLevels = {
 	id: 1,


### PR DESCRIPTION
## Describe your changes

Each test suite would create an instance of the app with supertest: `const request = supertest(app);`. If instead the apps share an instance, it should speed up tests.

Only applied to api for now, because web is more involved.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
