### PR TITLE
feat(appeals/api): add api endpoint to get the lpa notification methods

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -99,6 +99,7 @@ const mockAppealSpecialismDeleteMany = jest.fn().mockResolvedValue({});
 const mockAppealSpecialismCreateMany = jest.fn().mockResolvedValue({});
 const mockDesignatedSiteFindMany = jest.fn().mockResolvedValue({});
 const mockKnowledgeOfOtherLandownersFindMany = jest.fn().mockResolvedValue({});
+const mockLPANotificationMethodsFindMany = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -388,6 +389,12 @@ class MockPrismaClient {
 	get knowledgeOfOtherLandowners() {
 		return {
 			findMany: mockKnowledgeOfOtherLandownersFindMany
+		};
+	}
+
+	get lPANotificationMethods() {
+		return {
+			findMany: mockLPANotificationMethodsFindMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -12,6 +12,7 @@ import { integrationsRoutes } from './integrations/integrations.routes.js';
 import initNotifyClientAndAddToRequest from '../middleware/init-notify-client-and-add-to-request.js';
 import { designatedSitesRoutes } from './designated-sites/designated-sites.routes.js';
 import { knowledgeOfOtherLandownersRoutes } from './knowledge-of-other-landowners/knowledge-of-other-landowners.routes.js';
+import { lpaNotificationMethodsRoutes } from './lpa-notification-methods/lpa-notification-methods.routes.js';
 
 const router = createRouter();
 
@@ -25,6 +26,7 @@ router.use(designatedSitesRoutes);
 router.use(documentsRoutes);
 router.use(integrationsRoutes);
 router.use(knowledgeOfOtherLandownersRoutes);
+router.use(lpaNotificationMethodsRoutes);
 router.use(lpaQuestionnaireIncompleteReasonsRoutes);
 router.use(lpaQuestionnairesRoutes);
 router.use(siteVisitRoutes);

--- a/appeals/api/src/server/endpoints/lpa-notification-methods/__tests__/lpa-notification-methods.test.js
+++ b/appeals/api/src/server/endpoints/lpa-notification-methods/__tests__/lpa-notification-methods.test.js
@@ -1,0 +1,45 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { lpaNotificationMethods } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('lpa notification methods routes', () => {
+	describe('/appeals/lpa-notification-methods', () => {
+		describe('GET', () => {
+			test('gets lpa notification methods', async () => {
+				// @ts-ignore
+				databaseConnector.lPANotificationMethods.findMany.mockResolvedValue(lpaNotificationMethods);
+
+				const response = await request.get('/appeals/lpa-notification-methods');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(lpaNotificationMethods);
+			});
+
+			test('returns an error if lpa notification methods are not found', async () => {
+				// @ts-ignore
+				databaseConnector.lPANotificationMethods.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/lpa-notification-methods');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get lpa notification methods', async () => {
+				// @ts-ignore
+				databaseConnector.lPANotificationMethods.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/lpa-notification-methods');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/lpa-notification-methods/lpa-notification-methods.routes.js
+++ b/appeals/api/src/server/endpoints/lpa-notification-methods/lpa-notification-methods.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/lpa-notification-methods',
+	/*
+		#swagger.tags = ['LPA Notification Methods']
+		#swagger.path = '/appeals/lpa-notification-methods'
+		#swagger.description = 'Gets LPA notification methods'
+		#swagger.responses[200] = {
+			description: 'LPA notification methods',
+			schema: { $ref: '#/definitions/AllLPANotificationMethodsResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('lPANotificationMethods'))
+);
+
+export { router as lpaNotificationMethodsRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -645,6 +645,33 @@
 				}
 			}
 		},
+		"/appeals/lpa-notification-methods": {
+			"get": {
+				"tags": ["LPA Notification Methods"],
+				"description": "Gets LPA notification methods",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "LPA notification methods",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllLPANotificationMethodsResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllLPANotificationMethodsResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/lpa-questionnaire-incomplete-reasons": {
 			"get": {
 				"tags": ["LPA Questionnaire Incomplete Reasons"],
@@ -2718,6 +2745,25 @@
 				},
 				"xml": {
 					"name": "AllKnowledgeOfOtherLandownersResponse"
+				}
+			},
+			"AllLPANotificationMethodsResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "A site notice"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllLPANotificationMethodsResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -486,6 +486,12 @@ const document = {
 				name: 'Yes',
 				id: 1
 			}
+		],
+		AllLPANotificationMethodsResponse: [
+			{
+				name: 'A site notice',
+				id: 1
+			}
 		]
 	},
 	components: {}

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -486,6 +486,17 @@ const knowledgeOfOtherLandowners = [
 	}
 ];
 
+const lpaNotificationMethods = [
+	{
+		id: 1,
+		name: 'Method 1'
+	},
+	{
+		id: 2,
+		name: 'Method 2'
+	}
+];
+
 /**
  * @param {RepositoryGetByIdResultItem} appeal
  * @returns {SingleLPAQuestionnaireResponse}
@@ -725,6 +736,7 @@ export {
 	householdAppealLPAQuestionnaireIncomplete,
 	knowledgeOfOtherLandowners,
 	linkedAppeals,
+	lpaNotificationMethods,
 	lpaQuestionnaireIncompleteReasons,
 	lpaQuestionnaireValidationOutcomes,
 	otherAppeals


### PR DESCRIPTION
## Describe your changes

Added an API endpoint to return the LPA Notification Methods, which provides values that can be used to dynamically create a field list in the UI.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-399

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
