### PR TITLE
fix(packages/event-client): ensure module definition includes EventType

### DIFF
--- a/packages/event-client/index.d.ts
+++ b/packages/event-client/index.d.ts
@@ -1,5 +1,7 @@
 import './src/event-client';
+import './src/event-type';
 
 declare module '@pins/event-client' {
 	export * from './src/event-client';
+	export * from './src/event-type';
 }


### PR DESCRIPTION
## Describe your changes

The `packages/event-client` type definition didn't include `event-type`, which results in errors in vscode. The definition has been updated to include this.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
