### PR TITLE
feat(appeals/api): add api endpoint to get the knowledge of other landowners

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -98,6 +98,7 @@ const mockAppealAllocationUpsert = jest.fn().mockResolvedValue({});
 const mockAppealSpecialismDeleteMany = jest.fn().mockResolvedValue({});
 const mockAppealSpecialismCreateMany = jest.fn().mockResolvedValue({});
 const mockDesignatedSiteFindMany = jest.fn().mockResolvedValue({});
+const mockKnowledgeOfOtherLandownersFindMany = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -381,6 +382,12 @@ class MockPrismaClient {
 	get designatedSite() {
 		return {
 			findMany: mockDesignatedSiteFindMany
+		};
+	}
+
+	get knowledgeOfOtherLandowners() {
+		return {
+			findMany: mockKnowledgeOfOtherLandownersFindMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -11,18 +11,20 @@ import { documentsRoutes } from './documents/documents.routes.js';
 import { integrationsRoutes } from './integrations/integrations.routes.js';
 import initNotifyClientAndAddToRequest from '../middleware/init-notify-client-and-add-to-request.js';
 import { designatedSitesRoutes } from './designated-sites/designated-sites.routes.js';
+import { knowledgeOfOtherLandownersRoutes } from './knowledge-of-other-landowners/knowledge-of-other-landowners.routes.js';
 
 const router = createRouter();
 
 router.use('/', initNotifyClientAndAddToRequest);
 
-router.use(integrationsRoutes);
+router.use(appealAllocationRouter);
 router.use(appellantCaseIncompleteReasonsRoutes);
 router.use(appellantCaseInvalidReasonsRoutes);
 router.use(appellantCasesRoutes);
 router.use(designatedSitesRoutes);
 router.use(documentsRoutes);
-router.use(appealAllocationRouter);
+router.use(integrationsRoutes);
+router.use(knowledgeOfOtherLandownersRoutes);
 router.use(lpaQuestionnaireIncompleteReasonsRoutes);
 router.use(lpaQuestionnairesRoutes);
 router.use(siteVisitRoutes);

--- a/appeals/api/src/server/endpoints/knowledge-of-other-landowners/__tests__/knowledge-of-other-landowners.test.js
+++ b/appeals/api/src/server/endpoints/knowledge-of-other-landowners/__tests__/knowledge-of-other-landowners.test.js
@@ -1,0 +1,47 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { knowledgeOfOtherLandowners } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('knowledge of other landowners routes', () => {
+	describe('/appeals/knowledge-of-other-landowners', () => {
+		describe('GET', () => {
+			test('gets knowledge of other landowners', async () => {
+				// @ts-ignore
+				databaseConnector.knowledgeOfOtherLandowners.findMany.mockResolvedValue(
+					knowledgeOfOtherLandowners
+				);
+
+				const response = await request.get('/appeals/knowledge-of-other-landowners');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(knowledgeOfOtherLandowners);
+			});
+
+			test('returns an error if knowledge of other landowners are not found', async () => {
+				// @ts-ignore
+				databaseConnector.knowledgeOfOtherLandowners.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/knowledge-of-other-landowners');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get knowledge of other landowners', async () => {
+				// @ts-ignore
+				databaseConnector.knowledgeOfOtherLandowners.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/knowledge-of-other-landowners');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/knowledge-of-other-landowners/knowledge-of-other-landowners.routes.js
+++ b/appeals/api/src/server/endpoints/knowledge-of-other-landowners/knowledge-of-other-landowners.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/knowledge-of-other-landowners',
+	/*
+		#swagger.tags = ['Knowledge Of Other Landowners']
+		#swagger.path = '/appeals/knowledge-of-other-landowners'
+		#swagger.description = 'Gets knowledge of other landowners values'
+		#swagger.responses[200] = {
+			description: 'Knowledge of other landowners values',
+			schema: { $ref: '#/definitions/AllKnowledgeOfOtherLandownersResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('knowledgeOfOtherLandowners'))
+);
+
+export { router as knowledgeOfOtherLandownersRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -15,94 +15,107 @@
 	],
 	"securityDefinitions": {},
 	"paths": {
-		"/appeals/case-submission": {
-			"post": {
-				"tags": ["Integration"],
-				"description": "Request the creation of a new case",
+		"/appeals/appeal-allocation-specialisms": {
+			"get": {
+				"tags": ["Appeal Allocation"],
+				"description": "Gets the list of specialisms used for allocation",
 				"parameters": [],
 				"responses": {
 					"200": {
-						"description": "Appeal successfully created",
+						"description": "List of allocation specialisms",
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/Appeal"
+									"$ref": "#/components/schemas/AllocationSpecialismsResponse"
 								}
 							},
 							"application/xml": {
 								"schema": {
-									"$ref": "#/components/schemas/Appeal"
+									"$ref": "#/components/schemas/AllocationSpecialismsResponse"
 								}
 							}
 						}
 					},
 					"400": {
 						"description": "Bad Request"
-					},
-					"404": {
-						"description": "Not Found"
-					}
-				},
-				"requestBody": {
-					"in": "body",
-					"description": "Case data",
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"$ref": "#/components/schemas/CaseData"
-							}
-						},
-						"application/xml": {
-							"schema": {
-								"$ref": "#/components/schemas/CaseData"
-							}
-						}
 					}
 				}
 			}
 		},
-		"/appeals/document-submission": {
-			"post": {
-				"tags": ["Integration"],
-				"description": "Imports a new document",
+		"/appeals/appeal-allocation-levels": {
+			"get": {
+				"tags": ["Appeal Allocation"],
+				"description": "Gets the list of levels and associated bands used for allocation",
 				"parameters": [],
 				"responses": {
 					"200": {
-						"description": "Document successfully created",
+						"description": "List of allocation levels",
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/DocumentDetails"
+									"$ref": "#/components/schemas/AllocationLevelsResponse"
 								}
 							},
 							"application/xml": {
 								"schema": {
-									"$ref": "#/components/schemas/DocumentDetails"
+									"$ref": "#/components/schemas/AllocationLevelsResponse"
 								}
 							}
 						}
 					},
 					"400": {
 						"description": "Bad Request"
+					}
+				}
+			}
+		},
+		"/appeals/{appealId}/appeal-allocation": {
+			"patch": {
+				"tags": ["Appeal Allocation"],
+				"description": "Adds or changes allocation for an appeal",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Patch appeal allocation",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AppealAllocation"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AppealAllocation"
+								}
+							}
+						}
 					},
-					"404": {
-						"description": "Not Found"
+					"400": {
+						"description": "Bad Request"
 					}
 				},
 				"requestBody": {
 					"in": "body",
-					"description": "Document",
+					"description": "Appeal allocation",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/DocumentDetails"
+								"$ref": "#/components/schemas/AppealAllocation"
 							}
 						},
 						"application/xml": {
 							"schema": {
-								"$ref": "#/components/schemas/DocumentDetails"
+								"$ref": "#/components/schemas/AppealAllocation"
 							}
 						}
 					}
@@ -511,109 +524,123 @@
 				}
 			}
 		},
-		"/appeals/appeal-allocation-specialisms": {
-			"get": {
-				"tags": ["Appeal Allocation"],
-				"description": "Gets the list of specialisms used for allocation",
+		"/appeals/case-submission": {
+			"post": {
+				"tags": ["Integration"],
+				"description": "Request the creation of a new case",
 				"parameters": [],
 				"responses": {
 					"200": {
-						"description": "List of allocation specialisms",
+						"description": "Appeal successfully created",
 						"content": {
 							"application/json": {
 								"schema": {
-									"$ref": "#/components/schemas/AllocationSpecialismsResponse"
+									"$ref": "#/components/schemas/Appeal"
 								}
 							},
 							"application/xml": {
 								"schema": {
-									"$ref": "#/components/schemas/AllocationSpecialismsResponse"
+									"$ref": "#/components/schemas/Appeal"
 								}
 							}
 						}
 					},
 					"400": {
 						"description": "Bad Request"
-					}
-				}
-			}
-		},
-		"/appeals/appeal-allocation-levels": {
-			"get": {
-				"tags": ["Appeal Allocation"],
-				"description": "Gets the list of levels and associated bands used for allocation",
-				"parameters": [],
-				"responses": {
-					"200": {
-						"description": "List of allocation levels",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AllocationLevelsResponse"
-								}
-							},
-							"application/xml": {
-								"schema": {
-									"$ref": "#/components/schemas/AllocationLevelsResponse"
-								}
-							}
-						}
 					},
-					"400": {
-						"description": "Bad Request"
-					}
-				}
-			}
-		},
-		"/appeals/{appealId}/appeal-allocation": {
-			"patch": {
-				"tags": ["Appeal Allocation"],
-				"description": "Adds or changes allocation for an appeal",
-				"parameters": [
-					{
-						"name": "appealId",
-						"in": "path",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Patch appeal allocation",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/AppealAllocation"
-								}
-							},
-							"application/xml": {
-								"schema": {
-									"$ref": "#/components/schemas/AppealAllocation"
-								}
-							}
-						}
-					},
-					"400": {
-						"description": "Bad Request"
+					"404": {
+						"description": "Not Found"
 					}
 				},
 				"requestBody": {
 					"in": "body",
-					"description": "Appeal allocation",
+					"description": "Case data",
 					"required": true,
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/AppealAllocation"
+								"$ref": "#/components/schemas/CaseData"
 							}
 						},
 						"application/xml": {
 							"schema": {
-								"$ref": "#/components/schemas/AppealAllocation"
+								"$ref": "#/components/schemas/CaseData"
 							}
 						}
+					}
+				}
+			}
+		},
+		"/appeals/document-submission": {
+			"post": {
+				"tags": ["Integration"],
+				"description": "Imports a new document",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Document successfully created",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/DocumentDetails"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/DocumentDetails"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Document",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/DocumentDetails"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/DocumentDetails"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/appeals/knowledge-of-other-landowners": {
+			"get": {
+				"tags": ["Knowledge Of Other Landowners"],
+				"description": "Gets knowledge of other landowners values",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Knowledge of other landowners values",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllKnowledgeOfOtherLandownersResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllKnowledgeOfOtherLandownersResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
 					}
 				}
 			}
@@ -2672,6 +2699,25 @@
 				},
 				"xml": {
 					"name": "AllDesignatedSitesResponse"
+				}
+			},
+			"AllKnowledgeOfOtherLandownersResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "Yes"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllKnowledgeOfOtherLandownersResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -480,6 +480,12 @@ const document = {
 				description: 'candidate special area of conservation',
 				id: 1
 			}
+		],
+		AllKnowledgeOfOtherLandownersResponse: [
+			{
+				name: 'Yes',
+				id: 1
+			}
 		]
 	},
 	components: {}

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -475,6 +475,17 @@ const lpaQuestionnaireIncompleteReasons = [
 	}
 ];
 
+const knowledgeOfOtherLandowners = [
+	{
+		id: 1,
+		name: 'Value 1'
+	},
+	{
+		id: 2,
+		name: 'Value 2'
+	}
+];
+
 /**
  * @param {RepositoryGetByIdResultItem} appeal
  * @returns {SingleLPAQuestionnaireResponse}
@@ -705,13 +716,14 @@ export {
 	fullPlanningAppeal,
 	fullPlanningAppealAppellantCaseIncomplete,
 	fullPlanningAppealAppellantCaseInvalid,
-	householdAppealLPAQuestionnaireComplete,
 	fullPlanningAppealLPAQuestionnaireIncomplete,
+	householdAppealLPAQuestionnaireComplete,
 	householdAppeal,
 	householdAppealAppellantCaseIncomplete,
 	householdAppealAppellantCaseInvalid,
 	householdAppealAppellantCaseValid,
 	householdAppealLPAQuestionnaireIncomplete,
+	knowledgeOfOtherLandowners,
 	linkedAppeals,
 	lpaQuestionnaireIncompleteReasons,
 	lpaQuestionnaireValidationOutcomes,


### PR DESCRIPTION
## Describe your changes

Added an API endpoint to return the knowledge of other landowners, which provides values that can be used to dynamically create a field list in the UI.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-398

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
