### PR TITLE
Fix/missing pins packages

### DIFF
--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -177,7 +177,7 @@ extends:
               source ~/.bashrc
               mkdir -p $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/@pins
               mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/
-              mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/@pins
+              cp -r $(Build.Repository.LocalPath)/packages/* $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -217,7 +217,7 @@ extends:
               source ~/.bashrc
               mkdir -p $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/@pins
               mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/
-              mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/@pins
+              cp -r $(Build.Repository.LocalPath)/packages/* $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -257,7 +257,7 @@ extends:
               source ~/.bashrc
               mkdir -p $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/@pins
               mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/
-              mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/@pins
+              cp -r $(Build.Repository.LocalPath)/packages/* $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -297,6 +297,7 @@ extends:
               source ~/.bashrc
               mkdir -p $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/@pins
               mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/@pins
+              cp -r $(Build.Repository.LocalPath)/packages/* $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -336,6 +337,7 @@ extends:
               source ~/.bashrc
               mkdir -p $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/@pins
               mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/@pins
+              cp -r $(Build.Repository.LocalPath)/packages/* $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:

--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -175,7 +175,8 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              cp -r $(Build.Repository.LocalPath)/node_modules $(Build.Repository.LocalPath)/apps/functions/document-check
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/
+              mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -213,7 +214,8 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              cp -r $(Build.Repository.LocalPath)/node_modules $(Build.Repository.LocalPath)/apps/functions/odw-integration
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/
+              mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -251,7 +253,8 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              cp -r $(Build.Repository.LocalPath)/node_modules $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/
+              mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -289,7 +292,8 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              cp -r $(Build.Repository.LocalPath)/node_modules $(Build.Repository.LocalPath)/apps/functions/deadline-submissions
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/
+              mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -327,7 +331,8 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              cp -r $(Build.Repository.LocalPath)/node_modules $(Build.Repository.LocalPath)/apps/functions/document-publish
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/
+              mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:

--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -175,8 +175,9 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              mkdir -p $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/@pins
               mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/
+              mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/document-check/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -214,8 +215,9 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              mkdir -p $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/@pins
               mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/
+              mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/odw-integration/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -253,8 +255,9 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              mkdir -p $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/@pins
               mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/
+              mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/handle-subscriptions/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -292,8 +295,8 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              mkdir -p $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/
-              mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/@pins
+              mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/deadline-submissions/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:
@@ -331,8 +334,8 @@ extends:
               workingDirectory: $(Build.Repository.LocalPath)
           - script: |
               source ~/.bashrc
-              mkdir -p $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/
-              mv -n $(Build.Repository.LocalPath)/node_modules/* $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/
+              mkdir -p $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/@pins
+              mv -n $(Build.Repository.LocalPath)/node_modules/@pins/* $(Build.Repository.LocalPath)/apps/functions/document-publish/node_modules/@pins
           - task: ArchiveFiles@2
             displayName: Archive files
             inputs:


### PR DESCRIPTION
## Describe your changes

A fix for the errors being thrown by the Azure functions. They're unable to find the `@pins` NPM modules. It seems to be because they're symlinked by NPM so when we come to copy the folder, the links are not respected. This solution is hacky but seems to work.

I've deployed this to dev and tested it there.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
