### PR TITLE
fix(api): seed script was missing a table clear

### DIFF
--- a/apps/api/src/database/seed/seed-clear.js
+++ b/apps/api/src/database/seed/seed-clear.js
@@ -24,6 +24,7 @@ export async function deleteAllRecords(databaseConnector) {
 	const deleteDocuments = databaseConnector.document.deleteMany();
 	const deleteDocumentsVersions = databaseConnector.documentVersion.deleteMany();
 	const deleteFolders = databaseConnector.folder.deleteMany();
+	const deleteRepresentationAttachment = databaseConnector.representationAttachment.deleteMany();
 	const deleteRepresentationContact = databaseConnector.representationContact.deleteMany();
 	const deleteRepresentation = databaseConnector.representation.deleteMany();
 	const deleteRepresentationAction = databaseConnector.representationAction.deleteMany();
@@ -58,6 +59,7 @@ export async function deleteAllRecords(databaseConnector) {
 	// Truncate calls on data tables
 	await deleteRepresentationAction;
 	await deleteRepresentationContact;
+	await deleteRepresentationAttachment;
 	await deleteRepresentation;
 
 	// delete document versions, documents, and THEN the folders.  Has to be in this order for integrity constraints


### PR DESCRIPTION
## Describe your changes

Seed script was missing a table clear for representation attachment, resulting in a key constraint error.
It ran fine with this change: [pipeline run](https://dev.azure.com/planninginspectorate/back-office/_build/results?buildId=55380&view=logs&j=4d131ff0-7253-50da-4307-161510b7aead&t=4d131ff0-7253-50da-4307-161510b7aead)

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
