### PR TITLE
fix(web): boas-860 - ensure item name has hint

### DIFF
--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -23,7 +23,9 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
-                    <input class=\\"govuk-input\\" id=\\"name\\" name=\\"name\\" type=\\"text\\">
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
+                    <input class=\\"govuk-input\\" id=\\"name\\"
+                    name=\\"name\\" type=\\"text\\" aria-describedby=\\"name-hint\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full \\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Date</label>
@@ -135,10 +137,11 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                 </div>
                 <div class=\\"govuk-form-group govuk-form-group--error govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
                     <p id=\\"name-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the item
                         name</p>
                     <input class=\\"govuk-input govuk-input--error\\" id=\\"name\\" name=\\"name\\"
-                    type=\\"text\\" aria-describedby=\\"name-error\\">
+                    type=\\"text\\" aria-describedby=\\"name-hint name-error\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full \\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Start date (optional)</label>
@@ -295,10 +298,11 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                 </div>
                 <div class=\\"govuk-form-group govuk-form-group--error govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
                     <p id=\\"name-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the item
                         name</p>
                     <input class=\\"govuk-input govuk-input--error\\" id=\\"name\\" name=\\"name\\"
-                    type=\\"text\\" aria-describedby=\\"name-error\\">
+                    type=\\"text\\" aria-describedby=\\"name-hint name-error\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full govuk-form-group--error\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Start date</label>
@@ -463,10 +467,11 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                 </div>
                 <div class=\\"govuk-form-group govuk-form-group--error govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
                     <p id=\\"name-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the item
                         name</p>
                     <input class=\\"govuk-input govuk-input--error\\" id=\\"name\\" name=\\"name\\"
-                    type=\\"text\\" aria-describedby=\\"name-error\\">
+                    type=\\"text\\" aria-describedby=\\"name-hint name-error\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full govuk-form-group--error\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Date</label>
@@ -556,10 +561,11 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                 </div>
                 <div class=\\"govuk-form-group govuk-form-group--error govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
                     <p id=\\"name-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the item
                         name</p>
                     <input class=\\"govuk-input govuk-input--error\\" id=\\"name\\" name=\\"name\\"
-                    type=\\"text\\" aria-describedby=\\"name-error\\">
+                    type=\\"text\\" aria-describedby=\\"name-hint name-error\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full govuk-form-group--error\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Date</label>
@@ -684,10 +690,11 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                 </div>
                 <div class=\\"govuk-form-group govuk-form-group--error govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
                     <p id=\\"name-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the item
                         name</p>
                     <input class=\\"govuk-input govuk-input--error\\" id=\\"name\\" name=\\"name\\"
-                    type=\\"text\\" aria-describedby=\\"name-error\\">
+                    type=\\"text\\" aria-describedby=\\"name-hint name-error\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full govuk-form-group--error\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Date</label>
@@ -806,10 +813,11 @@ exports[`Create examination timetable page should display errors if start date a
                 </div>
                 <div class=\\"govuk-form-group govuk-form-group--error govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
                     <p id=\\"name-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the item
                         name</p>
                     <input class=\\"govuk-input govuk-input--error\\" id=\\"name\\" name=\\"name\\"
-                    type=\\"text\\" aria-describedby=\\"name-error\\">
+                    type=\\"text\\" aria-describedby=\\"name-hint name-error\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full govuk-form-group--error\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Start date (optional)</label>
@@ -954,10 +962,11 @@ exports[`Create examination timetable page should display errors if start time a
                 </div>
                 <div class=\\"govuk-form-group govuk-form-group--error govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
                     <p id=\\"name-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the item
                         name</p>
                     <input class=\\"govuk-input govuk-input--error\\" id=\\"name\\" name=\\"name\\"
-                    type=\\"text\\" aria-describedby=\\"name-error\\">
+                    type=\\"text\\" aria-describedby=\\"name-hint name-error\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full \\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Start date (optional)</label>
@@ -1203,8 +1212,9 @@ exports[`Edit examination timetable GET /case/123/examination-timetable/item/1/e
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-one-half\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"name\\">Item name</label>
-                    <input class=\\"govuk-input\\" id=\\"name\\" name=\\"name\\" type=\\"text\\"
-                    value=\\"Test\\">
+                    <div id=\\"name-hint\\" class=\\"govuk-hint\\">There is a limit of 200 characters</div>
+                    <input class=\\"govuk-input\\" id=\\"name\\"
+                    name=\\"name\\" type=\\"text\\" value=\\"Test\\" aria-describedby=\\"name-hint\\">
                 </div>
                 <div class=\\"govuk-form-group govuk-grid-column-full \\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"\\">Start date (optional)</label>

--- a/apps/web/src/server/views/applications/case-timetable/timetable-details-form.njk
+++ b/apps/web/src/server/views/applications/case-timetable/timetable-details-form.njk
@@ -69,7 +69,10 @@
 								classes: 'font-weight--700 govuk-!-margin-bottom-4'
 								},
 							errorMessage: errors.name | errorMessage,
-							value: values.name
+							value: values.name,
+							hint: {
+								text: "There is a limit of 200 characters"
+							}
 					}) }}
 				{% endif %}
 


### PR DESCRIPTION
## Describe your changes

Fix for: 

"There is no hint text for Item name field.  (See image)

Requirements say 'There is a limit of 200 characters'"

## Issue ticket number and link
https://pins-ds.atlassian.net/jira/software/projects/BOAS/boards/172?isInsightsOpen=true&selectedIssue=BOAS-860
## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)
