### PR TITLE
chore(tooling): test script doesn't need to clear jest cache

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -12,7 +12,7 @@
   },
   "type": "module",
   "scripts": {
-    "test": "npx jest --clearCache && npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --detectOpenHandles --forceExit",
+    "test": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --detectOpenHandles --forceExit",
     "test:watch": "npm run test -- --watch",
     "coverage": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",
     "dev": "npm run prisma-generate && nodemon --experimental-json-modules -e js ./src/server.js",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,7 @@
   },
   "type": "module",
   "scripts": {
-    "test": "npx jest --clearCache && npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --detectOpenHandles --forceExit",
+    "test": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --detectOpenHandles --forceExit",
     "test:watch": "npm run test -- --watch",
     "coverage": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",
     "dev": "npm run prisma-generate && nodemon --experimental-json-modules -e js ./src/server.js",


### PR DESCRIPTION
## Describe your changes

We are clearing the jest cache for API tests, but no one knows why! The docs state this can slow down tests significantly, and should only be done if there are issues. All the other packages run with the cache and are OK.

The other issue is that since tests are run concurrently across packages (with turbo), some test runs fail because the cache is cleared while another test suite is running, e,g,  [failed test logs](https://dev.azure.com/planninginspectorate/back-office/_build/results?buildId=55021&view=logs&j=4915e90a-f1c2-55b0-f3a8-aede04c03102&t=b9fc72a1-1467-5c9b-5728-71623aec9bc0&l=56).

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
