### PR TITLE
fix(appeals/api): add additional lpa questionnaire fields

### DIFF
--- a/appeals/api/src/database/migrations/20230707131036_update_lpa_questionnaire/migration.sql
+++ b/appeals/api/src/database/migrations/20230707131036_update_lpa_questionnaire/migration.sql
@@ -1,0 +1,37 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[LPAQuestionnaire] ADD [isAffectingNeighbouringSites] BIT;
+
+-- CreateTable
+CREATE TABLE [dbo].[NeighbouringSiteContact] (
+    [id] INT NOT NULL IDENTITY(1,1),
+    [addressId] INT,
+    [lpaQuestionnaireId] INT,
+    [firstName] NVARCHAR(1000) NOT NULL,
+    [lastName] NVARCHAR(1000),
+    [telephone] NVARCHAR(1000) NOT NULL,
+    [email] NVARCHAR(1000) NOT NULL,
+    CONSTRAINT [NeighbouringSiteContact_pkey] PRIMARY KEY CLUSTERED ([id])
+);
+
+-- AddForeignKey
+ALTER TABLE [dbo].[NeighbouringSiteContact] ADD CONSTRAINT [NeighbouringSiteContact_lpaQuestionnaireId_fkey] FOREIGN KEY ([lpaQuestionnaireId]) REFERENCES [dbo].[LPAQuestionnaire]([id]) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[NeighbouringSiteContact] ADD CONSTRAINT [NeighbouringSiteContact_addressId_fkey] FOREIGN KEY ([addressId]) REFERENCES [dbo].[Address]([id]) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -18,6 +18,7 @@ export {
 	DocumentVersion,
 	KnowledgeOfOtherLandowners,
 	LPAQuestionnaire,
+	NeighbouringSiteContact,
 	ReviewQuestionnaire,
 	LPAQuestionnaireIncompleteReason,
 	LPAQuestionnaireValidationOutcome,
@@ -251,6 +252,7 @@ export interface LPAQuestionnaire extends schema.LPAQuestionnaire {
 		| null;
 	lpaQuestionnaireValidationOutcome: LPAQuestionnaireValidationOutcome | null;
 	meetsOrExceedsThresholdOrCriteriaInColumn2: boolean | null;
+	neighbouringSiteContact: schema.NeighbouringSiteContact[] | null;
 	procedureType: ProcedureType | null;
 	scheduleType: ScheduleType | null;
 	sensitiveAreaDetails: string | null;

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -159,16 +159,17 @@ model ServiceCustomer {
 /// Address model
 /// Contains information on addresses
 model Address {
-  id                    Int                     @id @default(autoincrement())
-  addressLine1          String?
-  addressLine2          String?
-  postcode              String?
-  county                String?
-  town                  String?
-  country               String?
-  Appeal                Appeal[]
-  ServiceCustomer       ServiceCustomer[]
-  RepresentationContact RepresentationContact[]
+  id                      Int                       @id @default(autoincrement())
+  addressLine1            String?
+  addressLine2            String?
+  postcode                String?
+  county                  String?
+  town                    String?
+  country                 String?
+  Appeal                  Appeal[]
+  ServiceCustomer         ServiceCustomer[]
+  RepresentationContact   RepresentationContact[]
+  NeighbouringSiteContact NeighbouringSiteContact[]
 }
 
 /// ValidationDecision model
@@ -229,6 +230,7 @@ model LPAQuestionnaire {
   includesScreeningOption                            Boolean?
   inquiryDays                                        Int?
   inspectorAccessDetails                             String?
+  isAffectingNeighbouringSites                       Boolean?
   isCommunityInfrastructureLevyFormallyAdopted       Boolean?
   isDevelopmentInOrNearDesignatedSites               Boolean?
   isGypsyOrTravellerSite                             Boolean?
@@ -253,6 +255,7 @@ model LPAQuestionnaire {
   listedBuildingDetails                              ListedBuildingDetails[]
   lpaQuestionnaireValidationOutcome                  LPAQuestionnaireValidationOutcome?                   @relation(fields: [lpaQuestionnaireValidationOutcomeId], references: [id])
   lpaQuestionnaireIncompleteReasonOnLPAQuestionnaire LPAQuestionnaireIncompleteReasonOnLPAQuestionnaire[]
+  neighbouringSiteContact                            NeighbouringSiteContact[]
 }
 
 /// ReviewQuestionnaire model
@@ -587,4 +590,16 @@ model LPAQuestionnaireIncompleteReasonOnLPAQuestionnaire {
   lpaQuestionnaireId                 Int
 
   @@id([lpaQuestionnaireIncompleteReasonId, lpaQuestionnaireId])
+}
+
+model NeighbouringSiteContact {
+  id                 Int               @id @default(autoincrement())
+  addressId          Int?
+  lpaQuestionnaireId Int?
+  firstName          String
+  lastName           String?
+  telephone          String
+  email              String
+  lpaQuestionnaire   LPAQuestionnaire? @relation(fields: [lpaQuestionnaireId], references: [id])
+  address            Address?          @relation(fields: [addressId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 }

--- a/appeals/api/src/database/seed/data-samples.js
+++ b/appeals/api/src/database/seed/data-samples.js
@@ -9,68 +9,110 @@ import {
 import config from '../../../src/server/config/config.js';
 
 /**
- * @typedef {import('appeals/api/src/database/schema').Appellant} Appellant
- * @typedef {import('appeals/api/src/database/schema').LPAQuestionnaire} LPAQuestionnaire
- * @typedef {import('appeals/api/src/database/schema').AppellantCase} AppellantCase
+ * @typedef {import('@pins/appeals.api').Schema.Appellant} Appellant
+ * @typedef {import('@pins/appeals.api').Schema.LPAQuestionnaire} LPAQuestionnaire
+ * @typedef {import('@pins/appeals.api').Schema.AppellantCase} AppellantCase
+ * @typedef {import('@pins/appeals.api').Schema.NeighbouringSiteContact} NeighbouringSiteContact
+ * @typedef {import('@pins/appeals.api').Appeals.AppealSite} AppealSite
  */
+
+export const personList = [
+	{
+		firstName: 'Lee',
+		lastName: 'Thornton',
+		company: 'Lee Thornton Ltd',
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Haley',
+		lastName: 'Eland',
+		company: null,
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Roger',
+		lastName: 'Simmons',
+		company: 'Roger Simmons Ltd',
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Sophie',
+		lastName: 'Skinner',
+		company: null,
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Ryan',
+		lastName: 'Marshall',
+		company: 'Ryan Marshall Ltd',
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Fiona',
+		lastName: 'Burgess',
+		company: null,
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Kevin',
+		lastName: 'Fowler',
+		company: 'Kevin Fowler Ltd',
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Bob',
+		lastName: 'Ross',
+		company: null,
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Eva',
+		lastName: 'Sharma',
+		company: 'Eva Sharma Ltd',
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	},
+	{
+		firstName: 'Elaine',
+		lastName: 'Madsen',
+		company: null,
+		email: config.govNotify.testMailbox,
+		telephone: '01234567891'
+	}
+];
 
 /**
  * An array of appellants, each containing a name and email address.
  *
  * @type {Pick<Appellant, 'name' | 'company' | 'email'>[]}
  */
-export const appellantsList = [
-	{
-		name: 'Lee Thornton',
-		company: 'Lee Thornton Ltd',
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Haley Eland',
-		company: null,
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Roger Simmons',
-		company: 'Roger Simmons Ltd',
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Sophie Skinner',
-		company: null,
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Ryan Marshall',
-		company: 'Ryan Marshall Ltd',
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Fiona Burgess',
-		company: null,
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Kevin Fowler',
-		company: 'Kevin Fowler Ltd',
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Bob Ross',
-		company: null,
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Eva Sharma',
-		company: 'Eva Sharma Ltd',
-		email: config.govNotify.testMailbox
-	},
-	{
-		name: 'Elaine Madsen',
-		company: null,
-		email: config.govNotify.testMailbox
-	}
-];
+export const appellantsList = personList.map(({ firstName, lastName, company, email }) => ({
+	name: `${firstName} ${lastName}`,
+	company,
+	email
+}));
+
+/**
+ * An array of neighbouring site contacts.
+ *
+ * @type {Pick<NeighbouringSiteContact, 'firstName' | 'lastName' | 'email' | 'telephone'>[]}
+ */
+export const neighbouringSiteContactsList = personList.map(
+	({ firstName, lastName, email, telephone }) => ({
+		firstName,
+		lastName,
+		email,
+		telephone
+	})
+);
 
 export const localPlanningDepartmentList = [
 	'Maidstone Borough Council',
@@ -178,6 +220,7 @@ export const addressesList = [
  *	'includesScreeningOption' |
  *	'inquiryDays' |
  *	'inspectorAccessDetails' |
+ *	'isAffectingNeighbouringSites' |
  *	'isCommunityInfrastructureLevyFormallyAdopted' |
  *	'isEnvironmentalStatementRequired' |
  *	'isGypsyOrTravellerSite' |
@@ -221,6 +264,7 @@ export const lpaQuestionnaireList = {
 		includesScreeningOption: true,
 		inquiryDays: 2,
 		inspectorAccessDetails: 'The entrance is at the back of the property',
+		isAffectingNeighbouringSites: true,
 		isCommunityInfrastructureLevyFormallyAdopted: true,
 		isEnvironmentalStatementRequired: true,
 		isGypsyOrTravellerSite: true,
@@ -262,6 +306,7 @@ export const lpaQuestionnaireList = {
 		includesScreeningOption: true,
 		inquiryDays: 2,
 		inspectorAccessDetails: 'The entrance is at the back of the property',
+		isAffectingNeighbouringSites: true,
 		isCommunityInfrastructureLevyFormallyAdopted: true,
 		isEnvironmentalStatementRequired: true,
 		isGypsyOrTravellerSite: true,

--- a/appeals/api/src/database/seed/seed-clear.js
+++ b/appeals/api/src/database/seed/seed-clear.js
@@ -32,6 +32,7 @@ export async function deleteAllRecords(databaseConnector) {
 		databaseConnector.appellantCaseInvalidReasonOnAppellantCase.deleteMany();
 	const deleteLPAQuestionnaireIncompleteReasonOnLPAQuestionnaire =
 		databaseConnector.lPAQuestionnaireIncompleteReasonOnLPAQuestionnaire.deleteMany();
+	const deleteNeighbouringSiteContacts = databaseConnector.neighbouringSiteContact.deleteMany();
 
 	// and reference data tables
 	const deleteAppealTypes = databaseConnector.appealType.deleteMany();
@@ -69,6 +70,7 @@ export async function deleteAllRecords(databaseConnector) {
 		deleteDesignatedSitesOnLPAQuestionnaires,
 		deleteLPANotificationMethodsOnLPAQuestionnaires,
 		deleteLPAQuestionnaireIncompleteReasonOnLPAQuestionnaire,
+		deleteNeighbouringSiteContacts,
 		deleteLPAQuestionnaire,
 		deleteReviewQuestionnaire,
 		deleteSiteVisit,

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -1,4 +1,4 @@
-/** @typedef {import('@pins/appeals.api').Schema} Schema */
+import { Schema } from 'index';
 
 declare global {
 	namespace Express {
@@ -135,6 +135,7 @@ interface SingleLPAQuestionnaireResponse {
 	includesScreeningOption?: boolean | null;
 	inquiryDays?: number | null;
 	inspectorAccessDetails?: string | null;
+	isAffectingNeighbouringSites?: boolean | null;
 	isCommunityInfrastructureLevyFormallyAdopted?: boolean | null;
 	isEnvironmentalStatementRequired?: boolean | null;
 	isGypsyOrTravellerSite?: boolean | null;
@@ -148,6 +149,7 @@ interface SingleLPAQuestionnaireResponse {
 	lpaNotificationMethods?: LPANotificationMethodDetails[] | null;
 	lpaQuestionnaireId?: number;
 	meetsOrExceedsThresholdOrCriteriaInColumn2?: boolean | null;
+	neighbouringSiteContacts: NeighbouringSiteContactsResponse[] | null;
 	otherAppeals: LinkedAppeal[];
 	procedureType?: string;
 	scheduleType?: string;
@@ -155,6 +157,14 @@ interface SingleLPAQuestionnaireResponse {
 	siteWithinGreenBelt?: boolean | null;
 	statutoryConsulteesDetails?: string | null;
 	validationOutcome: string | null;
+}
+
+interface NeighbouringSiteContactsResponse {
+	address: AppealSite;
+	email: Schema.NeighbouringSiteContact.email;
+	firstName: Schema.NeighbouringSiteContact.firstName;
+	lastName: Schema.NeighbouringSiteContact.lastName;
+	telephone: Schema.NeighbouringSiteContact.telephone;
 }
 
 interface SingleAppealDetailsResponse {

--- a/appeals/api/src/server/endpoints/appeals/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/lpa-questionnaires.test.js
@@ -21,8 +21,8 @@ import {
 	baseExpectedLPAQuestionnaireResponse,
 	fullPlanningAppeal,
 	householdAppeal,
-	householdappealWithCompleteLPAQuestionnaire,
-	householdappealWithIncompleteLPAQuestionnaire,
+	householdAppealWithCompleteLPAQuestionnaire,
+	householdAppealWithIncompleteLPAQuestionnaire,
 	lpaQuestionnaireIncompleteReasons,
 	lpaQuestionnaireValidationOutcomes,
 	otherAppeals
@@ -56,12 +56,12 @@ describe('lpa questionnaires routes', () => {
 			test('gets a single lpa questionnaire with an outcome of Complete', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(
-					householdappealWithCompleteLPAQuestionnaire
+					householdAppealWithCompleteLPAQuestionnaire
 				);
 				// @ts-ignore
 				databaseConnector.appeal.findMany.mockResolvedValue(otherAppeals);
 
-				const { lpaQuestionnaire } = householdappealWithCompleteLPAQuestionnaire;
+				const { lpaQuestionnaire } = householdAppealWithCompleteLPAQuestionnaire;
 				const response = await request.get(
 					`/appeals/${householdAppeal.id}/lpa-questionnaires/${lpaQuestionnaire.id}`
 				);
@@ -76,12 +76,12 @@ describe('lpa questionnaires routes', () => {
 			test('gets a single lpa questionnaire with an outcome of Incomplete', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(
-					householdappealWithIncompleteLPAQuestionnaire
+					householdAppealWithIncompleteLPAQuestionnaire
 				);
 				// @ts-ignore
 				databaseConnector.appeal.findMany.mockResolvedValue(otherAppeals);
 
-				const { lpaQuestionnaire } = householdappealWithIncompleteLPAQuestionnaire;
+				const { lpaQuestionnaire } = householdAppealWithIncompleteLPAQuestionnaire;
 				const response = await request.get(
 					`/appeals/${householdAppeal.id}/lpa-questionnaires/${lpaQuestionnaire.id}`
 				);

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -172,6 +172,7 @@ const appealFormatter = {
 			}),
 			inquiryDays: lpaQuestionnaire?.inquiryDays,
 			inspectorAccessDetails: lpaQuestionnaire?.inspectorAccessDetails,
+			isAffectingNeighbouringSites: lpaQuestionnaire?.isAffectingNeighbouringSites,
 			isCommunityInfrastructureLevyFormallyAdopted:
 				lpaQuestionnaire?.isCommunityInfrastructureLevyFormallyAdopted,
 			isEnvironmentalStatementRequired: lpaQuestionnaire?.isEnvironmentalStatementRequired,
@@ -192,6 +193,15 @@ const appealFormatter = {
 			lpaQuestionnaireId: lpaQuestionnaire?.id,
 			meetsOrExceedsThresholdOrCriteriaInColumn2:
 				lpaQuestionnaire?.meetsOrExceedsThresholdOrCriteriaInColumn2,
+			neighbouringSiteContacts: lpaQuestionnaire?.neighbouringSiteContact?.length
+				? lpaQuestionnaire.neighbouringSiteContact.map((contact) => ({
+						address: formatAddress(contact.address),
+						email: contact.email,
+						firstName: contact.firstName,
+						lastName: contact.lastName,
+						telephone: contact.telephone
+				  }))
+				: null,
 			otherAppeals: formatLinkedAppeals(appeal.otherAppeals, appeal.id),
 			...(isOutcomeIncomplete(lpaQuestionnaire?.lpaQuestionnaireValidationOutcome?.name || '') && {
 				...(isOutcomeIncomplete(

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -2187,6 +2187,10 @@
 						"type": "string",
 						"example": "The entrance is at the back of the property"
 					},
+					"isAffectingNeighbouringSites": {
+						"type": "boolean",
+						"example": true
+					},
 					"isCommunityInfrastructureLevyFormallyAdopted": {
 						"type": "boolean",
 						"example": true
@@ -2258,6 +2262,47 @@
 					"meetsOrExceedsThresholdOrCriteriaInColumn2": {
 						"type": "boolean",
 						"example": true
+					},
+					"neighbouringSiteContacts": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"address": {
+									"type": "object",
+									"properties": {
+										"addressLine1": {
+											"type": "string",
+											"example": "44 Rivervale"
+										},
+										"town": {
+											"type": "string",
+											"example": "Bridport"
+										},
+										"postCode": {
+											"type": "string",
+											"example": "DT6 5RN"
+										}
+									}
+								},
+								"email": {
+									"type": "string",
+									"example": "eva.sharma@example.com"
+								},
+								"firstName": {
+									"type": "string",
+									"example": "Eva"
+								},
+								"lastName": {
+									"type": "string",
+									"example": "Sharma"
+								},
+								"telephone": {
+									"type": "string",
+									"example": "07000123456"
+								}
+							}
+						}
 					},
 					"otherAppeals": {
 						"type": "array",

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -131,6 +131,11 @@ const appealRepository = (function () {
 								}
 							},
 							lpaQuestionnaireValidationOutcome: true,
+							neighbouringSiteContact: {
+								include: {
+									address: true
+								}
+							},
 							procedureType: true,
 							scheduleType: true
 						}
@@ -251,7 +256,7 @@ const appealRepository = (function () {
 		 *  relationOne: string,
 		 *  relationTwo: string,
 		 * }} param0
-		 * @returns {object[]}
+		 * @returns {LookupTables[]}
 		 */
 		updateManyToManyRelationTable({ id, data, databaseTable, relationOne, relationTwo }) {
 			return [
@@ -383,7 +388,7 @@ const appealRepository = (function () {
 		/**
 		 * @param {number} appealId
 		 * @param {string} status
-		 * @returns {PrismaPromise<object>}
+		 * @returns {Promise<object>}
 		 */
 		updateAppealStatus(appealId, status) {
 			return databaseConnector.$transaction([

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -427,6 +427,7 @@ const document = {
 			includesScreeningOption: true,
 			inquiryDays: 2,
 			inspectorAccessDetails: 'The entrance is at the back of the property',
+			isAffectingNeighbouringSites: true,
 			isCommunityInfrastructureLevyFormallyAdopted: true,
 			isEnvironmentalStatementRequired: true,
 			isGypsyOrTravellerSite: true,
@@ -449,6 +450,19 @@ const document = {
 			],
 			lpaQuestionnaireId: 1,
 			meetsOrExceedsThresholdOrCriteriaInColumn2: true,
+			neighbouringSiteContacts: [
+				{
+					address: {
+						addressLine1: '44 Rivervale',
+						town: 'Bridport',
+						postCode: 'DT6 5RN'
+					},
+					email: 'eva.sharma@example.com',
+					firstName: 'Eva',
+					lastName: 'Sharma',
+					telephone: '01234567891'
+				}
+			],
 			otherAppeals: [
 				{
 					appealId: 1,

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -8,6 +8,7 @@ import {
 	VALIDATION_OUTCOME_INVALID,
 	VALIDATION_OUTCOME_VALID
 } from '../endpoints/constants.js';
+import formatAddress from '../utils/address-block-formtter.js';
 
 const householdAppeal = {
 	id: 1,
@@ -113,6 +114,7 @@ const householdAppeal = {
 		hasTreePreservationOrder: null,
 		inCAOrrelatesToCA: null,
 		includesScreeningOption: null,
+		isAffectingNeighbouringSites: true,
 		isCommunityInfrastructureLevyFormallyAdopted: null,
 		isDevelopmentInOrNearDesignatedSites: null,
 		isEnvironmentalStatementRequired: null,
@@ -142,6 +144,23 @@ const householdAppeal = {
 			}
 		],
 		meetsOrExceedsThresholdOrCriteriaInColumn2: null,
+		neighbouringSiteContact: [
+			{
+				firstName: 'Eva',
+				lastName: 'Sharma',
+				telephone: '01234567891',
+				email: 'eva.sharma@example.com',
+				address: {
+					id: 1,
+					addressLine1: '44 Rivervale',
+					addressLine2: null,
+					town: 'Bridport',
+					postcode: 'DT6 5RN',
+					county: null,
+					country: null
+				}
+			}
+		],
 		procedureType: {
 			name: 'Written'
 		},
@@ -290,7 +309,7 @@ const lpaQuestionnaireIncompleteReasons = [
 	}
 ];
 
-const householdappealWithCompleteLPAQuestionnaire = {
+const householdAppealWithCompleteLPAQuestionnaire = {
 	...householdAppeal,
 	lpaQuestionnaire: {
 		...householdAppeal.lpaQuestionnaire,
@@ -298,7 +317,7 @@ const householdappealWithCompleteLPAQuestionnaire = {
 	}
 };
 
-const householdappealWithIncompleteLPAQuestionnaire = {
+const householdAppealWithIncompleteLPAQuestionnaire = {
 	...householdAppeal,
 	lpaQuestionnaire: {
 		...householdAppeal.lpaQuestionnaire,
@@ -374,6 +393,7 @@ const baseExpectedLPAQuestionnaireResponse = (lpaQuestionnaire) => ({
 	hasTreePreservationOrder: lpaQuestionnaire.hasTreePreservationOrder,
 	inCAOrrelatesToCA: lpaQuestionnaire.inCAOrrelatesToCA,
 	includesScreeningOption: lpaQuestionnaire.includesScreeningOption,
+	isAffectingNeighbouringSites: lpaQuestionnaire.isAffectingNeighbouringSites,
 	isCommunityInfrastructureLevyFormallyAdopted:
 		lpaQuestionnaire.isCommunityInfrastructureLevyFormallyAdopted,
 	isEnvironmentalStatementRequired: lpaQuestionnaire.isEnvironmentalStatementRequired,
@@ -396,6 +416,12 @@ const baseExpectedLPAQuestionnaireResponse = (lpaQuestionnaire) => ({
 	lpaQuestionnaireId: lpaQuestionnaire.id,
 	meetsOrExceedsThresholdOrCriteriaInColumn2:
 		lpaQuestionnaire.meetsOrExceedsThresholdOrCriteriaInColumn2,
+	neighbouringSiteContacts: [
+		{
+			...lpaQuestionnaire.neighbouringSiteContact[0],
+			address: formatAddress(lpaQuestionnaire.neighbouringSiteContact[0].address)
+		}
+	],
 	otherAppeals: [
 		{
 			appealId: otherAppeals[1].id,
@@ -416,8 +442,8 @@ export {
 	fullPlanningAppeal,
 	householdAppeal,
 	householdAppealTwo,
-	householdappealWithCompleteLPAQuestionnaire,
-	householdappealWithIncompleteLPAQuestionnaire,
+	householdAppealWithCompleteLPAQuestionnaire,
+	householdAppealWithIncompleteLPAQuestionnaire,
 	linkedAppeals,
 	lpaQuestionnaireIncompleteReasons,
 	lpaQuestionnaireValidationOutcomes,


### PR DESCRIPTION
## Describe your changes

Add additional LPA Questionnaire fields related to neighbouring sites.

- `isAffectingNeighbouringSites`
- `neighbouringSiteContacts`

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-263

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
