### PR TITLE
chore(deps): update prisma and @prisma/client to 4.16.1

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -38,7 +38,7 @@
     "@pins/event-client": "^0.0.0",
     "@pins/express": "^0.0.0",
     "@pins/platform": "^0.0.0",
-    "@prisma/client": "^4.11.0",
+    "@prisma/client": "^4.16.1",
     "@supercharge/promise-pool": "^2.4.0",
     "body-parser": "1.20.0",
     "c8": "^7.11.3",
@@ -77,7 +77,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "jest-mock-extended": "^3.0.1",
     "nodemon": "^2.0.18",
-    "prisma": "^4.9.0",
+    "prisma": "^4.16.1",
     "rimraf": "^3.0.2",
     "supertest": "6.2.3",
     "swagger-autogen": "^2.21.4"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
     "@pins/event-client": "^0.0.0",
     "@pins/express": "^0.0.0",
     "@pins/platform": "^0.0.0",
-    "@prisma/client": "^4.11.0",
+    "@prisma/client": "^4.16.1",
     "@supercharge/promise-pool": "^2.4.0",
     "body-parser": "1.20.0",
     "c8": "^7.11.3",
@@ -78,7 +78,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "jest-mock-extended": "^3.0.1",
     "nodemon": "^2.0.18",
-    "prisma": "^4.9.0",
+    "prisma": "^4.16.1",
     "rimraf": "^3.0.2",
     "supertest": "6.2.3",
     "swagger-autogen": "^2.21.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@pins/event-client": "^0.0.0",
         "@pins/express": "^0.0.0",
         "@pins/platform": "^0.0.0",
-        "@prisma/client": "^4.11.0",
+        "@prisma/client": "^4.16.1",
         "@supercharge/promise-pool": "^2.4.0",
         "body-parser": "1.20.0",
         "c8": "^7.11.3",
@@ -88,7 +88,7 @@
         "jest-environment-jsdom": "^29.3.1",
         "jest-mock-extended": "^3.0.1",
         "nodemon": "^2.0.18",
-        "prisma": "^4.9.0",
+        "prisma": "^4.16.1",
         "rimraf": "^3.0.2",
         "supertest": "6.2.3",
         "swagger-autogen": "^2.21.4"
@@ -374,6 +374,38 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "appeals/api/node_modules/@prisma/client": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.1.tgz",
+      "integrity": "sha512-CoDHu7Bt+NuDo40ijoeHP79EHtECsPBTy3yte5Yo3op8TqXt/kV0OT5OrsWewKvQGKFMHhYQ+ePed3zzjYdGAw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines-version": "4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "appeals/api/node_modules/@prisma/engines": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.1.tgz",
+      "integrity": "sha512-gpZG0kGGxfemgvK/LghHdBIz+crHkZjzszja94xp4oytpsXrgt/Ice82MvPsWMleVIniKuARrowtsIsim0PFJQ==",
+      "devOptional": true,
+      "hasInstallScript": true
+    },
+    "appeals/api/node_modules/@prisma/engines-version": {
+      "version": "4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c.tgz",
+      "integrity": "sha512-tMWAF/qF00fbUH1HB4Yjmz6bjh7fzkb7Y3NRoUfMlHu6V+O45MGvqwYxqwBjn1BIUXkl3r04W351D4qdJjrgvA=="
     },
     "appeals/api/node_modules/@sinclair/typebox": {
       "version": "0.25.24",
@@ -1386,6 +1418,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "appeals/api/node_modules/prisma": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.1.tgz",
+      "integrity": "sha512-C2Xm7yxHxjFjjscBEW4tmoraPHH/Vyu/A0XABdbaFtoiOZARsxvOM7rwc2iZ0qVxbh0bGBGBWZUSXO/52/nHBQ==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "4.16.1"
+      },
+      "bin": {
+        "prisma": "build/index.js",
+        "prisma2": "build/index.js"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "appeals/api/node_modules/process-warning": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
@@ -1725,7 +1774,7 @@
         "@pins/event-client": "^0.0.0",
         "@pins/express": "^0.0.0",
         "@pins/platform": "^0.0.0",
-        "@prisma/client": "^4.11.0",
+        "@prisma/client": "^4.16.1",
         "@supercharge/promise-pool": "^2.4.0",
         "body-parser": "1.20.0",
         "c8": "^7.11.3",
@@ -1764,7 +1813,7 @@
         "jest-environment-jsdom": "^29.3.1",
         "jest-mock-extended": "^3.0.1",
         "nodemon": "^2.0.18",
-        "prisma": "^4.9.0",
+        "prisma": "^4.16.1",
         "rimraf": "^3.0.2",
         "supertest": "6.2.3",
         "swagger-autogen": "^2.21.4"
@@ -2164,6 +2213,38 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "apps/api/node_modules/@prisma/client": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.1.tgz",
+      "integrity": "sha512-CoDHu7Bt+NuDo40ijoeHP79EHtECsPBTy3yte5Yo3op8TqXt/kV0OT5OrsWewKvQGKFMHhYQ+ePed3zzjYdGAw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines-version": "4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "apps/api/node_modules/@prisma/engines": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.1.tgz",
+      "integrity": "sha512-gpZG0kGGxfemgvK/LghHdBIz+crHkZjzszja94xp4oytpsXrgt/Ice82MvPsWMleVIniKuARrowtsIsim0PFJQ==",
+      "devOptional": true,
+      "hasInstallScript": true
+    },
+    "apps/api/node_modules/@prisma/engines-version": {
+      "version": "4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c.tgz",
+      "integrity": "sha512-tMWAF/qF00fbUH1HB4Yjmz6bjh7fzkb7Y3NRoUfMlHu6V+O45MGvqwYxqwBjn1BIUXkl3r04W351D4qdJjrgvA=="
     },
     "apps/api/node_modules/@sinclair/typebox": {
       "version": "0.25.21",
@@ -3158,6 +3239,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "apps/api/node_modules/prisma": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.1.tgz",
+      "integrity": "sha512-C2Xm7yxHxjFjjscBEW4tmoraPHH/Vyu/A0XABdbaFtoiOZARsxvOM7rwc2iZ0qVxbh0bGBGBWZUSXO/52/nHBQ==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "4.16.1"
+      },
+      "bin": {
+        "prisma": "build/index.js",
+        "prisma2": "build/index.js"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "apps/api/node_modules/process-warning": {
@@ -12121,38 +12219,6 @@
       "engines": {
         "node": ">= 12.13.0"
       }
-    },
-    "node_modules/@prisma/client": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.11.0.tgz",
-      "integrity": "sha512-0INHYkQIqgAjrt7NzhYpeDQi8x3Nvylc2uDngKyFDDj1tTRQ4uV1HnVmd1sQEraeVAN63SOK0dgCKQHlvjL0KA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@prisma/engines-version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "prisma": "*"
-      },
-      "peerDependenciesMeta": {
-        "prisma": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@prisma/engines": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.13.0.tgz",
-      "integrity": "sha512-HrniowHRZXHuGT9XRgoXEaP2gJLXM5RMoItaY2PkjvuZ+iHc0Zjbm/302MB8YsPdWozAPHHn+jpFEcEn71OgPw==",
-      "devOptional": true,
-      "hasInstallScript": true
-    },
-    "node_modules/@prisma/engines-version": {
-      "version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.11.0-57.8fde8fef4033376662cad983758335009d522acb.tgz",
-      "integrity": "sha512-3Vd8Qq06d5xD8Ch5WauWcUUrsVPdMC6Ge8ILji8RFfyhUpqon6qSyGM0apvr1O8n8qH8cKkEFqRPsYjuz5r83g=="
     },
     "node_modules/@prisma/prisma-fmt-wasm": {
       "version": "4.13.0-52.integration-mobc-upstream-d100a9299fcb9cffb064301998e9a94ce2722c49",
@@ -29355,23 +29421,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/prisma": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.13.0.tgz",
-      "integrity": "sha512-L9mqjnSmvWIRCYJ9mQkwCtj4+JDYYTdhoyo8hlsHNDXaZLh/b4hR0IoKIBbTKxZuyHQzLopb/+0Rvb69uGV7uA==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@prisma/engines": "4.13.0"
-      },
-      "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "license": "MIT",
@@ -37236,7 +37285,7 @@
         "@pins/event-client": "^0.0.0",
         "@pins/express": "^0.0.0",
         "@pins/platform": "^0.0.0",
-        "@prisma/client": "^4.11.0",
+        "@prisma/client": "^4.16.1",
         "@supercharge/promise-pool": "^2.4.0",
         "@types/express": "^4.17.13",
         "@types/express-pino-logger": "^4.0.3",
@@ -37270,7 +37319,7 @@
         "pino": "^8.1.0",
         "pino-http": "^8.1.0",
         "pino-pretty": "^8.1.0",
-        "prisma": "^4.9.0",
+        "prisma": "^4.16.1",
         "rhea": "3.0.1",
         "rimraf": "^3.0.2",
         "supertest": "6.2.3",
@@ -37498,6 +37547,25 @@
             "@types/yargs": "^17.0.8",
             "chalk": "^4.0.0"
           }
+        },
+        "@prisma/client": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.1.tgz",
+          "integrity": "sha512-CoDHu7Bt+NuDo40ijoeHP79EHtECsPBTy3yte5Yo3op8TqXt/kV0OT5OrsWewKvQGKFMHhYQ+ePed3zzjYdGAw==",
+          "requires": {
+            "@prisma/engines-version": "4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c"
+          }
+        },
+        "@prisma/engines": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.1.tgz",
+          "integrity": "sha512-gpZG0kGGxfemgvK/LghHdBIz+crHkZjzszja94xp4oytpsXrgt/Ice82MvPsWMleVIniKuARrowtsIsim0PFJQ==",
+          "devOptional": true
+        },
+        "@prisma/engines-version": {
+          "version": "4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c",
+          "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c.tgz",
+          "integrity": "sha512-tMWAF/qF00fbUH1HB4Yjmz6bjh7fzkb7Y3NRoUfMlHu6V+O45MGvqwYxqwBjn1BIUXkl3r04W351D4qdJjrgvA=="
         },
         "@sinclair/typebox": {
           "version": "0.25.24",
@@ -38279,6 +38347,15 @@
             }
           }
         },
+        "prisma": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.1.tgz",
+          "integrity": "sha512-C2Xm7yxHxjFjjscBEW4tmoraPHH/Vyu/A0XABdbaFtoiOZARsxvOM7rwc2iZ0qVxbh0bGBGBWZUSXO/52/nHBQ==",
+          "devOptional": true,
+          "requires": {
+            "@prisma/engines": "4.16.1"
+          }
+        },
         "process-warning": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
@@ -38574,7 +38651,7 @@
         "@pins/event-client": "^0.0.0",
         "@pins/express": "^0.0.0",
         "@pins/platform": "^0.0.0",
-        "@prisma/client": "^4.11.0",
+        "@prisma/client": "^4.16.1",
         "@supercharge/promise-pool": "^2.4.0",
         "@types/express": "^4.17.13",
         "@types/express-pino-logger": "^4.0.3",
@@ -38607,7 +38684,7 @@
         "pino": "^8.1.0",
         "pino-http": "^8.1.0",
         "pino-pretty": "^8.1.0",
-        "prisma": "^4.9.0",
+        "prisma": "^4.16.1",
         "rhea": "3.0.1",
         "rimraf": "^3.0.2",
         "sanitize-html": "^2.11.0",
@@ -38836,6 +38913,25 @@
             "@types/yargs": "^17.0.8",
             "chalk": "^4.0.0"
           }
+        },
+        "@prisma/client": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.1.tgz",
+          "integrity": "sha512-CoDHu7Bt+NuDo40ijoeHP79EHtECsPBTy3yte5Yo3op8TqXt/kV0OT5OrsWewKvQGKFMHhYQ+ePed3zzjYdGAw==",
+          "requires": {
+            "@prisma/engines-version": "4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c"
+          }
+        },
+        "@prisma/engines": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.16.1.tgz",
+          "integrity": "sha512-gpZG0kGGxfemgvK/LghHdBIz+crHkZjzszja94xp4oytpsXrgt/Ice82MvPsWMleVIniKuARrowtsIsim0PFJQ==",
+          "devOptional": true
+        },
+        "@prisma/engines-version": {
+          "version": "4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c",
+          "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.0-66.b20ead4d3ab9e78ac112966e242ded703f4a052c.tgz",
+          "integrity": "sha512-tMWAF/qF00fbUH1HB4Yjmz6bjh7fzkb7Y3NRoUfMlHu6V+O45MGvqwYxqwBjn1BIUXkl3r04W351D4qdJjrgvA=="
         },
         "@sinclair/typebox": {
           "version": "0.25.21",
@@ -39615,6 +39711,15 @@
               "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
               "dev": true
             }
+          }
+        },
+        "prisma": {
+          "version": "4.16.1",
+          "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.16.1.tgz",
+          "integrity": "sha512-C2Xm7yxHxjFjjscBEW4tmoraPHH/Vyu/A0XABdbaFtoiOZARsxvOM7rwc2iZ0qVxbh0bGBGBWZUSXO/52/nHBQ==",
+          "devOptional": true,
+          "requires": {
+            "@prisma/engines": "4.16.1"
           }
         },
         "process-warning": {
@@ -42993,25 +43098,6 @@
           }
         }
       }
-    },
-    "@prisma/client": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.11.0.tgz",
-      "integrity": "sha512-0INHYkQIqgAjrt7NzhYpeDQi8x3Nvylc2uDngKyFDDj1tTRQ4uV1HnVmd1sQEraeVAN63SOK0dgCKQHlvjL0KA==",
-      "requires": {
-        "@prisma/engines-version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb"
-      }
-    },
-    "@prisma/engines": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.13.0.tgz",
-      "integrity": "sha512-HrniowHRZXHuGT9XRgoXEaP2gJLXM5RMoItaY2PkjvuZ+iHc0Zjbm/302MB8YsPdWozAPHHn+jpFEcEn71OgPw==",
-      "devOptional": true
-    },
-    "@prisma/engines-version": {
-      "version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.11.0-57.8fde8fef4033376662cad983758335009d522acb.tgz",
-      "integrity": "sha512-3Vd8Qq06d5xD8Ch5WauWcUUrsVPdMC6Ge8ILji8RFfyhUpqon6qSyGM0apvr1O8n8qH8cKkEFqRPsYjuz5r83g=="
     },
     "@prisma/prisma-fmt-wasm": {
       "version": "4.13.0-52.integration-mobc-upstream-d100a9299fcb9cffb064301998e9a94ce2722c49",
@@ -55146,15 +55232,6 @@
           "version": "5.2.0",
           "dev": true
         }
-      }
-    },
-    "prisma": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.13.0.tgz",
-      "integrity": "sha512-L9mqjnSmvWIRCYJ9mQkwCtj4+JDYYTdhoyo8hlsHNDXaZLh/b4hR0IoKIBbTKxZuyHQzLopb/+0Rvb69uGV7uA==",
-      "devOptional": true,
-      "requires": {
-        "@prisma/engines": "4.13.0"
       }
     },
     "process": {


### PR DESCRIPTION
## Describe your changes

The versions of `prisma` and `@prisma/client` were out of sync. Both have been updated to 4.16.1, for applications and appeals.

Note this isn't the latest, 4.16.2, because of a typescript issue and I didn't want to update both (https://github.com/prisma/prisma/issues/20024). We should investigate going to v5 soon, which is meant to be significantly faster.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
