### PR TITLE
feat(appeals/api): add an api endpoint to get the site visit types

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -93,6 +93,7 @@ const mockLPAQuestionnaireIncompleteReasonOnLPAQuestionnaireUpdate = jest
 const mockSiteVisitCreate = jest.fn().mockResolvedValue({});
 const mockSiteVisitUpdate = jest.fn().mockResolvedValue({});
 const mockSiteVisitTypeFindUnique = jest.fn().mockResolvedValue({});
+const mockSiteVisitTypeFindMany = jest.fn().mockResolvedValue({});
 const mockSpecialismsFindUnique = jest.fn().mockResolvedValue({});
 const mockAppealAllocationUpsert = jest.fn().mockResolvedValue({});
 const mockAppealSpecialismDeleteMany = jest.fn().mockResolvedValue({});
@@ -360,7 +361,8 @@ class MockPrismaClient {
 
 	get siteVisitType() {
 		return {
-			findUnique: mockSiteVisitTypeFindUnique
+			findUnique: mockSiteVisitTypeFindUnique,
+			findMany: mockSiteVisitTypeFindMany
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -17,6 +17,7 @@ import { lpaQuestionnaireValidationOutcomesRoutes } from './lpa-questionnaire-va
 import { planningObligationStatusesRoutes } from './planning-obligation-statuses/planning-obligation-statuses.routes.js';
 import { procedureTypesRoutes } from './procedure-types/procedure-types.routes.js';
 import { scheduleTypesRoutes } from './schedule-types/schedule-types.routes.js';
+import { siteVisitTypesRoutes } from './site-visit-types/site-visit-types.routes.js';
 
 const router = createRouter();
 
@@ -38,6 +39,7 @@ router.use(planningObligationStatusesRoutes);
 router.use(procedureTypesRoutes);
 router.use(scheduleTypesRoutes);
 router.use(siteVisitRoutes);
+router.use(siteVisitTypesRoutes);
 router.use(appealsRoutes);
 
 export { router as appealsRoutes };

--- a/appeals/api/src/server/endpoints/site-visit-types/__tests__/site-visit-types.test.js
+++ b/appeals/api/src/server/endpoints/site-visit-types/__tests__/site-visit-types.test.js
@@ -1,0 +1,45 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { siteVisitTypes } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('site visit types routes', () => {
+	describe('/appeals/site-visit-types', () => {
+		describe('GET', () => {
+			test('gets site visit types', async () => {
+				// @ts-ignore
+				databaseConnector.siteVisitType.findMany.mockResolvedValue(siteVisitTypes);
+
+				const response = await request.get('/appeals/site-visit-types');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(siteVisitTypes);
+			});
+
+			test('returns an error if site visit types are not found', async () => {
+				// @ts-ignore
+				databaseConnector.siteVisitType.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/site-visit-types');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get site visit types', async () => {
+				// @ts-ignore
+				databaseConnector.siteVisitType.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/site-visit-types');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/site-visit-types/site-visit-types.routes.js
+++ b/appeals/api/src/server/endpoints/site-visit-types/site-visit-types.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/site-visit-types',
+	/*
+		#swagger.tags = ['Site Visit Types']
+		#swagger.path = '/appeals/site-visit-types'
+		#swagger.description = 'Gets site visit types'
+		#swagger.responses[200] = {
+			description: 'Site visit types',
+			schema: { $ref: '#/definitions/AllSiteVisitTypesResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('siteVisitType'))
+);
+
+export { router as siteVisitTypesRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -1087,6 +1087,33 @@
 				}
 			}
 		},
+		"/appeals/site-visit-types": {
+			"get": {
+				"tags": ["Site Visit Types"],
+				"description": "Gets site visit types",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Site visit types",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllSiteVisitTypesResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllSiteVisitTypesResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals": {
 			"get": {
 				"tags": ["Appeals"],
@@ -2948,6 +2975,25 @@
 				},
 				"xml": {
 					"name": "AllScheduleTypesResponse"
+				}
+			},
+			"AllSiteVisitTypesResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "Access required"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllSiteVisitTypesResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -516,6 +516,12 @@ const document = {
 				name: 'Schedule 1',
 				id: 1
 			}
+		],
+		AllSiteVisitTypesResponse: [
+			{
+				name: 'Access required',
+				id: 1
+			}
 		]
 	},
 	components: {}

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -415,6 +415,7 @@ const lpaNotificationMethods = lookupListData;
 const planningObligationStatuses = lookupListData;
 const procedureTypes = lookupListData;
 const scheduleTypes = lookupListData;
+const siteVisitTypes = lookupListData;
 
 const designatedSites = [
 	{
@@ -700,5 +701,6 @@ export {
 	otherAppeals,
 	planningObligationStatuses,
 	procedureTypes,
-	scheduleTypes
+	scheduleTypes,
+	siteVisitTypes
 };


### PR DESCRIPTION
## Describe your changes

Added an API endpoint to return the Site Visit Types, which provides values that can be used to dynamically create a field list in the UI.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-404

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
