### PR TITLE
feat(appeals/api): add an api endpoint to get the schedule types

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -102,6 +102,7 @@ const mockKnowledgeOfOtherLandownersFindMany = jest.fn().mockResolvedValue({});
 const mockLPANotificationMethodsFindMany = jest.fn().mockResolvedValue({});
 const mockPlanningObligationStatusFindMany = jest.fn().mockResolvedValue({});
 const mockProcedureTypeFindMany = jest.fn().mockResolvedValue({});
+const mockScheduleTypeFindMany = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -409,6 +410,12 @@ class MockPrismaClient {
 	get procedureType() {
 		return {
 			findMany: mockProcedureTypeFindMany
+		};
+	}
+
+	get scheduleType() {
+		return {
+			findMany: mockScheduleTypeFindMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -16,6 +16,7 @@ import { lpaNotificationMethodsRoutes } from './lpa-notification-methods/lpa-not
 import { lpaQuestionnaireValidationOutcomesRoutes } from './lpa-questionnaire-validation-outcomes/lpa-questionnaire-validation-outcomes.routes.js';
 import { planningObligationStatusesRoutes } from './planning-obligation-statuses/planning-obligation-statuses.routes.js';
 import { procedureTypesRoutes } from './procedure-types/procedure-types.routes.js';
+import { scheduleTypesRoutes } from './schedule-types/schedule-types.routes.js';
 
 const router = createRouter();
 
@@ -35,6 +36,7 @@ router.use(lpaQuestionnairesRoutes);
 router.use(lpaQuestionnaireValidationOutcomesRoutes);
 router.use(planningObligationStatusesRoutes);
 router.use(procedureTypesRoutes);
+router.use(scheduleTypesRoutes);
 router.use(siteVisitRoutes);
 router.use(appealsRoutes);
 

--- a/appeals/api/src/server/endpoints/procedure-types/__tests__/procedure-types.test.js
+++ b/appeals/api/src/server/endpoints/procedure-types/__tests__/procedure-types.test.js
@@ -10,13 +10,10 @@ describe('procedure types routes', () => {
 	describe('/appeals/procedure-types', () => {
 		describe('GET', () => {
 			test('gets procedure types', async () => {
-				console.log({ procedureTypes });
 				// @ts-ignore
 				databaseConnector.procedureType.findMany.mockResolvedValue(procedureTypes);
 
 				const response = await request.get('/appeals/procedure-types');
-
-				console.log(response.body);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(procedureTypes);

--- a/appeals/api/src/server/endpoints/schedule-types/__tests__/schedule-types.test.js
+++ b/appeals/api/src/server/endpoints/schedule-types/__tests__/schedule-types.test.js
@@ -1,0 +1,45 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { scheduleTypes } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('schedule types routes', () => {
+	describe('/appeals/schedule-types', () => {
+		describe('GET', () => {
+			test('gets schedule types', async () => {
+				// @ts-ignore
+				databaseConnector.scheduleType.findMany.mockResolvedValue(scheduleTypes);
+
+				const response = await request.get('/appeals/schedule-types');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(scheduleTypes);
+			});
+
+			test('returns an error if schedule types are not found', async () => {
+				// @ts-ignore
+				databaseConnector.scheduleType.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/schedule-types');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get schedule types', async () => {
+				// @ts-ignore
+				databaseConnector.scheduleType.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/schedule-types');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/schedule-types/schedule-types.routes.js
+++ b/appeals/api/src/server/endpoints/schedule-types/schedule-types.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/schedule-types',
+	/*
+		#swagger.tags = ['Schedule Types']
+		#swagger.path = '/appeals/schedule-types'
+		#swagger.description = 'Gets schedule types'
+		#swagger.responses[200] = {
+			description: 'Schedule types',
+			schema: { $ref: '#/definitions/AllScheduleTypesResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('scheduleType'))
+);
+
+export { router as scheduleTypesRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -889,6 +889,33 @@
 				}
 			}
 		},
+		"/appeals/schedule-types": {
+			"get": {
+				"tags": ["Schedule Types"],
+				"description": "Gets schedule types",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Schedule types",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllScheduleTypesResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllScheduleTypesResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/site-visits": {
 			"post": {
 				"tags": ["Site Visits"],
@@ -2902,6 +2929,25 @@
 				},
 				"xml": {
 					"name": "AllProcedureTypesResponse"
+				}
+			},
+			"AllScheduleTypesResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "Schedule 1"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllScheduleTypesResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -510,6 +510,12 @@ const document = {
 				name: 'Hearing',
 				id: 1
 			}
+		],
+		AllScheduleTypesResponse: [
+			{
+				name: 'Schedule 1',
+				id: 1
+			}
 		]
 	},
 	components: {}

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -414,6 +414,7 @@ const knowledgeOfOtherLandowners = lookupListData;
 const lpaNotificationMethods = lookupListData;
 const planningObligationStatuses = lookupListData;
 const procedureTypes = lookupListData;
+const scheduleTypes = lookupListData;
 
 const designatedSites = [
 	{
@@ -698,5 +699,6 @@ export {
 	lpaQuestionnaireValidationOutcomes,
 	otherAppeals,
 	planningObligationStatuses,
-	procedureTypes
+	procedureTypes,
+	scheduleTypes
 };

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -1297,6 +1297,81 @@
 				}
 			}
 		},
+		"/applications/{id}/documents/{guid}/mark-as-published": {
+			"post": {
+				"tags": ["Applications"],
+				"description": "Marks as published ",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					},
+					{
+						"name": "guid",
+						"in": "path",
+						"required": true,
+						"type": "string",
+						"description": "Document GUID"
+					},
+					{
+						"name": "version",
+						"in": "path",
+						"description": "Version",
+						"required": true,
+						"type": "integer"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"description": "Mark as Published Request",
+						"schema": {
+							"$ref": "#/definitions/markAsPublishedRequestBody"
+						},
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Updated document response",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"guid": {
+									"type": "string",
+									"example": "0084b156-006b-48b1-a47f-e7176414db29"
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					},
+					"400": {
+						"description": "Example of an error response",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"errors": {
+									"type": "object",
+									"properties": {
+										"id": {
+											"type": "string",
+											"example": "Must be an existing application"
+										}
+									}
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/applications/{id}/documents/{guid}/properties": {
 			"get": {
 				"tags": ["Applications"],
@@ -2379,20 +2454,20 @@
 				}
 			}
 		},
-		"/applications/{caseId}/s51-advice/{id}": {
+		"/applications/{id}/s51-advice/{adviceId}": {
 			"get": {
 				"tags": ["Applications"],
 				"description": "Application case ID",
 				"parameters": [
 					{
-						"name": "caseId",
+						"name": "id",
 						"in": "path",
 						"required": true,
 						"type": "integer",
 						"description": "Application case ID"
 					},
 					{
-						"name": "id",
+						"name": "adviceId",
 						"in": "path",
 						"required": true,
 						"type": "integer",


### PR DESCRIPTION
## Describe your changes

Added an API endpoint to return the Schedule Types, which provides values that can be used to dynamically create a field list in the UI.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-403

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
