### PR TITLE
fix(applications): document-storage-api was expecting a .env file

### DIFF
--- a/apps/document-storage/Dockerfile
+++ b/apps/document-storage/Dockerfile
@@ -7,7 +7,7 @@ COPY packages ./packages
 COPY apps/document-storage apps/document-storage
 ENV NODE_ENV=production
 RUN npm ci
-COPY apps/document-storage/.env.development ./.env
+COPY apps/document-storage/.env.development apps/document-storage/.env
 
 # relative to cwd
 ENV SWAGGER_JSON_DIR=./src/server/swagger-output.json


### PR DESCRIPTION
## Describe your changes

We want to move away from using `.env` files in builds, but a recent change to the Dockerfiles broke the document-storage-api as an environment variable was missing. This will be added to Azure, but for now this will fix it.

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
