### PR TITLE
feat(web/appeals): load users from msgraph BOAT-350

### DIFF
--- a/appeals/web/src/server/app/app.controller.js
+++ b/appeals/web/src/server/app/app.controller.js
@@ -15,19 +15,14 @@ import * as authSession from './auth/auth-session.service.js';
  *
  * @type {import('@pins/express').RenderHandler<ViewHomepageRenderOptions>}
  */
-export function viewHomepage(request, response) {
+export const viewHomepage = async (request, response) => {
 	const account = /** @type {AccountInfo} */ (authSession.getAccount(request.session));
 	const userGroups = account?.idTokenClaims?.groups ?? [];
-
-	// Determine those group ids the user belongs to for the appeals domain
 	const appealGroupIds = intersection(Object.values(config.referenceData.appeals), userGroups);
 
-	// TODO: confirm every login will have read-only access
-	// if (appealGroupIds.length === 0) {
-	// 	return response.render('app/403');
-	// }
-
-	// The user belongs to a single group in the appeals service only
+	if (appealGroupIds.length === 0) {
+		return response.render('app/403');
+	}
 
 	if (appealGroupIds.length === 1) {
 		switch (appealGroupIds[0]) {
@@ -40,11 +35,8 @@ export function viewHomepage(request, response) {
 		}
 	}
 
-	response.render('app/dashboard', {
-		referenceData: config.referenceData,
-		appealGroupIds
-	});
-}
+	response.render('app/dashboard');
+};
 
 /** @type {import('express').RequestHandler} */
 export function handleHeathCheck(_, response) {

--- a/appeals/web/src/server/app/auth/auth.service.js
+++ b/appeals/web/src/server/app/auth/auth.service.js
@@ -36,6 +36,9 @@ export const acquireTokenByCode = async (code) => {
  * @returns {Promise<AuthenticationResult | null>}
  */
 export const acquireTokenSilent = async (account, customScopes = scopes) => {
+	if (config.authDisabled) {
+		return null;
+	}
 	return transformAuthenticationResult(
 		await msalClient.acquireTokenSilent({
 			account,

--- a/appeals/web/src/server/appeals/appeal-users/users-service.js
+++ b/appeals/web/src/server/appeals/appeal-users/users-service.js
@@ -1,0 +1,58 @@
+import { getData } from '#lib/graph-request.js';
+import { fetchFromCache, storeInCache } from '#lib/cache-handler.js';
+import getActiveDirectoryAccessToken from '#lib/active-directory-token.js';
+import config from '#environment/config.js';
+
+/** @typedef {import('../../app/auth/auth-session.service').SessionWithAuth} SessionWithAuth */
+
+/**
+ * Get all the users belonging to a specific group.
+ * Requires the web project to run over https, with auth enabled. An empty array will be returned if these conditions are not met.
+ * @param {string} roleName The group name or ID in Active Directory
+ * @param {SessionWithAuth} session The current user's session
+ * @returns {Promise<{ id:string; name: string; email:string;}[]>}
+ * @example `const caseOfficers = await getUsersByRole(caseOfficerGroupId, session)`
+ */
+export const getUsersByRole = async (roleName, session) => {
+	if (config.authDisabled) {
+		return [];
+	}
+
+	const cacheName = `cache_users_${roleName}`;
+	let cache = await fetchFromCache(cacheName);
+	if (!cache) {
+		cache = (await fetchRolesAndUsersFromGraph(roleName, session)) || [];
+		await storeInCache(cacheName, cache);
+	}
+	return cache;
+};
+
+/**
+ * Get all the users belonging to a specific group, from AD
+ *
+ * @param {string} roleName
+ * @param {SessionWithAuth} session
+ * @returns {Promise<{ id:string; name: string; email:string;}[]>}
+ */
+const fetchRolesAndUsersFromGraph = async (roleName, session) => {
+	const token = await getActiveDirectoryAccessToken(session, ['GroupMember.Read.All']);
+	if (token?.token) {
+		const data = await getData(
+			`groups/${roleName}/members?$select=id,displayName,userPrincipalName`,
+			{
+				headers: { authorization: `Bearer ${token.token}` }
+			}
+		);
+
+		// @ts-ignore
+		return data.value.map((user) => {
+			return {
+				id: user.id,
+				name: user.displayName,
+				email: user.userPrincipalName
+			};
+		});
+	}
+
+	return [];
+};

--- a/appeals/web/src/server/appeals/appeals.router.js
+++ b/appeals/web/src/server/appeals/appeals.router.js
@@ -1,31 +1,11 @@
-import config from '@pins/appeals.web/environment/config.js';
 import { Router as createRouter } from 'express';
-import { assertGroupAccess } from '../app/auth/auth.guards.js';
 import nationalListRouter from '../appeals/national-list/national-list.router.js';
 import appealDetailsRouter from './appeal-details/appeal-details.router.js';
 
 const router = createRouter();
 
-const groupIds = config.referenceData.appeals;
+router.use('/appeals-list', nationalListRouter);
 
-router.use(
-	'/appeals-list',
-	assertGroupAccess(
-		groupIds.validationOfficerGroupId,
-		groupIds.caseOfficerGroupId,
-		groupIds.inspectorGroupId
-	),
-	nationalListRouter
-);
-
-router.use(
-	'/appeal-details',
-	assertGroupAccess(
-		groupIds.validationOfficerGroupId,
-		groupIds.caseOfficerGroupId,
-		groupIds.inspectorGroupId
-	),
-	appealDetailsRouter
-);
+router.use('/appeal-details', appealDetailsRouter);
 
 export default router;

--- a/appeals/web/src/server/lib/active-directory-token.js
+++ b/appeals/web/src/server/lib/active-directory-token.js
@@ -11,7 +11,10 @@ import { getAccount } from '../app/auth/auth-session.service.js';
  * @param {SessionWithAuth} session
  * @returns {Promise<AccessToken>}
  */
-const getActiveDirectoryAccessToken = async (session) => {
+const getActiveDirectoryAccessToken = async (
+	session,
+	customScopes = ['https://storage.azure.com/user_impersonation']
+) => {
 	const sessionAccount = getAccount(session);
 
 	if (!sessionAccount) {
@@ -19,15 +22,13 @@ const getActiveDirectoryAccessToken = async (session) => {
 	}
 
 	/** @type {{accessToken: string, expiresOn: any} | null} * */
-	const blobResourceAuthResult = await acquireTokenSilent(sessionAccount, [
-		'https://storage.azure.com/user_impersonation'
-	]);
+	const resourceAuthResult = await acquireTokenSilent(sessionAccount, customScopes);
 
-	if (!blobResourceAuthResult?.accessToken) {
+	if (!resourceAuthResult?.accessToken) {
 		throw new Error('Active Directory access token not found');
 	}
 
-	const { accessToken, expiresOn } = blobResourceAuthResult;
+	const { accessToken, expiresOn } = resourceAuthResult;
 
 	return { token: accessToken, expiresOnTimestamp: expiresOn };
 };

--- a/appeals/web/src/server/lib/graph-request.js
+++ b/appeals/web/src/server/lib/graph-request.js
@@ -1,0 +1,28 @@
+import { createHttpLoggerHooks } from '@pins/platform';
+import config from '@pins/appeals.web/environment/config.js';
+import got from 'got';
+import pino from './logger.js';
+
+const [requestLogger, responseLogger] = createHttpLoggerHooks(pino, config.logLevelStdOut);
+
+const instance = got.extend({
+	prefixUrl: 'https://graph.microsoft.com/v1.0/',
+	responseType: 'json',
+	resolveBodyOnly: true,
+	hooks: {
+		beforeRequest: [requestLogger],
+		afterResponse: [responseLogger]
+	}
+});
+
+/**
+ * Type-safe implementation of a post request using the got instance.
+ *
+ * @template T
+ * @param {string | URL} url
+ * @param {import('got').OptionsOfJSONResponseBody=} options
+ * @returns {import('got').CancelableRequest<T>}
+ */
+export function getData(url, options) {
+	return /** @type {import('got').CancelableRequest<*>} */ (instance.get(url, options));
+}

--- a/appeals/web/src/server/views/app/dashboard.njk
+++ b/appeals/web/src/server/views/app/dashboard.njk
@@ -12,60 +12,13 @@
   <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main" {% if mainLang %} lang="{{ mainLang }}" {% endif %}>
     <div class="govuk-width-container {{ containerClasses }}">
       <div class="govuk-grid-row">
-        {% if applicationGroupIds.length > 0 %}
-          <div class="govuk-grid-column-one-half">
-            <h2 class="govuk-heading-m">Applications</h2>
-            <ul class="govuk-list">
-              {% if applicationGroupIds | includes(referenceData.applications.caseTeamGroupId) %}
-                <li>
-                  <a href="/applications-service/case-team" class="govuk-link">Case team</a>
-                </li>
-              {% endif %}
-              {% if applicationGroupIds | includes(referenceData.applications.caseAdminOfficerGroupId) %}
-                <li>
-                  <a href="/applications-service/case-admin-officer" class="govuk-link">Case admin officer</a>
-                </li>
-              {% endif %}
-              {% if applicationGroupIds | includes(referenceData.applications.inspectorGroupId) %}
-                <li>
-                  <a href="/applications-service/inspector" class="govuk-link">Inspector</a>
-                </li>
-              {% endif %}
-            </ul>
-          </div>
-        {% endif %}
-
-        {% if appealGroupIds.length > 0 %}
-          <div class="govuk-grid-column-one-half">
-            <h2 class="govuk-heading-m">Appeals</h2>
-            <ul class="govuk-list">
-                <li>
-                  <a href="/appeals-service/appeals-list" class="govuk-link">National List</a>
-                </li>
-              {# {% if appealGroupIds | includes(referenceData.appeals.caseOfficerGroupId) %}
-                <li>
-                  <a href="/appeals-service/case-officer" class="govuk-link">Case officer</a>
-                </li>
-              {% endif %}
-              {% if appealGroupIds | includes(referenceData.appeals.inspectorGroupId) %}
-                <li>
-                  <a href="/appeals-service/inspector" class="govuk-link">Inspector</a>
-                </li>
-              {% endif %}
-              {% if appealGroupIds | includes(referenceData.appeals.validationOfficerGroupId) %}
-                <li>
-                  <a href="/appeals-service/validation" class="govuk-link">Validation officer</a>
-                </li>
-              {% endif %} #}
-            </ul>
-          </div>
-        {% endif %}
-
-        {% if applicationGroupdIds.length === 0 and appealGroupIds.length === 0 %}
-          <div class="govuk-grid-column-two-thirds">
-            <p class="govuk-body">No groups found.</p>
-          </div>
-        {% endif %}
+				<div class="govuk-grid-column-one-half">
+					<h2 class="govuk-heading-m">Appeals</h2>
+					<ul class="govuk-list">
+							<li>
+								<a href="/appeals-service/appeals-list" class="govuk-link">National List</a>
+							</li>
+				</div>
       </div>
     </div>
   </main>


### PR DESCRIPTION
Implementation of user service to read list of users belonging to an AD group.
In order to run locally, requires web to run over HTTPS and with auth enabled.

[BOAT-350](https://pins-ds.atlassian.net/browse/BOAT-350)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
