### PR TITLE
fix(appeals/api): update get appeals endpoint to return the appeal due date

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -59,14 +59,14 @@ interface RepositoryGetAllResultItem {
 
 interface RepositoryGetByIdResultItem {
 	address?: Schema.Address | null;
+	allocation?: Schema.AppealAllocation | null;
 	appealStatus: Schema.AppealStatus[];
 	appealTimetable: Schema.AppealTimetable | null;
 	appealType: Schema.AppealType | null;
 	appellant: Schema.Appellant | null;
 	appellantCase?: Schema.AppellantCase | null;
-	allocation?: Schema.AppealAllocation | null;
-	specialisms: Schema.AppealSpecialism[];
 	createdAt: Date;
+	dueDate: Date | null;
 	id: number;
 	inspectorDecision?: { outcome: string } | null;
 	linkedAppealId: number | null;
@@ -77,6 +77,7 @@ interface RepositoryGetByIdResultItem {
 	planningApplicationReference: string;
 	reference: string;
 	siteVisit: Schema.SiteVisit | null;
+	specialisms: Schema.AppealSpecialism[];
 	startedAt: Date | null;
 }
 

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -414,7 +414,7 @@ describe('appeals routes', () => {
 					documentationSummary: {
 						appellantCase: {
 							status: 'received',
-							dueDate: null
+							dueDate: householdAppeal.dueDate
 						},
 						lpaQuestionnaire: {
 							dueDate: '2023-05-16T01:00:00.000Z',
@@ -508,7 +508,7 @@ describe('appeals routes', () => {
 					documentationSummary: {
 						appellantCase: {
 							status: 'received',
-							dueDate: null
+							dueDate: fullPlanningAppeal.dueDate
 						},
 						lpaQuestionnaire: {
 							dueDate: '2023-05-16T01:00:00.000Z',

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -97,7 +97,7 @@ const formatAppeal = (appeal) => {
 			documentationSummary: {
 				appellantCase: {
 					status: formatAppellantCaseDocumentationStatus(appeal),
-					dueDate: null
+					dueDate: appeal.dueDate
 				},
 				lpaQuestionnaire: {
 					status: formatLpaQuestionnaireDocumentationStatus(appeal),

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -80,6 +80,7 @@ const householdAppeal = {
 		otherNotValidReasons: null,
 		visibilityRestrictions: 'The site is behind a tall hedge'
 	},
+	dueDate: '2023-08-10T01:00:00.000Z',
 	inspectorDecision: {
 		outcome: 'Not issued yet'
 	},


### PR DESCRIPTION
## Describe your changes

Updated the GET appeals endpoint to return the Appeal Due Date rather than the hardcoded `null` value.

The value is returned as `documentationSummary.appellantCase.dueDate`

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
