### PR TITLE
refactor(api): add subpath imports for common paths

### DIFF
--- a/appeals/api/jsconfig.json
+++ b/appeals/api/jsconfig.json
@@ -1,4 +1,10 @@
 {
 	"extends": "../../jsconfig.json",
-	"include": ["**/*.js", "../../packages/event-client/src/event-client.js"]
+	"include": ["**/*.js", "../../packages/event-client/src/event-client.js"],
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"#db-client": ["./src/server/utils/db-client"]
+		}
+	}
 }

--- a/apps/api/jsconfig.json
+++ b/apps/api/jsconfig.json
@@ -1,4 +1,15 @@
 {
 	"extends": "../../jsconfig.json",
-	"include": ["**/*.js", "../../packages/event-client/src/event-client.js"]
+	"include": ["**/*.js", "../../packages/event-client/src/event-client.js"],
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+			"#app-test": ["./src/server/app-test.js"],
+			"#config/*": ["./src/server/config/*"],
+			"#infrastructure/*": ["./src/server/infrastructure/*"],
+			"#middleware/*": ["./src/server/middleware/*"],
+			"#repositories/*": ["./src/server/repositories/*"],
+			"#utils/*": ["./src/server/utils/*"]
+		}
+	}
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -80,5 +80,13 @@
     "rimraf": "^3.0.2",
     "supertest": "6.2.3",
     "swagger-autogen": "^2.21.4"
+  },
+  "imports": {
+    "#app-test": "./src/server/app-test.js",
+    "#config/*": "./src/server/config/*",
+    "#infrastructure/*": "./src/server/infrastructure/*",
+    "#middleware/*": "./src/server/middleware/*",
+    "#repositories/*": "./src/server/repositories/*",
+    "#utils/*": "./src/server/utils/*"
   }
 }

--- a/apps/api/src/server/applications/subscriptions/__tests__/subscriptions.test.js
+++ b/apps/api/src/server/applications/subscriptions/__tests__/subscriptions.test.js
@@ -1,8 +1,8 @@
 import supertest from 'supertest';
-import { app } from '../../../app-test';
-import { databaseConnector } from '../../../utils/database-connector.js';
+import { app } from '#app-test';
+import { databaseConnector } from '#utils/database-connector.js';
 import { prepareInput } from '../subscriptions.service.js';
-const { eventClient } = await import('../../../infrastructure/event-client.js');
+import { eventClient } from '#infrastructure/event-client.js';
 
 /**
  * @typedef {import('../../../../message-schemas/events/nsip-subscription.d.js').NSIPSubscription} NSIPSubscription

--- a/apps/api/src/server/applications/subscriptions/subscriptions.controller.js
+++ b/apps/api/src/server/applications/subscriptions/subscriptions.controller.js
@@ -1,9 +1,9 @@
-import * as subscriptionRepository from '../../repositories/subscription.respository.js';
-import { eventClient } from '../../infrastructure/event-client.js';
+import * as subscriptionRepository from '#repositories/subscription.respository.js';
+import { eventClient } from '#infrastructure/event-client.js';
 import { EventType } from '@pins/event-client';
-import { NSIP_SUBSCRIPTION } from '../../infrastructure/topics.js';
+import { NSIP_SUBSCRIPTION } from '#infrastructure/topics.js';
 import { buildSubscriptionPayloads, subscriptionToResponse } from './subscriptions.js';
-import logger from '../../utils/logger.js';
+import logger from '#utils/logger.js';
 import { createOrUpdateSubscription } from './subscriptions.service.js';
 
 /**

--- a/apps/api/src/server/applications/subscriptions/subscriptions.routes.js
+++ b/apps/api/src/server/applications/subscriptions/subscriptions.routes.js
@@ -1,5 +1,5 @@
 import { Router as createRouter } from 'express';
-import { asyncHandler } from '../../middleware/async-handler.js';
+import { asyncHandler } from '#middleware/async-handler.js';
 import {
 	getSubscription,
 	putSubscription,

--- a/apps/api/src/server/applications/subscriptions/subscriptions.service.js
+++ b/apps/api/src/server/applications/subscriptions/subscriptions.service.js
@@ -1,6 +1,6 @@
-import { eventClient } from '../../infrastructure/event-client.js';
-import { NSIP_SUBSCRIPTION } from '../../infrastructure/topics.js';
-import * as subscriptionRepository from '../../repositories/subscription.respository.js';
+import { eventClient } from '#infrastructure/event-client.js';
+import { NSIP_SUBSCRIPTION } from '#infrastructure/topics.js';
+import * as subscriptionRepository from '#repositories/subscription.respository.js';
 import {
 	buildSubscriptionPayloads,
 	subscriptionTypeChanges,

--- a/apps/api/src/server/applications/subscriptions/subscriptions.validators.js
+++ b/apps/api/src/server/applications/subscriptions/subscriptions.validators.js
@@ -1,6 +1,6 @@
 import { composeMiddleware } from '@pins/express';
 import { body, param, query } from 'express-validator';
-import { validationErrorHandler } from '../../middleware/error-handler.js';
+import { validationErrorHandler } from '#middleware/error-handler.js';
 
 export const validateGetSubscription = composeMiddleware(
 	query('caseReference').notEmpty().withMessage(`caseReference is required`),

--- a/apps/api/src/server/repositories/subscription.respository.js
+++ b/apps/api/src/server/repositories/subscription.respository.js
@@ -1,4 +1,4 @@
-import { databaseConnector } from '../utils/database-connector.js';
+import { databaseConnector } from '#utils/database-connector.js';
 
 /**
  * Get an existing subscription entry


### PR DESCRIPTION
## Describe your changes

Using [subpath-imports](https://nodejs.org/docs/latest-v18.x/api/packages.html#subpath-imports) for common paths makes the imports clearer, regardless of folder depth. 

An example refactoring has been applied to the subscriptions endpoint.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
