### PR TITLE
feat(appeals/api): add get/patch api endpoints for addresses

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -68,6 +68,7 @@ const mockExaminationTimetableItemCreate = jest.fn().mockResolvedValue({});
 const mockExaminationTimetableItemUpdateMany = jest.fn().mockResolvedValue({});
 const mockExaminationTimetableItemDelete = jest.fn().mockResolvedValue({});
 const mockAddressDelete = jest.fn().mockResolvedValue({});
+const mockAddressUpdate = jest.fn().mockResolvedValue({});
 const mockAppellantCaseIncompleteReasonFindMany = jest.fn().mockResolvedValue({});
 const mockAppellantCaseIncompleteReasonOnAppellantCaseDeleteMany = jest.fn().mockResolvedValue({});
 const mockAppellantCaseIncompleteReasonOnAppellantCaseCreateMany = jest.fn().mockResolvedValue({});
@@ -109,7 +110,8 @@ const mockAppellantUpdate = jest.fn().mockResolvedValue({});
 class MockPrismaClient {
 	get address() {
 		return {
-			delete: mockAddressDelete
+			delete: mockAddressDelete,
+			update: mockAddressUpdate
 		};
 	}
 	get appeal() {

--- a/appeals/api/src/server/common/validators/string-parameter.js
+++ b/appeals/api/src/server/common/validators/string-parameter.js
@@ -1,0 +1,27 @@
+import { body } from 'express-validator';
+import {
+	ERROR_CANNOT_BE_EMPTY_STRING,
+	ERROR_MAX_LENGTH_CHARACTERS,
+	ERROR_MUST_BE_STRING,
+	MAX_LENGTH_300
+} from '#endpoints/constants.js';
+import errorMessageReplacement from '#utils/error-message-replacement.js';
+
+/** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {string} parameterName
+ * @param {number} maxLength
+ * @returns {ValidationChain}
+ */
+const validateStringParameter = (parameterName, maxLength = MAX_LENGTH_300) =>
+	body(parameterName)
+		.optional()
+		.isString()
+		.withMessage(ERROR_MUST_BE_STRING)
+		.notEmpty()
+		.withMessage(ERROR_CANNOT_BE_EMPTY_STRING)
+		.isLength({ max: maxLength })
+		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, maxLength));
+
+export default validateStringParameter;

--- a/appeals/api/src/server/endpoints/addresses/__tests__/addresses.test.js
+++ b/appeals/api/src/server/endpoints/addresses/__tests__/addresses.test.js
@@ -1,0 +1,540 @@
+import { request } from '../../../app-test.js';
+import {
+	ERROR_CANNOT_BE_EMPTY_STRING,
+	ERROR_FAILED_TO_SAVE_DATA,
+	ERROR_MAX_LENGTH_CHARACTERS,
+	ERROR_MUST_BE_NUMBER,
+	ERROR_MUST_BE_STRING,
+	ERROR_NOT_FOUND,
+	MAX_LENGTH_300,
+	MAX_LENGTH_8
+} from '../../constants.js';
+import { householdAppeal } from '#tests/data.js';
+import errorMessageReplacement from '#utils/error-message-replacement.js';
+
+const { databaseConnector } = await import('#utils/database-connector.js');
+
+describe('addresses routes', () => {
+	describe('/appeals/:appealId/addresses/:addressId', () => {
+		describe('GET', () => {
+			test('gets a single address', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.get(
+					`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`
+				);
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					addressId: householdAppeal.address.id,
+					addressLine1: householdAppeal.address.addressLine1,
+					addressLine2: householdAppeal.address.addressLine2,
+					country: householdAppeal.address.country,
+					county: householdAppeal.address.county,
+					postcode: householdAppeal.address.postcode,
+					town: householdAppeal.address.town
+				});
+			});
+
+			test('returns an error if appealId is not numeric', async () => {
+				const response = await request.get(`/appeals/one/addresses/${householdAppeal.address.id}`);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appealId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request.get(`/appeals/3/addresses/${householdAppeal.address.id}`);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if addressId is not numeric', async () => {
+				const response = await request.get(`/appeals/${householdAppeal.id}/addresses/one`);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						addressId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if addressId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request.get(`/appeals/${householdAppeal.id}/addresses/3`);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						addressId: ERROR_NOT_FOUND
+					}
+				});
+			});
+		});
+
+		describe('PATCH', () => {
+			const patchBody = {
+				addressLine1: householdAppeal.address.addressLine1,
+				addressLine2: householdAppeal.address.addressLine2,
+				country: householdAppeal.address.country,
+				county: householdAppeal.address.county,
+				postcode: householdAppeal.address.postcode,
+				town: householdAppeal.address.town
+			};
+
+			test('updates an address', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send(patchBody);
+
+				expect(databaseConnector.address.update).toHaveBeenCalledWith({
+					data: patchBody,
+					where: {
+						id: householdAppeal.address.id
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(patchBody);
+			});
+
+			test('returns an error if appealId is not numeric', async () => {
+				const response = await request
+					.patch(`/appeals/one/addresses/${householdAppeal.address.id}`)
+					.send(patchBody);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if appealId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(null);
+
+				const response = await request
+					.patch(`/appeals/3/addresses/${householdAppeal.address.id}`)
+					.send(patchBody);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						appealId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if addressId is not numeric', async () => {
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/one`)
+					.send(patchBody);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						addressId: ERROR_MUST_BE_NUMBER
+					}
+				});
+			});
+
+			test('returns an error if addressId is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/3`)
+					.send(patchBody);
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({
+					errors: {
+						addressId: ERROR_NOT_FOUND
+					}
+				});
+			});
+
+			test('returns an error if addressLine1 is not a string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						addressLine1: [patchBody.addressLine1]
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						addressLine1: ERROR_MUST_BE_STRING
+					}
+				});
+			});
+
+			test('returns an error if addressLine1 is an empty string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						addressLine1: ''
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						addressLine1: ERROR_CANNOT_BE_EMPTY_STRING
+					}
+				});
+			});
+
+			test('returns an error if addressLine1 is more than 300 characters', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						addressLine1: 'A'.repeat(MAX_LENGTH_300 + 1)
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						addressLine1: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+					}
+				});
+			});
+
+			test('returns an error if addressLine2 is not a string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						addressLine2: [patchBody.addressLine2]
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						addressLine2: ERROR_MUST_BE_STRING
+					}
+				});
+			});
+
+			test('returns an error if addressLine2 is an empty string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						addressLine2: ''
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						addressLine2: ERROR_CANNOT_BE_EMPTY_STRING
+					}
+				});
+			});
+
+			test('returns an error if addressLine2 is more than 300 characters', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						addressLine2: 'A'.repeat(MAX_LENGTH_300 + 1)
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						addressLine2: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+					}
+				});
+			});
+
+			test('returns an error if country is not a string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						country: [patchBody.country]
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						country: ERROR_MUST_BE_STRING
+					}
+				});
+			});
+
+			test('returns an error if country is an empty string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						country: ''
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						country: ERROR_CANNOT_BE_EMPTY_STRING
+					}
+				});
+			});
+
+			test('returns an error if country is more than 300 characters', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						country: 'A'.repeat(MAX_LENGTH_300 + 1)
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						country: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+					}
+				});
+			});
+
+			test('returns an error if county is not a string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						county: [patchBody.county]
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						county: ERROR_MUST_BE_STRING
+					}
+				});
+			});
+
+			test('returns an error if county is an empty string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						county: ''
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						county: ERROR_CANNOT_BE_EMPTY_STRING
+					}
+				});
+			});
+
+			test('returns an error if county is more than 300 characters', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						county: 'A'.repeat(MAX_LENGTH_300 + 1)
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						county: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+					}
+				});
+			});
+
+			test('returns an error if postcode is not a string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						postcode: [patchBody.postcode]
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						postcode: ERROR_MUST_BE_STRING
+					}
+				});
+			});
+
+			test('returns an error if postcode is an empty string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						postcode: ''
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						postcode: ERROR_CANNOT_BE_EMPTY_STRING
+					}
+				});
+			});
+
+			test('returns an error if postcode is more than 8 characters', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						postcode: 'A'.repeat(MAX_LENGTH_8 + 1)
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						postcode: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_8)
+					}
+				});
+			});
+
+			test('returns an error if town is not a string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						town: [patchBody.town]
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						town: ERROR_MUST_BE_STRING
+					}
+				});
+			});
+
+			test('returns an error if town is an empty string', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						town: ''
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						town: ERROR_CANNOT_BE_EMPTY_STRING
+					}
+				});
+			});
+
+			test('returns an error if town is more than 300 characters', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({
+						town: 'A'.repeat(MAX_LENGTH_300 + 1)
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						town: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+					}
+				});
+			});
+
+			test('does not return an error when given an empty body', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send({});
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({});
+			});
+
+			test('returns an error when unable to save the data', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.address.update.mockImplementation(() => {
+					throw new Error('Internal Server Error');
+				});
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.send(patchBody);
+
+				expect(databaseConnector.address.update).toHaveBeenCalledWith({
+					data: patchBody,
+					where: {
+						id: householdAppeal.address.id
+					}
+				});
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({
+					errors: {
+						body: ERROR_FAILED_TO_SAVE_DATA
+					}
+				});
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/addresses/addresses.controller.js
+++ b/appeals/api/src/server/endpoints/addresses/addresses.controller.js
@@ -1,0 +1,50 @@
+import logger from '#utils/logger.js';
+import { ERROR_FAILED_TO_SAVE_DATA } from '../constants.js';
+import { formatAddress } from './addresses.formatter.js';
+import addressRepository from '#repositories/address.repository.js';
+
+/** @typedef {import('express').RequestHandler} RequestHandler */
+/** @typedef {import('express').Response} Response */
+
+/**
+ * @type {RequestHandler}
+ * @returns {Response}
+ */
+const getAddressById = (req, res) => {
+	const { address } = req.appeal;
+	const formattedAddress = formatAddress(address);
+
+	return res.send(formattedAddress);
+};
+
+/**
+ * @type {RequestHandler}
+ * @returns {Promise<Response>}
+ */
+const updateAddressById = async (req, res) => {
+	const {
+		body,
+		body: { addressLine1, addressLine2, country, county, postcode, town },
+		params: { addressId }
+	} = req;
+
+	try {
+		await addressRepository.updateAddressById(Number(addressId), {
+			addressLine1,
+			addressLine2,
+			country,
+			county,
+			postcode,
+			town
+		});
+	} catch (error) {
+		if (error) {
+			logger.error(error);
+			return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
+		}
+	}
+
+	return res.send(body);
+};
+
+export { getAddressById, updateAddressById };

--- a/appeals/api/src/server/endpoints/addresses/addresses.formatter.js
+++ b/appeals/api/src/server/endpoints/addresses/addresses.formatter.js
@@ -1,0 +1,18 @@
+/** @typedef {import('@pins/appeals.api').Schema.Address} Address */
+/** @typedef {import('@pins/appeals.api').Appeals.SingleAddressResponse} SingleAddressResponse */
+
+/**
+ * @param {Address} address
+ * @returns {SingleAddressResponse}
+ */
+const formatAddress = (address) => ({
+	addressId: address.id,
+	addressLine1: address.addressLine1,
+	addressLine2: address.addressLine2,
+	country: address.country,
+	county: address.county,
+	postcode: address.postcode,
+	town: address.town
+});
+
+export { formatAddress };

--- a/appeals/api/src/server/endpoints/addresses/addresses.routes.js
+++ b/appeals/api/src/server/endpoints/addresses/addresses.routes.js
@@ -1,0 +1,54 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getAddressById, updateAddressById } from './addresses.controller.js';
+import checkAppealExistsAndAddToRequest from '#middleware/check-appeal-exists-and-add-to-request.js';
+import { checkAddressExists } from './addresses.service.js';
+import { getAddressValidator, patchAddressValidator } from './addresses.validators.js';
+
+const router = createRouter();
+
+router.get(
+	'/:appealId/addresses/:addressId',
+	/*
+		#swagger.tags = ['Addresses']
+		#swagger.path = '/appeals/{appealId}/addresses/{addressId}'
+		#swagger.description = Gets a single address by id
+		#swagger.responses[200] = {
+			description: 'Gets a single address by id',
+			schema: { $ref: '#/definitions/SingleAddressResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	getAddressValidator,
+	checkAppealExistsAndAddToRequest,
+	checkAddressExists,
+	asyncHandler(getAddressById)
+);
+
+router.patch(
+	'/:appealId/addresses/:addressId',
+	/*
+		#swagger.tags = ['Addresses']
+		#swagger.path = '/appeals/{appealId}/addresses/{addressId}'
+		#swagger.description = Updates a single address by id
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Address details to update',
+			schema: { $ref: '#/definitions/UpdateAddressRequest' },
+			required: true
+		}
+		#swagger.responses[200] = {
+			description: 'Updates a single address by id',
+			schema: { $ref: '#/definitions/UpdateAddressResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	patchAddressValidator,
+	checkAppealExistsAndAddToRequest,
+	checkAddressExists,
+	asyncHandler(updateAddressById)
+);
+
+export { router as addressesRoutes };

--- a/appeals/api/src/server/endpoints/addresses/addresses.service.js
+++ b/appeals/api/src/server/endpoints/addresses/addresses.service.js
@@ -1,0 +1,23 @@
+import { ERROR_NOT_FOUND } from '../constants.js';
+
+/** @typedef {import('express').RequestHandler} RequestHandler */
+
+/**
+ * @type {RequestHandler}
+ * @returns {Promise<object | void>}
+ */
+const checkAddressExists = async (req, res, next) => {
+	const {
+		appeal,
+		params: { addressId }
+	} = req;
+	const hasAddress = appeal.address?.id === Number(addressId);
+
+	if (!hasAddress) {
+		return res.status(404).send({ errors: { addressId: ERROR_NOT_FOUND } });
+	}
+
+	next();
+};
+
+export { checkAddressExists };

--- a/appeals/api/src/server/endpoints/addresses/addresses.validators.js
+++ b/appeals/api/src/server/endpoints/addresses/addresses.validators.js
@@ -1,0 +1,25 @@
+import { composeMiddleware } from '@pins/express';
+import { validationErrorHandler } from '#middleware/error-handler.js';
+import validateIdParameter from '#common/validators/id-parameter.js';
+import validateStringParameter from '#common/validators/string-parameter.js';
+import { MAX_LENGTH_8 } from '#endpoints/constants.js';
+
+const getAddressValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateIdParameter('addressId'),
+	validationErrorHandler
+);
+
+const patchAddressValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validateIdParameter('addressId'),
+	validateStringParameter('addressLine1'),
+	validateStringParameter('addressLine2'),
+	validateStringParameter('country'),
+	validateStringParameter('county'),
+	validateStringParameter('postcode', MAX_LENGTH_8),
+	validateStringParameter('town'),
+	validationErrorHandler
+);
+
+export { getAddressValidator, patchAddressValidator };

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -58,7 +58,7 @@ interface RepositoryGetAllResultItem {
 }
 
 interface RepositoryGetByIdResultItem {
-	address?: Schema.Address | null;
+	address: Schema.Address;
 	allocation?: Schema.AppealAllocation | null;
 	appealStatus: Schema.AppealStatus[];
 	appealTimetable: Schema.AppealTimetable | null;
@@ -362,6 +362,25 @@ interface UpdateAppellantRequest {
 	name?: string;
 }
 
+interface SingleAddressResponse {
+	addressId: number;
+	addressLine1: string | null;
+	addressLine2: string | null;
+	country: string | null;
+	county: string | null;
+	postcode: string | null;
+	town: string | null;
+}
+
+interface UpdateAddressRequest {
+	addressLine1?: string;
+	addressLine2?: string;
+	country?: string;
+	county?: string;
+	postcode?: string;
+	town?: string;
+}
+
 type ListedBuildingDetailsResponse = Pick<ListedBuildingDetails, 'grade' | 'description'>[];
 
 type LookupTables = AppellantCaseIncompleteReason | AppellantCaseInvalidReason | ValidationOutcome;
@@ -386,12 +405,14 @@ export {
 	NotValidReasons,
 	RepositoryGetAllResultItem,
 	RepositoryGetByIdResultItem,
+	SingleAddressResponse,
 	SingleAppealDetailsResponse,
 	SingleAppellantCaseResponse,
 	SingleAppellantResponse,
 	SingleLPAQuestionnaireResponse,
 	SingleSiteVisitDetailsResponse,
 	TimetableDeadlineDate,
+	UpdateAddressRequest,
 	UpdateAppellantRequest,
 	ValidationOutcomeResponse
 };

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -20,11 +20,13 @@ import { scheduleTypesRoutes } from './schedule-types/schedule-types.routes.js';
 import { siteVisitTypesRoutes } from './site-visit-types/site-visit-types.routes.js';
 import { appellantCaseValidationOutcomesRoutes } from './appellant-case-validation-outcomes/appellant-case-validation-outcomes.routes.js';
 import { appellantsRoutes } from './appellants/appellants.routes.js';
+import { addressesRoutes } from './addresses/addresses.routes.js';
 
 const router = createRouter();
 
 router.use('/', initNotifyClientAndAddToRequest);
 
+router.use(addressesRoutes);
 router.use(appealAllocationRouter);
 router.use(appellantCaseIncompleteReasonsRoutes);
 router.use(appellantCaseInvalidReasonsRoutes);

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -45,6 +45,7 @@ describe('appeals routes', () => {
 							appealReference: householdAppeal.reference,
 							appealSite: {
 								addressLine1: householdAppeal.address.addressLine1,
+								addressLine2: householdAppeal.address.addressLine2,
 								town: householdAppeal.address.town,
 								county: householdAppeal.address.county,
 								postCode: householdAppeal.address.postcode
@@ -59,6 +60,7 @@ describe('appeals routes', () => {
 							appealReference: fullPlanningAppeal.reference,
 							appealSite: {
 								addressLine1: fullPlanningAppeal.address.addressLine1,
+								addressLine2: fullPlanningAppeal.address.addressLine2,
 								town: fullPlanningAppeal.address.town,
 								county: fullPlanningAppeal.address.county,
 								postCode: fullPlanningAppeal.address.postcode
@@ -98,6 +100,7 @@ describe('appeals routes', () => {
 							appealReference: fullPlanningAppeal.reference,
 							appealSite: {
 								addressLine1: fullPlanningAppeal.address.addressLine1,
+								addressLine2: fullPlanningAppeal.address.addressLine2,
 								town: fullPlanningAppeal.address.town,
 								county: fullPlanningAppeal.address.county,
 								postCode: fullPlanningAppeal.address.postcode
@@ -156,6 +159,7 @@ describe('appeals routes', () => {
 							appealReference: householdAppeal.reference,
 							appealSite: {
 								addressLine1: householdAppeal.address.addressLine1,
+								addressLine2: householdAppeal.address.addressLine2,
 								town: householdAppeal.address.town,
 								county: householdAppeal.address.county,
 								postCode: householdAppeal.address.postcode
@@ -214,6 +218,7 @@ describe('appeals routes', () => {
 							appealReference: householdAppeal.reference,
 							appealSite: {
 								addressLine1: householdAppeal.address.addressLine1,
+								addressLine2: householdAppeal.address.addressLine2,
 								town: householdAppeal.address.town,
 								county: householdAppeal.address.county,
 								postCode: householdAppeal.address.postcode
@@ -272,6 +277,7 @@ describe('appeals routes', () => {
 							appealReference: householdAppeal.reference,
 							appealSite: {
 								addressLine1: householdAppeal.address.addressLine1,
+								addressLine2: householdAppeal.address.addressLine2,
 								town: householdAppeal.address.town,
 								county: householdAppeal.address.county,
 								postCode: householdAppeal.address.postcode
@@ -399,6 +405,7 @@ describe('appeals routes', () => {
 					appealReference: householdAppeal.reference,
 					appealSite: {
 						addressLine1: householdAppeal.address.addressLine1,
+						addressLine2: householdAppeal.address.addressLine2,
 						town: householdAppeal.address.town,
 						county: householdAppeal.address.county,
 						postCode: householdAppeal.address.postcode
@@ -491,6 +498,7 @@ describe('appeals routes', () => {
 					appealReference: fullPlanningAppeal.reference,
 					appealSite: {
 						addressLine1: fullPlanningAppeal.address.addressLine1,
+						addressLine2: fullPlanningAppeal.address.addressLine2,
 						town: fullPlanningAppeal.address.town,
 						county: fullPlanningAppeal.address.county,
 						postCode: fullPlanningAppeal.address.postcode

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.validators.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.validators.js
@@ -2,17 +2,19 @@ import { composeMiddleware } from '@pins/express';
 import { body } from 'express-validator';
 import { validationErrorHandler } from '#middleware/error-handler.js';
 import {
-	ERROR_MAX_LENGTH_300_CHARACTERS,
+	ERROR_MAX_LENGTH_CHARACTERS,
 	ERROR_MUST_BE_STRING,
 	ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME,
 	ERROR_ONLY_FOR_INVALID_VALIDATION_OUTCOME,
 	ERROR_VALID_VALIDATION_OUTCOME_NO_REASONS,
-	ERROR_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED
+	ERROR_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED,
+	MAX_LENGTH_300
 } from '../constants.js';
 import { isOutcomeIncomplete, isOutcomeInvalid } from '#utils/check-validation-outcome.js';
 import validateDateParameter from '#common/validators/date-parameter.js';
 import validateIdParameter from '#common/validators/id-parameter.js';
 import validateValidationOutcomeReasons from '#common/validators/validation-outcome-reasons.js';
+import errorMessageReplacement from '#utils/error-message-replacement.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 
@@ -68,8 +70,8 @@ const patchAppellantCaseValidator = composeMiddleware(
 		.optional()
 		.isString()
 		.withMessage(ERROR_MUST_BE_STRING)
-		.isLength({ min: 0, max: 300 })
-		.withMessage(ERROR_MAX_LENGTH_300_CHARACTERS)
+		.isLength({ min: 0, max: MAX_LENGTH_300 })
+		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300))
 		.custom((value, { req }) => {
 			if (
 				value &&

--- a/appeals/api/src/server/endpoints/appellants/__tests__/appellants.test.js
+++ b/appeals/api/src/server/endpoints/appellants/__tests__/appellants.test.js
@@ -2,12 +2,14 @@ import { request } from '../../../app-test.js';
 import {
 	ERROR_CANNOT_BE_EMPTY_STRING,
 	ERROR_FAILED_TO_SAVE_DATA,
-	ERROR_MAX_LENGTH_300_CHARACTERS,
+	ERROR_MAX_LENGTH_CHARACTERS,
 	ERROR_MUST_BE_NUMBER,
 	ERROR_MUST_BE_STRING,
-	ERROR_NOT_FOUND
+	ERROR_NOT_FOUND,
+	MAX_LENGTH_300
 } from '../../constants.js';
 import { householdAppeal } from '#tests/data.js';
+import errorMessageReplacement from '#utils/error-message-replacement.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -49,9 +51,7 @@ describe('appellants routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request.get(
-					`/appeals/3/lpa-questionnaires/${householdAppeal.appellant.id}`
-				);
+				const response = await request.get(`/appeals/3/appellants/${householdAppeal.appellant.id}`);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -211,13 +211,13 @@ describe('appellants routes', () => {
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
 					.send({
-						name: 'A'.repeat(301)
+						name: 'A'.repeat(MAX_LENGTH_300 + 1)
 					});
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						name: ERROR_MAX_LENGTH_300_CHARACTERS
+						name: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
 					}
 				});
 			});

--- a/appeals/api/src/server/endpoints/appellants/appellants.validators.js
+++ b/appeals/api/src/server/endpoints/appellants/appellants.validators.js
@@ -1,12 +1,7 @@
 import { composeMiddleware } from '@pins/express';
-import { body } from 'express-validator';
 import { validationErrorHandler } from '#middleware/error-handler.js';
-import {
-	ERROR_CANNOT_BE_EMPTY_STRING,
-	ERROR_MAX_LENGTH_300_CHARACTERS,
-	ERROR_MUST_BE_STRING
-} from '../constants.js';
 import validateIdParameter from '#common/validators/id-parameter.js';
+import validateStringParameter from '#common/validators/string-parameter.js';
 
 const getAppellantValidator = composeMiddleware(
 	validateIdParameter('appealId'),
@@ -17,14 +12,7 @@ const getAppellantValidator = composeMiddleware(
 const patchAppellantValidator = composeMiddleware(
 	validateIdParameter('appealId'),
 	validateIdParameter('appellantId'),
-	body('name')
-		.optional()
-		.isString()
-		.withMessage(ERROR_MUST_BE_STRING)
-		.notEmpty()
-		.withMessage(ERROR_CANNOT_BE_EMPTY_STRING)
-		.isLength({ max: 300 })
-		.withMessage(ERROR_MAX_LENGTH_300_CHARACTERS),
+	validateStringParameter('name'),
 	validationErrorHandler
 );
 

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -31,7 +31,7 @@ export const ERROR_INVALID_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME = `Must be one o
 export const ERROR_INVALID_SITE_VISIT_TYPE =
 	'Must be one of access required, accompanied, unaccompanied';
 export const ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS = 'Must be between 2 and 8 characters';
-export const ERROR_MAX_LENGTH_300_CHARACTERS = 'Must be 300 characters or less';
+export const ERROR_MAX_LENGTH_CHARACTERS = 'Must be {replacement} characters or less';
 export const ERROR_MUST_BE_ARRAY_OF_IDS = 'Must be an array of ids';
 export const ERROR_MUST_BE_CORRECT_DATE_FORMAT = `Must be a valid date and in the format ${DEFAULT_DATE_FORMAT_DATABASE}`;
 export const ERROR_MUST_BE_CORRECT_TIME_FORMAT = `Must be a valid time and in the format hh:mm`;
@@ -60,6 +60,9 @@ export const ERROR_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED =
 	'Validation outcome reasons are required when validationOutcome is Incomplete or Invalid';
 export const ERROR_LPA_QUESTIONNAIRE_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED =
 	'Validation outcome reasons are required when validationOutcome is Incomplete';
+
+export const MAX_LENGTH_300 = 300;
+export const MAX_LENGTH_8 = 8;
 
 export const STATE_TARGET_ARRANGE_SITE_VISIT = 'arrange_site_visit';
 export const STATE_TARGET_COMPLETE = 'complete';

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -5,7 +5,7 @@ import {
 	ERROR_FAILED_TO_SAVE_DATA,
 	ERROR_INVALID_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME,
 	ERROR_LPA_QUESTIONNAIRE_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED,
-	ERROR_MAX_LENGTH_300_CHARACTERS,
+	ERROR_MAX_LENGTH_CHARACTERS,
 	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
 	ERROR_MUST_BE_NUMBER,
 	ERROR_MUST_BE_STRING,
@@ -14,6 +14,7 @@ import {
 	ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME,
 	ERROR_OTHER_NOT_VALID_REASONS_REQUIRED,
 	ERROR_VALID_VALIDATION_OUTCOME_NO_REASONS,
+	MAX_LENGTH_300,
 	STATE_TARGET_ARRANGE_SITE_VISIT,
 	STATE_TARGET_STATEMENT_REVIEW
 } from '../../constants.js';
@@ -28,6 +29,7 @@ import {
 	otherAppeals
 } from '../../../tests/data.js';
 import createManyToManyRelationData from '#utils/create-many-to-many-relation-data.js';
+import errorMessageReplacement from '#utils/error-message-replacement.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -676,14 +678,17 @@ describe('lpa questionnaires routes', () => {
 					)
 					.send({
 						incompleteReasons: [1, 3],
-						otherNotValidReasons: 'A'.repeat(301),
+						otherNotValidReasons: 'A'.repeat(MAX_LENGTH_300 + 1),
 						validationOutcome: 'Incomplete'
 					});
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						otherNotValidReasons: ERROR_MAX_LENGTH_300_CHARACTERS
+						otherNotValidReasons: errorMessageReplacement(
+							ERROR_MAX_LENGTH_CHARACTERS,
+							MAX_LENGTH_300
+						)
 					}
 				});
 			});
@@ -913,7 +918,7 @@ describe('lpa questionnaires routes', () => {
 				);
 				// @ts-ignore
 				databaseConnector.lPAQuestionnaire.update.mockImplementation(() => {
-					throw new Error('InternalServer Error');
+					throw new Error('Internal Server Error');
 				});
 
 				const body = {

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
@@ -3,15 +3,17 @@ import { body } from 'express-validator';
 import { validationErrorHandler } from '#middleware/error-handler.js';
 import {
 	ERROR_LPA_QUESTIONNAIRE_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED,
-	ERROR_MAX_LENGTH_300_CHARACTERS,
+	ERROR_MAX_LENGTH_CHARACTERS,
 	ERROR_MUST_BE_STRING,
 	ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME,
-	ERROR_VALID_VALIDATION_OUTCOME_NO_REASONS
+	ERROR_VALID_VALIDATION_OUTCOME_NO_REASONS,
+	MAX_LENGTH_300
 } from '../constants.js';
 import { isOutcomeIncomplete, isOutcomeInvalid } from '#utils/check-validation-outcome.js';
 import validateDateParameter from '#common/validators/date-parameter.js';
 import validateIdParameter from '#common/validators/id-parameter.js';
 import validateValidationOutcomeReasons from '#common/validators/validation-outcome-reasons.js';
+import errorMessageReplacement from '#utils/error-message-replacement.js';
 
 const getLPAQuestionnaireValidator = composeMiddleware(
 	validateIdParameter('appealId'),
@@ -39,8 +41,8 @@ const patchLPAQuestionnaireValidator = composeMiddleware(
 		.optional()
 		.isString()
 		.withMessage(ERROR_MUST_BE_STRING)
-		.isLength({ min: 0, max: 300 })
-		.withMessage(ERROR_MAX_LENGTH_300_CHARACTERS)
+		.isLength({ min: 0, max: MAX_LENGTH_300 })
+		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300))
 		.custom((value, { req }) => {
 			if (
 				value &&

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -15,6 +15,115 @@
 	],
 	"securityDefinitions": {},
 	"paths": {
+		"/appeals/{appealId}/addresses/{addressId}": {
+			"get": {
+				"tags": ["Addresses"],
+				"description": "Gets a single address by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "addressId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Gets a single address by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/SingleAddressResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/SingleAddressResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			},
+			"patch": {
+				"tags": ["Addresses"],
+				"description": "Updates a single address by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "addressId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Updates a single address by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateAddressResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateAddressResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Address details to update",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateAddressRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateAddressRequest"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals/appeal-allocation-specialisms": {
 			"get": {
 				"tags": ["Appeal Allocation"],
@@ -3201,6 +3310,106 @@
 				},
 				"xml": {
 					"name": "UpdateAppellantResponse"
+				}
+			},
+			"SingleAddressResponse": {
+				"type": "object",
+				"properties": {
+					"addressId": {
+						"type": "number",
+						"example": 1
+					},
+					"addressLine1": {
+						"type": "string",
+						"example": "1 Grove Cottage"
+					},
+					"addressLine2": {
+						"type": "string",
+						"example": "Shotesham Road"
+					},
+					"country": {
+						"type": "string",
+						"example": "United Kingdom"
+					},
+					"county": {
+						"type": "string",
+						"example": "Devon"
+					},
+					"postcode": {
+						"type": "string",
+						"example": "NR35 2ND"
+					},
+					"town": {
+						"type": "string",
+						"example": "Woodton"
+					}
+				},
+				"xml": {
+					"name": "SingleAddressResponse"
+				}
+			},
+			"UpdateAddressRequest": {
+				"type": "object",
+				"properties": {
+					"addressLine1": {
+						"type": "string",
+						"example": "1 Grove Cottage"
+					},
+					"addressLine2": {
+						"type": "string",
+						"example": "Shotesham Road"
+					},
+					"country": {
+						"type": "string",
+						"example": "United Kingdom"
+					},
+					"county": {
+						"type": "string",
+						"example": "Devon"
+					},
+					"postcode": {
+						"type": "string",
+						"example": "NR35 2ND"
+					},
+					"town": {
+						"type": "string",
+						"example": "Woodton"
+					}
+				},
+				"xml": {
+					"name": "UpdateAddressRequest"
+				}
+			},
+			"UpdateAddressResponse": {
+				"type": "object",
+				"properties": {
+					"addressLine1": {
+						"type": "string",
+						"example": "1 Grove Cottage"
+					},
+					"addressLine2": {
+						"type": "string",
+						"example": "Shotesham Road"
+					},
+					"country": {
+						"type": "string",
+						"example": "United Kingdom"
+					},
+					"county": {
+						"type": "string",
+						"example": "Devon"
+					},
+					"postcode": {
+						"type": "string",
+						"example": "NR35 2ND"
+					},
+					"town": {
+						"type": "string",
+						"example": "Woodton"
+					}
+				},
+				"xml": {
+					"name": "UpdateAddressResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/repositories/address.repository.js
+++ b/appeals/api/src/server/repositories/address.repository.js
@@ -1,0 +1,21 @@
+import { databaseConnector } from '#utils/database-connector.js';
+
+/** @typedef {import('@pins/appeals.api').Appeals.UpdateAddressRequest} UpdateAddressRequest */
+/** @typedef {import('@pins/appeals.api').Schema.Address} Address */
+/**
+ * @typedef {import('#db-client').Prisma.PrismaPromise<T>} PrismaPromise
+ * @template T
+ */
+
+/**
+ * @param {number} id
+ * @param {UpdateAddressRequest} data
+ * @returns {PrismaPromise<Address>}
+ */
+const updateAddressById = (id, data) =>
+	databaseConnector.address.update({
+		where: { id },
+		data
+	});
+
+export default { updateAddressById };

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -541,6 +541,31 @@ const document = {
 		},
 		UpdateAppellantResponse: {
 			name: 'Eva Sharma'
+		},
+		SingleAddressResponse: {
+			addressId: 1,
+			addressLine1: '1 Grove Cottage',
+			addressLine2: 'Shotesham Road',
+			country: 'United Kingdom',
+			county: 'Devon',
+			postcode: 'NR35 2ND',
+			town: 'Woodton'
+		},
+		UpdateAddressRequest: {
+			addressLine1: '1 Grove Cottage',
+			addressLine2: 'Shotesham Road',
+			country: 'United Kingdom',
+			county: 'Devon',
+			postcode: 'NR35 2ND',
+			town: 'Woodton'
+		},
+		UpdateAddressResponse: {
+			addressLine1: '1 Grove Cottage',
+			addressLine2: 'Shotesham Road',
+			country: 'United Kingdom',
+			county: 'Devon',
+			postcode: 'NR35 2ND',
+			town: 'Woodton'
 		}
 	},
 	components: {}

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -37,7 +37,10 @@ const householdAppeal = {
 	startedAt: new Date(2022, 4, 18),
 	address: {
 		addressLine1: '96 The Avenue',
+		addressLine2: 'Leftfield',
+		country: 'United Kingdom',
 		county: 'Kent',
+		id: 1,
 		postcode: 'MD21 5XY',
 		town: 'Maidstone'
 	},
@@ -474,6 +477,7 @@ const baseExpectedLPAQuestionnaireResponse = (appeal) => ({
 	appealReference: appeal.reference,
 	appealSite: {
 		addressLine1: '96 The Avenue',
+		addressLine2: 'Leftfield',
 		county: 'Kent',
 		postCode: 'MD21 5XY',
 		town: 'Maidstone'
@@ -585,6 +589,7 @@ const baseExpectedAppellantCaseResponse = (appeal) => ({
 	appealReference: appeal.reference,
 	appealSite: {
 		addressLine1: appeal.address?.addressLine1,
+		addressLine2: appeal.address?.addressLine2,
 		town: appeal.address?.town,
 		county: appeal.address?.county,
 		postCode: appeal.address?.postcode

--- a/appeals/api/src/server/utils/error-message-replacement.js
+++ b/appeals/api/src/server/utils/error-message-replacement.js
@@ -1,0 +1,9 @@
+/**
+ * @param {string} errorMessage
+ * @param {number} replacement
+ * @returns {string}
+ */
+const errorMessageReplacement = (errorMessage, replacement) =>
+	errorMessage.replace('{replacement}', String(replacement));
+
+export default errorMessageReplacement;


### PR DESCRIPTION
## Describe your changes

Added GET/PATCH API endpoints for Addresses. Initially this is used for saving the Site Address on the Appellant Case page.

Also added validation, swagger docs and unit tests.

Also a little refactoring for replacing hard coded max character length values with a constant and error messages that can handle dynamic replacement of values (max character length, for example).

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-427

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
