### PR TITLE
feat(api): add appeals search using appeal reference or postcode

### DIFF
--- a/appeals/api/src/server/appeals/appeals/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/appeals/appeals/__tests__/lpa-questionnaires.test.js
@@ -5,7 +5,7 @@ import {
 	ERROR_INCOMPLETE_REASONS_ONLY_FOR_INCOMPLETE_OUTCOME,
 	ERROR_INVALID_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME,
 	ERROR_LPA_QUESTIONNAIRE_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED,
-	ERROR_MAX_LENGTH_300,
+	ERROR_MAX_LENGTH_300_CHARACTERS,
 	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
 	ERROR_MUST_BE_NUMBER,
 	ERROR_MUST_BE_STRING,
@@ -647,7 +647,7 @@ describe('lpa questionnaires routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						otherNotValidReasons: ERROR_MAX_LENGTH_300
+						otherNotValidReasons: ERROR_MAX_LENGTH_300_CHARACTERS
 					}
 				});
 			});

--- a/appeals/api/src/server/appeals/appeals/appeals.controller.js
+++ b/appeals/api/src/server/appeals/appeals/appeals.controller.js
@@ -17,10 +17,12 @@ import {
  * @returns {Promise<object>}
  */
 const getAppeals = async (req, res) => {
-	const pageNumber = Number(req.query.pageNumber) || DEFAULT_PAGE_NUMBER;
-	const pageSize = Number(req.query.pageSize) || DEFAULT_PAGE_SIZE;
+	const { query } = req;
+	const pageNumber = Number(query.pageNumber) || DEFAULT_PAGE_NUMBER;
+	const pageSize = Number(query.pageSize) || DEFAULT_PAGE_SIZE;
+	const searchTerm = String(query.searchTerm);
 
-	const [itemCount, appeals = []] = await appealRepository.getAll(pageNumber, pageSize);
+	const [itemCount, appeals = []] = await appealRepository.getAll(pageNumber, pageSize, searchTerm);
 	const formattedAppeals = appeals.map((appeal) => appealFormatter.formatAppeals(appeal));
 
 	return res.send({

--- a/appeals/api/src/server/appeals/appeals/appeals.routes.js
+++ b/appeals/api/src/server/appeals/appeals/appeals.routes.js
@@ -17,10 +17,10 @@ import {
 	checkValidationOutcomeExistsAndAddToRequest
 } from './appeals.service.js';
 import {
+	getAppealsValidator,
 	getAppealValidator,
 	getAppellantCaseValidator,
 	getLPAQuestionnaireValidator,
-	paginationParameterValidator,
 	patchAppealValidator,
 	patchAppellantCaseValidator,
 	patchLPAQuestionnaireValidator
@@ -40,13 +40,18 @@ router.get(
 		#swagger.description = 'Gets requested appeals, limited to the first 30 appeals if no pagination params are given'
 		#swagger.parameters['pageNumber'] = {
 			in: 'query',
-			description: 'The pagination page number, required if pageSize is given',
+			description: 'The pagination page number - required if pageSize is given',
 			example: 1,
 		}
 		#swagger.parameters['pageSize'] = {
 			in: 'query',
-			description: 'The pagination page size, required if pageNumber is given',
+			description: 'The pagination page size - required if pageNumber is given',
 			example: 30,
+		}
+		#swagger.parameters['searchTerm'] = {
+			in: 'query',
+			description: 'The search term - does a partial, case-insensitive match of appeal reference and postcode fields',
+			example: 'NR35 2ND',
 		}
 		#swagger.responses[200] = {
 			description: 'Requested appeals',
@@ -54,7 +59,7 @@ router.get(
 		}
 		#swagger.responses[400] = {}
 	 */
-	paginationParameterValidator,
+	getAppealsValidator,
 	asyncHandler(getAppeals)
 );
 

--- a/appeals/api/src/server/appeals/appeals/appeals.validators.js
+++ b/appeals/api/src/server/appeals/appeals/appeals.validators.js
@@ -5,8 +5,9 @@ import {
 	ERROR_INCOMPLETE_REASONS_ONLY_FOR_INCOMPLETE_OUTCOME,
 	ERROR_INVALID_REASONS_ONLY_FOR_INVALID_OUTCOME,
 	ERROR_LPA_QUESTIONNAIRE_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED,
-	ERROR_MAX_LENGTH_300,
+	ERROR_MAX_LENGTH_300_CHARACTERS,
 	ERROR_MUST_BE_ARRAY_OF_IDS,
+	ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS,
 	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
 	ERROR_MUST_BE_GREATER_THAN_ZERO,
 	ERROR_MUST_BE_NUMBER,
@@ -94,6 +95,17 @@ const validateValidationOutcomeReasons = (parameterName, customFn) =>
 		.withMessage(ERROR_MUST_CONTAIN_AT_LEAST_1_VALUE)
 		.custom(customFn);
 
+const getAppealsValidator = composeMiddleware(
+	validatePaginationParameter('pageNumber'),
+	validatePaginationParameter('pageSize'),
+	query('searchTerm')
+		.optional()
+		.isString()
+		.isLength({ min: 2, max: 8 })
+		.withMessage(ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS),
+	validationErrorHandler
+);
+
 const getAppealValidator = composeMiddleware(
 	validateIdParameter('appealId'),
 	validationErrorHandler
@@ -108,12 +120,6 @@ const getLPAQuestionnaireValidator = composeMiddleware(
 const getAppellantCaseValidator = composeMiddleware(
 	validateIdParameter('appealId'),
 	validateIdParameter('appellantCaseId'),
-	validationErrorHandler
-);
-
-const paginationParameterValidator = composeMiddleware(
-	validatePaginationParameter('pageNumber'),
-	validatePaginationParameter('pageSize'),
 	validationErrorHandler
 );
 
@@ -147,7 +153,7 @@ const patchAppellantCaseValidator = composeMiddleware(
 		.isString()
 		.withMessage(ERROR_MUST_BE_STRING)
 		.isLength({ min: 0, max: 300 })
-		.withMessage(ERROR_MAX_LENGTH_300)
+		.withMessage(ERROR_MAX_LENGTH_300_CHARACTERS)
 		.custom((value, { req }) => {
 			if (
 				value &&
@@ -191,7 +197,7 @@ const patchLPAQuestionnaireValidator = composeMiddleware(
 		.isString()
 		.withMessage(ERROR_MUST_BE_STRING)
 		.isLength({ min: 0, max: 300 })
-		.withMessage(ERROR_MAX_LENGTH_300)
+		.withMessage(ERROR_MAX_LENGTH_300_CHARACTERS)
 		.custom((value, { req }) => {
 			if (
 				value &&
@@ -217,10 +223,10 @@ const patchLPAQuestionnaireValidator = composeMiddleware(
 );
 
 export {
+	getAppealsValidator,
 	getAppealValidator,
 	getAppellantCaseValidator,
 	getLPAQuestionnaireValidator,
-	paginationParameterValidator,
 	patchAppealValidator,
 	patchAppellantCaseValidator,
 	patchLPAQuestionnaireValidator

--- a/appeals/api/src/server/appeals/constants.js
+++ b/appeals/api/src/server/appeals/constants.js
@@ -23,7 +23,8 @@ export const ERROR_INVALID_APPELLANT_CASE_VALIDATION_OUTCOME = `Validation outco
 export const ERROR_INVALID_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME = `Validation outcome must be one of Complete, Incomplete`;
 export const ERROR_INVALID_REASONS_ONLY_FOR_INVALID_OUTCOME =
 	'Invalid reasons should only be given if the validation outcome is Invalid';
-export const ERROR_MAX_LENGTH_300 = 'Must be 300 characters or less';
+export const ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS = 'Must be between 2 and 8 characters';
+export const ERROR_MAX_LENGTH_300_CHARACTERS = 'Must be 300 characters or less';
 export const ERROR_MUST_BE_ARRAY_OF_IDS = 'Must be an array of ids';
 export const ERROR_MUST_BE_CORRECT_DATE_FORMAT =
 	'Must be a valid date and in the format yyyy-mm-dd';

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -104,7 +104,7 @@
 					{
 						"name": "pageNumber",
 						"in": "query",
-						"description": "The pagination page number, required if pageSize is given",
+						"description": "The pagination page number - required if pageSize is given",
 						"example": 1,
 						"schema": {
 							"type": "string"
@@ -113,8 +113,17 @@
 					{
 						"name": "pageSize",
 						"in": "query",
-						"description": "The pagination page size, required if pageNumber is given",
+						"description": "The pagination page size - required if pageNumber is given",
 						"example": 30,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "searchTerm",
+						"in": "query",
+						"description": "The search term - does a partial, case-insensitive match of appeal reference and postcode fields",
+						"example": "NR35 2ND",
 						"schema": {
 							"type": "string"
 						}

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -37,15 +37,32 @@ const appealRepository = (function () {
 		/**
 		 * @param {number} pageNumber
 		 * @param {number} pageSize
+		 * @param {string} searchTerm
 		 * @returns {Promise<[number, RepositoryGetAllResultItem[]]>}
 		 */
-		getAll(pageNumber, pageSize) {
+		getAll(pageNumber, pageSize, searchTerm) {
 			const where = {
 				appealStatus: {
 					some: {
 						valid: true
 					}
-				}
+				},
+				...(searchTerm !== 'undefined' && {
+					OR: [
+						{
+							reference: {
+								contains: searchTerm
+							}
+						},
+						{
+							address: {
+								postcode: {
+									contains: searchTerm
+								}
+							}
+						}
+					]
+				})
 			};
 
 			return databaseConnector.$transaction([


### PR DESCRIPTION
## Describe your changes

Updated the GET Appeals API to accept a `searchTerm` parameter, which searches the Appeal Reference and Postcode fields and does a case-insensitive, partial match. 

Added validation to check that the `searchTerm` param is between 2 and 8 characters.

Added unit tests

Updated swagger

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-243

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
