### PR TITLE
feat(appeals/api): update patch appellant case api endpoint to save additional fields

### DIFF
--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -22,7 +22,8 @@ export {
 	LPAQuestionnaireValidationOutcome,
 	AppellantCaseValidationOutcome,
 	PlanningObligationStatus,
-	SiteVisitType
+	SiteVisitType,
+	ValidationOutcome
 } from '../../src/server/utils/db-client';
 
 export interface Appeal extends schema.Appeal {

--- a/appeals/api/src/server/common/validators/boolean-parameter.js
+++ b/appeals/api/src/server/common/validators/boolean-parameter.js
@@ -1,0 +1,17 @@
+import { body } from 'express-validator';
+import { ERROR_MUST_BE_BOOLEAN } from '#endpoints/constants.js';
+
+/** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {string} parameterName
+ * @returns {ValidationChain}
+ */
+const validateBooleanParameter = (parameterName) =>
+	body(parameterName)
+		.optional()
+		.isBoolean()
+		.withMessage(ERROR_MUST_BE_BOOLEAN)
+		.customSanitizer((value) => (['false', '0'].includes(value) ? false : !!value));
+
+export default validateBooleanParameter;

--- a/appeals/api/src/server/common/validators/boolean-with-conditional-string-parameters.js
+++ b/appeals/api/src/server/common/validators/boolean-with-conditional-string-parameters.js
@@ -1,0 +1,39 @@
+import { body } from 'express-validator';
+import validateBooleanParameter from './boolean-parameter.js';
+import validateStringParameter from './string-parameter.js';
+import { ERROR_MUST_HAVE_DETAILS, ERROR_MUST_NOT_HAVE_DETAILS } from '#endpoints/constants.js';
+import errorMessageReplacement from '#utils/error-message-replacement.js';
+
+/** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {string} booleanParameterName
+ * @param {string} detailsParameterName
+ * @param {boolean} triggerValue
+ * @returns {ValidationChain[]}
+ */
+const validateBooleanWithConditionalStringParameters = (
+	booleanParameterName,
+	detailsParameterName,
+	triggerValue
+) => [
+	validateBooleanParameter(booleanParameterName),
+	validateStringParameter(detailsParameterName),
+	body(booleanParameterName)
+		.optional()
+		.custom((value, { req }) => {
+			const errorMessageReplacements = [detailsParameterName, booleanParameterName, value];
+
+			if (value === triggerValue && !req.body[detailsParameterName]) {
+				throw new Error(errorMessageReplacement(ERROR_MUST_HAVE_DETAILS, errorMessageReplacements));
+			} else if (value !== triggerValue && req.body[detailsParameterName]) {
+				throw new Error(
+					errorMessageReplacement(ERROR_MUST_NOT_HAVE_DETAILS, errorMessageReplacements)
+				);
+			}
+
+			return true;
+		})
+];
+
+export default validateBooleanWithConditionalStringParameters;

--- a/appeals/api/src/server/common/validators/string-parameter.js
+++ b/appeals/api/src/server/common/validators/string-parameter.js
@@ -22,6 +22,6 @@ const validateStringParameter = (parameterName, maxLength = MAX_LENGTH_300) =>
 		.notEmpty()
 		.withMessage(ERROR_CANNOT_BE_EMPTY_STRING)
 		.isLength({ max: maxLength })
-		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, maxLength));
+		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [maxLength]));
 
 export default validateStringParameter;

--- a/appeals/api/src/server/endpoints/addresses/__tests__/addresses.test.js
+++ b/appeals/api/src/server/endpoints/addresses/__tests__/addresses.test.js
@@ -223,7 +223,7 @@ describe('addresses routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						addressLine1: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+						addressLine1: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_300])
 					}
 				});
 			});
@@ -277,7 +277,7 @@ describe('addresses routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						addressLine2: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+						addressLine2: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_300])
 					}
 				});
 			});
@@ -331,7 +331,7 @@ describe('addresses routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						country: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+						country: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_300])
 					}
 				});
 			});
@@ -385,7 +385,7 @@ describe('addresses routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						county: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+						county: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_300])
 					}
 				});
 			});
@@ -439,7 +439,7 @@ describe('addresses routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						postcode: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_8)
+						postcode: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_8])
 					}
 				});
 			});
@@ -493,7 +493,7 @@ describe('addresses routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						town: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+						town: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_300])
 					}
 				});
 			});

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -381,6 +381,33 @@ interface UpdateAddressRequest {
 	town?: string;
 }
 
+interface UpdateAppellantCaseRequest {
+	appellantCaseValidationOutcomeId?: number;
+	applicantFirstName?: string;
+	applicantSurname?: string;
+	areAllOwnersKnown?: boolean;
+	hasAdvertisedAppeal?: boolean;
+	hasAttemptedToIdentifyOwners?: boolean;
+	hasHealthAndSafetyIssues?: boolean;
+	healthAndSafetyIssues?: string;
+	isSiteFullyOwned?: boolean;
+	isSitePartiallyOwned?: boolean;
+	isSiteVisibleFromPublicRoad?: boolean;
+	otherNotValidReasons?: string;
+	visibilityRestrictions?: string;
+}
+
+interface UpdateAppellantCaseValidationOutcome {
+	appellantCaseId: number;
+	validationOutcomeId: number;
+	otherNotValidReasons: string;
+	incompleteReasons?: NotValidReasons;
+	invalidReasons?: NotValidReasons;
+	appealId?: number;
+	timetable?: TimetableDeadlineDate;
+	startedAt?: Date;
+}
+
 type ListedBuildingDetailsResponse = Pick<ListedBuildingDetails, 'grade' | 'description'>[];
 
 type LookupTables = AppellantCaseIncompleteReason | AppellantCaseInvalidReason | ValidationOutcome;
@@ -413,6 +440,8 @@ export {
 	SingleSiteVisitDetailsResponse,
 	TimetableDeadlineDate,
 	UpdateAddressRequest,
+	UpdateAppellantCaseRequest,
+	UpdateAppellantCaseValidationOutcome,
 	UpdateAppellantRequest,
 	ValidationOutcomeResponse
 };

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
@@ -1,23 +1,9 @@
-import { format } from 'date-fns';
-import appealRepository from '#repositories/appeal.repository.js';
-import appellantCaseRepository from '#repositories/appellant-case.repository.js';
 import { getFoldersForAppeal } from '#endpoints/documents/documents.service.js';
+import appellantCaseRepository from '#repositories/appellant-case.repository.js';
 import logger from '#utils/logger.js';
-import {
-	DEFAULT_DATE_FORMAT_DATABASE,
-	DEFAULT_DATE_FORMAT_DISPLAY,
-	ERROR_FAILED_TO_SAVE_DATA
-} from '../constants.js';
+import { ERROR_FAILED_TO_SAVE_DATA } from '../constants.js';
 import { formatAppellantCase } from './appellant-cases.formatter.js';
-import joinDateAndTime from '#utils/join-date-and-time.js';
-import {
-	isOutcomeIncomplete,
-	isOutcomeInvalid,
-	isOutcomeValid
-} from '#utils/check-validation-outcome.js';
-import { calculateTimetable, recalculateDateIfNotBusinessDay } from '../../utils/business-days.js';
-import transitionState from '../../state/transition-state.js';
-import config from '../../config/config.js';
+import { updateAppellantCaseValidationOutcome } from './appellant-cases.service.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 /** @typedef {import('express').Response} Response */
@@ -40,48 +26,48 @@ const getAppellantCaseById = async (req, res) => {
  */
 const updateAppellantCaseById = async (req, res) => {
 	const {
-		appeal: { id: appealId, appealStatus, appealType, reference, appellant },
+		appeal,
 		body,
-		body: { appealDueDate, incompleteReasons, invalidReasons, otherNotValidReasons },
-		params: { appellantCaseId },
+		body: {
+			applicantFirstName,
+			applicantSurname,
+			areAllOwnersKnown,
+			hasAdvertisedAppeal,
+			hasAttemptedToIdentifyOwners,
+			hasHealthAndSafetyIssues,
+			healthAndSafetyIssues,
+			isSiteFullyOwned,
+			isSitePartiallyOwned,
+			isSiteVisibleFromPublicRoad,
+			visibilityRestrictions
+		},
+		params,
 		validationOutcome
 	} = req;
+	const appellantCaseId = Number(params.appellantCaseId);
 
 	try {
-		let startedAt = undefined;
-		let timetable = undefined;
-
-		if (isOutcomeValid(validationOutcome.name) && appealType) {
-			startedAt = await recalculateDateIfNotBusinessDay(
-				joinDateAndTime(format(new Date(), DEFAULT_DATE_FORMAT_DATABASE))
-			);
-			timetable = await calculateTimetable(appealType.shorthand, startedAt);
-
-			await req.notifyClient.sendEmail(
-				config.govNotify.template.validAppellantCase,
-				appellant?.email,
-				{
-					appeal_reference: reference,
-					appeal_type: appealType.shorthand,
-					date_started: format(startedAt, DEFAULT_DATE_FORMAT_DISPLAY)
-				}
-			);
-		}
-
-		await appellantCaseRepository.updateAppellantCaseValidationOutcome({
-			appellantCaseId: Number(appellantCaseId),
-			validationOutcomeId: validationOutcome.id,
-			otherNotValidReasons,
-			...(isOutcomeIncomplete(validationOutcome.name) && { incompleteReasons }),
-			...(isOutcomeInvalid(validationOutcome.name) && { invalidReasons }),
-			...(isOutcomeValid(validationOutcome.name) && { appealId, startedAt, timetable })
-		});
-
-		await transitionState(appealId, appealType, appealStatus, validationOutcome.name);
-
-		if (appealDueDate) {
-			await appealRepository.updateAppealById(appealId, { dueDate: appealDueDate });
-		}
+		validationOutcome
+			? await updateAppellantCaseValidationOutcome({
+					appeal,
+					appellantCaseId,
+					data: body,
+					notifyClient: req.notifyClient,
+					validationOutcome
+			  })
+			: await appellantCaseRepository.updateAppellantCaseById(appellantCaseId, {
+					applicantFirstName,
+					applicantSurname,
+					areAllOwnersKnown,
+					hasAdvertisedAppeal,
+					hasAttemptedToIdentifyOwners,
+					hasHealthAndSafetyIssues,
+					healthAndSafetyIssues,
+					isSiteFullyOwned,
+					isSitePartiallyOwned,
+					isSiteVisibleFromPublicRoad,
+					visibilityRestrictions
+			  });
 	} catch (error) {
 		if (error) {
 			logger.error(error);

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.service.js
@@ -1,6 +1,24 @@
-import { ERROR_NOT_FOUND } from '../constants.js';
+import { calculateTimetable, recalculateDateIfNotBusinessDay } from '#utils/business-days.js';
+import {
+	isOutcomeIncomplete,
+	isOutcomeInvalid,
+	isOutcomeValid
+} from '#utils/check-validation-outcome.js';
+import joinDateAndTime from '#utils/join-date-and-time.js';
+import { format } from 'date-fns';
+import {
+	DEFAULT_DATE_FORMAT_DATABASE,
+	DEFAULT_DATE_FORMAT_DISPLAY,
+	ERROR_NOT_FOUND
+} from '../constants.js';
+import config from '../../config/config.js';
+import appellantCaseRepository from '#repositories/appellant-case.repository.js';
+import transitionState from '../../state/transition-state.js';
+import appealRepository from '#repositories/appeal.repository.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
+/** @typedef {import('@pins/appeals.api').Schema.ValidationOutcome} ValidationOutcome */
+/** @typedef {import('@pins/appeals.api').Appeals.NotifyClient} NotifyClient */
 
 /**
  * @type {RequestHandler}
@@ -20,4 +38,56 @@ const checkAppellantCaseExists = async (req, res, next) => {
 	next();
 };
 
-export { checkAppellantCaseExists };
+/**
+ *
+ * @param {{
+ *  appeal: { appealStatus: *, appealType: *, appellant: *, id: number, reference: string }
+ *  appellantCaseId: number
+ *  data: { appealDueDate: string, incompleteReasons: number[], invalidReasons: number[], otherNotValidReasons: string }
+ *  notifyClient: NotifyClient
+ *  validationOutcome: ValidationOutcome
+ * }} param0
+ */
+const updateAppellantCaseValidationOutcome = async ({
+	appeal,
+	appellantCaseId,
+	data,
+	notifyClient,
+	validationOutcome
+}) => {
+	const { appealStatus, appealType, appellant, id: appealId, reference } = appeal;
+	const { appealDueDate, incompleteReasons, invalidReasons, otherNotValidReasons } = data;
+
+	let startedAt = undefined;
+	let timetable = undefined;
+
+	if (isOutcomeValid(validationOutcome.name) && appealType) {
+		startedAt = await recalculateDateIfNotBusinessDay(
+			joinDateAndTime(format(new Date(), DEFAULT_DATE_FORMAT_DATABASE))
+		);
+		timetable = await calculateTimetable(appealType.shorthand, startedAt);
+
+		await notifyClient.sendEmail(config.govNotify.template.validAppellantCase, appellant?.email, {
+			appeal_reference: reference,
+			appeal_type: appealType.shorthand,
+			date_started: format(startedAt, DEFAULT_DATE_FORMAT_DISPLAY)
+		});
+	}
+
+	await appellantCaseRepository.updateAppellantCaseValidationOutcome({
+		appellantCaseId,
+		validationOutcomeId: validationOutcome.id,
+		otherNotValidReasons,
+		...(isOutcomeIncomplete(validationOutcome.name) && { incompleteReasons }),
+		...(isOutcomeInvalid(validationOutcome.name) && { invalidReasons }),
+		...(isOutcomeValid(validationOutcome.name) && { appealId, startedAt, timetable })
+	});
+
+	await transitionState(appealId, appealType, appealStatus, validationOutcome.name);
+
+	if (appealDueDate) {
+		await appealRepository.updateAppealById(appealId, { dueDate: appealDueDate });
+	}
+};
+
+export { checkAppellantCaseExists, updateAppellantCaseValidationOutcome };

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.validators.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.validators.js
@@ -15,6 +15,9 @@ import validateDateParameter from '#common/validators/date-parameter.js';
 import validateIdParameter from '#common/validators/id-parameter.js';
 import validateValidationOutcomeReasons from '#common/validators/validation-outcome-reasons.js';
 import errorMessageReplacement from '#utils/error-message-replacement.js';
+import validateStringParameter from '#common/validators/string-parameter.js';
+import validateBooleanParameter from '#common/validators/boolean-parameter.js';
+import validateBooleanWithConditionalStringParameters from '#common/validators/boolean-with-conditional-string-parameters.js';
 
 /** @typedef {import('express').RequestHandler} RequestHandler */
 
@@ -71,7 +74,7 @@ const patchAppellantCaseValidator = composeMiddleware(
 		.isString()
 		.withMessage(ERROR_MUST_BE_STRING)
 		.isLength({ min: 0, max: MAX_LENGTH_300 })
-		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300))
+		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_300]))
 		.custom((value, { req }) => {
 			if (
 				value &&
@@ -84,6 +87,7 @@ const patchAppellantCaseValidator = composeMiddleware(
 			return value;
 		}),
 	body('validationOutcome')
+		.optional()
 		.isString()
 		.custom((value, { req }) => {
 			if (isOutcomeIncomplete(value) && !req.body.incompleteReasons) {
@@ -96,6 +100,23 @@ const patchAppellantCaseValidator = composeMiddleware(
 
 			return value;
 		}),
+	validateStringParameter('applicantFirstName'),
+	validateStringParameter('applicantSurname'),
+	validateBooleanParameter('isSiteFullyOwned'),
+	validateBooleanParameter('isSitePartiallyOwned'),
+	validateBooleanParameter('areAllOwnersKnown'),
+	validateBooleanParameter('hasAttemptedToIdentifyOwners'),
+	validateBooleanParameter('hasAdvertisedAppeal'),
+	validateBooleanWithConditionalStringParameters(
+		'isSiteVisibleFromPublicRoad',
+		'visibilityRestrictions',
+		false
+	),
+	validateBooleanWithConditionalStringParameters(
+		'hasHealthAndSafetyIssues',
+		'healthAndSafetyIssues',
+		true
+	),
 	validationErrorHandler
 );
 

--- a/appeals/api/src/server/endpoints/appellants/__tests__/appellants.test.js
+++ b/appeals/api/src/server/endpoints/appellants/__tests__/appellants.test.js
@@ -217,7 +217,7 @@ describe('appellants routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						name: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300)
+						name: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_300])
 					}
 				});
 			});

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -31,18 +31,23 @@ export const ERROR_INVALID_LPA_QUESTIONNAIRE_VALIDATION_OUTCOME = `Must be one o
 export const ERROR_INVALID_SITE_VISIT_TYPE =
 	'Must be one of access required, accompanied, unaccompanied';
 export const ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS = 'Must be between 2 and 8 characters';
-export const ERROR_MAX_LENGTH_CHARACTERS = 'Must be {replacement} characters or less';
+export const ERROR_MAX_LENGTH_CHARACTERS = 'Must be {replacement0} characters or less';
 export const ERROR_MUST_BE_ARRAY_OF_IDS = 'Must be an array of ids';
+export const ERROR_MUST_BE_BOOLEAN = 'Must be a boolean';
 export const ERROR_MUST_BE_CORRECT_DATE_FORMAT = `Must be a valid date and in the format ${DEFAULT_DATE_FORMAT_DATABASE}`;
-export const ERROR_MUST_BE_CORRECT_TIME_FORMAT = `Must be a valid time and in the format hh:mm`;
+export const ERROR_MUST_BE_CORRECT_TIME_FORMAT = 'Must be a valid time and in the format hh:mm';
 export const ERROR_MUST_BE_GREATER_THAN_ZERO = 'Must be greater than 0';
 export const ERROR_MUST_BE_NUMBER = 'Must be a number';
 export const ERROR_MUST_BE_STRING = 'Must be a string';
 export const ERROR_MUST_BE_GUID = 'Must be a guid';
 export const ERROR_MUST_BE_VALID_FILEINFO = 'Must be a valid file';
 export const ERROR_MUST_CONTAIN_AT_LEAST_1_VALUE = 'Must contain at least one value';
+export const ERROR_MUST_HAVE_DETAILS =
+	'Must have {replacement0} when {replacement1} is {replacement2}';
 export const ERROR_MUST_NOT_CONTAIN_VALIDATION_OUTCOME_REASONS =
 	'Must not be included when invalidReasons or incompleteReasons does not contain Other';
+export const ERROR_MUST_NOT_HAVE_DETAILS =
+	'Must not have {replacement0} when {replacement1} is {replacement2}';
 export const ERROR_NOT_FOUND = 'Not found';
 export const ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME = `Should only be given if the validation outcome is ${VALIDATION_OUTCOME_INCOMPLETE}`;
 export const ERROR_ONLY_FOR_INVALID_VALIDATION_OUTCOME = `Should only be given if the validation outcome is ${VALIDATION_OUTCOME_INVALID}`;

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -685,10 +685,9 @@ describe('lpa questionnaires routes', () => {
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						otherNotValidReasons: errorMessageReplacement(
-							ERROR_MAX_LENGTH_CHARACTERS,
+						otherNotValidReasons: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [
 							MAX_LENGTH_300
-						)
+						])
 					}
 				});
 			});

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
@@ -42,7 +42,7 @@ const patchLPAQuestionnaireValidator = composeMiddleware(
 		.isString()
 		.withMessage(ERROR_MUST_BE_STRING)
 		.isLength({ min: 0, max: MAX_LENGTH_300 })
-		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, MAX_LENGTH_300))
+		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [MAX_LENGTH_300]))
 		.custom((value, { req }) => {
 			if (
 				value &&

--- a/appeals/api/src/server/repositories/appellant-case.repository.js
+++ b/appeals/api/src/server/repositories/appellant-case.repository.js
@@ -5,6 +5,8 @@ import commonRepository from './common.repository.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.TimetableDeadlineDate} TimetableDeadlineDate */
 /** @typedef {import('@pins/appeals.api').Appeals.NotValidReasons} NotValidReasons */
+/** @typedef {import('@pins/appeals.api').Appeals.UpdateAppellantCaseRequest} UpdateAppellantCaseRequest */
+/** @typedef {import('@pins/appeals.api').Appeals.UpdateAppellantCaseValidationOutcome} UpdateAppellantCaseValidationOutcome */
 /**
  * @typedef {import('#db-client').Prisma.PrismaPromise<T>} PrismaPromise
  * @template T
@@ -12,10 +14,7 @@ import commonRepository from './common.repository.js';
 
 /**
  * @param {number} id
- * @param {{
- *  otherNotValidReasons?: string;
- *  appellantCaseValidationOutcomeId?: number;
- * }} data
+ * @param {UpdateAppellantCaseRequest} data
  * @returns {PrismaPromise<object>}
  */
 const updateAppellantCaseById = (id, data) =>
@@ -25,16 +24,7 @@ const updateAppellantCaseById = (id, data) =>
 	});
 
 /**
- * @param {{
- * 	appellantCaseId: number,
- *	validationOutcomeId: number,
- *	otherNotValidReasons: string,
- *	incompleteReasons?: NotValidReasons,
- *	invalidReasons?: NotValidReasons,
- *	appealId?: number,
- *	timetable?: TimetableDeadlineDate,
- *	startedAt?: Date
- * }} param0
+ * @param {UpdateAppellantCaseValidationOutcome} param0
  * @returns {Promise<object>}
  */
 const updateAppellantCaseValidationOutcome = ({
@@ -88,4 +78,4 @@ const updateAppellantCaseValidationOutcome = ({
 	return databaseConnector.$transaction(transaction);
 };
 
-export default { updateAppellantCaseValidationOutcome };
+export default { updateAppellantCaseById, updateAppellantCaseValidationOutcome };

--- a/appeals/api/src/server/utils/error-message-replacement.js
+++ b/appeals/api/src/server/utils/error-message-replacement.js
@@ -1,9 +1,15 @@
 /**
  * @param {string} errorMessage
- * @param {number} replacement
+ * @param {Array<string | number>} replacements
  * @returns {string}
  */
-const errorMessageReplacement = (errorMessage, replacement) =>
-	errorMessage.replace('{replacement}', String(replacement));
+const errorMessageReplacement = (errorMessage, replacements) =>
+	replacements
+		.map((replacement) => String(replacement))
+		.reduce(
+			(replacedErrorMessage, replacement, index) =>
+				replacedErrorMessage.replace(`{replacement${index}}`, replacement),
+			errorMessage
+		);
 
 export default errorMessageReplacement;


### PR DESCRIPTION
## Describe your changes

Updated the PATCH Appellant Case API endpoint to enable the saving of the fields on the Appellant Case page..

Also added validation, swagger docs and unit tests.

Also a little refactoring for error message replacement so that multiple replacements can be done in a single error message.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-428

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
