### PR TITLE
fix(appeals/api): missing migration for folder constraints

### DIFF
--- a/appeals/api/src/database/migrations/20230707180928_enforce_folder_appeal_constraint/migration.sql
+++ b/appeals/api/src/database/migrations/20230707180928_enforce_folder_appeal_constraint/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - Made the column `caseId` on table `Folder` required. This step will fail if there are existing NULL values in that column.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropForeignKey
+ALTER TABLE [dbo].[Folder] DROP CONSTRAINT [Folder_caseId_path_key]
+ALTER TABLE [dbo].[Folder] DROP CONSTRAINT [Folder_caseId_fkey];
+
+DELETE FROM [dbo].[Folder];
+
+-- AlterTable
+ALTER TABLE [dbo].[Folder] ALTER COLUMN [caseId] INT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[Folder] ADD CONSTRAINT [Folder_caseId_fkey] FOREIGN KEY ([caseId]) REFERENCES [dbo].[Appeal]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
+ALTER TABLE [dbo].[Folder] ADD CONSTRAINT [Folder_caseId_path_key] UNIQUE NONCLUSTERED ([caseId], [path]);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH


### PR DESCRIPTION
Additional migration to add constraints to folder and making Appeal.reference unique.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
