### PR TITLE
fix(appeals/web): display of lpaq review if null BOAT-271

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -174,9 +174,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                         <th scope=\\"row\\" class=\\"govuk-table__header\\">LPA Questionnaire</th>
                                         <td class=\\"govuk-table__cell\\">Not received</td>
                                         <td class=\\"govuk-table__cell\\">23 May 2024</td>
-                                        <td class=\\"govuk-table__cell\\"><a href=\\"/appeals-service/appeal-details/1/lpa-questionnaire-review/undefined\\"
-                                            class=\\"govuk-link\\">Review</a>
-                                        </td>
+                                        <td class=\\"govuk-table__cell\\"></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -360,9 +358,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                         <th scope=\\"row\\" class=\\"govuk-table__header\\">LPA Questionnaire</th>
                                         <td class=\\"govuk-table__cell\\">Not received</td>
                                         <td class=\\"govuk-table__cell\\">23 May 2024</td>
-                                        <td class=\\"govuk-table__cell\\"><a href=\\"/appeals-service/appeal-details/3/lpa-questionnaire-review/undefined\\"
-                                            class=\\"govuk-link\\">Review</a>
-                                        </td>
+                                        <td class=\\"govuk-table__cell\\"></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -548,9 +544,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                         <th scope=\\"row\\" class=\\"govuk-table__header\\">LPA Questionnaire</th>
                                         <td class=\\"govuk-table__cell\\">Not received</td>
                                         <td class=\\"govuk-table__cell\\">23 May 2024</td>
-                                        <td class=\\"govuk-table__cell\\"><a href=\\"/appeals-service/appeal-details/2/lpa-questionnaire-review/undefined\\"
-                                            class=\\"govuk-link\\">Review</a>
-                                        </td>
+                                        <td class=\\"govuk-table__cell\\"></td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -725,9 +719,7 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                                         <th scope=\\"row\\" class=\\"govuk-table__header\\">LPA Questionnaire</th>
                                         <td class=\\"govuk-table__cell\\">Not received</td>
                                         <td class=\\"govuk-table__cell\\">23 May 2024</td>
-                                        <td class=\\"govuk-table__cell\\"><a href=\\"/appeals-service/appeal-details/1/lpa-questionnaire-review/undefined\\"
-                                            class=\\"govuk-link\\">Review</a>
-                                        </td>
+                                        <td class=\\"govuk-table__cell\\"></td>
                                     </tr>
                                 </tbody>
                             </table>

--- a/appeals/web/src/server/views/appeals/appeal/appeal-details.njk
+++ b/appeals/web/src/server/views/appeals/appeal/appeal-details.njk
@@ -355,7 +355,7 @@
 									text: appeal.documentationSummary.lpaQuestionnaire.dueDate | displayDate({ condensed: true }) if appeal.documentationSummary.lpaQuestionnaire.dueDate else ''
 								},
 								{
-									html: '<a href="/appeals-service/appeal-details/'+  appeal.id + '/lpa-questionnaire-review/' + appeal.lpaQuestionnaireId + '" class="govuk-link">Review</a>'
+									html: '<a href="/appeals-service/appeal-details/'+  appeal.id + '/lpa-questionnaire-review/' + appeal.lpaQuestionnaireId + '" class="govuk-link">Review</a>' if appeal.lpaQuestionnaireId
 								}
 							]
 						]


### PR DESCRIPTION
Fix display of LPAQ review link, if review is null

BOAT-271

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
