### PR TITLE
feat(appeals/api): add api endpoint to get the appellant case validation outcomes

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -18,6 +18,7 @@ import { planningObligationStatusesRoutes } from './planning-obligation-statuses
 import { procedureTypesRoutes } from './procedure-types/procedure-types.routes.js';
 import { scheduleTypesRoutes } from './schedule-types/schedule-types.routes.js';
 import { siteVisitTypesRoutes } from './site-visit-types/site-visit-types.routes.js';
+import { appellantCaseValidationOutcomesRoutes } from './appellant-case-validation-outcomes/appellant-case-validation-outcomes.routes.js';
 
 const router = createRouter();
 
@@ -27,6 +28,7 @@ router.use(appealAllocationRouter);
 router.use(appellantCaseIncompleteReasonsRoutes);
 router.use(appellantCaseInvalidReasonsRoutes);
 router.use(appellantCasesRoutes);
+router.use(appellantCaseValidationOutcomesRoutes);
 router.use(designatedSitesRoutes);
 router.use(documentsRoutes);
 router.use(integrationsRoutes);

--- a/appeals/api/src/server/endpoints/appellant-case-validation-outcomes/__tests__/appellant-case-validation-outcomes.test.js
+++ b/appeals/api/src/server/endpoints/appellant-case-validation-outcomes/__tests__/appellant-case-validation-outcomes.test.js
@@ -1,0 +1,47 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { appellantCaseValidationOutcomes } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('appellant case validation outcomes routes', () => {
+	describe('/appeals/appellant-case-validation-outcomes', () => {
+		describe('GET', () => {
+			test('gets appellant case validation outcomes', async () => {
+				// @ts-ignore
+				databaseConnector.appellantCaseValidationOutcome.findMany.mockResolvedValue(
+					appellantCaseValidationOutcomes
+				);
+
+				const response = await request.get('/appeals/appellant-case-validation-outcomes');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(appellantCaseValidationOutcomes);
+			});
+
+			test('returns an error if appellant case validation outcomes are not found', async () => {
+				// @ts-ignore
+				databaseConnector.appellantCaseValidationOutcome.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/appellant-case-validation-outcomes');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get appellant case validation outcomes', async () => {
+				// @ts-ignore
+				databaseConnector.appellantCaseValidationOutcome.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/appellant-case-validation-outcomes');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/appellant-case-validation-outcomes/appellant-case-validation-outcomes.routes.js
+++ b/appeals/api/src/server/endpoints/appellant-case-validation-outcomes/appellant-case-validation-outcomes.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/appellant-case-validation-outcomes',
+	/*
+		#swagger.tags = ['Appellant Case Validation Outcomes']
+		#swagger.path = '/appeals/appellant-case-validation-outcomes'
+		#swagger.description = 'Gets appellant case validation outcomes'
+		#swagger.responses[200] = {
+			description: 'Appellant case validation outcomes',
+			schema: { $ref: '#/definitions/AllAppellantCaseValidationOutcomesResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('appellantCaseValidationOutcome'))
+);
+
+export { router as appellantCaseValidationOutcomesRoutes };

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -285,6 +285,33 @@
 				}
 			}
 		},
+		"/appeals/appellant-case-validation-outcomes": {
+			"get": {
+				"tags": ["Appellant Case Validation Outcomes"],
+				"description": "Gets appellant case validation outcomes",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Appellant case validation outcomes",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllAppellantCaseValidationOutcomesResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllAppellantCaseValidationOutcomesResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/designated-sites": {
 			"get": {
 				"tags": ["Designated Sites"],
@@ -2994,6 +3021,25 @@
 				},
 				"xml": {
 					"name": "AllSiteVisitTypesResponse"
+				}
+			},
+			"AllAppellantCaseValidationOutcomesResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string",
+							"example": "Valid"
+						},
+						"id": {
+							"type": "number",
+							"example": 1
+						}
+					}
+				},
+				"xml": {
+					"name": "AllAppellantCaseValidationOutcomesResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -522,6 +522,12 @@ const document = {
 				name: 'Access required',
 				id: 1
 			}
+		],
+		AllAppellantCaseValidationOutcomesResponse: [
+			{
+				name: 'Valid',
+				id: 1
+			}
 		]
 	},
 	components: {}


### PR DESCRIPTION
 Describe your changes

Added an API endpoint to return the Appellant Case Validation Outcomes, which provides values that can be used to dynamically create a field list in the UI.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-396

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
