### PR TITLE
fix(applications/api): use single date in tests

### DIFF
--- a/apps/api/src/server/applications/application/project-updates/notification-logs/__tests__/notification-logs.test.js
+++ b/apps/api/src/server/applications/application/project-updates/notification-logs/__tests__/notification-logs.test.js
@@ -4,6 +4,8 @@ import { DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE } from '../../../../constants.js
 import { ERROR_MUST_BE_NUMBER } from '#middleware/errors.js';
 
 describe('notification-logs', () => {
+	const now = new Date();
+
 	describe('get', () => {
 		/**
 		 * @param {number} projectUpdateId
@@ -13,7 +15,7 @@ describe('notification-logs', () => {
 			return {
 				id: 1,
 				emailSent: true,
-				entryDate: new Date(),
+				entryDate: now,
 				functionInvocationId: 'id-1',
 				projectUpdateId,
 				subscriptionId: 1
@@ -202,7 +204,7 @@ describe('notification-logs', () => {
 					{
 						projectUpdateId: 1,
 						subscriptionId: 2,
-						entryDate: new Date().toISOString(),
+						entryDate: now.toISOString(),
 						emailSent: true,
 						functionInvocationId: 'some-id'
 					}


### PR DESCRIPTION
## Describe your changes

Notification log tests used several instances of new Date() that wouldn't always match, resulting in some test failures.

## Issue ticket number and link

N/A

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
