### PR TITLE
fix(api): ensure subscription updates reset previously set fields

### DIFF
--- a/apps/api/src/server/applications/subscriptions/subscriptions.js
+++ b/apps/api/src/server/applications/subscriptions/subscriptions.js
@@ -106,6 +106,12 @@ export function subscriptionToTypes(subscription) {
  * @param {import('@prisma/client').Prisma.SubscriptionCreateInput} subscription
  */
 export function typesToSubscription(types, subscription) {
+	// ensure all fields are reset to false (not just left as they are) for updates
+	subscription.subscribedToAllUpdates = false;
+	subscription.subscribedToApplicationDecided = false;
+	subscription.subscribedToApplicationSubmitted = false;
+	subscription.subscribedToRegistrationOpen = false;
+
 	if (types.includes(SubscriptionTypes.AllUpdates)) {
 		subscription.subscribedToAllUpdates = true;
 	} else {


### PR DESCRIPTION
## Describe your changes

Subscription update API didn't work as expected as previous "subscribed to" values were left in the DB, but should've been cleared.

## Issue ticket number and link

[ASB-1511](https://pins-ds.atlassian.net/jira/software/c/projects/ASB/boards/166?modal=detail&selectedIssue=ASB-1511)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[ASB-1511]: https://pins-ds.atlassian.net/browse/ASB-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ