### PR TITLE
feat(appeals/api): remove neighbouring site contact details from get appeals api endpoint

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -166,11 +166,6 @@ interface SingleLPAQuestionnaireResponse {
 
 interface NeighbouringSiteContactsResponse {
 	address: AppealSite;
-	contactId: Schema.NeighbouringSiteContact.id;
-	email: Schema.NeighbouringSiteContact.email;
-	firstName: Schema.NeighbouringSiteContact.firstName;
-	lastName: Schema.NeighbouringSiteContact.lastName;
-	telephone: Schema.NeighbouringSiteContact.telephone;
 }
 
 interface SingleAppealDetailsResponse {

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -15,7 +15,7 @@ import {
 	linkedAppeals,
 	otherAppeals
 } from '#tests/data.js';
-import formatNeighbouringSiteContacts from '#utils/format-neighbouring-site-contacts.js';
+import formatAddress from '#utils/format-address.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -458,9 +458,9 @@ describe('appeals routes', () => {
 					localPlanningDepartment: householdAppeal.localPlanningDepartment,
 					lpaQuestionnaireId: householdAppeal.lpaQuestionnaire.id,
 					neighbouringSite: {
-						contacts: formatNeighbouringSiteContacts(
-							householdAppeal.lpaQuestionnaire.neighbouringSiteContact
-						),
+						contacts: householdAppeal.lpaQuestionnaire.neighbouringSiteContact.map((contact) => ({
+							address: formatAddress(contact.address)
+						})),
 						isAffected: householdAppeal.lpaQuestionnaire.isAffectingNeighbouringSites
 					},
 					otherAppeals: [
@@ -553,8 +553,10 @@ describe('appeals routes', () => {
 					localPlanningDepartment: fullPlanningAppeal.localPlanningDepartment,
 					lpaQuestionnaireId: fullPlanningAppeal.lpaQuestionnaire.id,
 					neighbouringSite: {
-						contacts: formatNeighbouringSiteContacts(
-							fullPlanningAppeal.lpaQuestionnaire.neighbouringSiteContact
+						contacts: fullPlanningAppeal.lpaQuestionnaire.neighbouringSiteContact.map(
+							(contact) => ({
+								address: formatAddress(contact.address)
+							})
 						),
 						isAffected: fullPlanningAppeal.lpaQuestionnaire.isAffectingNeighbouringSites
 					},

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -1,7 +1,6 @@
 import formatAddress from '#utils/format-address.js';
 import isFPA from '#utils/is-fpa.js';
 import formatLinkedAppeals from '#utils/format-linked-appeals.js';
-import formatNeighbouringSiteContacts from '#utils/format-neighbouring-site-contacts.js';
 import {
 	formatAppellantCaseDocumentationStatus,
 	formatLpaQuestionnaireDocumentationStatus
@@ -83,7 +82,9 @@ const formatAppeal = (appeal) => {
 			lpaQuestionnaireId: appeal.lpaQuestionnaire?.id || null,
 			neighbouringSite: {
 				contacts:
-					formatNeighbouringSiteContacts(appeal.lpaQuestionnaire?.neighbouringSiteContact) || null,
+					appeal.lpaQuestionnaire?.neighbouringSiteContact?.map((contact) => ({
+						address: formatAddress(contact.address)
+					})) || null,
 				isAffected: appeal.lpaQuestionnaire?.isAffectingNeighbouringSites || null
 			},
 			otherAppeals: formatLinkedAppeals(appeal.otherAppeals, appeal.id),

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -1943,26 +1943,6 @@
 													"example": "Woodton"
 												}
 											}
-										},
-										"contactId": {
-											"type": "number",
-											"example": 1
-										},
-										"email": {
-											"type": "string",
-											"example": "appellant@example.com"
-										},
-										"firstName": {
-											"type": "string",
-											"example": "Lee"
-										},
-										"lastName": {
-											"type": "string",
-											"example": "Thornton"
-										},
-										"telephone": {
-											"type": "string",
-											"example": "01234567891"
 										}
 									}
 								}

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -168,12 +168,7 @@ const document = {
 							addressLine2: 'Shotesham Road',
 							postCode: 'NR35 2ND',
 							town: 'Woodton'
-						},
-						contactId: 1,
-						email: 'appellant@example.com',
-						firstName: 'Lee',
-						lastName: 'Thornton',
-						telephone: '01234567891'
+						}
 					}
 				],
 				isAffected: true


### PR DESCRIPTION
## Describe your changes

Removed name, telephone and email neighbouring site contact details from the GET Appeals API endpoint as these properties are no longer required on the Case Details page.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-395

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
