### PR TITLE
chore(appeals): full tests and new appeals script

### DIFF
--- a/appeals/api/src/server/appeals/appeals/appeals.routes.js
+++ b/appeals/api/src/server/appeals/appeals/appeals.routes.js
@@ -76,7 +76,7 @@ router.patch(
 		#swagger.tags = ['Appeals']
 		#swagger.path = '/appeals/{appealId}'
 		#swagger.description = 'Updates a single appeal by id'
-		#swagger.parameters['body'] = {
+		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appeal details to update',
 			schema: { $ref: '#/definitions/UpdateAppealRequest' },
@@ -138,7 +138,7 @@ router.patch(
 		#swagger.tags = ['Appeals']
 		#swagger.path = '/appeals/{appealId}/appellant-cases/{appellantCaseId}'
 		#swagger.description = Updates a single appellant case for an appeal by id
-		#swagger.parameters['body'] = {
+		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appellant case details to update',
 			schema: { $ref: '#/definitions/UpdateAppellantCaseRequest' },

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -2,8 +2,8 @@
 	"openapi": "3.0.0",
 	"info": {
 		"version": "2.0",
-		"title": "PINS Back Office API",
-		"description": "PINS Back Office API documentation from Swagger"
+		"title": "PINS Back Office Appeals API",
+		"description": "PINS Back Office Appeals API documentation from Swagger"
 	},
 	"host": "",
 	"basePath": "",
@@ -164,15 +164,6 @@
 						"schema": {
 							"type": "string"
 						}
-					},
-					{
-						"name": "body",
-						"in": "body",
-						"description": "Appeal details to update",
-						"schema": {
-							"$ref": "#/components/schemas/UpdateAppealRequest"
-						},
-						"required": true
 					}
 				],
 				"responses": {
@@ -199,6 +190,23 @@
 					},
 					"500": {
 						"description": "Internal Server Error"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Appeal details to update",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateAppealRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateAppealRequest"
+							}
+						}
 					}
 				}
 			}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -5,9 +5,9 @@ const document = {
 		// by default: '1.0.0'
 		version: '2.0',
 		// by default: 'REST API'
-		title: 'PINS Back Office API',
+		title: 'PINS Back Office Appeals API',
 		// by default: ''
-		description: 'PINS Back Office API documentation from Swagger'
+		description: 'PINS Back Office Appeals API documentation from Swagger'
 	},
 	// by default: 'localhost:3000'
 	host: '',
@@ -1067,9 +1067,6 @@ const document = {
 };
 
 const outputFile = './src/server/openapi.json';
-const endpointsFiles = [
-	'./src/server/appeals/**/*.routes.js',
-	'./src/server/applications/**/*.routes.js'
-];
+const endpointsFiles = ['./src/server/appeals/**/*.routes.js'];
 
 swaggerAutogen({ openapi: '3.0.0' })(outputFile, endpointsFiles, document);

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "web": "npm run dev --workspace=@pins/web",
     "dev:appeals": "turbo run dev --filter=./appeals/* --no-cache --parallel --continue",
     "test:appeals": "turbo run test --filter=./appeals/*",
-		"web:appeals": "npm run dev --workspace=@pins/appeals.web",
-		"api:appeals": "npm run dev --workspace=@pins/appeals.api"
+    "web:appeals": "npm run dev --workspace=@pins/appeals.web",
+    "api:appeals": "npm run dev --workspace=@pins/appeals.api"
   },
   "dependencies": {
     "got": "^12.5.2",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "lint:js:fix": "npx eslint . --fix",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "release": "multi-semantic-release --ignore-packages=packages/**",
-    "test": "turbo run test --filter=!./appeals/*",
+    "test": "turbo run test",
     "tscheck": "turbo run prisma-generate && turbo run tscheck --parallel --filter=!@pins/api --filter=!@pins/appeals.api",
     "web": "npm run dev --workspace=@pins/web",
     "dev:appeals": "turbo run dev --filter=./appeals/* --no-cache --parallel --continue",
-    "test:appeals": "turbo run test --filter=./appeals/*"
+    "test:appeals": "turbo run test --filter=./appeals/*",
+		"web:appeals": "npm run dev --workspace=@pins/appeals.web",
+		"api:appeals": "npm run dev --workspace=@pins/appeals.api"
   },
   "dependencies": {
     "got": "^12.5.2",


### PR DESCRIPTION
## Describe your changes

Restored ability to run ALL tests from `npm run test`.
Added specific scripts for appeals development:

- web:appeals
- api:appeals

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
