### PR TITLE
feat(appeals/api): add an api endpoint to get the planning obligation statuses

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -100,6 +100,7 @@ const mockAppealSpecialismCreateMany = jest.fn().mockResolvedValue({});
 const mockDesignatedSiteFindMany = jest.fn().mockResolvedValue({});
 const mockKnowledgeOfOtherLandownersFindMany = jest.fn().mockResolvedValue({});
 const mockLPANotificationMethodsFindMany = jest.fn().mockResolvedValue({});
+const mockPlanningObligationStatusFindMany = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -395,6 +396,12 @@ class MockPrismaClient {
 	get lPANotificationMethods() {
 		return {
 			findMany: mockLPANotificationMethodsFindMany
+		};
+	}
+
+	get planningObligationStatus() {
+		return {
+			findMany: mockPlanningObligationStatusFindMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -14,6 +14,7 @@ import { designatedSitesRoutes } from './designated-sites/designated-sites.route
 import { knowledgeOfOtherLandownersRoutes } from './knowledge-of-other-landowners/knowledge-of-other-landowners.routes.js';
 import { lpaNotificationMethodsRoutes } from './lpa-notification-methods/lpa-notification-methods.routes.js';
 import { lpaQuestionnaireValidationOutcomesRoutes } from './lpa-questionnaire-validation-outcomes/lpa-questionnaire-validation-outcomes.routes.js';
+import { planningObligationStatusesRoutes } from './planning-obligation-statuses/planning-obligation-statuses.routes.js';
 
 const router = createRouter();
 
@@ -31,6 +32,7 @@ router.use(lpaNotificationMethodsRoutes);
 router.use(lpaQuestionnaireIncompleteReasonsRoutes);
 router.use(lpaQuestionnairesRoutes);
 router.use(lpaQuestionnaireValidationOutcomesRoutes);
+router.use(planningObligationStatusesRoutes);
 router.use(siteVisitRoutes);
 router.use(appealsRoutes);
 

--- a/appeals/api/src/server/endpoints/planning-obligation-statuses/__tests__/planning-obligation-statuses.test.js
+++ b/appeals/api/src/server/endpoints/planning-obligation-statuses/__tests__/planning-obligation-statuses.test.js
@@ -1,0 +1,47 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { planningObligationStatuses } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('planning obligation statuses routes', () => {
+	describe('/appeals/planning-obligation-statuses', () => {
+		describe('GET', () => {
+			test('gets planning obligation statuses', async () => {
+				// @ts-ignore
+				databaseConnector.planningObligationStatus.findMany.mockResolvedValue(
+					planningObligationStatuses
+				);
+
+				const response = await request.get('/appeals/planning-obligation-statuses');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(planningObligationStatuses);
+			});
+
+			test('returns an error if planning obligation statuses are not found', async () => {
+				// @ts-ignore
+				databaseConnector.planningObligationStatus.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/planning-obligation-statuses');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get planning obligation statuses', async () => {
+				// @ts-ignore
+				databaseConnector.planningObligationStatus.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/planning-obligation-statuses');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/planning-obligation-statuses/planning-obligation-statuses.routes.js
+++ b/appeals/api/src/server/endpoints/planning-obligation-statuses/planning-obligation-statuses.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/planning-obligation-statuses',
+	/*
+		#swagger.tags = ['Planning Obligation Statuses']
+		#swagger.path = '/appeals/planning-obligation-statuses'
+		#swagger.description = 'Gets planning obligation statuses'
+		#swagger.responses[200] = {
+			description: 'Planning obligation statuses',
+			schema: { $ref: '#/definitions/AllPlanningObligationStatusesResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('planningObligationStatus'))
+);
+
+export { router as planningObligationStatusesRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -835,6 +835,33 @@
 				}
 			}
 		},
+		"/appeals/planning-obligation-statuses": {
+			"get": {
+				"tags": ["Planning Obligation Statuses"],
+				"description": "Gets planning obligation statuses",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Planning obligation statuses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllPlanningObligationStatusesResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllPlanningObligationStatusesResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/site-visits": {
 			"post": {
 				"tags": ["Site Visits"],
@@ -2810,6 +2837,25 @@
 				},
 				"xml": {
 					"name": "AllLPAQuestionnaireValidationOutcomesResponse"
+				}
+			},
+			"AllPlanningObligationStatusesResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "Finalised"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllPlanningObligationStatusesResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -498,6 +498,12 @@ const document = {
 				name: 'Complete',
 				id: 1
 			}
+		],
+		AllPlanningObligationStatusesResponse: [
+			{
+				name: 'Finalised',
+				id: 1
+			}
 		]
 	},
 	components: {}

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -497,6 +497,17 @@ const lpaNotificationMethods = [
 	}
 ];
 
+const planningObligationStatuses = [
+	{
+		id: 1,
+		name: 'Status 1'
+	},
+	{
+		id: 2,
+		name: 'Status 2'
+	}
+];
+
 /**
  * @param {RepositoryGetByIdResultItem} appeal
  * @returns {SingleLPAQuestionnaireResponse}
@@ -739,5 +750,6 @@ export {
 	lpaNotificationMethods,
 	lpaQuestionnaireIncompleteReasons,
 	lpaQuestionnaireValidationOutcomes,
-	otherAppeals
+	otherAppeals,
+	planningObligationStatuses
 };


### PR DESCRIPTION
## Describe your changes

Added an API endpoint to return the Planning Obligation Statuses, which provides values that can be used to dynamically create a field list in the UI.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-401

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
