### PR TITLE
fix(web): sessionSecret isn't required for web build

### DIFF
--- a/appeals/web/environment/schema.js
+++ b/appeals/web/environment/schema.js
@@ -22,7 +22,7 @@ export default joi.object({
 	serverPort: joi.number(),
 	sessionSecret: joi
 		.string()
-		.when('env', { is: 'test', then: joi.optional(), otherwise: joi.required() }),
+		.when('env', { is: 'test', then: joi.optional(), otherwise: joi.optional() }),
 	sslCertificateFile: joi.string(),
 	sslCertificateKeyFile: joi.string(),
 	referenceData: joi.object({

--- a/apps/web/environment/schema.js
+++ b/apps/web/environment/schema.js
@@ -22,7 +22,7 @@ export default joi.object({
 	serverPort: joi.number(),
 	sessionSecret: joi
 		.string()
-		.when('env', { is: 'test', then: joi.optional(), otherwise: joi.required() }),
+		.when('env', { is: 'test', then: joi.optional(), otherwise: joi.optional() }),
 	sslCertificateFile: joi.string(),
 	sslCertificateKeyFile: joi.string(),
 	referenceData: joi.object({

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -36,3 +36,7 @@ extends:
           - template: ../steps/node_script.yml
             parameters:
               script: npm run test
+          - template: ../steps/node_script.yml
+            parameters:
+              # check web build script works
+              script: npm run build:release


### PR DESCRIPTION
## Describe your changes

Temporary fix to let web build correctly, session secret env var isn't required.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
