### PR TITLE
fix(api): sort-by should handle empty string

### DIFF
--- a/apps/api/src/server/utils/query/__tests__/sort-by.test.js
+++ b/apps/api/src/server/utils/query/__tests__/sort-by.test.js
@@ -14,6 +14,11 @@ describe('sort-by', () => {
 				want: undefined
 			},
 			{
+				name: 'empty string',
+				queryStr: '',
+				want: undefined
+			},
+			{
 				name: 'no explicit +/-',
 				queryStr: 'myField',
 				want: { myField: 'asc' }

--- a/apps/api/src/server/utils/query/sort-by.js
+++ b/apps/api/src/server/utils/query/sort-by.js
@@ -7,7 +7,7 @@
 export function sortByFromQuery(queryStr) {
 	let orderBy;
 
-	if (typeof queryStr !== 'string') {
+	if (typeof queryStr !== 'string' || queryStr === '') {
 		return orderBy;
 	}
 


### PR DESCRIPTION
## Describe your changes

`sortByFromQuery` should handle an empty string, and not return an invalid sort by object.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
