### PR TITLE
feat(appeals/api): add an api endpoint for returning the designated sites

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -97,6 +97,7 @@ const mockSpecialismsFindUnique = jest.fn().mockResolvedValue({});
 const mockAppealAllocationUpsert = jest.fn().mockResolvedValue({});
 const mockAppealSpecialismDeleteMany = jest.fn().mockResolvedValue({});
 const mockAppealSpecialismCreateMany = jest.fn().mockResolvedValue({});
+const mockDesignatedSiteFindMany = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -374,6 +375,12 @@ class MockPrismaClient {
 	get appealAllocation() {
 		return {
 			upsert: mockAppealAllocationUpsert
+		};
+	}
+
+	get designatedSite() {
+		return {
+			findMany: mockDesignatedSiteFindMany
 		};
 	}
 

--- a/appeals/api/src/server/common/controllers/lookup-data.controller.js
+++ b/appeals/api/src/server/common/controllers/lookup-data.controller.js
@@ -7,22 +7,21 @@ import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../endpoints/const
 
 /**
  * @param {string} databaseTable
- * @returns {() => Promise<object | void>}
+ * @returns {(req: Request, res: Response) => Promise<object | void>}
  */
-const getLookupData =
-	(databaseTable) => async (/** @type {Request} */ req, /** @type {Response} */ res) => {
-		try {
-			const lookupData = await commonRepository.getLookupList(databaseTable);
+const getLookupData = (databaseTable) => async (req, res) => {
+	try {
+		const lookupData = await commonRepository.getLookupList(databaseTable);
 
-			if (!lookupData.length) {
-				return res.status(404).send({ errors: ERROR_NOT_FOUND });
-			}
-
-			return res.send(lookupData);
-		} catch (error) {
-			logger.error(error);
-			return res.status(500).send({ errors: ERROR_FAILED_TO_GET_DATA });
+		if (!lookupData.length) {
+			return res.status(404).send({ errors: ERROR_NOT_FOUND });
 		}
-	};
+
+		return res.send(lookupData);
+	} catch (error) {
+		logger.error(error);
+		return res.status(500).send({ errors: ERROR_FAILED_TO_GET_DATA });
+	}
+};
 
 export { getLookupData };

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -10,6 +10,7 @@ import { appealAllocationRouter } from './appeal-allocation/appeal-allocation-ro
 import { documentsRoutes } from './documents/documents.routes.js';
 import { integrationsRoutes } from './integrations/integrations.routes.js';
 import initNotifyClientAndAddToRequest from '../middleware/init-notify-client-and-add-to-request.js';
+import { designatedSitesRoutes } from './designated-sites/designated-sites.routes.js';
 
 const router = createRouter();
 
@@ -19,6 +20,7 @@ router.use(integrationsRoutes);
 router.use(appellantCaseIncompleteReasonsRoutes);
 router.use(appellantCaseInvalidReasonsRoutes);
 router.use(appellantCasesRoutes);
+router.use(designatedSitesRoutes);
 router.use(documentsRoutes);
 router.use(appealAllocationRouter);
 router.use(lpaQuestionnaireIncompleteReasonsRoutes);

--- a/appeals/api/src/server/endpoints/designated-sites/__tests__/designated-sites.test.js
+++ b/appeals/api/src/server/endpoints/designated-sites/__tests__/designated-sites.test.js
@@ -1,0 +1,45 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { designatedSites } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('designated sites routes', () => {
+	describe('/appeals/designated-sites', () => {
+		describe('GET', () => {
+			test('gets designated sites', async () => {
+				// @ts-ignore
+				databaseConnector.designatedSite.findMany.mockResolvedValue(designatedSites);
+
+				const response = await request.get('/appeals/designated-sites');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(designatedSites);
+			});
+
+			test('returns an error if designated sites are not found', async () => {
+				// @ts-ignore
+				databaseConnector.designatedSite.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/designated-sites');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get designated sites', async () => {
+				// @ts-ignore
+				databaseConnector.designatedSite.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/designated-sites');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/designated-sites/designated-sites.routes.js
+++ b/appeals/api/src/server/endpoints/designated-sites/designated-sites.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/designated-sites',
+	/*
+		#swagger.tags = ['Designated Sites']
+		#swagger.path = '/appeals/designated-sites'
+		#swagger.description = 'Gets designated sites'
+		#swagger.responses[200] = {
+			description: 'Designated sites',
+			schema: { $ref: '#/definitions/AllDesignatedSitesResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('designatedSite'))
+);
+
+export { router as designatedSitesRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -15,6 +15,100 @@
 	],
 	"securityDefinitions": {},
 	"paths": {
+		"/appeals/case-submission": {
+			"post": {
+				"tags": ["Integration"],
+				"description": "Request the creation of a new case",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Appeal successfully created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Appeal"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/Appeal"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Case data",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/CaseData"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/CaseData"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/appeals/document-submission": {
+			"post": {
+				"tags": ["Integration"],
+				"description": "Imports a new document",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Document successfully created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DocumentDetails"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/DocumentDetails"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Document",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/DocumentDetails"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/DocumentDetails"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals/appellant-case-incomplete-reasons": {
 			"get": {
 				"tags": ["Appellant Case Incomplete Reasons"],
@@ -174,6 +268,33 @@
 								"$ref": "#/components/schemas/UpdateAppellantCaseRequest"
 							}
 						}
+					}
+				}
+			}
+		},
+		"/appeals/designated-sites": {
+			"get": {
+				"tags": ["Designated Sites"],
+				"description": "Gets designated sites",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Designated sites",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllDesignatedSitesResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllDesignatedSitesResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
 					}
 				}
 			}
@@ -946,100 +1067,6 @@
 						"application/xml": {
 							"schema": {
 								"$ref": "#/components/schemas/UpdateAppealRequest"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/appeals/case-submission": {
-			"post": {
-				"tags": ["Integration"],
-				"description": "Request the creation of a new case",
-				"parameters": [],
-				"responses": {
-					"200": {
-						"description": "Appeal successfully created",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Appeal"
-								}
-							},
-							"application/xml": {
-								"schema": {
-									"$ref": "#/components/schemas/Appeal"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request"
-					},
-					"404": {
-						"description": "Not Found"
-					}
-				},
-				"requestBody": {
-					"in": "body",
-					"description": "Case data",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CaseData"
-							}
-						},
-						"application/xml": {
-							"schema": {
-								"$ref": "#/components/schemas/CaseData"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/appeals/document-submission": {
-			"post": {
-				"tags": ["Integration"],
-				"description": "Imports a new document",
-				"parameters": [],
-				"responses": {
-					"200": {
-						"description": "Document successfully created",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/DocumentDetails"
-								}
-							},
-							"application/xml": {
-								"schema": {
-									"$ref": "#/components/schemas/DocumentDetails"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request"
-					},
-					"404": {
-						"description": "Not Found"
-					}
-				},
-				"requestBody": {
-					"in": "body",
-					"description": "Document",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/DocumentDetails"
-							}
-						},
-						"application/xml": {
-							"schema": {
-								"$ref": "#/components/schemas/DocumentDetails"
 							}
 						}
 					}
@@ -2622,6 +2649,29 @@
 				},
 				"xml": {
 					"name": "AppealAllocation"
+				}
+			},
+			"AllDesignatedSitesResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "cSAC"
+						},
+						"description": {
+							"type": "string",
+							"example": "candidate special area of conservation"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllDesignatedSitesResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -473,7 +473,14 @@ const document = {
 		AppealAllocation: {
 			level: 'A',
 			specialisms: [70, 71, 72]
-		}
+		},
+		AllDesignatedSitesResponse: [
+			{
+				name: 'cSAC',
+				description: 'candidate special area of conservation',
+				id: 1
+			}
+		]
 	},
 	components: {}
 };

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -421,6 +421,19 @@ const appellantCaseInvalidReasons = [
 	}
 ];
 
+const designatedSites = [
+	{
+		description: 'Site 1',
+		id: 1,
+		name: 'Site 1'
+	},
+	{
+		description: 'Site 2',
+		id: 2,
+		name: 'Site 2'
+	}
+];
+
 const appellantCaseValidationOutcomes = [
 	{
 		id: 1,
@@ -688,6 +701,7 @@ export {
 	appellantCaseValidationOutcomes,
 	baseExpectedAppellantCaseResponse,
 	baseExpectedLPAQuestionnaireResponse,
+	designatedSites,
 	fullPlanningAppeal,
 	fullPlanningAppealAppellantCaseIncomplete,
 	fullPlanningAppealAppellantCaseInvalid,


### PR DESCRIPTION
## Describe your changes

Added an API endpoint to return the designated sites, which provides values that can be used to dynamically create a field list in the UI. 

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-397

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
