### PR TITLE
feat(appeals/api): add get/patch api endpoints for appellants

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -104,6 +104,7 @@ const mockLPANotificationMethodsFindMany = jest.fn().mockResolvedValue({});
 const mockPlanningObligationStatusFindMany = jest.fn().mockResolvedValue({});
 const mockProcedureTypeFindMany = jest.fn().mockResolvedValue({});
 const mockScheduleTypeFindMany = jest.fn().mockResolvedValue({});
+const mockAppellantUpdate = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -418,6 +419,12 @@ class MockPrismaClient {
 	get scheduleType() {
 		return {
 			findMany: mockScheduleTypeFindMany
+		};
+	}
+
+	get appellant() {
+		return {
+			update: mockAppellantUpdate
 		};
 	}
 

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -63,7 +63,7 @@ interface RepositoryGetByIdResultItem {
 	appealStatus: Schema.AppealStatus[];
 	appealTimetable: Schema.AppealTimetable | null;
 	appealType: Schema.AppealType | null;
-	appellant: Schema.Appellant | null;
+	appellant: Schema.Appellant;
 	appellantCase?: Schema.AppellantCase | null;
 	createdAt: Date;
 	dueDate: Date | null;
@@ -350,6 +350,18 @@ interface SingleSiteVisitDetailsResponse {
 	visitType: string;
 }
 
+interface SingleAppellantResponse {
+	agentName: string | null;
+	appellantId: number;
+	company: string | null;
+	email: string;
+	name: string;
+}
+
+interface UpdateAppellantRequest {
+	name?: string;
+}
+
 type ListedBuildingDetailsResponse = Pick<ListedBuildingDetails, 'grade' | 'description'>[];
 
 type LookupTables = AppellantCaseIncompleteReason | AppellantCaseInvalidReason | ValidationOutcome;
@@ -376,8 +388,10 @@ export {
 	RepositoryGetByIdResultItem,
 	SingleAppealDetailsResponse,
 	SingleAppellantCaseResponse,
+	SingleAppellantResponse,
 	SingleLPAQuestionnaireResponse,
 	SingleSiteVisitDetailsResponse,
 	TimetableDeadlineDate,
+	UpdateAppellantRequest,
 	ValidationOutcomeResponse
 };

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -19,6 +19,7 @@ import { procedureTypesRoutes } from './procedure-types/procedure-types.routes.j
 import { scheduleTypesRoutes } from './schedule-types/schedule-types.routes.js';
 import { siteVisitTypesRoutes } from './site-visit-types/site-visit-types.routes.js';
 import { appellantCaseValidationOutcomesRoutes } from './appellant-case-validation-outcomes/appellant-case-validation-outcomes.routes.js';
+import { appellantsRoutes } from './appellants/appellants.routes.js';
 
 const router = createRouter();
 
@@ -29,6 +30,7 @@ router.use(appellantCaseIncompleteReasonsRoutes);
 router.use(appellantCaseInvalidReasonsRoutes);
 router.use(appellantCasesRoutes);
 router.use(appellantCaseValidationOutcomesRoutes);
+router.use(appellantsRoutes);
 router.use(designatedSitesRoutes);
 router.use(documentsRoutes);
 router.use(integrationsRoutes);

--- a/appeals/api/src/server/endpoints/appellants/__tests__/appellants.test.js
+++ b/appeals/api/src/server/endpoints/appellants/__tests__/appellants.test.js
@@ -1,0 +1,264 @@
+import { request } from '../../../app-test.js';
+import {
+	ERROR_CANNOT_BE_EMPTY_STRING,
+	ERROR_FAILED_TO_SAVE_DATA,
+	ERROR_MAX_LENGTH_300_CHARACTERS,
+	ERROR_MUST_BE_NUMBER,
+	ERROR_MUST_BE_STRING,
+	ERROR_NOT_FOUND
+} from '../../constants.js';
+import { householdAppeal } from '#tests/data.js';
+
+const { databaseConnector } = await import('#utils/database-connector.js');
+
+describe('appellants routes', () => {
+	describe('/appeals/:appealId/appellants/:appellantId', () => {
+		describe('GET', () => {
+			test('gets a single appellant', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.get(
+					`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`
+				);
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					agentName: householdAppeal.appellant.agentName,
+					appellantId: householdAppeal.appellant.id,
+					company: householdAppeal.appellant.company,
+					email: householdAppeal.appellant.email,
+					name: householdAppeal.appellant.name
+				});
+			});
+
+			test('returns an error if appealId is not numeric', async () => {
+				const response = await request.get(
+					`/appeals/one/appellants/${householdAppeal.appellant.id}`
+				);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appealId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request.get(
+					`/appeals/3/lpa-questionnaires/${householdAppeal.appellant.id}`
+				);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if appellantId is not numeric', async () => {
+				const response = await request.get(`/appeals/${householdAppeal.id}/appellants/one`);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appellantId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appellantId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.get(`/appeals/${householdAppeal.id}/appellants/3`);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appellantId: ERROR_NOT_FOUND
+					}
+				});
+			});
+		});
+
+		describe('PATCH', () => {
+			const patchBody = {
+				name: 'Eva Sharma'
+			};
+
+			test('updates an appellant', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
+					.send(patchBody);
+
+				expect(databaseConnector.appellant.update).toHaveBeenCalledWith({
+					data: patchBody,
+					where: {
+						id: householdAppeal.appellant.id
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(patchBody);
+			});
+
+			test('returns an error if appealId is not numeric', async () => {
+				const response = await request
+					.patch(`/appeals/one/appellants/${householdAppeal.appellant.id}`)
+					.send(patchBody);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appealId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request
+					.patch(`/appeals/3/appellants/${householdAppeal.appellant.id}`)
+					.send(patchBody);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if appellantId is not numeric', async () => {
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/appellants/one`)
+					.send(patchBody);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appellantId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appellantId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/appellants/3`)
+					.send(patchBody);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appellantId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if name is not a string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
+					.send({
+						name: [patchBody.name]
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						name: ERROR_MUST_BE_STRING
+					}
+				});
+			});
+
+			test('returns an error if name is an empty string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
+					.send({
+						name: ''
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						name: ERROR_CANNOT_BE_EMPTY_STRING
+					}
+				});
+			});
+
+			test('returns an error if name is more than 300 characters', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
+					.send({
+						name: 'A'.repeat(301)
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						name: ERROR_MAX_LENGTH_300_CHARACTERS
+					}
+				});
+			});
+
+			test('does not return an error when given an empty body', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
+					.send({});
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({});
+			});
+
+			test('returns an error when unable to save the data', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appellant.update.mockImplementation(() => {
+					throw new Error('Internal Server Error');
+				});
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
+					.send(patchBody);
+
+				expect(databaseConnector.appellant.update).toHaveBeenCalledWith({
+					data: patchBody,
+					where: {
+						id: householdAppeal.appellant.id
+					}
+				});
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({
+					errors: {
+						body: ERROR_FAILED_TO_SAVE_DATA
+					}
+				});
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/appellants/appellants.controller.js
+++ b/appeals/api/src/server/endpoints/appellants/appellants.controller.js
@@ -1,0 +1,45 @@
+import logger from '#utils/logger.js';
+import { ERROR_FAILED_TO_SAVE_DATA } from '../constants.js';
+import { formatAppellant } from './appellants.formatter.js';
+import appellantRepository from '#repositories/appellant.repository.js';
+
+/** @typedef {import('express').RequestHandler} RequestHandler */
+/** @typedef {import('express').Response} Response */
+
+/**
+ * @type {RequestHandler}
+ * @returns {Response}
+ */
+const getAppellantById = (req, res) => {
+	const { appellant } = req.appeal;
+	const formattedAppellant = formatAppellant(appellant);
+
+	return res.send(formattedAppellant);
+};
+
+/**
+ * @type {RequestHandler}
+ * @returns {Promise<Response>}
+ */
+const updateAppellantById = async (req, res) => {
+	const {
+		body,
+		body: { name },
+		params: { appellantId }
+	} = req;
+
+	try {
+		await appellantRepository.updateAppellantById(Number(appellantId), {
+			name
+		});
+	} catch (error) {
+		if (error) {
+			logger.error(error);
+			return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
+		}
+	}
+
+	return res.send(body);
+};
+
+export { getAppellantById, updateAppellantById };

--- a/appeals/api/src/server/endpoints/appellants/appellants.formatter.js
+++ b/appeals/api/src/server/endpoints/appellants/appellants.formatter.js
@@ -1,0 +1,16 @@
+/** @typedef {import('@pins/appeals.api').Schema.Appellant} Appellant */
+/** @typedef {import('@pins/appeals.api').Appeals.SingleAppellantResponse} SingleAppellantResponse */
+
+/**
+ * @param {Appellant} appellant
+ * @returns {SingleAppellantResponse}
+ */
+const formatAppellant = (appellant) => ({
+	agentName: appellant.agentName,
+	appellantId: appellant.id,
+	company: appellant.company,
+	email: appellant.email,
+	name: appellant.name
+});
+
+export { formatAppellant };

--- a/appeals/api/src/server/endpoints/appellants/appellants.routes.js
+++ b/appeals/api/src/server/endpoints/appellants/appellants.routes.js
@@ -1,0 +1,54 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getAppellantById, updateAppellantById } from './appellants.controller.js';
+import checkAppealExistsAndAddToRequest from '#middleware/check-appeal-exists-and-add-to-request.js';
+import { checkAppellantExists } from './appellants.service.js';
+import { getAppellantValidator, patchAppellantValidator } from './appellants.validators.js';
+
+const router = createRouter();
+
+router.get(
+	'/:appealId/appellants/:appellantId',
+	/*
+		#swagger.tags = ['Appellants']
+		#swagger.path = '/appeals/{appealId}/appellants/{appellantId}'
+		#swagger.description = Gets a single appellant by id
+		#swagger.responses[200] = {
+			description: 'Gets a single appellant by id',
+			schema: { $ref: '#/definitions/SingleAppellantResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	getAppellantValidator,
+	checkAppealExistsAndAddToRequest,
+	checkAppellantExists,
+	asyncHandler(getAppellantById)
+);
+
+router.patch(
+	'/:appealId/appellants/:appellantId',
+	/*
+		#swagger.tags = ['Appellants']
+		#swagger.path = '/appeals/{appealId}/appellants/{appellantId}'
+		#swagger.description = Updates a single appellant by id
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Appellant details to update',
+			schema: { $ref: '#/definitions/UpdateAppellantRequest' },
+			required: true
+		}
+		#swagger.responses[200] = {
+			description: 'Updates a single appellant by id',
+			schema: { $ref: '#/definitions/UpdateAppellantResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	patchAppellantValidator,
+	checkAppealExistsAndAddToRequest,
+	checkAppellantExists,
+	asyncHandler(updateAppellantById)
+);
+
+export { router as appellantsRoutes };

--- a/appeals/api/src/server/endpoints/appellants/appellants.service.js
+++ b/appeals/api/src/server/endpoints/appellants/appellants.service.js
@@ -1,0 +1,23 @@
+import { ERROR_NOT_FOUND } from '../constants.js';
+
+/** @typedef {import('express').RequestHandler} RequestHandler */
+
+/**
+ * @type {RequestHandler}
+ * @returns {Promise<object | void>}
+ */
+const checkAppellantExists = async (req, res, next) => {
+	const {
+		appeal,
+		params: { appellantId }
+	} = req;
+	const hasAppellant = appeal.appellant?.id === Number(appellantId);
+
+	if (!hasAppellant) {
+		return res.status(404).send({ errors: { appellantId: ERROR_NOT_FOUND } });
+	}
+
+	next();
+};
+
+export { checkAppellantExists };

--- a/appeals/api/src/server/endpoints/appellants/appellants.validators.js
+++ b/appeals/api/src/server/endpoints/appellants/appellants.validators.js
@@ -1,0 +1,31 @@
+import { composeMiddleware } from '@pins/express';
+import { body } from 'express-validator';
+import { validationErrorHandler } from '#middleware/error-handler.js';
+import {
+	ERROR_CANNOT_BE_EMPTY_STRING,
+	ERROR_MAX_LENGTH_300_CHARACTERS,
+	ERROR_MUST_BE_STRING
+} from '../constants.js';
+import validateIdParameter from '#common/validators/id-parameter.js';
+
+const getAppellantValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateIdParameter('appellantId'),
+	validationErrorHandler
+);
+
+const patchAppellantValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateIdParameter('appellantId'),
+	body('name')
+		.optional()
+		.isString()
+		.withMessage(ERROR_MUST_BE_STRING)
+		.notEmpty()
+		.withMessage(ERROR_CANNOT_BE_EMPTY_STRING)
+		.isLength({ max: 300 })
+		.withMessage(ERROR_MAX_LENGTH_300_CHARACTERS),
+	validationErrorHandler
+);
+
+export { getAppellantValidator, patchAppellantValidator };

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -20,6 +20,7 @@ export const DEFAULT_TIMESTAMP_TIME = '01:00:00.000';
 export const DOCUMENT_STATUS_NOT_RECEIVED = 'not_received';
 export const DOCUMENT_STATUS_RECEIVED = 'received';
 
+export const ERROR_CANNOT_BE_EMPTY_STRING = 'Cannot be an empty string';
 export const ERROR_FAILED_TO_GET_DATA = 'Failed to get data';
 export const ERROR_FAILED_TO_SAVE_DATA = 'Failed to save data';
 export const ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL = 'Failed to send notification email';

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -312,6 +312,115 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/appellants/{appellantId}": {
+			"get": {
+				"tags": ["Appellants"],
+				"description": "Gets a single appellant by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "appellantId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Gets a single appellant by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/SingleAppellantResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/SingleAppellantResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"patch": {
+				"tags": ["Appellants"],
+				"description": "Updates a single appellant by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "appellantId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Updates a single appellant by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateAppellantResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateAppellantResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Appellant details to update",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateAppellantRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateAppellantRequest"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals/designated-sites": {
 			"get": {
 				"tags": ["Designated Sites"],
@@ -3040,6 +3149,58 @@
 				},
 				"xml": {
 					"name": "AllAppellantCaseValidationOutcomesResponse"
+				}
+			},
+			"SingleAppellantResponse": {
+				"type": "object",
+				"properties": {
+					"agentName": {
+						"type": "string",
+						"example": "Fiona Burgess"
+					},
+					"appellantId": {
+						"type": "number",
+						"example": 1
+					},
+					"company": {
+						"type": "string",
+						"example": "Sophie Skinner Ltd"
+					},
+					"email": {
+						"type": "string",
+						"example": "sophie.skinner@example.com"
+					},
+					"name": {
+						"type": "string",
+						"example": "Sophie Skinner"
+					}
+				},
+				"xml": {
+					"name": "SingleAppellantResponse"
+				}
+			},
+			"UpdateAppellantRequest": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string",
+						"example": "Eva Sharma"
+					}
+				},
+				"xml": {
+					"name": "UpdateAppellantRequest"
+				}
+			},
+			"UpdateAppellantResponse": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string",
+						"example": "Eva Sharma"
+					}
+				},
+				"xml": {
+					"name": "UpdateAppellantResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/repositories/appellant.repository.js
+++ b/appeals/api/src/server/repositories/appellant.repository.js
@@ -1,0 +1,21 @@
+import { databaseConnector } from '#utils/database-connector.js';
+
+/** @typedef {import('@pins/appeals.api').Appeals.UpdateAppellantRequest} UpdateAppellantRequest */
+/** @typedef {import('@pins/appeals.api').Schema.Appellant} Appellant */
+/**
+ * @typedef {import('#db-client').Prisma.PrismaPromise<T>} PrismaPromise
+ * @template T
+ */
+
+/**
+ * @param {number} id
+ * @param {UpdateAppellantRequest} data
+ * @returns {PrismaPromise<Appellant>}
+ */
+const updateAppellantById = (id, data) =>
+	databaseConnector.appellant.update({
+		where: { id },
+		data
+	});
+
+export default { updateAppellantById };

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -528,7 +528,20 @@ const document = {
 				name: 'Valid',
 				id: 1
 			}
-		]
+		],
+		SingleAppellantResponse: {
+			agentName: 'Fiona Burgess',
+			appellantId: 1,
+			company: 'Sophie Skinner Ltd',
+			email: 'sophie.skinner@example.com',
+			name: 'Sophie Skinner'
+		},
+		UpdateAppellantRequest: {
+			name: 'Eva Sharma'
+		},
+		UpdateAppellantResponse: {
+			name: 'Eva Sharma'
+		}
 	},
 	components: {}
 };

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -31,6 +31,7 @@ const householdAppeal = {
 		agentName: 'Mr Agent',
 		company: 'Lee Thornton Ltd',
 		email: 'l.thornton@example.com',
+		id: 1,
 		name: 'Lee Thornton'
 	},
 	startedAt: new Date(2022, 4, 18),


### PR DESCRIPTION
## Describe your changes

Added GET/PATCH API endpoints for Appellants. Initially this is used for saving the Appellant Name on the Appellant Case page.

Also added validation, swagger docs and unit tests.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-425

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
