### PR TITLE
Improve scalability of document querying on upload

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -464,6 +464,19 @@ export const getNextDocumentReferenceIndex = (documents) => {
 };
 
 /**
+ * @param {string} reference
+ * @returns {number | null}
+ * */
+export const getIndexFromReference = (reference) => {
+	const match = reference.match(/-(\d+)/);
+	if (!match) {
+		return null;
+	}
+
+	return Number(match[1]);
+};
+
+/**
  * @param {string} caseId
  * @param {number} index
  * @returns {string}

--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -42,12 +42,19 @@ export const getById = (documentGuid) => {
 /**
  * Get a document by caseid
  *
- * @param {number} caseId
- * @returns {import('@prisma/client').PrismaPromise<import('@pins/applications.api').Schema.Document[] |null>}
+ * @param {{ caseId: number, skipValue?: number, pageSize?: number }} _
+ * @returns {import('@prisma/client').PrismaPromise<import('@pins/applications.api').Schema.Document[]>}
  */
-export const getByCaseId = (caseId) => {
+export const getByCaseId = ({ caseId, skipValue, pageSize }) => {
 	return databaseConnector.document.findMany({
-		where: { caseId }
+		where: { caseId },
+		skip: skipValue,
+		take: pageSize,
+		orderBy: [
+			{
+				createdAt: 'desc'
+			}
+		]
 	});
 };
 


### PR DESCRIPTION
## Describe your changes

When uploading new documents, we currently fetch all existing documents in a case to derive the next document reference. This change improves scalability by using SQL to only fetch the latest row.

Tested locally and working.

## Issue ticket number and link

Related to [BOAS-770](https://pins-ds.atlassian.net/browse/BOAS-770)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-770]: https://pins-ds.atlassian.net/browse/BOAS-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ