### PR TITLE
feat(appeals/api): add api endpoints for creating/updating/getting an appeals site visit

### DIFF
--- a/appeals/api/jsconfig.json
+++ b/appeals/api/jsconfig.json
@@ -10,7 +10,8 @@
 			"#infrastructure/*": ["./src/server/infrastructure/*"],
 			"#middleware/*": ["./src/server/middleware/*"],
 			"#endpoints/*": ["./src/server/endpoints/*"],
-			"#tests/*": ["./src/server/tests/*"]
+			"#tests/*": ["./src/server/tests/*"],
+			"#common/*": ["./src/server/common/*"]
 		}
 	}
 }

--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -48,7 +48,7 @@
     "dotenv": "16.0.3",
     "express": "4.18.1",
     "express-pino-logger": "^7.0.0",
-    "express-validator": "6.14.2",
+    "express-validator": "^7.0.1",
     "got": "^12.5.2",
     "helmet": "5.1.0",
     "joi": "^17.7.0",
@@ -89,6 +89,7 @@
     "#infrastructure/*": "./src/server/infrastructure/*",
     "#middleware/*": "./src/server/middleware/*",
     "#endpoints/*": "./src/server/endpoints/*",
-    "#tests/*": "./src/server/tests/*"
+    "#tests/*": "./src/server/tests/*",
+    "#common/*": "./src/server/common/*"
   }
 }

--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -90,6 +90,9 @@ const mockLPAQuestionnaireIncompleteReasonOnLPAQuestionnaireCreateMany = jest
 const mockLPAQuestionnaireIncompleteReasonOnLPAQuestionnaireUpdate = jest
 	.fn()
 	.mockResolvedValue({});
+const mockSiteVisitCreate = jest.fn().mockResolvedValue({});
+const mockSiteVisitUpdate = jest.fn().mockResolvedValue({});
+const mockSiteVisitTypeFindUnique = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -335,6 +338,19 @@ class MockPrismaClient {
 			deleteMany: mockLPAQuestionnaireIncompleteReasonOnLPAQuestionnaireDeleteMany,
 			createMany: mockLPAQuestionnaireIncompleteReasonOnLPAQuestionnaireCreateMany,
 			update: mockLPAQuestionnaireIncompleteReasonOnLPAQuestionnaireUpdate
+		};
+	}
+
+	get siteVisit() {
+		return {
+			create: mockSiteVisitCreate,
+			update: mockSiteVisitUpdate
+		};
+	}
+
+	get siteVisitType() {
+		return {
+			findUnique: mockSiteVisitTypeFindUnique
 		};
 	}
 

--- a/appeals/api/src/database/migrations/20230713091434_update_site_visit/migration.sql
+++ b/appeals/api/src/database/migrations/20230713091434_update_site_visit/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `visitSlot` on the `SiteVisit` table. All the data in the column will be lost.
+  - You are about to drop the column `visitType` on the `SiteVisit` table. All the data in the column will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[SiteVisit] ALTER COLUMN [visitDate] DATETIME2 NULL;
+ALTER TABLE [dbo].[SiteVisit] DROP COLUMN [visitSlot],
+[visitType];
+ALTER TABLE [dbo].[SiteVisit] ADD [siteVisitTypeId] INT,
+[visitEndTime] NVARCHAR(1000),
+[visitStartTime] NVARCHAR(1000);
+
+-- CreateTable
+CREATE TABLE [dbo].[SiteVisitType] (
+    [id] INT NOT NULL IDENTITY(1,1),
+    [name] NVARCHAR(1000) NOT NULL,
+    CONSTRAINT [SiteVisitType_pkey] PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT [SiteVisitType_name_key] UNIQUE NONCLUSTERED ([name])
+);
+
+-- AddForeignKey
+ALTER TABLE [dbo].[SiteVisit] ADD CONSTRAINT [SiteVisit_siteVisitTypeId_fkey] FOREIGN KEY ([siteVisitTypeId]) REFERENCES [dbo].[SiteVisitType]([id]) ON DELETE SET NULL ON UPDATE CASCADE;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -23,7 +23,8 @@ export {
 	LPAQuestionnaireIncompleteReason,
 	LPAQuestionnaireValidationOutcome,
 	AppellantCaseValidationOutcome,
-	PlanningObligationStatus
+	PlanningObligationStatus,
+	SiteVisitType
 } from '../../src/server/utils/db-client';
 
 export interface ServiceCustomer extends schema.ServiceCustomer {
@@ -73,8 +74,8 @@ export interface FolderTemplate {
 }
 
 export interface AppealStatus extends schema.AppealStatus {
-	status: AppealStatusType;
-	subStateMachineName: AppealStatusMachineType | null;
+	status: string;
+	subStateMachineName: string | null;
 }
 
 export interface AppealType extends schema.AppealType {
@@ -176,10 +177,8 @@ export type ValidationDecision =
 	| IncompleteValidationDecision;
 
 export interface SiteVisit extends schema.SiteVisit {
-	visitType: SiteVisitType;
+	siteVisitType?: SiteVisitType;
 }
-
-export type SiteVisitType = 'accompanied' | 'unaccompanied' | 'access required';
 
 export interface InspectorDecision extends schema.InspectorDecision {
 	outcome: InspectorDecisionOutcomeType;

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -294,12 +294,14 @@ model ReviewQuestionnaire {
 /// SiteVisit model
 /// Contains information regarding a scheduled site visit for an appeal
 model SiteVisit {
-  id        Int      @id @default(autoincrement())
-  appealId  Int      @unique
-  visitDate DateTime
-  visitSlot String
-  visitType String?
-  appeal    Appeal   @relation(fields: [appealId], references: [id])
+  id              Int            @id @default(autoincrement())
+  appealId        Int            @unique
+  siteVisitTypeId Int?
+  visitDate       DateTime?
+  visitStartTime  String?
+  visitEndTime    String?
+  appeal          Appeal         @relation(fields: [appealId], references: [id])
+  siteVisitType   SiteVisitType? @relation(fields: [siteVisitTypeId], references: [id])
 }
 
 /// InspectorDecision model
@@ -602,4 +604,10 @@ model NeighbouringSiteContact {
   email              String
   lpaQuestionnaire   LPAQuestionnaire? @relation(fields: [lpaQuestionnaireId], references: [id])
   address            Address?          @relation(fields: [addressId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+}
+
+model SiteVisitType {
+  id        Int         @id @default(autoincrement())
+  name      String      @unique
+  siteVisit SiteVisit[]
 }

--- a/appeals/api/src/database/seed/data-static.js
+++ b/appeals/api/src/database/seed/data-static.js
@@ -3,17 +3,18 @@
  */
 
 /**
- * @typedef {import('appeals/api/src/database/schema.js').ProcedureType} ProcedureType
- * @typedef {import('appeals/api/src/database/schema.js').DesignatedSiteDetails} DesignatedSiteDetails
- * @typedef {import('appeals/api/src/database/schema.js').LPANotificationMethodDetails} LPANotificationMethodDetails
- * @typedef {import('appeals/api/src/database/schema.js').ScheduleType} ScheduleType
- * @typedef {import('appeals/api/src/database/schema.js').PlanningObligationStatus} PlanningObligationStatus
- * @typedef {import('appeals/api/src/database/schema.js').KnowledgeOfOtherLandowners} KnowledgeOfOtherLandowners
- * @typedef {import('appeals/api/src/database/schema.js').AppellantCaseValidationOutcome} AppellantCaseValidationOutcome
- * @typedef {import('appeals/api/src/database/schema.js').AppellantCaseIncompleteReason} AppellantCaseIncompleteReason
- * @typedef {import('appeals/api/src/database/schema.js').AppellantCaseInvalidReason} AppellantCaseInvalidReason
- * @typedef {import('appeals/api/src/database/schema.js').LPAQuestionnaireValidationOutcome} LPAQuestionnaireValidationOutcome
- * @typedef {import('appeals/api/src/database/schema.js').LPAQuestionnaireIncompleteReason} LPAQuestionnaireIncompleteReason
+ * @typedef {import('@pins/appeals.api').Schema.ProcedureType} ProcedureType
+ * @typedef {import('@pins/appeals.api').Schema.DesignatedSiteDetails} DesignatedSiteDetails
+ * @typedef {import('@pins/appeals.api').Schema.LPANotificationMethodDetails} LPANotificationMethodDetails
+ * @typedef {import('@pins/appeals.api').Schema.ScheduleType} ScheduleType
+ * @typedef {import('@pins/appeals.api').Schema.PlanningObligationStatus} PlanningObligationStatus
+ * @typedef {import('@pins/appeals.api').Schema.KnowledgeOfOtherLandowners} KnowledgeOfOtherLandowners
+ * @typedef {import('@pins/appeals.api').Schema.AppellantCaseValidationOutcome} AppellantCaseValidationOutcome
+ * @typedef {import('@pins/appeals.api').Schema.AppellantCaseIncompleteReason} AppellantCaseIncompleteReason
+ * @typedef {import('@pins/appeals.api').Schema.AppellantCaseInvalidReason} AppellantCaseInvalidReason
+ * @typedef {import('@pins/appeals.api').Schema.LPAQuestionnaireValidationOutcome} LPAQuestionnaireValidationOutcome
+ * @typedef {import('@pins/appeals.api').Schema.LPAQuestionnaireIncompleteReason} LPAQuestionnaireIncompleteReason
+ * @typedef {import('@pins/appeals.api').Schema.SiteVisitType} SiteVisitType
  */
 
 /**
@@ -241,6 +242,17 @@ export const lpaQuestionnaireIncompleteReasons = [
 ];
 
 /**
+ * An array of site visit types.
+ *
+ * @type {Pick<SiteVisitType, 'name'>[]}
+ */
+export const siteVisitTypes = [
+	{ name: 'Access required' },
+	{ name: 'Accompanied' },
+	{ name: 'Unaccompanied' }
+];
+
+/**
  * Seed static data into the database. Does not disconnect from the database or handle errors.
  *
  * @param {import('../../server/utils/db-client/index.js').PrismaClient} databaseConnector
@@ -327,6 +339,13 @@ export async function seedStaticData(databaseConnector) {
 		await databaseConnector.lPAQuestionnaireIncompleteReason.upsert({
 			create: lpaQuestionnaireIncompleteReason,
 			where: { name: lpaQuestionnaireIncompleteReason.name },
+			update: {}
+		});
+	}
+	for (const siteVisitType of siteVisitTypes) {
+		await databaseConnector.siteVisitType.upsert({
+			create: { name: siteVisitType.name },
+			where: { name: siteVisitType.name },
 			update: {}
 		});
 	}

--- a/appeals/api/src/server/common/validators/date-parameter.js
+++ b/appeals/api/src/server/common/validators/date-parameter.js
@@ -1,0 +1,18 @@
+import { joinDateAndTime } from '#endpoints/appeals/appeals.service.js';
+import { ERROR_MUST_BE_CORRECT_DATE_FORMAT } from '#endpoints/constants.js';
+import { body } from 'express-validator';
+
+/** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {string} parameterName
+ * @returns {ValidationChain}
+ */
+const validateDateParameter = (parameterName) =>
+	body(parameterName)
+		.optional()
+		.isDate()
+		.withMessage(ERROR_MUST_BE_CORRECT_DATE_FORMAT)
+		.customSanitizer(joinDateAndTime);
+
+export default validateDateParameter;

--- a/appeals/api/src/server/common/validators/id-parameter.js
+++ b/appeals/api/src/server/common/validators/id-parameter.js
@@ -1,0 +1,13 @@
+import { ERROR_MUST_BE_NUMBER } from '#endpoints/constants.js';
+import { param } from 'express-validator';
+
+/** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {string} parameterName
+ * @returns {ValidationChain}
+ */
+const validateIdParameter = (parameterName) =>
+	param(parameterName).isInt().withMessage(ERROR_MUST_BE_NUMBER);
+
+export default validateIdParameter;

--- a/appeals/api/src/server/common/validators/time-parameter.js
+++ b/appeals/api/src/server/common/validators/time-parameter.js
@@ -1,0 +1,13 @@
+import { ERROR_MUST_BE_CORRECT_TIME_FORMAT } from '#endpoints/constants.js';
+import { body } from 'express-validator';
+
+/** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {string} parameterName
+ * @returns {ValidationChain}
+ */
+const validateTimeParameter = (parameterName) =>
+	body(parameterName).optional().isTime({}).withMessage(ERROR_MUST_BE_CORRECT_TIME_FORMAT);
+
+export default validateTimeParameter;

--- a/appeals/api/src/server/common/validators/time-range-parameters.js
+++ b/appeals/api/src/server/common/validators/time-range-parameters.js
@@ -1,0 +1,34 @@
+import {
+	DEFAULT_TIME_FORMAT,
+	ERROR_START_TIME_MUST_BE_EARLIER_THAN_END_TIME
+} from '#endpoints/constants.js';
+import { compareDesc, parse } from 'date-fns';
+import { body } from 'express-validator';
+
+/** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {string} startParameter
+ * @param {string} endParameter
+ * @returns {ValidationChain}
+ */
+const validateTimeRangeParameters = (startParameter, endParameter) =>
+	body(startParameter)
+		.optional()
+		.custom((value, { req }) => {
+			const startValue = req.body[startParameter];
+			const endValue = req.body[endParameter];
+
+			if (startValue && endValue) {
+				const startDate = parse(startValue, DEFAULT_TIME_FORMAT, new Date());
+				const endDate = parse(endValue, DEFAULT_TIME_FORMAT, new Date());
+
+				if (compareDesc(startDate, endDate) < 1) {
+					throw new Error(ERROR_START_TIME_MUST_BE_EARLIER_THAN_END_TIME);
+				}
+			}
+
+			return value;
+		});
+
+export default validateTimeRangeParameters;

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -4,9 +4,10 @@ declare global {
 	namespace Express {
 		interface Request {
 			appeal: RepositoryGetByIdResultItem;
-			validationOutcome: ValidationOutcome;
-			notifyClient: NotifyClient;
 			document: Schema.Document;
+			notifyClient: NotifyClient;
+			visitType: SiteVisitType;
+			validationOutcome: ValidationOutcome;
 		}
 	}
 }
@@ -14,7 +15,7 @@ declare global {
 interface NotifyClient {
 	sendEmail: (
 		template: NotifyTemplate,
-		recipientEmail: string,
+		recipientEmail?: string,
 		personalisation: { [key: string]: string }
 	) => void;
 }
@@ -48,8 +49,8 @@ interface AppealTimetable {
 
 interface RepositoryGetAllResultItem {
 	address?: Schema.Address | null;
-	appealStatus: { status: string; subStateMachineName: string | null }[];
-	appealType: { shorthand: string; type: item } | null;
+	appealStatus: Schema.AppealStatus[];
+	appealType: Schema.AppealType | null;
 	createdAt: Date;
 	id: number;
 	localPlanningDepartment: string;
@@ -58,9 +59,9 @@ interface RepositoryGetAllResultItem {
 
 interface RepositoryGetByIdResultItem {
 	address?: Schema.Address | null;
-	appealStatus: { status: string; subStateMachineName: string | null }[];
+	appealStatus: Schema.AppealStatus[];
 	appealTimetable: Schema.AppealTimetable | null;
-	appealType: { shorthand: string; type: string } | null;
+	appealType: Schema.AppealType | null;
 	appellant: Schema.Appellant | null;
 	appellantCase?: Schema.AppellantCase | null;
 	createdAt: Date;
@@ -73,7 +74,7 @@ interface RepositoryGetByIdResultItem {
 	otherAppeals: Appeal[];
 	planningApplicationReference: string;
 	reference: string;
-	siteVisit?: { visitDate: Date } | null;
+	siteVisit: Schema.SiteVisit | null;
 	startedAt: Date | null;
 }
 
@@ -246,6 +247,10 @@ interface SingleAppellantCaseResponse {
 		isPartiallyOwned: boolean | null;
 		knowsOtherLandowners: string | null;
 	};
+	siteVisit: {
+		siteVisitId: number | null;
+		visitType: string | null;
+	};
 	visibility: {
 		details: string | null;
 		isVisible: boolean | null;
@@ -280,6 +285,15 @@ interface DocumentationSummary {
 
 interface CaseFolder {}
 
+interface SingleSiteVisitDetailsResponse {
+	appealId: number;
+	visitDate: Date | null;
+	siteVisitId: number;
+	visitEndTime: string | null;
+	visitStartTime: string | null;
+	visitType: string;
+}
+
 type ListedBuildingDetailsResponse = Pick<ListedBuildingDetails, 'grade' | 'description'>[];
 
 type LookupTables = AppellantCaseIncompleteReason | AppellantCaseInvalidReason | ValidationOutcome;
@@ -304,5 +318,6 @@ export {
 	SingleAppealDetailsResponse,
 	SingleAppellantCaseResponse,
 	SingleLPAQuestionnaireResponse,
+	SingleSiteVisitDetailsResponse,
 	TimetableDeadlineDate
 };

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -3,13 +3,16 @@ import { appealsRoutes } from './appeals/appeals.routes.js';
 import { appellantCaseIncompleteReasonsRoutes } from './appellant-case-incomplete-reasons/appellant-case-incomplete-reasons.routes.js';
 import { appellantCaseInvalidReasonsRoutes } from './appellant-case-invalid-reasons/appellant-case-invalid-reasons.routes.js';
 import { lpaQuestionnaireIncompleteReasonsRoutes } from './lpa-questionnaire-incomplete-reasons/lpa-questionnaire-incomplete-reasons.routes.js';
+import { siteVisitRoutes } from './site-visit/site-visit.routes.js';
 import initNotifyClientAndAddToRequest from '../middleware/init-notify-client-and-add-to-request.js';
 
 const router = createRouter();
 
+router.use('/', initNotifyClientAndAddToRequest);
 router.use('/appellant-case-incomplete-reasons', appellantCaseIncompleteReasonsRoutes);
 router.use('/appellant-case-invalid-reasons', appellantCaseInvalidReasonsRoutes);
 router.use('/lpa-questionnaire-incomplete-reasons', lpaQuestionnaireIncompleteReasonsRoutes);
-router.use('/', initNotifyClientAndAddToRequest, appealsRoutes);
+router.use(siteVisitRoutes);
+router.use('/', appealsRoutes);
 
 export { router as appealsRoutes };

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appellant-cases.test.js
@@ -48,7 +48,7 @@ describe('appellant cases routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const { appellantCase } = householdAppeal;
+				const { appellantCase, siteVisit } = householdAppeal;
 				const response = await request.get(
 					`/appeals/${householdAppeal.id}/appellant-cases/${appellantCase.id}`
 				);
@@ -99,6 +99,10 @@ describe('appellant cases routes', () => {
 						isPartiallyOwned: appellantCase.isSitePartiallyOwned,
 						knowsOtherLandowners: appellantCase.knowledgeOfOtherLandowners.name
 					},
+					siteVisit: {
+						siteVisitId: siteVisit.id,
+						visitType: siteVisit.siteVisitType.name
+					},
 					visibility: {
 						details: appellantCase.visibilityRestrictions,
 						isVisible: appellantCase.isSiteVisibleFromPublicRoad
@@ -110,7 +114,7 @@ describe('appellant cases routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(fullPlanningAppeal);
 
-				const { appellantCase } = fullPlanningAppeal;
+				const { appellantCase, siteVisit } = fullPlanningAppeal;
 				const response = await request.get(
 					`/appeals/${fullPlanningAppeal.id}/appellant-cases/${appellantCase.id}`
 				);
@@ -185,6 +189,10 @@ describe('appellant cases routes', () => {
 						isFullyOwned: appellantCase.isSiteFullyOwned,
 						isPartiallyOwned: appellantCase.isSitePartiallyOwned,
 						knowsOtherLandowners: appellantCase.knowledgeOfOtherLandowners.name
+					},
+					siteVisit: {
+						siteVisitId: siteVisit.id,
+						visitType: siteVisit.siteVisitType.name
 					},
 					visibility: {
 						details: appellantCase.visibilityRestrictions,

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -123,7 +123,7 @@ const updateAppellantCaseById = async (req, res) => {
 
 			await req.notifyClient.sendEmail(
 				config.govNotify.template.validAppellantCase,
-				appellant.email,
+				appellant?.email,
 				{
 					appeal_reference: reference,
 					appeal_type: appealType.shorthand,
@@ -141,12 +141,7 @@ const updateAppellantCaseById = async (req, res) => {
 			...(isOutcomeValid(validationOutcome.name) && { appealId, startedAt, timetable })
 		});
 
-		await transitionState({
-			appealId,
-			appealType: String(appealType?.shorthand),
-			currentState: appealStatus[0].status,
-			trigger: validationOutcome.name
-		});
+		await transitionState(appealId, appealType, appealStatus, validationOutcome.name);
 	} catch (error) {
 		if (error) {
 			logger.error(error);
@@ -190,12 +185,7 @@ const updateLPAQuestionnaireById = async (req, res) => {
 			})
 		});
 
-		await transitionState({
-			appealId,
-			appealType: String(appealType?.shorthand),
-			currentState: appealStatus[0].status,
-			trigger: validationOutcome.name
-		});
+		await transitionState(appealId, appealType, appealStatus, validationOutcome.name);
 
 		body.lpaQuestionnaireDueDate = timetable?.lpaQuestionnaireDueDate;
 	} catch (error) {

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -221,7 +221,7 @@ const appealFormatter = {
 	 * @returns {SingleAppellantCaseResponse | void}}
 	 */
 	formatAppellantCase(appeal) {
-		const { appellantCase } = appeal;
+		const { appellantCase, siteVisit } = appeal;
 
 		if (appellantCase) {
 			return {
@@ -302,6 +302,10 @@ const appealFormatter = {
 					isFullyOwned: appellantCase.isSiteFullyOwned,
 					isPartiallyOwned: appellantCase.isSitePartiallyOwned,
 					knowsOtherLandowners: appellantCase.knowledgeOfOtherLandowners?.name || null
+				},
+				siteVisit: {
+					siteVisitId: siteVisit?.id || null,
+					visitType: siteVisit?.siteVisitType?.name || null
 				},
 				visibility: {
 					details: appellantCase.visibilityRestrictions,

--- a/appeals/api/src/server/endpoints/appeals/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.routes.js
@@ -15,7 +15,7 @@ import {
 	checkAppellantCaseExists,
 	checkLookupValuesAreValid,
 	checkLPAQuestionnaireExists,
-	checkValidationOutcomeExistsAndAddToRequest
+	checkLookupValueIsValidAndAddToRequest
 } from './appeals.service.js';
 import {
 	getAppealsValidator,
@@ -149,7 +149,8 @@ router.patch(
 	patchLPAQuestionnaireValidator,
 	checkAppealExistsAndAddToRequest,
 	checkLPAQuestionnaireExists,
-	checkValidationOutcomeExistsAndAddToRequest(
+	checkLookupValueIsValidAndAddToRequest(
+		'validationOutcome',
 		'lPAQuestionnaireValidationOutcome',
 		ERROR_INVALID_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME
 	),
@@ -198,7 +199,8 @@ router.patch(
 	patchAppellantCaseValidator,
 	checkAppealExistsAndAddToRequest,
 	checkAppellantCaseExists,
-	checkValidationOutcomeExistsAndAddToRequest(
+	checkLookupValueIsValidAndAddToRequest(
+		'validationOutcome',
 		'appellantCaseValidationOutcome',
 		ERROR_INVALID_APPELLANT_CASE_VALIDATION_OUTCOME
 	),

--- a/appeals/api/src/server/endpoints/appeals/appeals.service.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.service.js
@@ -273,30 +273,32 @@ const checkLookupValuesAreValid = (fieldName, databaseTable) => async (req, res,
 };
 
 /**
+ * @param {string} fieldName
  * @param {string} databaseTable
  * @param {string} errorMessage
  * @returns {(req: Request, res: Response, next: NextFunction) => Promise<object | void>}
  */
-const checkValidationOutcomeExistsAndAddToRequest =
-	(databaseTable, errorMessage) => async (req, res, next) => {
-		const {
-			body: { validationOutcome }
-		} = req;
+const checkLookupValueIsValidAndAddToRequest =
+	(fieldName, databaseTable, errorMessage) => async (req, res, next) => {
+		const { [fieldName]: lookupField } = req.body;
 
-		const validationOutcomeMatch = await appealRepository.getLookupListValueByName(
-			databaseTable,
-			validationOutcome
-		);
+		if (lookupField) {
+			const validationOutcomeMatch = await appealRepository.getLookupListValueByName(
+				databaseTable,
+				lookupField
+			);
 
-		if (!validationOutcomeMatch) {
-			return res.status(400).send({
-				errors: {
-					validationOutcome: errorMessage
-				}
-			});
+			if (!validationOutcomeMatch) {
+				return res.status(400).send({
+					errors: {
+						[fieldName]: errorMessage
+					}
+				});
+			}
+
+			// @ts-ignore
+			req[fieldName] = validationOutcomeMatch;
 		}
-
-		req.validationOutcome = validationOutcomeMatch;
 
 		next();
 	};
@@ -372,7 +374,7 @@ export {
 	checkAppellantCaseExists,
 	checkLPAQuestionnaireExists,
 	checkLookupValuesAreValid,
-	checkValidationOutcomeExistsAndAddToRequest,
+	checkLookupValueIsValidAndAddToRequest,
 	createManyToManyRelationData,
 	fetchBankHolidaysForDivision,
 	isFPA,

--- a/appeals/api/src/server/endpoints/appeals/appeals.validators.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.validators.js
@@ -1,6 +1,6 @@
 import { composeMiddleware } from '@pins/express';
-import { body, param, query } from 'express-validator';
-import { validationErrorHandler } from '../../middleware/error-handler.js';
+import { body, query } from 'express-validator';
+import { validationErrorHandler } from '#middleware/error-handler.js';
 import {
 	ERROR_INCOMPLETE_REASONS_ONLY_FOR_INCOMPLETE_OUTCOME,
 	ERROR_INVALID_REASONS_ONLY_FOR_INVALID_OUTCOME,
@@ -8,7 +8,6 @@ import {
 	ERROR_LPA_QUESTIONNAIRE_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED,
 	ERROR_MAX_LENGTH_300_CHARACTERS,
 	ERROR_MUST_BE_ARRAY_OF_IDS,
-	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
 	ERROR_MUST_BE_GREATER_THAN_ZERO,
 	ERROR_MUST_BE_NUMBER,
 	ERROR_MUST_BE_STRING,
@@ -17,7 +16,9 @@ import {
 	ERROR_VALID_VALIDATION_OUTCOME_NO_REASONS,
 	ERROR_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED
 } from '../constants.js';
-import { isOutcomeIncomplete, isOutcomeInvalid, joinDateAndTime } from './appeals.service.js';
+import { isOutcomeIncomplete, isOutcomeInvalid } from './appeals.service.js';
+import validateDateParameter from '#common/validators/date-parameter.js';
+import validateIdParameter from '#common/validators/id-parameter.js';
 
 /** @typedef {import('express-validator').ValidationChain} ValidationChain */
 
@@ -57,24 +58,6 @@ const validatePaginationParameter = (parameterName) =>
 		.withMessage(ERROR_PAGENUMBER_AND_PAGESIZE_ARE_REQUIRED);
 
 /**
- * @param {string} parameterName
- * @returns {ValidationChain}
- */
-const validateIdParameter = (parameterName) =>
-	param(parameterName).isInt().withMessage(ERROR_MUST_BE_NUMBER);
-
-/**
- * @param {string} parameterName
- * @returns {ValidationChain}
- */
-const validateDateParameter = (parameterName) =>
-	body(parameterName)
-		.optional()
-		.isDate()
-		.withMessage(ERROR_MUST_BE_CORRECT_DATE_FORMAT)
-		.customSanitizer(joinDateAndTime);
-
-/**
  *
  * @param {string} parameterName
  * @param {() => void} customFn
@@ -85,7 +68,7 @@ const validateValidationOutcomeReasons = (parameterName, customFn) =>
 		.optional()
 		.isArray()
 		.withMessage(ERROR_MUST_BE_ARRAY_OF_IDS)
-		.isLength({ min: 1 })
+		.custom((value) => value[0])
 		.withMessage(ERROR_MUST_CONTAIN_AT_LEAST_1_VALUE)
 		.custom(customFn);
 

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -12,6 +12,7 @@ export const DEFAULT_DATE_FORMAT_DATABASE = 'yyyy-MM-dd';
 export const DEFAULT_DATE_FORMAT_DISPLAY = 'dd LLL yyyy';
 export const DEFAULT_PAGE_NUMBER = 1;
 export const DEFAULT_PAGE_SIZE = 30;
+export const DEFAULT_TIME_FORMAT = 'HH:mm';
 export const DEFAULT_TIMESTAMP_TIME = '01:00:00.000';
 
 export const DOCUMENT_STATUS_NOT_RECEIVED = 'not_received';
@@ -23,15 +24,18 @@ export const ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL = 'Failed to send notificat
 export const ERROR_GOV_NOTIFY_API_KEY_NOT_SET = 'Gov Notify API key is not set';
 export const ERROR_INCOMPLETE_REASONS_ONLY_FOR_INCOMPLETE_OUTCOME =
 	'Incomplete reasons should only be given if the validation outcome is Incomplete';
-export const ERROR_INVALID_APPEAL_TYPE = `Appeal type must be one of ${APPEAL_TYPE_SHORTCODE_FPA}, ${APPEAL_TYPE_SHORTCODE_HAS}`;
-export const ERROR_INVALID_APPELLANT_CASE_VALIDATION_OUTCOME = `Validation outcome must be one of ${VALIDATION_OUTCOME_INCOMPLETE}, ${VALIDATION_OUTCOME_INVALID}, ${VALIDATION_OUTCOME_VALID}`;
-export const ERROR_INVALID_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME = `Validation outcome must be one of ${VALIDATION_OUTCOME_COMPLETE}, ${VALIDATION_OUTCOME_INCOMPLETE}`;
+export const ERROR_INVALID_APPEAL_TYPE = `Must be one of ${APPEAL_TYPE_SHORTCODE_FPA}, ${APPEAL_TYPE_SHORTCODE_HAS}`;
+export const ERROR_INVALID_APPELLANT_CASE_VALIDATION_OUTCOME = `Must be one of ${VALIDATION_OUTCOME_INCOMPLETE}, ${VALIDATION_OUTCOME_INVALID}, ${VALIDATION_OUTCOME_VALID}`;
+export const ERROR_INVALID_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME = `Must be one of ${VALIDATION_OUTCOME_COMPLETE}, ${VALIDATION_OUTCOME_INCOMPLETE}`;
 export const ERROR_INVALID_REASONS_ONLY_FOR_INVALID_OUTCOME =
 	'Invalid reasons should only be given if the validation outcome is Invalid';
+export const ERROR_INVALID_SITE_VISIT_TYPE =
+	'Must be one of access required, accompanied, unaccompanied';
 export const ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS = 'Must be between 2 and 8 characters';
 export const ERROR_MAX_LENGTH_300_CHARACTERS = 'Must be 300 characters or less';
 export const ERROR_MUST_BE_ARRAY_OF_IDS = 'Must be an array of ids';
 export const ERROR_MUST_BE_CORRECT_DATE_FORMAT = `Must be a valid date and in the format ${DEFAULT_DATE_FORMAT_DATABASE}`;
+export const ERROR_MUST_BE_CORRECT_TIME_FORMAT = `Must be a valid time and in the format hh:mm`;
 export const ERROR_MUST_BE_GREATER_THAN_ZERO = 'Must be greater than 0';
 export const ERROR_MUST_BE_NUMBER = 'Must be a number';
 export const ERROR_MUST_BE_STRING = 'Must be a string';
@@ -43,6 +47,10 @@ export const ERROR_OTHER_NOT_VALID_REASONS_REQUIRED =
 	'Required when invalidReasons or incompleteReasons contains Other';
 export const ERROR_PAGENUMBER_AND_PAGESIZE_ARE_REQUIRED =
 	'Both pageNumber and pageSize are required for pagination';
+export const ERROR_SITE_VISIT_REQUIRED_FIELDS =
+	'If any of visitDate, visitStartTime or visitEndTime are given then all these fields are required';
+export const ERROR_START_TIME_MUST_BE_EARLIER_THAN_END_TIME =
+	'Start time must be earlier than end time';
 export const ERROR_VALID_VALIDATION_OUTCOME_NO_REASONS =
 	'Should not include validation outcome reasons when validationOutcome is Valid';
 export const ERROR_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED =

--- a/appeals/api/src/server/endpoints/site-visit/__tests__/site-visit.test.js
+++ b/appeals/api/src/server/endpoints/site-visit/__tests__/site-visit.test.js
@@ -1,0 +1,887 @@
+import { request } from '../../../app-test.js';
+import {
+	ERROR_INVALID_SITE_VISIT_TYPE,
+	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
+	ERROR_MUST_BE_CORRECT_TIME_FORMAT,
+	ERROR_MUST_BE_NUMBER,
+	ERROR_NOT_FOUND,
+	ERROR_SITE_VISIT_REQUIRED_FIELDS,
+	ERROR_START_TIME_MUST_BE_EARLIER_THAN_END_TIME,
+	STATE_TARGET_ISSUE_DETERMINATION
+} from '../../constants.js';
+import { householdAppeal } from '../../../tests/data.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+
+describe('site visit routes', () => {
+	describe('/:appealId/site-visits', () => {
+		describe('POST', () => {
+			test('creates a site visit without updating the status', async () => {
+				const { siteVisit } = householdAppeal;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitType: siteVisit.siteVisitType.name
+				});
+
+				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(databaseConnector.appealStatus.create).not.toHaveBeenCalled();
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('creates a site visit with updating the status and time fields with leading zeros', async () => {
+				householdAppeal.appealStatus[0].status = 'arrange_site_visit';
+
+				const { siteVisit } = householdAppeal;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: siteVisit.visitDate.split('T')[0],
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name
+				});
+
+				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						visitDate: siteVisit.visitDate,
+						visitEndTime: siteVisit.visitEndTime,
+						visitStartTime: siteVisit.visitStartTime,
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						createdAt: expect.any(Date),
+						status: STATE_TARGET_ISSUE_DETERMINATION,
+						valid: true
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('creates a site visit with updating the status and time fields without leading zeros', async () => {
+				householdAppeal.appealStatus[0].status = 'arrange_site_visit';
+
+				const { siteVisit } = householdAppeal;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: siteVisit.visitDate.split('T')[0],
+					visitEndTime: '9:00',
+					visitStartTime: '7:00',
+					visitType: siteVisit.siteVisitType.name
+				});
+
+				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						visitDate: siteVisit.visitDate,
+						visitEndTime: '9:00',
+						visitStartTime: '7:00',
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						createdAt: expect.any(Date),
+						status: STATE_TARGET_ISSUE_DETERMINATION,
+						valid: true
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: '9:00',
+					visitStartTime: '7:00',
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('creates a site visit with time fields in 24h format', async () => {
+				const { siteVisit } = householdAppeal;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: siteVisit.visitDate.split('T')[0],
+					visitEndTime: '18:00',
+					visitStartTime: '16:00',
+					visitType: siteVisit.siteVisitType.name
+				});
+
+				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						visitDate: siteVisit.visitDate,
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: '18:00',
+					visitStartTime: '16:00',
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('returns an error if appealId is not numeric', async () => {
+				const response = await request.post('/appeals/one/site-visits').send({
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appealId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if visitType is not a string value', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitType: 123
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitType: ERROR_INVALID_SITE_VISIT_TYPE
+					}
+				});
+			});
+
+			test('returns an error if visitType is an incorrect value', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(null);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitType: 'access not required'
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitType: ERROR_INVALID_SITE_VISIT_TYPE
+					}
+				});
+			});
+
+			test('returns an error if visitDate is not given when visitEndTime and visitStartTime are given', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitEndTime: '18:00',
+					visitStartTime: '16:00',
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_SITE_VISIT_REQUIRED_FIELDS
+					}
+				});
+			});
+
+			test('returns an error if visitEndTime is not given when visitDate and visitStartTime are given', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: '2023-12-07',
+					visitStartTime: '16:00',
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_SITE_VISIT_REQUIRED_FIELDS
+					}
+				});
+			});
+
+			test('returns an error if visitStartTime is not given when visitDate and visitEndTime are given', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: '2023-12-07',
+					visitEndTime: '16:00',
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_SITE_VISIT_REQUIRED_FIELDS
+					}
+				});
+			});
+
+			test('returns an error if visitDate is in an invalid format', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: '07/12/2023',
+					visitEndTime: '18:00',
+					visitStartTime: '16:00',
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitDate: ERROR_MUST_BE_CORRECT_DATE_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if visitDate is not a valid date', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: '56/12/2023',
+					visitEndTime: '18:00',
+					visitStartTime: '16:00',
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitDate: ERROR_MUST_BE_CORRECT_DATE_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if visitEndTime is not a valid time', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: '2023-07-12',
+					visitEndTime: '56:00',
+					visitStartTime: '16:00',
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitEndTime: ERROR_MUST_BE_CORRECT_TIME_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if visitStartTime is not a valid time', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: '2023-07-12',
+					visitEndTime: '18:00',
+					visitStartTime: '56:00',
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitStartTime: ERROR_MUST_BE_CORRECT_TIME_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if visitStartTime is not before visitEndTime', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: '2023-07-12',
+					visitEndTime: '16:00',
+					visitStartTime: '18:00',
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitStartTime: ERROR_START_TIME_MUST_BE_EARLIER_THAN_END_TIME
+					}
+				});
+			});
+		});
+	});
+
+	describe('/:appealId/site-visits/:siteVisitId', () => {
+		describe('GET', () => {
+			test('gets a single site visit', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const { siteVisit } = householdAppeal;
+				const response = await request.get(
+					`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`
+				);
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					appealId: siteVisit.appealId,
+					visitDate: siteVisit.visitDate,
+					siteVisitId: siteVisit.id,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('returns an error if appealId is not numeric', async () => {
+				const response = await request.get('/appeals/one');
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appealId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request.get('/appeals/3');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if siteVisitId is not numeric', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.get(`/appeals/${householdAppeal.id}/site-visits/one`);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						siteVisitId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if siteVistId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.get(`/appeals/${householdAppeal.id}/site-visits/2`);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						siteVisitId: ERROR_NOT_FOUND
+					}
+				});
+			});
+		});
+
+		describe('PATCH', () => {
+			test('updates a site visit without updating the status', async () => {
+				const { siteVisit } = householdAppeal;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`)
+					.send({
+						visitType: siteVisit.siteVisitType.name
+					});
+
+				expect(databaseConnector.siteVisit.update).toHaveBeenCalledWith({
+					where: { id: siteVisit.id },
+					data: {
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(databaseConnector.appealStatus.create).not.toHaveBeenCalledWith();
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('updates a site visit with updating the status and time fields with leading zeros', async () => {
+				householdAppeal.appealStatus[0].status = 'arrange_site_visit';
+
+				const { siteVisit } = householdAppeal;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						visitEndTime: siteVisit.visitEndTime,
+						visitStartTime: siteVisit.visitStartTime,
+						visitType: siteVisit.siteVisitType.name
+					});
+
+				expect(databaseConnector.siteVisit.update).toHaveBeenCalledWith({
+					where: { id: siteVisit.id },
+					data: {
+						visitDate: siteVisit.visitDate,
+						visitEndTime: siteVisit.visitEndTime,
+						visitStartTime: siteVisit.visitStartTime,
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						createdAt: expect.any(Date),
+						status: STATE_TARGET_ISSUE_DETERMINATION,
+						valid: true
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: siteVisit.visitEndTime,
+					visitStartTime: siteVisit.visitStartTime,
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('updates a site visit with updating the status and time fields without leading zeros', async () => {
+				householdAppeal.appealStatus[0].status = 'arrange_site_visit';
+
+				const { siteVisit } = householdAppeal;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						visitEndTime: '3:00',
+						visitStartTime: '1:00',
+						visitType: siteVisit.siteVisitType.name
+					});
+
+				expect(databaseConnector.siteVisit.update).toHaveBeenCalledWith({
+					where: { id: siteVisit.id },
+					data: {
+						visitDate: siteVisit.visitDate,
+						visitEndTime: '3:00',
+						visitStartTime: '1:00',
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(databaseConnector.appealStatus.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						createdAt: expect.any(Date),
+						status: STATE_TARGET_ISSUE_DETERMINATION,
+						valid: true
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: '3:00',
+					visitStartTime: '1:00',
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('updates a site visit with time fields in 24h format', async () => {
+				const { siteVisit } = householdAppeal;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						visitType: siteVisit.siteVisitType.name
+					});
+
+				expect(databaseConnector.siteVisit.update).toHaveBeenCalledWith({
+					where: { id: siteVisit.id },
+					data: {
+						visitDate: siteVisit.visitDate,
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					visitEndTime: '18:00',
+					visitStartTime: '16:00',
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
+			test('returns an error if appealId is not numeric', async () => {
+				const response = await request
+					.patch(`/appeals/one/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appealId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if siteVisitId is not numeric', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/one`)
+					.send({
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						siteVisitId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if siteVisitId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.patch(`/appeals/${householdAppeal.id}/site-visits/2`).send({
+					visitType: householdAppeal.siteVisit.siteVisitType.name
+				});
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						siteVisitId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if visitType is not a string value', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitType: 123
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitType: ERROR_INVALID_SITE_VISIT_TYPE
+					}
+				});
+			});
+
+			test('returns an error if visitType is an incorrect value', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(null);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitType: 'access not required'
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitType: ERROR_INVALID_SITE_VISIT_TYPE
+					}
+				});
+			});
+
+			test('returns an error if visitDate is not given when visitEndTime and visitStartTime are given', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_SITE_VISIT_REQUIRED_FIELDS
+					}
+				});
+			});
+
+			test('returns an error if visitEndTime is not given when visitDate and visitStartTime are given', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitDate: '2023-12-07',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_SITE_VISIT_REQUIRED_FIELDS
+					}
+				});
+			});
+
+			test('returns an error if visitStartTime is not given when visitDate and visitEndTime are given', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitDate: '2023-12-07',
+						visitEndTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_SITE_VISIT_REQUIRED_FIELDS
+					}
+				});
+			});
+
+			test('returns an error if visitDate is in an invalid format', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitDate: '07/12/2023',
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitDate: ERROR_MUST_BE_CORRECT_DATE_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if visitDate is not a valid date', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitDate: '56/12/2023',
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitDate: ERROR_MUST_BE_CORRECT_DATE_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if visitEndTime is not a valid time', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitDate: '2023-07-12',
+						visitEndTime: '56:00',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitEndTime: ERROR_MUST_BE_CORRECT_TIME_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if visitStartTime is not a valid time', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitDate: '2023-07-12',
+						visitEndTime: '18:00',
+						visitStartTime: '56:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitStartTime: ERROR_MUST_BE_CORRECT_TIME_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if visitStartTime is not before visitEndTime', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
+					.send({
+						visitDate: '2023-07-12',
+						visitEndTime: '16:00',
+						visitStartTime: '18:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						visitStartTime: ERROR_START_TIME_MUST_BE_EARLIER_THAN_END_TIME
+					}
+				});
+			});
+
+			test('does not throw an error if given an empty body', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.update.mockResolvedValue(householdAppeal);
+
+				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({});
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({});
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/site-visit/site-visit.controller.js
+++ b/appeals/api/src/server/endpoints/site-visit/site-visit.controller.js
@@ -1,0 +1,98 @@
+import {
+	ERROR_FAILED_TO_SAVE_DATA,
+	STATE_TARGET_ISSUE_DETERMINATION
+} from '#endpoints/constants.js';
+import appealRepository from '#repositories/appeal.repository.js';
+import logger from '#utils/logger.js';
+import transitionState from '../../state/transition-state.js';
+import siteVisitFormatter from './site-visit.formatter.js';
+
+/** @typedef {import('express').RequestHandler} RequestHandler */
+
+/**
+ * @type {RequestHandler}
+ * @returns {object}
+ */
+const getSiteVisitById = (req, res) => {
+	const { appeal } = req;
+	const formattedAppeal = siteVisitFormatter.formatSiteVisit(appeal);
+
+	return res.send(formattedAppeal);
+};
+
+/**
+ * @type {RequestHandler}
+ * @returns {Promise<object>}
+ */
+const createSiteVisit = async (req, res) => {
+	const {
+		appeal: { appealStatus, appealType },
+		body,
+		body: { visitDate, visitEndTime, visitStartTime },
+		params,
+		visitType
+	} = req;
+	const appealId = Number(params.appealId);
+
+	try {
+		await appealRepository.createSiteVisitById({
+			appealId,
+			visitDate,
+			visitEndTime,
+			visitStartTime,
+			siteVisitTypeId: visitType.id
+		});
+
+		if (visitDate) {
+			await transitionState(appealId, appealType, appealStatus, STATE_TARGET_ISSUE_DETERMINATION);
+		}
+
+		return res.send(body);
+	} catch (error) {
+		logger.error(error);
+		return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
+	}
+};
+
+/**
+ * @type {RequestHandler}
+ * @returns {Promise<object>}
+ */
+const updateSiteVisit = async (req, res) => {
+	const {
+		appeal: { appealStatus, appealType },
+		body,
+		body: { visitDate, visitEndTime, visitStartTime },
+		params: { appealId, siteVisitId },
+		visitType
+	} = req;
+
+	try {
+		await appealRepository.updateById(
+			Number(siteVisitId),
+			{
+				...(visitDate && { visitDate }),
+				...(visitEndTime && { visitEndTime }),
+				...(visitStartTime && { visitStartTime }),
+				...(visitType && { siteVisitTypeId: visitType?.id })
+			},
+			'siteVisit'
+		);
+
+		if (visitType && visitDate) {
+			await transitionState(
+				Number(appealId),
+				appealType,
+				appealStatus,
+				STATE_TARGET_ISSUE_DETERMINATION
+			);
+		}
+
+		return res.send(body);
+	} catch (error) {
+		logger.error(error);
+		return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
+	}
+};
+
+export { createSiteVisit, getSiteVisitById, updateSiteVisit };

--- a/appeals/api/src/server/endpoints/site-visit/site-visit.formatter.js
+++ b/appeals/api/src/server/endpoints/site-visit/site-visit.formatter.js
@@ -1,0 +1,25 @@
+/** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetByIdResultItem} RepositoryGetByIdResultItem */
+/** @typedef {import('@pins/appeals.api').Appeals.SingleSiteVisitDetailsResponse} SingleSiteVisitDetailsResponse */
+
+const siteVisitFormatter = {
+	/**
+	 * @param {RepositoryGetByIdResultItem} appeal
+	 * @returns {SingleSiteVisitDetailsResponse | void}}
+	 */
+	formatSiteVisit(appeal) {
+		const { siteVisit } = appeal;
+
+		if (siteVisit) {
+			return {
+				appealId: siteVisit.appealId,
+				visitDate: siteVisit.visitDate,
+				siteVisitId: siteVisit.id,
+				visitEndTime: siteVisit.visitEndTime,
+				visitStartTime: siteVisit.visitStartTime,
+				visitType: siteVisit.siteVisitType.name
+			};
+		}
+	}
+};
+
+export default siteVisitFormatter;

--- a/appeals/api/src/server/endpoints/site-visit/site-visit.routes.js
+++ b/appeals/api/src/server/endpoints/site-visit/site-visit.routes.js
@@ -1,0 +1,96 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '#middleware/async-handler.js';
+import { createSiteVisit, getSiteVisitById, updateSiteVisit } from './site-visit.controller.js';
+import {
+	checkAppealExistsAndAddToRequest,
+	checkLookupValueIsValidAndAddToRequest
+} from './../appeals/appeals.service.js';
+import {
+	getSiteVisitValidator,
+	patchSiteVisitValidator,
+	postSiteVisitValidator
+} from './site-visit.validators.js';
+import { ERROR_INVALID_SITE_VISIT_TYPE } from '#endpoints/constants.js';
+import { checkSiteVisitExists } from './site-visit.service.js';
+
+const router = createRouter();
+
+router.post(
+	'/:appealId/site-visits',
+	/*
+		#swagger.tags = ['Appeals']
+		#swagger.path = '/appeals/{appealId}/site-visits'
+		#swagger.description = 'Creates a single site visit'
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Site visit details to create',
+			schema: { $ref: '#/definitions/CreateSiteVisitRequest' },
+			required: true
+		}
+		#swagger.responses[200] = {
+			description: 'Creates a single site visit',
+			schema: { $ref: '#/definitions/CreateSiteVisitResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[500] = {}
+	 */
+	postSiteVisitValidator,
+	checkAppealExistsAndAddToRequest,
+	checkLookupValueIsValidAndAddToRequest(
+		'visitType',
+		'siteVisitType',
+		ERROR_INVALID_SITE_VISIT_TYPE
+	),
+	asyncHandler(createSiteVisit)
+);
+
+router.get(
+	'/:appealId/site-visits/:siteVisitId',
+	/*
+		#swagger.tags = ['Appeals']
+		#swagger.path = '/appeals/{appealId}/site-visits/{siteVisitId}'
+		#swagger.description = 'Gets a single site visit by id'
+		#swagger.responses[200] = {
+			description: 'Gets a single site visit by id',
+			schema: { $ref: '#/definitions/SingleSiteVisitResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[500] = {}
+	 */
+	getSiteVisitValidator,
+	checkAppealExistsAndAddToRequest,
+	checkSiteVisitExists,
+	asyncHandler(getSiteVisitById)
+);
+
+router.patch(
+	'/:appealId/site-visits/:siteVisitId',
+	/*
+		#swagger.tags = ['Appeals']
+		#swagger.path = '/appeals/{appealId}/site-visits/{siteVisitId}'
+		#swagger.description = 'Updates a single site visit by id'
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Site visit details to create',
+			schema: { $ref: '#/definitions/UpdateSiteVisitRequest' },
+			required: true
+		}
+		#swagger.responses[200] = {
+			description: 'Creates a single site visit by id',
+			schema: { $ref: '#/definitions/UpdateSiteVisitResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[500] = {}
+	 */
+	patchSiteVisitValidator,
+	checkAppealExistsAndAddToRequest,
+	checkSiteVisitExists,
+	checkLookupValueIsValidAndAddToRequest(
+		'visitType',
+		'siteVisitType',
+		ERROR_INVALID_SITE_VISIT_TYPE
+	),
+	asyncHandler(updateSiteVisit)
+);
+
+export { router as siteVisitRoutes };

--- a/appeals/api/src/server/endpoints/site-visit/site-visit.service.js
+++ b/appeals/api/src/server/endpoints/site-visit/site-visit.service.js
@@ -1,0 +1,23 @@
+/** @typedef {import('express').RequestHandler} RequestHandler */
+
+import { ERROR_NOT_FOUND } from '#endpoints/constants.js';
+
+/**
+ * @type {RequestHandler}
+ * @returns {Promise<object | void>}
+ */
+const checkSiteVisitExists = async (req, res, next) => {
+	const {
+		appeal,
+		params: { siteVisitId }
+	} = req;
+	const hasSiteVisit = appeal.siteVisit?.id === Number(siteVisitId);
+
+	if (!hasSiteVisit) {
+		return res.status(404).send({ errors: { siteVisitId: ERROR_NOT_FOUND } });
+	}
+
+	next();
+};
+
+export { checkSiteVisitExists };

--- a/appeals/api/src/server/endpoints/site-visit/site-visit.validators.js
+++ b/appeals/api/src/server/endpoints/site-visit/site-visit.validators.js
@@ -1,0 +1,72 @@
+import { body, param } from 'express-validator';
+import { validationErrorHandler } from '#middleware/error-handler.js';
+import { composeMiddleware } from '@pins/express';
+import validateIdParameter from '#common/validators/id-parameter.js';
+import validateDateParameter from '#common/validators/date-parameter.js';
+import validateTimeParameter from '#common/validators/time-parameter.js';
+import validateTimeRangeParameters from '#common/validators/time-range-parameters.js';
+import {
+	ERROR_INVALID_SITE_VISIT_TYPE,
+	ERROR_SITE_VISIT_REQUIRED_FIELDS
+} from '#endpoints/constants.js';
+
+/** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {boolean} isRequired
+ * @returns {ValidationChain}
+ */
+const validateSiteVisitType = (isRequired = false) => {
+	const validator = body('visitType');
+
+	if (!isRequired) {
+		validator.optional();
+	}
+
+	validator.isString().withMessage(ERROR_INVALID_SITE_VISIT_TYPE);
+
+	return validator;
+};
+
+const validateSiteVisitRequiredDateTimeFields = param('appealId').custom((value, { req }) => {
+	const { visitDate, visitEndTime, visitStartTime } = req.body;
+
+	if (visitDate || visitStartTime || visitEndTime) {
+		if (!visitDate || !visitStartTime || !visitEndTime) {
+			throw new Error(ERROR_SITE_VISIT_REQUIRED_FIELDS);
+		}
+	}
+
+	return value;
+});
+
+const getSiteVisitValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateIdParameter('siteVisitId'),
+	validationErrorHandler
+);
+
+const postSiteVisitValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateSiteVisitRequiredDateTimeFields,
+	validateSiteVisitType(true),
+	validateDateParameter('visitDate'),
+	validateTimeParameter('visitStartTime'),
+	validateTimeParameter('visitEndTime'),
+	validateTimeRangeParameters('visitStartTime', 'visitEndTime'),
+	validationErrorHandler
+);
+
+const patchSiteVisitValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateIdParameter('siteVisitId'),
+	validateSiteVisitRequiredDateTimeFields,
+	validateSiteVisitType(),
+	validateDateParameter('visitDate'),
+	validateTimeParameter('visitStartTime'),
+	validateTimeParameter('visitEndTime'),
+	validateTimeRangeParameters('visitStartTime', 'visitEndTime'),
+	validationErrorHandler
+);
+
+export { getSiteVisitValidator, patchSiteVisitValidator, postSiteVisitValidator };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -96,6 +96,180 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/site-visits": {
+			"post": {
+				"tags": ["Appeals"],
+				"description": "Creates a single site visit",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Creates a single site visit",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/CreateSiteVisitResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/CreateSiteVisitResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Site visit details to create",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateSiteVisitRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/CreateSiteVisitRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/appeals/{appealId}/site-visits/{siteVisitId}": {
+			"get": {
+				"tags": ["Appeals"],
+				"description": "Gets a single site visit by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "siteVisitId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Gets a single site visit by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/SingleSiteVisitResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/SingleSiteVisitResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				}
+			},
+			"patch": {
+				"tags": ["Appeals"],
+				"description": "Updates a single site visit by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "siteVisitId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Creates a single site visit by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateSiteVisitResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateSiteVisitResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Site visit details to create",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateSiteVisitRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateSiteVisitRequest"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals": {
 			"get": {
 				"tags": ["Appeals"],
@@ -695,182 +869,6 @@
 					"name": "Folder"
 				}
 			},
-			"documentsPropertiesRequestBody": {
-				"type": "object",
-				"properties": {
-					"version": {
-						"type": "number",
-						"example": 1
-					},
-					"createdAt": {
-						"type": "string",
-						"example": "2023-02-27T10:00:00Z"
-					},
-					"lastModified": {
-						"type": "string",
-						"example": "2023-02-27T12:00:00Z"
-					},
-					"documentType": {
-						"type": "string",
-						"example": "PDF"
-					},
-					"published": {
-						"type": "boolean",
-						"example": false
-					},
-					"sourceSystem": {
-						"type": "string",
-						"example": "Salesforce"
-					},
-					"origin": {
-						"type": "string",
-						"example": "Email"
-					},
-					"representative": {
-						"type": "string",
-						"example": "John Doe"
-					},
-					"description": {
-						"type": "string",
-						"example": "Marketing Brochure"
-					},
-					"documentGuid": {
-						"type": "string",
-						"example": "ab12cd34-5678-90ef-ghij-klmnopqrstuv"
-					},
-					"datePublished": {
-						"type": "string",
-						"example": "2023-03-01T10:00:00Z"
-					},
-					"owner": {
-						"type": "string",
-						"example": "Jane Doe"
-					},
-					"author": {
-						"type": "string",
-						"example": "Marketing Team"
-					},
-					"securityClassification": {
-						"type": "string",
-						"example": "Confidential"
-					},
-					"mime": {
-						"type": "string",
-						"example": "application/pdf"
-					},
-					"horizonDataID": {
-						"type": "string",
-						"example": "123456789"
-					},
-					"fileMD5": {
-						"type": "string",
-						"example": "f60c381d96dcedec4b4fb4b9e1f6e14e"
-					},
-					"path": {
-						"type": "string",
-						"example": "/documents/marketing/ab12cd34-5678-90ef-ghij-klmnopqrstuv.pdf"
-					},
-					"virusCheckStatus": {
-						"type": "string",
-						"example": "Clean"
-					},
-					"size": {
-						"type": "number",
-						"example": 1024
-					},
-					"stage": {
-						"type": "number",
-						"example": 3
-					},
-					"filter1": {
-						"type": "string",
-						"example": "Marketing"
-					},
-					"filter2": {
-						"type": "string",
-						"example": "Brochure"
-					}
-				},
-				"xml": {
-					"name": "documentsPropertiesRequestBody"
-				}
-			},
-			"documentsMetadataResponseBody": {
-				"type": "object",
-				"properties": {
-					"version": {
-						"type": "number",
-						"example": 1
-					},
-					"documentId": {
-						"type": "string",
-						"example": "a6f9f2e0-12c9-49b7-8a1c-3b5edc34dd99"
-					},
-					"datePublished": {
-						"type": "string",
-						"example": ""
-					},
-					"caseRef": {
-						"type": "string",
-						"example": "BC0210002"
-					},
-					"documentName": {
-						"type": "string",
-						"example": "5"
-					},
-					"blobStorageContainer": {
-						"type": "string",
-						"example": "document-service-uploads"
-					},
-					"documentURI": {
-						"type": "string",
-						"example": "/application/BC010001/1111-2222-3333/my doc.pdf"
-					},
-					"from": {
-						"type": "string",
-						"example": "joe blogs"
-					},
-					"dateCreated": {
-						"type": "number",
-						"example": 1677585578
-					},
-					"size": {
-						"type": "number",
-						"example": 0
-					},
-					"fileType": {
-						"type": "string",
-						"example": ""
-					},
-					"redacted": {
-						"type": "boolean",
-						"example": false
-					},
-					"status": {
-						"type": "string",
-						"example": "awaiting_upload"
-					},
-					"description": {
-						"type": "string",
-						"example": ""
-					},
-					"agent": {
-						"type": "string",
-						"example": ""
-					},
-					"documentType": {
-						"type": "string",
-						"example": ""
-					},
-					"webFilter": {
-						"type": "string",
-						"example": ""
-					}
-				},
-				"xml": {
-					"name": "documentsMetadataResponseBody"
-				}
-			},
 			"DocumentDetails": {
 				"type": "object",
 				"properties": {
@@ -965,423 +963,6 @@
 				},
 				"xml": {
 					"name": "DocumentDetails"
-				}
-			},
-			"AppealToValidate": {
-				"type": "object",
-				"properties": {
-					"AppealId": {
-						"type": "number",
-						"example": 1
-					},
-					"AppealReference": {
-						"type": "string",
-						"example": "APP/Q9999/D/21/1345264"
-					},
-					"AppellantName": {
-						"type": "string",
-						"example": "Lee Thornton"
-					},
-					"AppealStatus": {
-						"type": "string",
-						"example": "new"
-					},
-					"Received": {
-						"type": "string",
-						"example": "18 Mar 2022"
-					},
-					"AppealSite": {
-						"type": "object",
-						"properties": {
-							"AddressLine1": {
-								"type": "string",
-								"example": "96 The Avenue"
-							},
-							"AddressLine2": {
-								"type": "string",
-								"example": ""
-							},
-							"Town": {
-								"type": "string",
-								"example": "Maidstone"
-							},
-							"County": {
-								"type": "string",
-								"example": "Kent"
-							},
-							"PostCode": {
-								"type": "string",
-								"example": "MD21 5XY"
-							}
-						}
-					},
-					"LocalPlanningDepartment": {
-						"type": "string",
-						"example": "Maidstone Borough Council"
-					},
-					"PlanningApplicationReference": {
-						"type": "string",
-						"example": "48269/APP/2021/1482"
-					},
-					"Documents": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"Type": {
-									"type": "string",
-									"example": ""
-								},
-								"Filename": {
-									"type": "string",
-									"example": ""
-								},
-								"URL": {
-									"type": "string",
-									"example": ""
-								}
-							}
-						}
-					},
-					"reason": {
-						"type": "object",
-						"properties": {
-							"inflammatoryComments": {
-								"type": "boolean",
-								"example": true
-							},
-							"missingApplicationForm": {
-								"type": "boolean",
-								"example": true
-							},
-							"missingDecisionNotice": {
-								"type": "boolean",
-								"example": true
-							},
-							"missingGroundsForAppeal": {
-								"type": "boolean",
-								"example": true
-							},
-							"missingSupportingDocuments": {
-								"type": "boolean",
-								"example": true
-							},
-							"namesDoNotMatch": {
-								"type": "boolean",
-								"example": true
-							},
-							"openedInError": {
-								"type": "boolean",
-								"example": true
-							},
-							"otherReasons": {
-								"type": "string",
-								"example": "Some other weird reason"
-							},
-							"sensitiveInfo": {
-								"type": "boolean",
-								"example": true
-							},
-							"wrongAppealTypeUsed": {
-								"type": "boolean",
-								"example": true
-							}
-						}
-					}
-				},
-				"xml": {
-					"name": "AppealToValidate"
-				}
-			},
-			"AppealDetailsAfterStatementUpload": {
-				"type": "object",
-				"properties": {
-					"AppealId": {
-						"type": "number",
-						"example": 2
-					},
-					"AppealReference": {
-						"type": "string",
-						"example": "ABC"
-					},
-					"canUploadStatementsUntil": {
-						"type": "string",
-						"example": "08 March 2022"
-					}
-				},
-				"xml": {
-					"name": "AppealDetailsAfterStatementUpload"
-				}
-			},
-			"AppealDetailsAfterFinalCommentUpload": {
-				"type": "object",
-				"properties": {
-					"AppealId": {
-						"type": "number",
-						"example": 2
-					},
-					"AppealReference": {
-						"type": "string",
-						"example": "ABC"
-					},
-					"canUploadFinalCommentsUntil": {
-						"type": "string",
-						"example": "08 March 2022"
-					}
-				},
-				"xml": {
-					"name": "AppealDetailsAfterFinalCommentUpload"
-				}
-			},
-			"AppealsToValidate": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"properties": {
-						"AppealId": {
-							"type": "number",
-							"example": 1
-						},
-						"AppealReference": {
-							"type": "string",
-							"example": "APP/Q9999/D/21/1345264"
-						},
-						"AppealStatus": {
-							"type": "string",
-							"enum": ["new", "incomplete"]
-						},
-						"Received": {
-							"type": "string",
-							"example": "18 Mar 2022"
-						},
-						"AppealSite": {
-							"type": "object",
-							"properties": {
-								"AddressLine1": {
-									"type": "string",
-									"example": "96 The Avenue"
-								},
-								"AddressLine2": {
-									"type": "string",
-									"example": ""
-								},
-								"Town": {
-									"type": "string",
-									"example": "Maidstone"
-								},
-								"County": {
-									"type": "string",
-									"example": "Kent"
-								},
-								"PostCode": {
-									"type": "string",
-									"example": "MD21 5XY"
-								}
-							}
-						}
-					}
-				},
-				"xml": {
-					"name": "AppealsToValidate"
-				}
-			},
-			"ChangeAppeal": {
-				"type": "object",
-				"properties": {
-					"AppellantName": {
-						"type": "string",
-						"example": "John Doe"
-					},
-					"Address": {
-						"type": "object",
-						"properties": {
-							"AddressLine1": {
-								"type": "string",
-								"example": ""
-							},
-							"AddressLine2": {
-								"type": "string",
-								"example": ""
-							},
-							"Town": {
-								"type": "string",
-								"example": ""
-							},
-							"County": {
-								"type": "string",
-								"example": ""
-							},
-							"PostCode": {
-								"type": "string",
-								"example": ""
-							}
-						},
-						"required": ["AddressLine1", "AddressLine2", "Town", "County", "PostCode"]
-					},
-					"LocalPlanningDepartment": {
-						"type": "string",
-						"example": ""
-					},
-					"PlanningApplicationReference": {
-						"type": "string",
-						"example": ""
-					}
-				},
-				"required": [
-					"AppellantName",
-					"Address",
-					"LocalPlanningDepartment",
-					"PlanningApplicationReference"
-				],
-				"xml": {
-					"name": "ChangeAppeal"
-				}
-			},
-			"ValidationDecision": {
-				"type": "object",
-				"properties": {
-					"AppealStatus": {
-						"type": "string",
-						"enum": ["invalid", "incomplete", "valid"]
-					},
-					"descriptionOfDevelopment": {
-						"type": "string",
-						"example": ""
-					},
-					"Reason": {
-						"type": "object",
-						"properties": {
-							"namesDoNotMatch": {
-								"type": "boolean",
-								"example": true
-							},
-							"sensitiveInfo": {
-								"type": "boolean",
-								"example": true
-							},
-							"missingApplicationForm": {
-								"type": "boolean",
-								"example": true
-							},
-							"missingDecisionNotice": {
-								"type": "boolean",
-								"example": true
-							},
-							"missingGroundsForAppeal": {
-								"type": "boolean",
-								"example": true
-							},
-							"missingSupportingDocuments": {
-								"type": "boolean",
-								"example": true
-							},
-							"inflammatoryComments": {
-								"type": "boolean",
-								"example": true
-							},
-							"openedInError": {
-								"type": "boolean",
-								"example": true
-							},
-							"wrongAppealTypeUsed": {
-								"type": "boolean",
-								"example": true
-							},
-							"outOfTime": {
-								"type": "boolean",
-								"example": true
-							},
-							"noRightOfAppeal": {
-								"type": "boolean",
-								"example": true
-							},
-							"notAppealable": {
-								"type": "boolean",
-								"example": true
-							},
-							"lPADeemedInvalid": {
-								"type": "boolean",
-								"example": true
-							},
-							"otherReasons": {
-								"type": "string",
-								"example": ""
-							}
-						},
-						"required": [
-							"namesDoNotMatch",
-							"sensitiveInfo",
-							"missingApplicationForm",
-							"missingDecisionNotice",
-							"missingGroundsForAppeal",
-							"missingSupportingDocuments",
-							"inflammatoryComments",
-							"openedInError",
-							"wrongAppealTypeUsed",
-							"outOfTime",
-							"noRightOfAppeal",
-							"notAppealable",
-							"lPADeemedInvalid",
-							"otherReasons"
-						]
-					}
-				},
-				"required": ["AppealStatus", "descriptionOfDevelopment", "Reason"],
-				"xml": {
-					"name": "ValidationDecision"
-				}
-			},
-			"AppealDetailsWhenUploadingStatementsAndFinalComments": {
-				"type": "object",
-				"properties": {
-					"AppealId": {
-						"type": "number",
-						"example": 1
-					},
-					"AppealReference": {
-						"type": "string",
-						"example": ""
-					},
-					"AppealSite": {
-						"type": "object",
-						"properties": {
-							"AddressLine1": {
-								"type": "string",
-								"example": ""
-							},
-							"AddressLine2": {
-								"type": "string",
-								"example": ""
-							},
-							"Town": {
-								"type": "string",
-								"example": ""
-							},
-							"County": {
-								"type": "string",
-								"example": ""
-							},
-							"PostCode": {
-								"type": "string",
-								"example": ""
-							}
-						}
-					},
-					"LocalPlanningDepartment": {
-						"type": "string",
-						"example": ""
-					},
-					"acceptingStatements": {
-						"type": "boolean",
-						"example": false
-					},
-					"acceptingFinalComments": {
-						"type": "boolean",
-						"example": true
-					}
-				},
-				"xml": {
-					"name": "AppealDetailsWhenUploadingStatementsAndFinalComments"
 				}
 			},
 			"AllAppeals": {
@@ -2379,6 +1960,134 @@
 					"name": "UpdateLPAQuestionnaireResponse"
 				}
 			},
+			"CreateSiteVisitRequest": {
+				"type": "object",
+				"properties": {
+					"visitDate": {
+						"type": "string",
+						"example": "2023-07-07"
+					},
+					"visitEndTime": {
+						"type": "string",
+						"example": "18:00"
+					},
+					"visitStartTime": {
+						"type": "string",
+						"example": "16:00"
+					},
+					"visitType": {
+						"type": "string",
+						"example": "access required"
+					}
+				},
+				"xml": {
+					"name": "CreateSiteVisitRequest"
+				}
+			},
+			"CreateSiteVisitResponse": {
+				"type": "object",
+				"properties": {
+					"visitDate": {
+						"type": "string",
+						"example": "2023-07-07T01:00:00.000Z"
+					},
+					"visitEndTime": {
+						"type": "string",
+						"example": "18:00"
+					},
+					"visitStartTime": {
+						"type": "string",
+						"example": "16:00"
+					},
+					"visitType": {
+						"type": "string",
+						"example": "access required"
+					}
+				},
+				"xml": {
+					"name": "CreateSiteVisitResponse"
+				}
+			},
+			"UpdateSiteVisitRequest": {
+				"type": "object",
+				"properties": {
+					"visitDate": {
+						"type": "string",
+						"example": "2023-07-09"
+					},
+					"visitEndTime": {
+						"type": "string",
+						"example": "12:00"
+					},
+					"visitStartTime": {
+						"type": "string",
+						"example": "10:00"
+					},
+					"visitType": {
+						"type": "string",
+						"example": "Accompanied"
+					}
+				},
+				"xml": {
+					"name": "UpdateSiteVisitRequest"
+				}
+			},
+			"UpdateSiteVisitResponse": {
+				"type": "object",
+				"properties": {
+					"visitDate": {
+						"type": "string",
+						"example": "2023-07-09T01:00:00.000Z"
+					},
+					"visitEndTime": {
+						"type": "string",
+						"example": "12:00"
+					},
+					"visitStartTime": {
+						"type": "string",
+						"example": "10:00"
+					},
+					"visitType": {
+						"type": "string",
+						"example": "Accompanied"
+					}
+				},
+				"xml": {
+					"name": "UpdateSiteVisitResponse"
+				}
+			},
+			"SingleSiteVisitResponse": {
+				"type": "object",
+				"properties": {
+					"appealId": {
+						"type": "number",
+						"example": 2
+					},
+					"siteVisitId": {
+						"type": "number",
+						"example": 1
+					},
+					"visitType": {
+						"type": "string",
+						"example": "Access required"
+					},
+					"visitDate": {
+						"type": "string",
+						"example": "2023-07-07"
+					},
+					"visitEndTime": {
+						"type": "string",
+						"example": "18:00"
+					},
+					"visitStartTime": {
+						"type": "string",
+						"example": "16:00"
+					}
+				},
+				"xml": {
+					"name": "SingleSiteVisitResponse"
+				}
+			},
 			"AllAppellantCaseIncompleteReasonsResponse": {
 				"type": "array",
 				"items": {
@@ -2434,1014 +2143,6 @@
 				},
 				"xml": {
 					"name": "AllLPAQuestionnaireIncompleteReasonsResponse"
-				}
-			},
-			"AppealsForCaseOfficer": {
-				"type": "object",
-				"properties": {
-					"AppealId": {
-						"type": "number",
-						"example": 1
-					},
-					"AppealReference": {
-						"type": "string",
-						"example": ""
-					},
-					"QuestionnaireDueDate": {
-						"type": "string",
-						"example": "01 Jun 2022"
-					},
-					"AppealSite": {
-						"type": "object",
-						"properties": {
-							"AddressLine1": {
-								"type": "string",
-								"example": "96 The Avenue"
-							},
-							"AddressLine2": {
-								"type": "string",
-								"example": ""
-							},
-							"Town": {
-								"type": "string",
-								"example": "Maidstone"
-							},
-							"County": {
-								"type": "string",
-								"example": "Kent"
-							},
-							"PostCode": {
-								"type": "string",
-								"example": "MD21 5XY"
-							}
-						},
-						"required": ["AddressLine1", "AddressLine2", "Town", "County", "PostCode"]
-					},
-					"QuestionnaireStatus": {
-						"type": "string",
-						"enum": ["awaiting", "received", "overdue"]
-					}
-				},
-				"required": [
-					"AppealId",
-					"AppealReference",
-					"QuestionnaireDueDate",
-					"AppealSite",
-					"QuestionnaireStatus"
-				],
-				"xml": {
-					"name": "AppealsForCaseOfficer"
-				}
-			},
-			"AppealForCaseOfficer": {
-				"type": "object",
-				"properties": {
-					"AppealId": {
-						"type": "number",
-						"example": 1
-					},
-					"AppealReference": {
-						"type": "string",
-						"example": ""
-					},
-					"LocalPlanningDepartment": {
-						"type": "string",
-						"example": ""
-					},
-					"PlanningApplicationReference": {
-						"type": "string",
-						"example": ""
-					},
-					"AppealSiteNearConservationArea": {
-						"type": "boolean",
-						"example": false
-					},
-					"WouldDevelopmentAffectSettingOfListedBuilding": {
-						"type": "boolean",
-						"example": false
-					},
-					"ListedBuildingDesc": {
-						"type": "string",
-						"example": ""
-					},
-					"AppealSite": {
-						"type": "object",
-						"properties": {
-							"AddressLine1": {
-								"type": "string",
-								"example": "96 The Avenue"
-							},
-							"AddressLine2": {
-								"type": "string",
-								"example": ""
-							},
-							"Town": {
-								"type": "string",
-								"example": "Maidstone"
-							},
-							"County": {
-								"type": "string",
-								"example": "Kent"
-							},
-							"PostCode": {
-								"type": "string",
-								"example": "MD21 5XY"
-							}
-						},
-						"required": ["AddressLine1", "AddressLine2", "Town", "County", "PostCode"]
-					},
-					"Documents": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"Type": {
-									"type": "string",
-									"example": ""
-								},
-								"Filename": {
-									"type": "string",
-									"example": ""
-								},
-								"URL": {
-									"type": "string",
-									"example": ""
-								}
-							},
-							"required": ["Type", "Filename", "URL"]
-						}
-					}
-				},
-				"required": [
-					"AppealId",
-					"AppealReference",
-					"LocalPlanningDepartment",
-					"PlanningApplicationReference",
-					"AppealSiteNearConservationArea",
-					"WouldDevelopmentAffectSettingOfListedBuilding",
-					"ListedBuildingDesc",
-					"AppealSite",
-					"Documents"
-				],
-				"xml": {
-					"name": "AppealForCaseOfficer"
-				}
-			},
-			"MoreAppealsForInspector": {
-				"type": "object",
-				"properties": {
-					"appealId": {
-						"type": "number",
-						"example": 1
-					},
-					"appealAge": {
-						"type": "number",
-						"example": 10
-					},
-					"address": {
-						"type": "object",
-						"properties": {
-							"addressLine1": {
-								"type": "string",
-								"example": ""
-							},
-							"addressLine2": {
-								"type": "string",
-								"example": ""
-							},
-							"town": {
-								"type": "string",
-								"example": ""
-							},
-							"county": {
-								"type": "string",
-								"example": ""
-							},
-							"postCode": {
-								"type": "string",
-								"example": ""
-							}
-						},
-						"required": ["addressLine1", "addressLine2", "town", "county", "postCode"]
-					},
-					"appealType": {
-						"type": "string",
-						"example": "HAS"
-					},
-					"specialist": {
-						"type": "string",
-						"example": "General"
-					},
-					"provisionalSiteVisitType": {
-						"type": "string",
-						"enum": ["unaccompanied", "access required"]
-					}
-				},
-				"required": ["appealId", "appealAge", "address", "appealType", "provisionalSiteVisitType"],
-				"xml": {
-					"name": "MoreAppealsForInspector"
-				}
-			},
-			"documentsMetadataResponse": {
-				"type": "object",
-				"properties": {
-					"id": {
-						"type": "number",
-						"example": 1
-					},
-					"caseRef": {
-						"type": "string",
-						"example": ""
-					},
-					"documentGuid": {
-						"type": "string",
-						"example": "1111-2222-3333"
-					},
-					"horizonDataID": {
-						"type": "string",
-						"example": ""
-					},
-					"version": {
-						"type": "string",
-						"example": ""
-					},
-					"path": {
-						"type": "string",
-						"example": ""
-					},
-					"virusCheckStatus": {
-						"type": "string",
-						"example": ""
-					},
-					"fileMD5": {
-						"type": "string",
-						"example": ""
-					},
-					"mime": {
-						"type": "string",
-						"example": ""
-					},
-					"fileSize": {
-						"type": "number",
-						"example": 0
-					},
-					"fileType": {
-						"type": "string",
-						"example": ""
-					},
-					"createdAt": {
-						"type": "string",
-						"example": ""
-					},
-					"lastModified": {
-						"type": "string",
-						"example": ""
-					},
-					"datePublished": {
-						"type": "string",
-						"example": ""
-					},
-					"documentType": {
-						"type": "string",
-						"example": ""
-					},
-					"securityClassification": {
-						"type": "string",
-						"example": ""
-					},
-					"sourceSystem": {
-						"type": "string",
-						"example": ""
-					},
-					"origin": {
-						"type": "string",
-						"example": ""
-					},
-					"owner": {
-						"type": "string",
-						"example": ""
-					},
-					"author": {
-						"type": "string",
-						"example": ""
-					},
-					"representative": {
-						"type": "string",
-						"example": ""
-					},
-					"description": {
-						"type": "string",
-						"example": ""
-					},
-					"stage": {
-						"type": "number",
-						"example": 1
-					}
-				},
-				"xml": {
-					"name": "documentsMetadataResponse"
-				}
-			},
-			"AppealsForInspector": {
-				"type": "object",
-				"properties": {
-					"appealId": {
-						"type": "number",
-						"example": 1
-					},
-					"appealAge": {
-						"type": "number",
-						"example": 10
-					},
-					"appealSite": {
-						"type": "object",
-						"properties": {
-							"addressLine1": {
-								"type": "string",
-								"example": ""
-							},
-							"addressLine2": {
-								"type": "string",
-								"example": ""
-							},
-							"town": {
-								"type": "string",
-								"example": ""
-							},
-							"county": {
-								"type": "string",
-								"example": ""
-							},
-							"postCode": {
-								"type": "string",
-								"example": ""
-							}
-						},
-						"required": ["addressLine1", "addressLine2", "town", "county", "postCode"]
-					},
-					"appealType": {
-						"type": "string",
-						"example": "HAS"
-					},
-					"reference": {
-						"type": "string",
-						"example": ""
-					},
-					"status": {
-						"type": "string",
-						"enum": ["not yet booked", "booked", "decision due"]
-					},
-					"siteVisitType": {
-						"type": "string",
-						"enum": ["accompanied", "unaccompanied", "access required"]
-					},
-					"provisionalSiteVisitType": {
-						"type": "string",
-						"enum": ["unaccompanied", "access required"]
-					}
-				},
-				"required": [
-					"appealId",
-					"appealAge",
-					"appealSite",
-					"appealType",
-					"reference",
-					"status",
-					"siteVisitType",
-					"provisionalSiteVisitType"
-				],
-				"xml": {
-					"name": "AppealsForInspector"
-				}
-			},
-			"AppealDetailsForInspector": {
-				"type": "object",
-				"properties": {
-					"appealId": {
-						"type": "number",
-						"example": 1
-					},
-					"status": {
-						"type": "string",
-						"enum": ["not yet booked", "booked", "decision due"]
-					},
-					"reference": {
-						"type": "string",
-						"example": "APP/2021/56789/4909983"
-					},
-					"availableForSiteVisitBooking": {
-						"type": "boolean",
-						"example": true
-					},
-					"provisionalSiteVisitType": {
-						"type": "string",
-						"enum": ["unaccompanied", "access required"]
-					},
-					"appellantName": {
-						"type": "string",
-						"example": "Maria Sharma"
-					},
-					"email": {
-						"type": "string",
-						"example": "maria.sharma@gmail.com"
-					},
-					"expectedSiteVisitBookingAvailableFrom": {
-						"type": "string",
-						"example": "19 June 2022"
-					},
-					"descriptionOfDevelopment": {
-						"type": "string",
-						"example": "some description of development"
-					},
-					"appealReceivedDate": {
-						"type": "string",
-						"example": "12 December 2020"
-					},
-					"extraConditions": {
-						"type": "boolean",
-						"example": false
-					},
-					"affectsListedBuilding": {
-						"type": "boolean",
-						"example": false
-					},
-					"inGreenBelt": {
-						"type": "boolean",
-						"example": false
-					},
-					"inOrNearConservationArea": {
-						"type": "boolean",
-						"example": false
-					},
-					"emergingDevelopmentPlanOrNeighbourhoodPlan": {
-						"type": "boolean",
-						"example": false
-					},
-					"emergingDevelopmentPlanOrNeighbourhoodPlanDescription": {
-						"type": "string",
-						"example": "plans"
-					},
-					"appealAge": {
-						"type": "number",
-						"example": 12
-					},
-					"localPlanningDepartment": {
-						"type": "string",
-						"example": "some other department"
-					},
-					"bookedSiteVisit": {
-						"type": "object",
-						"properties": {
-							"visitDate": {
-								"type": "string",
-								"example": "12 December 2022"
-							},
-							"visitSlot": {
-								"type": "string",
-								"example": "1pm - 2pm"
-							},
-							"visitType": {
-								"type": "string",
-								"enum": ["accompanied", "unaccompanied", "access required"]
-							}
-						}
-					},
-					"address": {
-						"type": "object",
-						"properties": {
-							"addressLine1": {
-								"type": "string",
-								"example": "66 Grove Road"
-							},
-							"postCode": {
-								"type": "string",
-								"example": "BS16 2BP"
-							},
-							"town": {
-								"type": "string",
-								"example": "Fishponds"
-							}
-						}
-					},
-					"lpaAnswers": {
-						"type": "object",
-						"properties": {
-							"canBeSeenFromPublic": {
-								"type": "boolean",
-								"example": true
-							},
-							"canBeSeenFromPublicDescription": {
-								"type": "string",
-								"example": "not visible from public land"
-							},
-							"inspectorNeedsToEnterSite": {
-								"type": "boolean",
-								"example": false
-							},
-							"inspectorNeedsToEnterSiteDescription": {
-								"type": "string",
-								"example": "inspector will want to enter site"
-							},
-							"inspectorNeedsAccessToNeighboursLand": {
-								"type": "boolean",
-								"example": false
-							},
-							"inspectorNeedsAccessToNeighboursLandDescription": {
-								"type": "string",
-								"example": "should be able to see ok"
-							},
-							"healthAndSafetyIssues": {
-								"type": "boolean",
-								"example": false
-							},
-							"healthAndSafetyIssuesDescription": {
-								"type": "string",
-								"example": "not really"
-							},
-							"appealsInImmediateArea": {
-								"type": "string",
-								"example": "abcd, ABC/DEF/GHI"
-							}
-						}
-					},
-					"appellantAnswers": {
-						"type": "object",
-						"properties": {
-							"canBeSeenFromPublic": {
-								"type": "boolean",
-								"example": true
-							},
-							"canBeSeenFromPublicDescription": {
-								"type": "string",
-								"example": "site visit description"
-							},
-							"appellantOwnsWholeSite": {
-								"type": "boolean",
-								"example": true
-							},
-							"appellantOwnsWholeSiteDescription": {
-								"type": "string",
-								"example": "i own the whole site"
-							},
-							"healthAndSafetyIssues": {
-								"type": "boolean",
-								"example": false
-							},
-							"healthAndSafetyIssuesDescription": {
-								"type": "string",
-								"example": "everything is super safe"
-							}
-						}
-					}
-				},
-				"xml": {
-					"name": "AppealDetailsForInspector"
-				}
-			},
-			"AppealsAssignedToInspector": {
-				"type": "object",
-				"properties": {
-					"successfullyAssigned": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"appealId": {
-									"type": "number",
-									"example": 1
-								},
-								"reference": {
-									"type": "string",
-									"example": "APP/Q9999/D/21/1345264"
-								},
-								"appealType": {
-									"type": "string",
-									"example": "HAS"
-								},
-								"specialist": {
-									"type": "string",
-									"example": "General"
-								},
-								"provisionalVisitType": {
-									"type": "string",
-									"enum": ["unaccompanied", "access required"]
-								},
-								"appealSite": {
-									"type": "object",
-									"properties": {
-										"addressLine1": {
-											"type": "string",
-											"example": "96 The Avenue"
-										},
-										"county": {
-											"type": "string",
-											"example": "Kent"
-										},
-										"town": {
-											"type": "string",
-											"example": "Maidstone"
-										},
-										"postCode": {
-											"type": "string",
-											"example": "MD21 5XY"
-										}
-									},
-									"required": ["addressLine1", "county", "town", "postCode"]
-								},
-								"appealAge": {
-									"type": "number",
-									"example": 41
-								}
-							},
-							"required": [
-								"appealId",
-								"reference",
-								"appealType",
-								"specialist",
-								"provisionalVisitType",
-								"appealSite",
-								"appealAge"
-							]
-						}
-					},
-					"unsuccessfullyAssigned": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"appealId": {
-									"type": "number",
-									"example": 4
-								},
-								"reference": {
-									"type": "string",
-									"example": "APP/Q9999/D/21/1345264"
-								},
-								"appealType": {
-									"type": "string",
-									"example": "HAS"
-								},
-								"specialist": {
-									"type": "string",
-									"example": "General"
-								},
-								"provisionalVisitType": {
-									"type": "string",
-									"enum": ["unaccompanied", "access required"]
-								},
-								"appealSite": {
-									"type": "object",
-									"properties": {
-										"addressLine1": {
-											"type": "string",
-											"example": "96 The Avenue"
-										},
-										"county": {
-											"type": "string",
-											"example": "Kent"
-										},
-										"town": {
-											"type": "string",
-											"example": "Maidstone"
-										},
-										"postCode": {
-											"type": "string",
-											"example": "MD21 5XY"
-										}
-									},
-									"required": ["addressLine1", "county", "town", "postCode"]
-								},
-								"appealAge": {
-									"type": "number",
-									"example": 41
-								},
-								"reason": {
-									"type": "string",
-									"enum": ["appeal in wrong state", "appeal already assigned"]
-								}
-							},
-							"required": [
-								"appealId",
-								"reference",
-								"appealType",
-								"specialist",
-								"provisionalVisitType",
-								"appealSite",
-								"appealAge",
-								"reason"
-							]
-						}
-					}
-				},
-				"required": ["successfullyAssigned", "unsuccessfullyAssigned"],
-				"xml": {
-					"name": "AppealsAssignedToInspector"
-				}
-			},
-			"UpdateAppealDetailsByCaseOfficer": {
-				"type": "object",
-				"properties": {
-					"listedBuildingDescription": {
-						"type": "string",
-						"example": ""
-					}
-				},
-				"required": ["listedBuildingDescription"],
-				"xml": {
-					"name": "UpdateAppealDetailsByCaseOfficer"
-				}
-			},
-			"AppealAfterUpdateForCaseOfficer": {
-				"type": "object",
-				"properties": {
-					"appealStatus": {
-						"type": "array",
-						"items": {
-							"type": "object",
-							"properties": {
-								"id": {
-									"type": "number",
-									"example": 2
-								},
-								"status": {
-									"type": "string",
-									"example": "incomplete_lpa_questionnaire"
-								},
-								"valid": {
-									"type": "boolean",
-									"example": true
-								}
-							},
-							"required": ["id", "status", "valid"]
-						}
-					},
-					"createdAt": {
-						"type": "string",
-						"example": "2022-01-01T00:00:00.000Z"
-					},
-					"id": {
-						"type": "number",
-						"example": 1
-					},
-					"localPlanningDepartment": {
-						"type": "string",
-						"example": "Local planning dept"
-					},
-					"lpaQuestionnaire": {
-						"type": "object",
-						"properties": {
-							"listedBuildingDescription": {
-								"type": "string",
-								"example": "*"
-							}
-						},
-						"required": ["listedBuildingDescription"]
-					},
-					"planningApplicationReference": {
-						"type": "string",
-						"example": "0181/811/8181"
-					},
-					"reference": {
-						"type": "string",
-						"example": "APP/Q9999/D/21/323259"
-					},
-					"updatedAt": {
-						"type": "string",
-						"example": "2022-01-01T00:00:00.000Z"
-					},
-					"userId": {
-						"type": "number",
-						"example": 100
-					}
-				},
-				"required": [
-					"appealStatus",
-					"createdAt",
-					"id",
-					"localPlanningDepartment",
-					"lpaQuestionnaire",
-					"planningApplicationReference",
-					"reference",
-					"updatedAt",
-					"userId"
-				],
-				"xml": {
-					"name": "AppealAfterUpdateForCaseOfficer"
-				}
-			},
-			"SendLPAQuestionnaireConfirmation": {
-				"type": "object",
-				"properties": {
-					"reason": {
-						"type": "object",
-						"properties": {
-							"applicationPlansToReachDecisionMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"applicationPlansToReachDecisionMissingOrIncorrectDescription": {
-								"type": "string",
-								"example": ""
-							},
-							"policiesStatutoryDevelopmentPlanPoliciesMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"policiesStatutoryDevelopmentPlanPoliciesMissingOrIncorrectDescription": {
-								"type": "string",
-								"example": ""
-							},
-							"policiesOtherRelevanPoliciesMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"policiesOtherRelevanPoliciesMissingOrIncorrectDescription": {
-								"type": "string",
-								"example": ""
-							},
-							"policiesSupplementaryPlanningDocumentsMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"policiesSupplementaryPlanningDocumentsMissingOrIncorrectDescription": {
-								"type": "string",
-								"example": ""
-							},
-							"siteConservationAreaMapAndGuidanceMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"siteConservationAreaMapAndGuidanceMissingOrIncorrectDescription": {
-								"type": "string",
-								"example": ""
-							},
-							"siteListedBuildingDescriptionMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"siteListedBuildingDescriptionMissingOrIncorrectDescription": {
-								"type": "string",
-								"example": ""
-							},
-							"thirdPartyApplicationNotificationMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"thirdPartyApplicationNotificationMissingOrIncorrectListOfAddresses": {
-								"type": "boolean",
-								"example": false
-							},
-							"thirdPartyApplicationNotificationMissingOrIncorrectCopyOfLetterOrSiteNotice": {
-								"type": "boolean",
-								"example": false
-							},
-							"thirdPartyRepresentationsMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"thirdPartyRepresentationsMissingOrIncorrectDescription": {
-								"type": "string",
-								"example": ""
-							},
-							"thirdPartyAppealNotificationMissingOrIncorrect": {
-								"type": "boolean",
-								"example": true
-							},
-							"thirdPartyAppealNotificationMissingOrIncorrectListOfAddresses": {
-								"type": "boolean",
-								"example": false
-							},
-							"thirdPartyAppealNotificationMissingOrIncorrectCopyOfLetterOrSiteNotice": {
-								"type": "boolean",
-								"example": false
-							}
-						}
-					}
-				},
-				"xml": {
-					"name": "SendLPAQuestionnaireConfirmation"
-				}
-			},
-			"BookSiteVisit": {
-				"type": "object",
-				"properties": {
-					"siteVisitType": {
-						"required": true,
-						"type": "string",
-						"enum": ["accompanied", "unaccompanied", "access required"]
-					},
-					"siteVisitDate": {
-						"type": "object",
-						"properties": {
-							"required": {
-								"type": "boolean",
-								"example": true
-							},
-							"type": {
-								"type": "string",
-								"example": "string"
-							},
-							"format": {
-								"type": "string",
-								"example": "date"
-							},
-							"example": {
-								"type": "string",
-								"example": "2022-01-01"
-							}
-						}
-					},
-					"siteVisitTimeSlot": {
-						"required": true,
-						"type": "string",
-						"enum": [
-							"8am to 10am",
-							"9am to 11am",
-							"10am to midday",
-							"11am to 1pm",
-							"midday to 2pm",
-							"1pm to 3pm",
-							"2pm to 4pm",
-							"3pm to 5pm",
-							"4pm to 6pm",
-							"5pm to 7pm"
-						]
-					}
-				},
-				"required": ["siteVisitType", "siteVisitDate", "siteVisitTimeSlot"],
-				"xml": {
-					"name": "BookSiteVisit"
-				}
-			},
-			"IssueDecision": {
-				"type": "object",
-				"properties": {
-					"decisionLetter": {
-						"type": "object",
-						"properties": {
-							"type": {
-								"type": "string",
-								"example": "file"
-							},
-							"required": {
-								"type": "boolean",
-								"example": true
-							}
-						}
-					},
-					"outcome": {
-						"required": true,
-						"type": "string",
-						"enum": ["allowed", "dismissed", "split decision"]
-					}
-				},
-				"required": ["decisionLetter", "outcome"],
-				"xml": {
-					"name": "IssueDecision"
-				}
-			},
-			"UploadStatement": {
-				"type": "object",
-				"properties": {
-					"statement": {
-						"type": "object",
-						"properties": {
-							"type": {
-								"type": "string",
-								"example": "file"
-							},
-							"required": {
-								"type": "boolean",
-								"example": true
-							}
-						}
-					}
-				},
-				"required": ["statement"],
-				"xml": {
-					"name": "UploadStatement"
-				}
-			},
-			"UploadFinalComment": {
-				"type": "object",
-				"properties": {
-					"finalcomment": {
-						"type": "object",
-						"properties": {
-							"type": {
-								"type": "string",
-								"example": "file"
-							},
-							"required": {
-								"type": "boolean",
-								"example": true
-							}
-						}
-					}
-				},
-				"required": ["finalcomment"],
-				"xml": {
-					"name": "UploadFinalComment"
 				}
 			}
 		}

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -17,6 +17,7 @@ import { createManyToManyRelationData } from '../endpoints/appeals/appeals.servi
 /** @typedef {import('@pins/appeals.api').Schema.AppellantCaseIncompleteReasonOnAppellantCase} AppellantCaseIncompleteReasonOnAppellantCase */
 /** @typedef {import('@pins/appeals.api').Schema.AppellantCaseInvalidReasonOnAppellantCase} AppellantCaseInvalidReasonOnAppellantCase */
 /** @typedef {import('@pins/appeals.api').Schema.LPAQuestionnaire} LPAQuestionnaire */
+/** @typedef {import('@pins/appeals.api').Schema.SiteVisit} SiteVisit */
 /**
  * @typedef {import('#db-client').Prisma.PrismaPromise<T>} PrismaPromise
  * @template T
@@ -140,7 +141,11 @@ const appealRepository = (function () {
 							scheduleType: true
 						}
 					},
-					siteVisit: true
+					siteVisit: {
+						include: {
+							siteVisitType: true
+						}
+					}
 				}
 			});
 
@@ -178,6 +183,10 @@ const appealRepository = (function () {
 		 *  otherNotValidReasons?: string;
 		 *  appellantCaseValidationOutcomeId?: number;
 		 *  lpaQuestionnaireValidationOutcomeId?: number;
+		 * 	visitDate?: Date;
+		 * 	visitEndTime?: string;
+		 * 	visitStartTime?: string;
+		 * 	siteVisitTypeId?: number;
 		 * }} data
 		 * @param {string} databaseTable
 		 * @returns {PrismaPromise<object>}
@@ -405,6 +414,21 @@ const appealRepository = (function () {
 					}
 				})
 			]);
+		},
+		/**
+		 * @param {{
+		 *  appealId: number;
+		 * 	visitDate?: Date;
+		 * 	visitEndTime?: string;
+		 * 	visitStartTime?: string;
+		 * 	siteVisitTypeId?: number;
+		 * }} data
+		 * @returns {PrismaPromise<SiteVisit>}
+		 */
+		createSiteVisitById(data) {
+			return databaseConnector.siteVisit.create({
+				data
+			});
 		}
 	};
 })();

--- a/appeals/api/src/server/state/create-state-machine.js
+++ b/appeals/api/src/server/state/create-state-machine.js
@@ -7,7 +7,7 @@ import hasStateMachine from './state-machines/has.js';
 import fpaStateMachine from './state-machines/fpa.js';
 
 /**
- * @param {string} appealType
+ * @param {string | undefined} appealType
  * @param {string} currentState
  */
 const createStateMachine = (appealType, currentState) => {

--- a/appeals/api/src/server/state/transition-state.js
+++ b/appeals/api/src/server/state/transition-state.js
@@ -3,19 +3,22 @@ import createStateMachine from './create-state-machine.js';
 import logger from '../utils/logger.js';
 import appealRepository from '../repositories/appeal.repository.js';
 
+/** @typedef {import('@prisma/client').AppealType} AppealType */
+/** @typedef {import('@prisma/client').AppealStatus} AppealStatus */
+/** @typedef {import('xstate').StateValue} StateValue */
+
 /**
- * @param {{
- *  appealId: number;
- *  appealType: string;
- *  currentState: string;
- *  trigger: string;
- * }} param0
+ *  @param {number} appealId
+ *  @param {AppealType | null} appealType
+ *  @param {AppealStatus[]} currentState
+ *  @param {string} trigger
  */
-const transitionState = async ({ appealId, appealType, currentState, trigger }) => {
-	const stateMachine = createStateMachine(appealType, currentState);
+const transitionState = async (appealId, appealType, currentState, trigger) => {
+	const currentStatus = currentState[0].status;
+	const stateMachine = createStateMachine(appealType?.shorthand, currentStatus);
 	const stateMachineService = interpret(stateMachine);
 
-	stateMachineService.onTransition((state) =>
+	stateMachineService.onTransition((/** @type {{value: StateValue}} */ state) =>
 		logger.debug(`Appeal ${appealId} transitioned to ${state.value}`)
 	);
 	stateMachineService.start();
@@ -23,7 +26,7 @@ const transitionState = async ({ appealId, appealType, currentState, trigger }) 
 
 	const newState = String(stateMachineService.state.value);
 
-	if (newState !== currentState) {
+	if (newState !== currentStatus) {
 		await appealRepository.updateAppealStatus(appealId, newState);
 	}
 

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -39,51 +39,6 @@ const document = {
 			caseId: 34,
 			documents: []
 		},
-		documentsPropertiesRequestBody: {
-			version: 1,
-			createdAt: '2023-02-27T10:00:00Z',
-			lastModified: '2023-02-27T12:00:00Z',
-			documentType: 'PDF',
-			published: false,
-			sourceSystem: 'Salesforce',
-			origin: 'Email',
-			representative: 'John Doe',
-			description: 'Marketing Brochure',
-			documentGuid: 'ab12cd34-5678-90ef-ghij-klmnopqrstuv',
-			datePublished: '2023-03-01T10:00:00Z',
-			owner: 'Jane Doe',
-			author: 'Marketing Team',
-			securityClassification: 'Confidential',
-			mime: 'application/pdf',
-			horizonDataID: '123456789',
-			fileMD5: 'f60c381d96dcedec4b4fb4b9e1f6e14e',
-			path: '/documents/marketing/ab12cd34-5678-90ef-ghij-klmnopqrstuv.pdf',
-			virusCheckStatus: 'Clean',
-			size: 1024,
-			stage: 3,
-			filter1: 'Marketing',
-			filter2: 'Brochure'
-		},
-		documentsMetadataResponseBody: {
-			version: 1,
-			documentId: 'a6f9f2e0-12c9-49b7-8a1c-3b5edc34dd99',
-			datePublished: '',
-			caseRef: 'BC0210002',
-			documentName: '5',
-			blobStorageContainer: 'document-service-uploads',
-			documentURI: '/application/BC010001/1111-2222-3333/my doc.pdf',
-			from: 'joe blogs',
-			dateCreated: 1_677_585_578,
-			size: 0,
-			fileType: '',
-			redacted: false,
-			status: 'awaiting_upload',
-			description: '',
-			agent: '',
-			documentType: '',
-			webFilter: ''
-		},
-
 		DocumentDetails: {
 			documentId: '123',
 			version: 1,
@@ -107,112 +62,6 @@ const document = {
 			documentType: 'contract',
 			caseRef: 'ABC-123',
 			examinationRefNo: 'EXM-456'
-		},
-		AppealToValidate: {
-			AppealId: 1,
-			AppealReference: 'APP/Q9999/D/21/1345264',
-			AppellantName: 'Lee Thornton',
-			AppealStatus: 'new',
-			Received: '18 Mar 2022',
-			AppealSite: {
-				AddressLine1: '96 The Avenue',
-				AddressLine2: '',
-				Town: 'Maidstone',
-				County: 'Kent',
-				PostCode: 'MD21 5XY'
-			},
-			LocalPlanningDepartment: 'Maidstone Borough Council',
-			PlanningApplicationReference: '48269/APP/2021/1482',
-			Documents: [
-				{
-					Type: '',
-					Filename: '',
-					URL: ''
-				}
-			],
-			reason: {
-				inflammatoryComments: true,
-				missingApplicationForm: true,
-				missingDecisionNotice: true,
-				missingGroundsForAppeal: true,
-				missingSupportingDocuments: true,
-				namesDoNotMatch: true,
-				openedInError: true,
-				otherReasons: 'Some other weird reason',
-				sensitiveInfo: true,
-				wrongAppealTypeUsed: true
-			}
-		},
-		AppealDetailsAfterStatementUpload: {
-			AppealId: 2,
-			AppealReference: 'ABC',
-			canUploadStatementsUntil: '08 March 2022'
-		},
-		AppealDetailsAfterFinalCommentUpload: {
-			AppealId: 2,
-			AppealReference: 'ABC',
-			canUploadFinalCommentsUntil: '08 March 2022'
-		},
-		AppealsToValidate: [
-			{
-				AppealId: 1,
-				AppealReference: 'APP/Q9999/D/21/1345264',
-				AppealStatus: { '@enum': ['new', 'incomplete'] },
-				Received: '18 Mar 2022',
-				AppealSite: {
-					AddressLine1: '96 The Avenue',
-					AddressLine2: '',
-					Town: 'Maidstone',
-					County: 'Kent',
-					PostCode: 'MD21 5XY'
-				}
-			}
-		],
-		ChangeAppeal: {
-			$AppellantName: 'John Doe',
-			$Address: {
-				$AddressLine1: '',
-				$AddressLine2: '',
-				$Town: '',
-				$County: '',
-				$PostCode: ''
-			},
-			$LocalPlanningDepartment: '',
-			$PlanningApplicationReference: ''
-		},
-		ValidationDecision: {
-			$AppealStatus: { '@enum': ['invalid', 'incomplete', 'valid'] },
-			$descriptionOfDevelopment: '',
-			$Reason: {
-				$namesDoNotMatch: true,
-				$sensitiveInfo: true,
-				$missingApplicationForm: true,
-				$missingDecisionNotice: true,
-				$missingGroundsForAppeal: true,
-				$missingSupportingDocuments: true,
-				$inflammatoryComments: true,
-				$openedInError: true,
-				$wrongAppealTypeUsed: true,
-				$outOfTime: true,
-				$noRightOfAppeal: true,
-				$notAppealable: true,
-				$lPADeemedInvalid: true,
-				$otherReasons: ''
-			}
-		},
-		AppealDetailsWhenUploadingStatementsAndFinalComments: {
-			AppealId: 1,
-			AppealReference: '',
-			AppealSite: {
-				AddressLine1: '',
-				AddressLine2: '',
-				Town: '',
-				County: '',
-				PostCode: ''
-			},
-			LocalPlanningDepartment: '',
-			acceptingStatements: false,
-			acceptingFinalComments: true
 		},
 		AllAppeals: {
 			itemCount: 57,
@@ -489,6 +338,38 @@ const document = {
 			validationOutcome: 'incomplete'
 		},
 		UpdateLPAQuestionnaireResponse: {},
+		CreateSiteVisitRequest: {
+			visitDate: '2023-07-07',
+			visitEndTime: '18:00',
+			visitStartTime: '16:00',
+			visitType: 'access required'
+		},
+		CreateSiteVisitResponse: {
+			visitDate: '2023-07-07T01:00:00.000Z',
+			visitEndTime: '18:00',
+			visitStartTime: '16:00',
+			visitType: 'access required'
+		},
+		UpdateSiteVisitRequest: {
+			visitDate: '2023-07-09',
+			visitEndTime: '12:00',
+			visitStartTime: '10:00',
+			visitType: 'Accompanied'
+		},
+		UpdateSiteVisitResponse: {
+			visitDate: '2023-07-09T01:00:00.000Z',
+			visitEndTime: '12:00',
+			visitStartTime: '10:00',
+			visitType: 'Accompanied'
+		},
+		SingleSiteVisitResponse: {
+			appealId: 2,
+			siteVisitId: 1,
+			visitType: 'Access required',
+			visitDate: '2023-07-07',
+			visitEndTime: '18:00',
+			visitStartTime: '16:00'
+		},
 		AllAppellantCaseIncompleteReasonsResponse: [
 			{
 				id: 1,
@@ -506,285 +387,7 @@ const document = {
 				id: 1,
 				name: 'Incomplete reason'
 			}
-		],
-		AppealsForCaseOfficer: {
-			$AppealId: 1,
-			$AppealReference: '',
-			$QuestionnaireDueDate: '01 Jun 2022',
-			$AppealSite: {
-				$AddressLine1: '96 The Avenue',
-				$AddressLine2: '',
-				$Town: 'Maidstone',
-				$County: 'Kent',
-				$PostCode: 'MD21 5XY'
-			},
-			$QuestionnaireStatus: { '@enum': ['awaiting', 'received', 'overdue'] }
-		},
-		AppealForCaseOfficer: {
-			$AppealId: 1,
-			$AppealReference: '',
-			$LocalPlanningDepartment: '',
-			$PlanningApplicationReference: '',
-			$AppealSiteNearConservationArea: false,
-			$WouldDevelopmentAffectSettingOfListedBuilding: false,
-			$ListedBuildingDesc: '',
-			$AppealSite: {
-				$AddressLine1: '96 The Avenue',
-				$AddressLine2: '',
-				$Town: 'Maidstone',
-				$County: 'Kent',
-				$PostCode: 'MD21 5XY'
-			},
-			$Documents: [
-				{
-					$Type: '',
-					$Filename: '',
-					$URL: ''
-				}
-			]
-		},
-		MoreAppealsForInspector: {
-			$appealId: 1,
-			$appealAge: 10,
-			$address: {
-				$addressLine1: '',
-				$addressLine2: '',
-				$town: '',
-				$county: '',
-				$postCode: ''
-			},
-			$appealType: 'HAS',
-			specialist: 'General',
-			$provisionalSiteVisitType: { '@enum': ['unaccompanied', 'access required'] }
-		},
-		documentsMetadataResponse: {
-			id: 1,
-			caseRef: '',
-			documentGuid: '1111-2222-3333',
-			horizonDataID: '',
-			version: '',
-			path: '',
-			virusCheckStatus: '',
-			fileMD5: '',
-			mime: '',
-			fileSize: 0,
-			fileType: '',
-			createdAt: '',
-			lastModified: '',
-			datePublished: '',
-			documentType: '',
-			securityClassification: '',
-			sourceSystem: '',
-			origin: '',
-			owner: '',
-			author: '',
-			representative: '',
-			description: '',
-			stage: 1
-		},
-		AppealsForInspector: {
-			$appealId: 1,
-			$appealAge: 10,
-			$appealSite: {
-				$addressLine1: '',
-				$addressLine2: '',
-				$town: '',
-				$county: '',
-				$postCode: ''
-			},
-			$appealType: 'HAS',
-			$reference: '',
-			$status: { '@enum': ['not yet booked', 'booked', 'decision due'] },
-			$siteVisitType: { '@enum': ['accompanied', 'unaccompanied', 'access required'] },
-			$provisionalSiteVisitType: { '@enum': ['unaccompanied', 'access required'] }
-		},
-		AppealDetailsForInspector: {
-			appealId: 1,
-			status: { '@enum': ['not yet booked', 'booked', 'decision due'] },
-			reference: 'APP/2021/56789/4909983',
-			availableForSiteVisitBooking: true,
-			provisionalSiteVisitType: { '@enum': ['unaccompanied', 'access required'] },
-			appellantName: 'Maria Sharma',
-			email: 'maria.sharma@gmail.com',
-			expectedSiteVisitBookingAvailableFrom: '19 June 2022',
-			descriptionOfDevelopment: 'some description of development',
-			appealReceivedDate: '12 December 2020',
-			extraConditions: false,
-			affectsListedBuilding: false,
-			inGreenBelt: false,
-			inOrNearConservationArea: false,
-			emergingDevelopmentPlanOrNeighbourhoodPlan: false,
-			emergingDevelopmentPlanOrNeighbourhoodPlanDescription: 'plans',
-			appealAge: 12,
-			localPlanningDepartment: 'some other department',
-			bookedSiteVisit: {
-				visitDate: '12 December 2022',
-				visitSlot: '1pm - 2pm',
-				visitType: { '@enum': ['accompanied', 'unaccompanied', 'access required'] }
-			},
-			address: {
-				addressLine1: '66 Grove Road',
-				postCode: 'BS16 2BP',
-				town: 'Fishponds'
-			},
-			lpaAnswers: {
-				canBeSeenFromPublic: true,
-				canBeSeenFromPublicDescription: 'not visible from public land',
-				inspectorNeedsToEnterSite: false,
-				inspectorNeedsToEnterSiteDescription: 'inspector will want to enter site',
-				inspectorNeedsAccessToNeighboursLand: false,
-				inspectorNeedsAccessToNeighboursLandDescription: 'should be able to see ok',
-				healthAndSafetyIssues: false,
-				healthAndSafetyIssuesDescription: 'not really',
-				appealsInImmediateArea: 'abcd, ABC/DEF/GHI'
-			},
-			appellantAnswers: {
-				canBeSeenFromPublic: true,
-				canBeSeenFromPublicDescription: 'site visit description',
-				appellantOwnsWholeSite: true,
-				appellantOwnsWholeSiteDescription: 'i own the whole site',
-				healthAndSafetyIssues: false,
-				healthAndSafetyIssuesDescription: 'everything is super safe'
-			}
-		},
-		AppealsAssignedToInspector: {
-			$successfullyAssigned: [
-				{
-					$appealId: 1,
-					$reference: 'APP/Q9999/D/21/1345264',
-					$appealType: 'HAS',
-					$specialist: 'General',
-					$provisionalVisitType: { '@enum': ['unaccompanied', 'access required'] },
-					$appealSite: {
-						$addressLine1: '96 The Avenue',
-						$county: 'Kent',
-						$town: 'Maidstone',
-						$postCode: 'MD21 5XY'
-					},
-					$appealAge: 41
-				}
-			],
-			$unsuccessfullyAssigned: [
-				{
-					$appealId: 4,
-					$reference: 'APP/Q9999/D/21/1345264',
-					$appealType: 'HAS',
-					$specialist: 'General',
-					$provisionalVisitType: { '@enum': ['unaccompanied', 'access required'] },
-					$appealSite: {
-						$addressLine1: '96 The Avenue',
-						$county: 'Kent',
-						$town: 'Maidstone',
-						$postCode: 'MD21 5XY'
-					},
-					$appealAge: 41,
-					$reason: { '@enum': ['appeal in wrong state', 'appeal already assigned'] }
-				}
-			]
-		},
-		UpdateAppealDetailsByCaseOfficer: {
-			$listedBuildingDescription: ''
-		},
-		AppealAfterUpdateForCaseOfficer: {
-			$appealStatus: [
-				{
-					$id: 2,
-					$status: 'incomplete_lpa_questionnaire',
-					$valid: true
-				}
-			],
-			$createdAt: '2022-01-01T00:00:00.000Z',
-			$id: 1,
-			$localPlanningDepartment: 'Local planning dept',
-			$lpaQuestionnaire: {
-				$listedBuildingDescription: '*'
-			},
-			$planningApplicationReference: '0181/811/8181',
-			$reference: 'APP/Q9999/D/21/323259',
-			$updatedAt: '2022-01-01T00:00:00.000Z',
-			$userId: 100
-		},
-		SendLPAQuestionnaireConfirmation: {
-			reason: {
-				applicationPlansToReachDecisionMissingOrIncorrect: true,
-				applicationPlansToReachDecisionMissingOrIncorrectDescription: '',
-				policiesStatutoryDevelopmentPlanPoliciesMissingOrIncorrect: true,
-				policiesStatutoryDevelopmentPlanPoliciesMissingOrIncorrectDescription: '',
-				policiesOtherRelevanPoliciesMissingOrIncorrect: true,
-				policiesOtherRelevanPoliciesMissingOrIncorrectDescription: '',
-				policiesSupplementaryPlanningDocumentsMissingOrIncorrect: true,
-				policiesSupplementaryPlanningDocumentsMissingOrIncorrectDescription: '',
-				siteConservationAreaMapAndGuidanceMissingOrIncorrect: true,
-				siteConservationAreaMapAndGuidanceMissingOrIncorrectDescription: '',
-				siteListedBuildingDescriptionMissingOrIncorrect: true,
-				siteListedBuildingDescriptionMissingOrIncorrectDescription: '',
-				thirdPartyApplicationNotificationMissingOrIncorrect: true,
-				thirdPartyApplicationNotificationMissingOrIncorrectListOfAddresses: false,
-				thirdPartyApplicationNotificationMissingOrIncorrectCopyOfLetterOrSiteNotice: false,
-				thirdPartyRepresentationsMissingOrIncorrect: true,
-				thirdPartyRepresentationsMissingOrIncorrectDescription: '',
-				thirdPartyAppealNotificationMissingOrIncorrect: true,
-				thirdPartyAppealNotificationMissingOrIncorrectListOfAddresses: false,
-				thirdPartyAppealNotificationMissingOrIncorrectCopyOfLetterOrSiteNotice: false
-			}
-		},
-		BookSiteVisit: {
-			$siteVisitType: {
-				required: true,
-				'@enum': /** @type {import('@pins/appeals.api').Schema.SiteVisitType} */ ([
-					'accompanied',
-					'unaccompanied',
-					'access required'
-				])
-			},
-			$siteVisitDate: {
-				required: true,
-				type: 'string',
-				format: 'date',
-				example: '2022-01-01'
-			},
-			$siteVisitTimeSlot: {
-				required: true,
-				'@enum': [
-					'8am to 10am',
-					'9am to 11am',
-					'10am to midday',
-					'11am to 1pm',
-					'midday to 2pm',
-					'1pm to 3pm',
-					'2pm to 4pm',
-					'3pm to 5pm',
-					'4pm to 6pm',
-					'5pm to 7pm'
-				]
-			}
-		},
-		IssueDecision: {
-			$decisionLetter: {
-				type: 'file',
-				required: true
-			},
-			$outcome: {
-				required: true,
-				'@enum': /** @type {import('@pins/appeals.api').Schema.InspectorDecisionOutcomeType} */ ([
-					'allowed',
-					'dismissed',
-					'split decision'
-				])
-			}
-		},
-		UploadStatement: {
-			$statement: {
-				type: 'file',
-				required: true
-			}
-		},
-		UploadFinalComment: {
-			$finalcomment: {
-				type: 'file',
-				required: true
-			}
-		}
+		]
 	},
 	components: {}
 };

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -79,9 +79,13 @@ const householdAppeal = {
 	siteVisit: {
 		id: 1,
 		appealId: 1,
-		visitDate: '2022-03-31T12:00:00.000Z',
-		visitSlot: '1pm - 2pm',
-		visitType: 'unaccompanied'
+		visitDate: '2022-03-31T01:00:00.000Z',
+		visitEndTime: '03:00',
+		visitStartTime: '01:00',
+		siteVisitType: {
+			id: 1,
+			name: 'Access required'
+		}
 	},
 	lpaQuestionnaire: {
 		id: 1,

--- a/appeals/api/src/server/utils/notify-client.js
+++ b/appeals/api/src/server/utils/notify-client.js
@@ -27,12 +27,12 @@ class NotifyClient {
 
 	/**
 	 * @param {NotifyTemplate} template
-	 * @param {string} recipientEmail
+	 * @param {string | undefined} recipientEmail
 	 * @param {{[key: string]: string}} [personalisation]
 	 */
 	sendEmail(template, recipientEmail, personalisation) {
 		try {
-			if (this.govNotify) {
+			if (this.govNotify && recipientEmail) {
 				return this.govNotify.sendEmail(template.id, recipientEmail, {
 					emailReplyToId: null,
 					personalisation,

--- a/appeals/web/testing/appeals/factory/site-visit.js
+++ b/appeals/web/testing/appeals/factory/site-visit.js
@@ -13,14 +13,16 @@ export const createSiteVisit = ({
 	id = fake.createUniqueId(),
 	appealId = fake.createUniqueId(),
 	visitDate = add(new Date(), { days: random(1, 7) }),
-	visitSlot = '1pm - 2pm',
-	visitType = 'accompanied'
+	visitEndTime = '16:00',
+	visitStartTime = '14:00',
+	siteVisitTypeId = 1
 } = {}) => {
 	return {
 		id,
 		appealId,
 		visitDate,
-		visitSlot,
-		visitType
+		visitEndTime,
+		visitStartTime,
+		siteVisitTypeId
 	};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "dotenv": "16.0.3",
         "express": "4.18.1",
         "express-pino-logger": "^7.0.0",
-        "express-validator": "6.14.2",
+        "express-validator": "^7.0.1",
         "got": "^12.5.2",
         "helmet": "5.1.0",
         "joi": "^17.7.0",
@@ -673,12 +673,12 @@
       }
     },
     "appeals/api/node_modules/express-validator": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.2.tgz",
-      "integrity": "sha512-8XfAUrQ6Y7dIIuy9KcUPCfG/uCbvREctrxf5EeeME+ulanJ4iiW71lWmm9r4YcKKYOCBMan0WpVg7FtHu4Z4Wg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
+      "integrity": "sha512-oB+z9QOzQIE8FnlINqyIFA8eIckahC6qc8KtqLdLJcU3/phVyuhXH3bA4qzcrhme+1RYaCSwrq+TlZ/kAKIARA==",
       "dependencies": {
         "lodash": "^4.17.21",
-        "validator": "^13.7.0"
+        "validator": "^13.9.0"
       },
       "engines": {
         "node": ">= 8.0.0"
@@ -32989,8 +32989,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.7.0",
-      "license": "MIT",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -37240,7 +37241,7 @@
         "eslint": "8.18.0",
         "express": "4.18.1",
         "express-pino-logger": "^7.0.0",
-        "express-validator": "6.14.2",
+        "express-validator": "^7.0.1",
         "got": "^12.5.2",
         "helmet": "5.1.0",
         "jest": "^29.4.2",
@@ -37704,12 +37705,12 @@
           }
         },
         "express-validator": {
-          "version": "6.14.2",
-          "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.14.2.tgz",
-          "integrity": "sha512-8XfAUrQ6Y7dIIuy9KcUPCfG/uCbvREctrxf5EeeME+ulanJ4iiW71lWmm9r4YcKKYOCBMan0WpVg7FtHu4Z4Wg==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
+          "integrity": "sha512-oB+z9QOzQIE8FnlINqyIFA8eIckahC6qc8KtqLdLJcU3/phVyuhXH3bA4qzcrhme+1RYaCSwrq+TlZ/kAKIARA==",
           "requires": {
             "lodash": "^4.17.21",
-            "validator": "^13.7.0"
+            "validator": "^13.9.0"
           }
         },
         "glob-parent": {
@@ -57700,7 +57701,9 @@
       }
     },
     "validator": {
-      "version": "13.7.0"
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
     },
     "vary": {
       "version": "1.1.2"


### PR DESCRIPTION
## Describe your changes

Add API endpoints for creating, updating and getting an appeals site visit.

Updated `express-validator` so we have the ability to use the `isTime()` validator.

Also a little refactoring to make some components more generic so they can be reused across different endpoints.

Added unit tests.

Updated swagger docs.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-308

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
