### PR TITLE
feat(api/applications): generate a reference for each uploaded document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ pids
 
 # Editors
 .idea
+**/*.swp
 
 # Env settings / local env files
 .env.local

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -58,7 +58,7 @@ export const provideDocumentUploadURLs = async ({ params, body }, response) => {
 
 	// Map the obtained URLs with documentName
 	const documentsWithUrls = documents.map((document) => {
-		return pick(document, ['documentName', 'blobStoreUrl', 'GUID']);
+		return pick(document, ['documentName', 'documentReference', 'blobStoreUrl', 'GUID']);
 	});
 
 	// Send response with blob storage host, container, and documents with URLs

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -429,6 +429,8 @@ export const publishNsipDocuments = async (documentVersionIds) => {
  * @returns {number}
  */
 export const getNextDocumentReferenceIndex = (documents) => {
+	if (documents.length === 0) return 1;
+
 	const references = documents.flatMap((d) => {
 		const match = d.documentReference.match(/-(\d+)/);
 		if (!match) return [];

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -423,3 +423,29 @@ export const publishNsipDocuments = async (documentVersionIds) => {
 		publishedStatus: 'publishing'
 	}));
 };
+
+/**
+ * @param {{documentReference: string}[]} documents
+ * @returns {number}
+ */
+export const getNextDocumentReferenceIndex = (documents) => {
+	const references = documents.flatMap((d) => {
+		const match = d.documentReference.match(/-(\d+)/);
+		if (!match) return [];
+
+		const index = Number(match);
+		if (isNaN(index)) return [];
+
+		return index;
+	});
+
+	return Math.max(...references) + 1;
+};
+
+/**
+ * @param {string} caseId
+ * @param {number} index
+ * @returns {string}
+ */
+export const makeDocumentReference = (caseId, index) =>
+	`${caseId}-${index.toString().padStart(6, '0')}`;

--- a/apps/api/src/server/applications/documents/documents.service.js
+++ b/apps/api/src/server/applications/documents/documents.service.js
@@ -4,6 +4,21 @@ import { NSIP_DOCUMENT } from '../../infrastructure/topics.js';
 import { buildNsipDocumentPayload } from '../application/documents/document.js';
 import * as documentRepository from '../../repositories/document.repository.js';
 import * as documentVersionRepository from '../../repositories/document-metadata.repository.js';
+import * as folderRepository from '../../repositories/folder.repository.js';
+
+/**
+ * @param {number} caseId
+ */
+export const getByCaseId = async (caseId) => {
+	const folders = await folderRepository.getByCaseId(caseId);
+	const documents = await Promise.all(
+		folders.map((f) =>
+			documentRepository.getDocumentsInFolder({ folderId: f.id, skipValue: 0, pageSize: 0 })
+		)
+	);
+
+	return documents.flat();
+};
 
 /**
  * @param {string} guid

--- a/apps/api/src/server/repositories/folder.repository.js
+++ b/apps/api/src/server/repositories/folder.repository.js
@@ -38,10 +38,15 @@ const folderCaseStageMappings = {
  * @param {number |null} parentFolderId
  * @returns {Promise<Folder[]>}
  */
-export const getByCaseId = (caseId, parentFolderId = null) => {
+export const getByCaseId = async (caseId, parentFolderId = null) => {
 	// if no parentFolderId, null value in the call, to get the top level folders on the case
 
-	return databaseConnector.folder.findMany({ where: { caseId, parentFolderId } });
+	const result = await databaseConnector.folder.findMany({ where: { caseId, parentFolderId } });
+	if (!Array.isArray(result)) {
+		return [];
+	}
+
+	return result;
 };
 
 /**

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -2578,6 +2578,10 @@
 								"type": "string",
 								"example": "document.pdf"
 							},
+							"documentReference": {
+								"type": "string",
+								"example": "docRef"
+							},
 							"blobStoreUrl": {
 								"type": "string",
 								"example": "/some/path/document.pdf"

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -60,6 +60,7 @@ const document = {
 			documents: [
 				{
 					documentName: 'document.pdf',
+					documentReference: 'docRef',
 					blobStoreUrl: '/some/path/document.pdf'
 				}
 			]


### PR DESCRIPTION
## Describe your changes

- When uploading new documents, generate a document reference in the format `{application_ref}-{index}` e.g. `T8-000001`
- The index part increments for each document uploaded

I'm unable to test locally as the change relies on blob storage which doesn't work locally. Will need to test in dev.

This will need to be followed up by some UI changes.

## Issue ticket number and link

[BOAS-770](https://pins-ds.atlassian.net/browse/BOAS-770)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-770]: https://pins-ds.atlassian.net/browse/BOAS-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ