### PR TITLE
fix(web): clearer error when missing session secret

### DIFF
--- a/appeals/web/environment/config.js
+++ b/appeals/web/environment/config.js
@@ -48,7 +48,7 @@ const { value: validatedConfig, error } = schema.validate({
 });
 
 if (error) {
-	throw error;
+	throw new Error(`Env validation error: ${error.message}`);
 }
 
 const cwd = url.fileURLToPath(new URL('..', import.meta.url));

--- a/appeals/web/environment/schema.js
+++ b/appeals/web/environment/schema.js
@@ -20,7 +20,7 @@ export default joi.object({
 	}),
 	serverProtocol: joi.string().valid('http', 'https'),
 	serverPort: joi.number(),
-	sessionSecret: joi.string(),
+	sessionSecret: joi.string().required(),
 	sslCertificateFile: joi.string(),
 	sslCertificateKeyFile: joi.string(),
 	referenceData: joi.object({

--- a/appeals/web/environment/schema.js
+++ b/appeals/web/environment/schema.js
@@ -20,7 +20,9 @@ export default joi.object({
 	}),
 	serverProtocol: joi.string().valid('http', 'https'),
 	serverPort: joi.number(),
-	sessionSecret: joi.string().required(),
+	sessionSecret: joi
+		.string()
+		.when('env', { is: 'test', then: joi.optional(), otherwise: joi.required() }),
 	sslCertificateFile: joi.string(),
 	sslCertificateKeyFile: joi.string(),
 	referenceData: joi.object({

--- a/apps/web/environment/config.js
+++ b/apps/web/environment/config.js
@@ -48,7 +48,7 @@ const { value: validatedConfig, error } = schema.validate({
 });
 
 if (error) {
-	throw error;
+	throw new Error(`Env validation error: ${error.message}`);
 }
 
 const cwd = url.fileURLToPath(new URL('..', import.meta.url));

--- a/apps/web/environment/schema.js
+++ b/apps/web/environment/schema.js
@@ -20,7 +20,7 @@ export default joi.object({
 	}),
 	serverProtocol: joi.string().valid('http', 'https'),
 	serverPort: joi.number(),
-	sessionSecret: joi.string(),
+	sessionSecret: joi.string().required(),
 	sslCertificateFile: joi.string(),
 	sslCertificateKeyFile: joi.string(),
 	referenceData: joi.object({

--- a/apps/web/environment/schema.js
+++ b/apps/web/environment/schema.js
@@ -20,7 +20,9 @@ export default joi.object({
 	}),
 	serverProtocol: joi.string().valid('http', 'https'),
 	serverPort: joi.number(),
-	sessionSecret: joi.string().required(),
+	sessionSecret: joi
+		.string()
+		.when('env', { is: 'test', then: joi.optional(), otherwise: joi.required() }),
 	sslCertificateFile: joi.string(),
 	sslCertificateKeyFile: joi.string(),
 	referenceData: joi.object({


### PR DESCRIPTION
## Describe your changes

If the web app was missing the require SESSION_SECRET env var, the resulting error was obscure and unhelpful. The schema validation for the environment setup doesn't require any fields by default. SessionSecret has been marked as required now, so the error is caught earlier and the message more helpful ("Error: Env validation error: "sessionSecret" is required")

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
