### PR TITLE
feat(appeals/api): add api endpoint to get the lpa questionnaire validation outcomes

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -13,6 +13,7 @@ import initNotifyClientAndAddToRequest from '../middleware/init-notify-client-an
 import { designatedSitesRoutes } from './designated-sites/designated-sites.routes.js';
 import { knowledgeOfOtherLandownersRoutes } from './knowledge-of-other-landowners/knowledge-of-other-landowners.routes.js';
 import { lpaNotificationMethodsRoutes } from './lpa-notification-methods/lpa-notification-methods.routes.js';
+import { lpaQuestionnaireValidationOutcomesRoutes } from './lpa-questionnaire-validation-outcomes/lpa-questionnaire-validation-outcomes.routes.js';
 
 const router = createRouter();
 
@@ -29,6 +30,7 @@ router.use(knowledgeOfOtherLandownersRoutes);
 router.use(lpaNotificationMethodsRoutes);
 router.use(lpaQuestionnaireIncompleteReasonsRoutes);
 router.use(lpaQuestionnairesRoutes);
+router.use(lpaQuestionnaireValidationOutcomesRoutes);
 router.use(siteVisitRoutes);
 router.use(appealsRoutes);
 

--- a/appeals/api/src/server/endpoints/lpa-questionnaire-validation-outcomes/__tests__/lpa-questionnaire-validation-outcomes.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaire-validation-outcomes/__tests__/lpa-questionnaire-validation-outcomes.test.js
@@ -1,0 +1,47 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { lpaQuestionnaireValidationOutcomes } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('lpa questionnaire validation outcomes routes', () => {
+	describe('/appeals/lpa-questionnaire-validation-outcomes', () => {
+		describe('GET', () => {
+			test('gets lpa questionnaire validation outcomes', async () => {
+				// @ts-ignore
+				databaseConnector.lPAQuestionnaireValidationOutcome.findMany.mockResolvedValue(
+					lpaQuestionnaireValidationOutcomes
+				);
+
+				const response = await request.get('/appeals/lpa-questionnaire-validation-outcomes');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(lpaQuestionnaireValidationOutcomes);
+			});
+
+			test('returns an error if lpa questionnaire validation outcomes are not found', async () => {
+				// @ts-ignore
+				databaseConnector.lPAQuestionnaireValidationOutcome.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/lpa-questionnaire-validation-outcomes');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get lpa questionnaire validation outcomes', async () => {
+				// @ts-ignore
+				databaseConnector.lPAQuestionnaireValidationOutcome.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/lpa-questionnaire-validation-outcomes');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/lpa-questionnaire-validation-outcomes/lpa-questionnaire-validation-outcomes.routes.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaire-validation-outcomes/lpa-questionnaire-validation-outcomes.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/lpa-questionnaire-validation-outcomes',
+	/*
+		#swagger.tags = ['LPA Questionnaire Validation Outcomes']
+		#swagger.path = '/appeals/lpa-questionnaire-validation-outcomes'
+		#swagger.description = 'Gets LPA questionnaire validation outcomes'
+		#swagger.responses[200] = {
+			description: 'LPA questionnaire validation outcomes',
+			schema: { $ref: '#/definitions/AllLPAQuestionnaireValidationOutcomesResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('lPAQuestionnaireValidationOutcome'))
+);
+
+export { router as lpaQuestionnaireValidationOutcomesRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -808,6 +808,33 @@
 				}
 			}
 		},
+		"/appeals/lpa-questionnaire-validation-outcomes": {
+			"get": {
+				"tags": ["LPA Questionnaire Validation Outcomes"],
+				"description": "Gets LPA questionnaire validation outcomes",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "LPA questionnaire validation outcomes",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllLPAQuestionnaireValidationOutcomesResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllLPAQuestionnaireValidationOutcomesResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/site-visits": {
 			"post": {
 				"tags": ["Site Visits"],
@@ -2764,6 +2791,25 @@
 				},
 				"xml": {
 					"name": "AllLPANotificationMethodsResponse"
+				}
+			},
+			"AllLPAQuestionnaireValidationOutcomesResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "Complete"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllLPAQuestionnaireValidationOutcomesResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -492,6 +492,12 @@ const document = {
 				name: 'A site notice',
 				id: 1
 			}
+		],
+		AllLPAQuestionnaireValidationOutcomesResponse: [
+			{
+				name: 'Complete',
+				id: 1
+			}
 		]
 	},
 	components: {}


### PR DESCRIPTION
## Describe your changes

Added an API endpoint to return the LPA Questionnaire Validation Outcomes, which provides values that can be used to dynamically create a field list in the UI.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-400

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
