### PR TITLE
fix(web): keyboard-only nav

### DIFF
--- a/apps/web/src/client/components/html-content-editor/html-content-editor.js
+++ b/apps/web/src/client/components/html-content-editor/html-content-editor.js
@@ -24,7 +24,18 @@ function initHtmlContentEditor() {
 			initialEditType: 'wysiwyg',
 			usageStatistics: false,
 			hideModeSwitch: true,
-			toolbarItems: [['bold', 'link', 'ul']]
+			toolbarItems: [['bold', 'link', 'ul']],
+			events: {
+				keydown(_, ev) {
+					// there is no option not to handle tab, but this is an accessibility issue
+					// we want tab to move to the next tab element, not insert spaces
+					if (ev.key === 'Tab') {
+						// by throwing an error, the other handlers don't run and
+						// tab get handled by the browser
+						throw new Error('no error: override tab handler');
+					}
+				}
+			}
 		});
 
 		if (input.value) {


### PR DESCRIPTION
## Describe your changes

It was not possible to get passed the rich-text editor with the keyboard (tabbing). This has been fixed. 

The solution is not ideal at all, unfortunately the library has very little options exposed, and by default overrides the tab behaviour. After much searching and trial-and-error with the library and it's inner workings, this seemed like the best solution unfortunately (short of using the underling library - `prosemirror` and building the editor ourselves).

## Issue ticket number and link

[ASB-1689](https://pins-ds.atlassian.net/jira/software/c/projects/ASB/boards/166?modal=detail&selectedIssue=ASB-1689)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[ASB-1689]: https://pins-ds.atlassian.net/browse/ASB-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ