### PR TITLE
feat(appeals/api): add an api endpoint to get the procedure types

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -101,6 +101,7 @@ const mockDesignatedSiteFindMany = jest.fn().mockResolvedValue({});
 const mockKnowledgeOfOtherLandownersFindMany = jest.fn().mockResolvedValue({});
 const mockLPANotificationMethodsFindMany = jest.fn().mockResolvedValue({});
 const mockPlanningObligationStatusFindMany = jest.fn().mockResolvedValue({});
+const mockProcedureTypeFindMany = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -402,6 +403,12 @@ class MockPrismaClient {
 	get planningObligationStatus() {
 		return {
 			findMany: mockPlanningObligationStatusFindMany
+		};
+	}
+
+	get procedureType() {
+		return {
+			findMany: mockProcedureTypeFindMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -15,6 +15,7 @@ import { knowledgeOfOtherLandownersRoutes } from './knowledge-of-other-landowner
 import { lpaNotificationMethodsRoutes } from './lpa-notification-methods/lpa-notification-methods.routes.js';
 import { lpaQuestionnaireValidationOutcomesRoutes } from './lpa-questionnaire-validation-outcomes/lpa-questionnaire-validation-outcomes.routes.js';
 import { planningObligationStatusesRoutes } from './planning-obligation-statuses/planning-obligation-statuses.routes.js';
+import { procedureTypesRoutes } from './procedure-types/procedure-types.routes.js';
 
 const router = createRouter();
 
@@ -33,6 +34,7 @@ router.use(lpaQuestionnaireIncompleteReasonsRoutes);
 router.use(lpaQuestionnairesRoutes);
 router.use(lpaQuestionnaireValidationOutcomesRoutes);
 router.use(planningObligationStatusesRoutes);
+router.use(procedureTypesRoutes);
 router.use(siteVisitRoutes);
 router.use(appealsRoutes);
 

--- a/appeals/api/src/server/endpoints/procedure-types/__tests__/procedure-types.test.js
+++ b/appeals/api/src/server/endpoints/procedure-types/__tests__/procedure-types.test.js
@@ -1,0 +1,48 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { procedureTypes } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('procedure types routes', () => {
+	describe('/appeals/procedure-types', () => {
+		describe('GET', () => {
+			test('gets procedure types', async () => {
+				console.log({ procedureTypes });
+				// @ts-ignore
+				databaseConnector.procedureType.findMany.mockResolvedValue(procedureTypes);
+
+				const response = await request.get('/appeals/procedure-types');
+
+				console.log(response.body);
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(procedureTypes);
+			});
+
+			test('returns an error if procedure types are not found', async () => {
+				// @ts-ignore
+				databaseConnector.procedureType.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/procedure-types');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get procedure types', async () => {
+				// @ts-ignore
+				databaseConnector.procedureType.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/procedure-types');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/procedure-types/procedure-types.routes.js
+++ b/appeals/api/src/server/endpoints/procedure-types/procedure-types.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/procedure-types',
+	/*
+		#swagger.tags = ['Procedure Types']
+		#swagger.path = '/appeals/procedure-types'
+		#swagger.description = 'Gets procedure types'
+		#swagger.responses[200] = {
+			description: 'Procedure types',
+			schema: { $ref: '#/definitions/AllProcedureTypesResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('procedureType'))
+);
+
+export { router as procedureTypesRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -862,6 +862,33 @@
 				}
 			}
 		},
+		"/appeals/procedure-types": {
+			"get": {
+				"tags": ["Procedure Types"],
+				"description": "Gets procedure types",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Procedure types",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllProcedureTypesResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllProcedureTypesResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/site-visits": {
 			"post": {
 				"tags": ["Site Visits"],
@@ -2856,6 +2883,25 @@
 				},
 				"xml": {
 					"name": "AllPlanningObligationStatusesResponse"
+				}
+			},
+			"AllProcedureTypesResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "Hearing"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllProcedureTypesResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -504,6 +504,12 @@ const document = {
 				name: 'Finalised',
 				id: 1
 			}
+		],
+		AllProcedureTypesResponse: [
+			{
+				name: 'Hearing',
+				id: 1
+			}
 		]
 	},
 	components: {}

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -392,14 +392,14 @@ const otherAppeals = [
 	}
 ];
 
-const appellantCaseIncompleteReasons = [
+const lookupListData = [
 	{
 		id: 1,
-		name: 'Reason 1'
+		name: 'Value 1'
 	},
 	{
 		id: 2,
-		name: 'Reason 2'
+		name: 'Value 2'
 	},
 	{
 		id: 3,
@@ -407,20 +407,13 @@ const appellantCaseIncompleteReasons = [
 	}
 ];
 
-const appellantCaseInvalidReasons = [
-	{
-		id: 1,
-		name: 'Reason 1'
-	},
-	{
-		id: 2,
-		name: 'Reason 2'
-	},
-	{
-		id: 3,
-		name: 'Other'
-	}
-];
+const appellantCaseIncompleteReasons = lookupListData;
+const appellantCaseInvalidReasons = lookupListData;
+const lpaQuestionnaireIncompleteReasons = lookupListData;
+const knowledgeOfOtherLandowners = lookupListData;
+const lpaNotificationMethods = lookupListData;
+const planningObligationStatuses = lookupListData;
+const procedureTypes = lookupListData;
 
 const designatedSites = [
 	{
@@ -458,54 +451,6 @@ const lpaQuestionnaireValidationOutcomes = [
 	{
 		id: 2,
 		name: VALIDATION_OUTCOME_INCOMPLETE
-	}
-];
-
-const lpaQuestionnaireIncompleteReasons = [
-	{
-		id: 1,
-		name: 'Reason 1'
-	},
-	{
-		id: 2,
-		name: 'Reason 2'
-	},
-	{
-		id: 3,
-		name: 'Other'
-	}
-];
-
-const knowledgeOfOtherLandowners = [
-	{
-		id: 1,
-		name: 'Value 1'
-	},
-	{
-		id: 2,
-		name: 'Value 2'
-	}
-];
-
-const lpaNotificationMethods = [
-	{
-		id: 1,
-		name: 'Method 1'
-	},
-	{
-		id: 2,
-		name: 'Method 2'
-	}
-];
-
-const planningObligationStatuses = [
-	{
-		id: 1,
-		name: 'Status 1'
-	},
-	{
-		id: 2,
-		name: 'Status 2'
 	}
 ];
 
@@ -752,5 +697,6 @@ export {
 	lpaQuestionnaireIncompleteReasons,
 	lpaQuestionnaireValidationOutcomes,
 	otherAppeals,
-	planningObligationStatuses
+	planningObligationStatuses,
+	procedureTypes
 };


### PR DESCRIPTION
## Describe your changes

Added an API endpoint to return the Procedure Types, which provides values that can be used to dynamically create a field list in the UI.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-402

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
