### PR TITLE
feat(api): publish representations endpoint

### DIFF
--- a/apps/api/setup-tests.js
+++ b/apps/api/setup-tests.js
@@ -58,6 +58,7 @@ const mockRepresentationFindMany = jest.fn().mockResolvedValue({});
 const mockRepresentationFindFirst = jest.fn().mockResolvedValue({});
 const mockRepresentationCreate = jest.fn().mockResolvedValue({});
 const mockRepresentationUpdate = jest.fn().mockResolvedValue({});
+const mockRepresentationUpdateMany = jest.fn().mockResolvedValue({});
 const mockRepresentationContactUpdate = jest.fn().mockResolvedValue({});
 const mockRepresentationContactFindFirst = jest.fn().mockResolvedValue({});
 const mockRepresentationContactDelete = jest.fn().mockResolvedValue({});
@@ -246,7 +247,8 @@ class MockPrismaClient {
 			findMany: mockRepresentationFindMany,
 			findFirst: mockRepresentationFindFirst,
 			create: mockRepresentationCreate,
-			update: mockRepresentationUpdate
+			update: mockRepresentationUpdate,
+			updateMany: mockRepresentationUpdateMany
 		};
 	}
 

--- a/apps/api/src/message-schemas/commands/register-representation.schema.json
+++ b/apps/api/src/message-schemas/commands/register-representation.schema.json
@@ -6,7 +6,7 @@
 	"required": ["representation", "interestedParty"],
 	"properties": {
 		"representation": {
-			"$ref": "representation.schema.json"
+			"$ref": "nsip-representation.schema.json"
 		},
 		"interestedParty": {
 			"$ref": "service-user.schema.json"

--- a/apps/api/src/message-schemas/events/nsip-representation.schema.json
+++ b/apps/api/src/message-schemas/events/nsip-representation.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "representation.schema.json",
+	"$id": "nsip-representation.schema.json",
 	"title": "Representation",
 	"type": "object",
 	"required": [
@@ -48,7 +48,7 @@
 		},
 		"representationFrom": {
 			"type": "string",
-			"enum": ["Myself", "Organisation", "Agent"]
+			"enum": ["PERSON", "ORGANISATION", "AGENT"]
 		},
 		"represented": {
 			"$ref": "interested-party.schema.json",
@@ -60,7 +60,7 @@
 		},
 		"registerFor": {
 			"type": "string",
-			"enum": ["person", "organisation", "family_group"]
+			"enum": ["PERSON", "ORGANISATION", "FAMILY_GROUP"]
 		},
 		"representationType": {
 			"type": "string",

--- a/apps/api/src/server/applications/application/representations/__tests__/publish-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/publish-representation.test.js
@@ -1,0 +1,269 @@
+import { request } from '../../../../app-test.js';
+import { eventClient } from '../../../../infrastructure/event-client.js';
+import { jest } from '@jest/globals';
+
+const { databaseConnector } = await import('../../../../utils/database-connector.js');
+
+const representations = [
+	{
+		id: 6409,
+		reference: 'BC0110001-55',
+		caseId: 151,
+		status: 'VALID',
+		unpublishedUpdates: false,
+		originalRepresentation: 'some rep text secret stuff',
+		redactedRepresentation: 'some rep text',
+		redacted: true,
+		userId: null,
+		received: '2023-08-11T10:52:56.516Z',
+		type: null,
+		user: null,
+		attachments: [
+			{
+				id: 1,
+				representationId: 6409,
+				documentGuid: '8e706443-3404-4b89-9fda-280ab7fd6b68'
+			}
+		],
+		case: {
+			id: 151,
+			reference: 'BC0110001',
+			modifiedAt: '2023-08-11T10:53:00.660Z',
+			createdAt: '2023-08-11T10:53:02.081Z',
+			description: 'A description of test case 1 which is a case of subsector type Office Use',
+			publishedAt: null,
+			title: 'Office Use Test Application 1'
+		},
+		contacts: [
+			{
+				id: 10105,
+				representationId: 6409,
+				firstName: '',
+				lastName: '',
+				jobTitle: null,
+				under18: false,
+				type: 'ORGANISATION',
+				organisationName: 'Environment Agency',
+				email: 'test@example.com',
+				phoneNumber: '01234 567890',
+				contactMethod: null,
+				addressId: 10105
+			}
+		],
+		representationActions: [
+			{
+				id: 1346,
+				representationId: 6409,
+				type: 'REDACTION',
+				status: null,
+				previousStatus: null,
+				redactStatus: true,
+				previousRedactStatus: true,
+				invalidReason: null,
+				referredTo: null,
+				actionBy: 'Bloggs, Joe',
+				actionDate: '2023-07-04T12:10:02.410Z',
+				notes: 'some notes here'
+			}
+		]
+	},
+	{
+		id: 6579,
+		reference: 'BC0110001-1533',
+		caseId: 151,
+		status: 'PUBLISHED',
+		unpublishedUpdates: true,
+		originalRepresentation: 'some words',
+		redactedRepresentation: null,
+		redacted: false,
+		userId: null,
+		received: '2023-08-11T10:52:56.516Z',
+		type: null,
+		user: null,
+		attachments: [],
+		case: {
+			id: 151,
+			reference: 'BC0110001',
+			modifiedAt: '2023-08-11T10:53:00.660Z',
+			createdAt: '2023-08-11T10:53:02.081Z',
+			description: 'A description of test case 1 which is a case of subsector type Office Use',
+			publishedAt: null,
+			title: 'Office Use Test Application 1'
+		},
+		contacts: [
+			{
+				id: 10381,
+				representationId: 6579,
+				firstName: 'Mrs',
+				lastName: 'Sue',
+				jobTitle: null,
+				under18: false,
+				type: 'PERSON',
+				organisationName: null,
+				email: 'test@example.com',
+				phoneNumber: '01234 567890',
+				contactMethod: null,
+				addressId: 10381
+			},
+			{
+				id: 10382,
+				representationId: 6579,
+				firstName: 'James',
+				lastName: 'Bond',
+				jobTitle: null,
+				under18: false,
+				type: 'AGENT',
+				organisationName: '',
+				email: 'test-agent@example.com',
+				phoneNumber: '01234 567890',
+				contactMethod: null,
+				addressId: 10382
+			}
+		],
+		representationActions: []
+	}
+];
+
+const expectedEventPayload = [
+	{
+		attachments: [
+			{
+				documentId: '8e706443-3404-4b89-9fda-280ab7fd6b68'
+			}
+		],
+		caseRef: 'BC0110001',
+		dateReceived: '2023-08-11T10:52:56.516Z',
+		examinationLibraryRef: '',
+		originalRepresentation: 'some rep text secret stuff',
+		redacted: true,
+		redactedBy: 'Bloggs, Joe',
+		redactedNotes: 'some notes here',
+		redactedRepresentation: 'some rep text',
+		referenceId: 'BC0110001-55',
+		registerFor: 'ORGANISATION',
+		representationFrom: 'ORGANISATION',
+		representationId: 6409,
+		representationType: null,
+		representative: {},
+		represented: {
+			contactMethod: null,
+			emailAddress: 'test@example.com',
+			firstName: '',
+			id: 6409,
+			lastName: '',
+			organisationName: 'Environment Agency',
+			telephone: '01234 567890',
+			under18: false
+		},
+		status: 'VALID'
+	},
+	{
+		attachments: [],
+		caseRef: 'BC0110001',
+		dateReceived: '2023-08-11T10:52:56.516Z',
+		examinationLibraryRef: '',
+		originalRepresentation: 'some words',
+		referenceId: 'BC0110001-1533',
+		registerFor: 'PERSON',
+		representationFrom: 'AGENT',
+		representationId: 6579,
+		representationType: null,
+		representative: {
+			contactMethod: null,
+			emailAddress: 'test-agent@example.com',
+			firstName: 'James',
+			id: 6579,
+			lastName: 'Bond',
+			organisationName: '',
+			telephone: '01234 567890',
+			under18: false
+		},
+		represented: {
+			contactMethod: null,
+			emailAddress: 'test@example.com',
+			firstName: 'Mrs',
+			id: 6579,
+			lastName: 'Sue',
+			organisationName: null,
+			telephone: '01234 567890',
+			under18: false
+		},
+		status: 'PUBLISHED'
+	}
+];
+
+describe('Publish Representations', () => {
+	jest.useFakeTimers({ now: 1_649_319_144_000 });
+
+	it('publishes representations with given ids', async () => {
+		databaseConnector.representation.findMany.mockResolvedValue(representations);
+
+		const response = await request.patch('/applications/1/representations/publish').send({
+			representationIds: [6409, 6579],
+			actionBy: 'Joe Bloggs'
+		});
+
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual({ publishedRepIds: [6409, 6579] });
+
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			'nsip-representation',
+			expectedEventPayload,
+			'Publish'
+		);
+		expect(databaseConnector.representation.update).toHaveBeenCalledWith({
+			where: {
+				id: 6409
+			},
+			data: {
+				status: 'PUBLISHED'
+			}
+		});
+		expect(databaseConnector.representationAction.create).toHaveBeenCalledWith({
+			data: {
+				representationId: 6409,
+				previousStatus: 'VALID',
+				status: 'PUBLISHED',
+				actionBy: 'Joe Bloggs',
+				actionDate: new Date(1_649_319_144_000),
+				type: 'STATUS'
+			}
+		});
+		expect(databaseConnector.representation.updateMany).toHaveBeenCalledWith({
+			where: { id: { in: [6579] } },
+			data: {
+				unpublishedUpdates: false
+			}
+		});
+	});
+
+	it.each([
+		{
+			name: 'missing representationIds property',
+			requestBody: { actionBy: 'foo' },
+			expectedError: { representationIds: 'at least 1 id must be provided' }
+		},
+		{
+			name: 'empty representationIds',
+			requestBody: { representationIds: [], actionBy: 'foo' },
+			expectedError: { representationIds: 'at least 1 id must be provided' }
+		},
+		{
+			name: 'representationIds not numbers',
+			requestBody: { representationIds: ['a'], actionBy: 'foo' },
+			expectedError: { representationIds: 'Must be an array of numbers' }
+		},
+		{
+			name: 'missing actionBy',
+			requestBody: { representationIds: [1] },
+			expectedError: { actionBy: 'is a mandatory field' }
+		}
+	])('$name', async ({ requestBody, expectedError }) => {
+		const response = await request
+			.patch('/applications/1/representations/publish')
+			.send(requestBody);
+
+		expect(response.status).toEqual(400);
+		expect(response.body.errors).toEqual(expectedError);
+	});
+});

--- a/apps/api/src/server/applications/application/representations/publish/publish.controller.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.controller.js
@@ -1,0 +1,13 @@
+import { publishCaseRepresentations } from './publish.service.js';
+
+export const publishRepresentations = async ({ params, body }, response) => {
+	const publishedRepresentations = await publishCaseRepresentations(
+		params.id,
+		body.representationIds,
+		body.actionBy
+	);
+
+	const publishedRepIds = publishedRepresentations.map((rep) => rep.id);
+
+	return response.status(200).json({ publishedRepIds });
+};

--- a/apps/api/src/server/applications/application/representations/publish/publish.route.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.route.js
@@ -1,0 +1,42 @@
+import { validateApplicationId } from '../../application.validators.js';
+import { asyncHandler } from '#middleware/async-handler.js';
+import { Router as createRouter } from 'express';
+import { publishRepresentations } from './publish.controller.js';
+import { validatePublishRepresentations } from './publish.validators.js';
+
+const router = createRouter({ mergeParams: true });
+
+router.patch(
+	'/',
+	/*
+			#swagger.tags = ['Applications']
+			#swagger.path = '/applications/{id}/representations/publish'
+			#swagger.description = 'Publishes representations on an application that are VALID or PUBLISHED with unpublishedUpdates'
+			#swagger.parameters['id'] = {
+									in: 'path',
+									description: 'Application ID',
+									required: true,
+									type: 'integer'
+			}
+			#swagger.parameters['body'] = {
+					in: 'body',
+					description: 'Representation IDs to publish, and user performing action',
+					required: true,
+					schema: {
+							representationIds: [123, 124, 125],
+							actionBy: "Joe Bloggs"
+					}
+			}
+			#swagger.responses[200] = {
+					description: 'Representation',
+					schema: {
+							publishedRepIds: [123, 134, 125]
+					}
+			}
+	 */
+	validateApplicationId,
+	validatePublishRepresentations,
+	asyncHandler(publishRepresentations)
+);
+
+export const representationsPublishRouter = router;

--- a/apps/api/src/server/applications/application/representations/publish/publish.service.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.service.js
@@ -1,0 +1,20 @@
+import * as representationsRepository from '#repositories/representation.repository.js';
+import { eventClient } from '#infrastructure/event-client.js';
+import { NSIP_REPRESENTATION } from '#infrastructure/topics.js';
+import { EventType } from '@pins/event-client';
+import { buildNsipRepresentationPayload } from './representation.js';
+import { setRepresentationsAsPublished } from '#repositories/representation.repository.js';
+
+export const publishCaseRepresentations = async (caseId, representationIds, actionBy) => {
+	const representations = await representationsRepository.getPublishableRepresentationsById(
+		caseId,
+		representationIds
+	);
+
+	const nsipRepresentationsPayload = representations.map(buildNsipRepresentationPayload);
+	await eventClient.sendEvents(NSIP_REPRESENTATION, nsipRepresentationsPayload, EventType.Publish);
+
+	await setRepresentationsAsPublished(representations, actionBy);
+
+	return representations;
+};

--- a/apps/api/src/server/applications/application/representations/publish/publish.validators.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.validators.js
@@ -1,0 +1,13 @@
+import { composeMiddleware } from '@pins/express';
+import { body } from 'express-validator';
+import { validationErrorHandler } from '#middleware/error-handler.js';
+
+export const validatePublishRepresentations = composeMiddleware(
+	body('representationIds')
+		.isArray({ min: 1 })
+		.withMessage('at least 1 id must be provided')
+		.custom((array) => array.every((value) => typeof value === 'number'))
+		.withMessage('Must be an array of numbers'),
+	body('actionBy').exists().withMessage('is a mandatory field'),
+	validationErrorHandler
+);

--- a/apps/api/src/server/applications/application/representations/publish/representation.js
+++ b/apps/api/src/server/applications/application/representations/publish/representation.js
@@ -1,0 +1,65 @@
+export const buildNsipRepresentationPayload = (representation) => {
+	let nsipRepresentation = {
+		representationId: representation.id,
+		referenceId: representation.reference,
+		examinationLibraryRef: '',
+		caseRef: representation.case.reference,
+		status: representation.status,
+		originalRepresentation: representation.originalRepresentation,
+		representationType: representation.type,
+		dateReceived: representation.received,
+		attachments: representation.attachments?.map(buildAttachment)
+	};
+
+	const representative = representation.contacts.find((contact) => contact.type === 'AGENT');
+	const represented = representation.contacts.find((contact) => contact.type !== 'AGENT');
+	nsipRepresentation = {
+		...nsipRepresentation,
+		representationFrom: (representative || represented)?.type,
+		representative: buildNsipInterestedPartyPayload(representative),
+		registerFor: represented?.type,
+		represented: buildNsipInterestedPartyPayload(represented)
+	};
+
+	if (representation.redacted) {
+		nsipRepresentation = {
+			...nsipRepresentation,
+			redacted: representation.redacted,
+			redactedRepresentation: representation.redactedRepresentation
+		};
+
+		const representationActions = representation.representationActions.filter(
+			(action) => action.type === 'REDACTION'
+		);
+		if (representationActions.length > 0) {
+			const redaction = representationActions[representationActions.length - 1];
+			nsipRepresentation = {
+				...nsipRepresentation,
+				redactedBy: redaction.actionBy,
+				redactedNotes: redaction.notes
+			};
+		}
+	}
+
+	return nsipRepresentation;
+};
+
+const buildNsipInterestedPartyPayload = (representationContact) => {
+	if (!representationContact) return {};
+	return {
+		id: representationContact.representationId,
+		firstName: representationContact.firstName,
+		lastName: representationContact.lastName,
+		under18: representationContact.under18,
+		organisationName: representationContact.organisationName,
+		contactMethod: representationContact.contactMethod,
+		emailAddress: representationContact.email,
+		telephone: representationContact.phoneNumber
+	};
+};
+
+const buildAttachment = (attachment) => {
+	return {
+		documentId: attachment.documentGuid
+	};
+};

--- a/apps/api/src/server/applications/application/representations/representations.routes.js
+++ b/apps/api/src/server/applications/application/representations/representations.routes.js
@@ -18,86 +18,87 @@ import { representationsContactsRouter } from './contacts/contacts.route.js';
 import { representationsAttachmentRouter } from './attachment/attachment.route.js';
 import { representationsStatusRouter } from './status/status.route.js';
 import { getRepDownloadRouter } from './download/rep-download.router.js';
+import { representationsPublishRouter } from './publish/publish.route.js';
 
 const router = createRouter({ mergeParams: true });
 
 router.get(
 	'/',
 	/*
-        #swagger.tags = ['Applications']
-        #swagger.path = '/applications/{id}/representations'
-        #swagger.description = 'Gets list of representations on an application'
-        #swagger.parameters['id'] = {
-            in: 'path',
-			description: 'Application ID',
-			required: true,
-			type: 'integer'
-		}
-		#swagger.parameters['page'] = {
-            in: 'query',
-			description: 'Page to show',
-			required: false,
-			type: 'integer',
-			example: 1,
-			minimum: 1,
-		}
-		#swagger.parameters['pageSize'] = {
-            in: 'query',
-			description: 'Page size',
-			required: false,
-			type: 'integer',
-			example: 25,
-			minimum: 1,
-			maximum: 100
-		}
-		#swagger.parameters['searchTerm'] = {
-			in: 'query',
-			description: 'Search Term',
-			required: false,
-			type: 'string'
-		}
-		#swagger.parameters['status'] = {
-			in: 'query',
-			description: 'Filter by status',
-			required: false,
-			schema: [''],
-			style: 'form',
-			explode: true
-		}
-		#swagger.parameters['under18'] = {
-			in: 'query',
-			description: 'Filter by under18',
-			required: false,
-			type: 'boolean'
-		}
-		#swagger.parameters['sortBy'] = {
-			in: 'query',
-			description: 'Sort by field. +field for ASC, -field for DESC',
-			required: false,
-			type: 'string'
-		}
-        #swagger.responses[200] = {
-            description: 'Representations',
-            schema: {
-				page: 1,
-				pageSize: 25,
-				pageCount: 1,
-				itemCount: 100,
-				items:  [
-					{
-						id: 1,
-						reference: 'BC0110001-2',
-						status: 'VALID',
-						redacted: true,
-						received: '2023-03-14T14:28:25.704Z',
-						firstName: 'James',
-						lastName: 'Bond',
-						organisationName: 'MI6'
-					}
-				]
+			#swagger.tags = ['Applications']
+			#swagger.path = '/applications/{id}/representations'
+			#swagger.description = 'Gets list of representations on an application'
+			#swagger.parameters['id'] = {
+					in: 'path',
+					description: 'Application ID',
+					required: true,
+					type: 'integer'
 			}
-		}
-    */
+			#swagger.parameters['page'] = {
+					in: 'query',
+					description: 'Page to show',
+					required: false,
+					type: 'integer',
+					example: 1,
+					minimum: 1,
+			}
+			#swagger.parameters['pageSize'] = {
+					in: 'query',
+					description: 'Page size',
+					required: false,
+					type: 'integer',
+					example: 25,
+					minimum: 1,
+					maximum: 100
+			}
+			#swagger.parameters['searchTerm'] = {
+					in: 'query',
+					description: 'Search Term',
+					required: false,
+					type: 'string'
+			}
+			#swagger.parameters['status'] = {
+					in: 'query',
+					description: 'Filter by status',
+					required: false,
+					schema: [''],
+					style: 'form',
+					explode: true
+			}
+			#swagger.parameters['under18'] = {
+					in: 'query',
+					description: 'Filter by under18',
+					required: false,
+					type: 'boolean'
+			}
+			#swagger.parameters['sortBy'] = {
+					in: 'query',
+					description: 'Sort by field. +field for ASC, -field for DESC',
+					required: false,
+					type: 'string'
+			}
+			#swagger.responses[200] = {
+					description: 'Representations',
+					schema: {
+							page: 1,
+							pageSize: 25,
+							pageCount: 1,
+							itemCount: 100,
+							items:  [
+									{
+											id: 1,
+											reference: 'BC0110001-2',
+											status: 'VALID',
+											redacted: true,
+											received: '2023-03-14T14:28:25.704Z',
+											firstName: 'James',
+											lastName: 'Bond',
+											organisationName: 'MI6'
+									}
+							]
+					}
+			}
+	*/
 	validateApplicationId,
 	validateGetRepresentationsQuery,
 	asyncHandler(getRepresentations)
@@ -105,40 +106,42 @@ router.get(
 
 router.use('/download', getRepDownloadRouter);
 
+router.use('/publish', representationsPublishRouter);
+
 router.get(
 	'/:repId',
 	/*
-        #swagger.tags = ['Applications']
-        #swagger.path = '/applications/{id}/representations/{repId}'
-        #swagger.description = 'Gets a representation on an application'
-        #swagger.parameters['id'] = {
-            in: 'path',
-			description: 'Application ID',
-			required: true,
-			type: 'integer'
-		}
-		#swagger.parameters['repId'] = {
-            in: 'path',
-			description: 'Representation ID',
-			required: true,
-			type: 'integer'
-		}
-        #swagger.responses[200] = {
-            description: 'Representation',
-            schema: {
-				id: 1,
-				reference: 'BC0110001-2',
-				status: 'VALID',
-				redacted: true,
-				received: '2023-03-14T14:28:25.704Z',
-				originalRepresentation: '',
-				redactedRepresentation: '',
-				redactedBy: {},
-				contacts: [],
-				attachments: []
+			#swagger.tags = ['Applications']
+			#swagger.path = '/applications/{id}/representations/{repId}'
+			#swagger.description = 'Gets a representation on an application'
+			#swagger.parameters['id'] = {
+					in: 'path',
+					description: 'Application ID',
+					required: true,
+					type: 'integer'
 			}
-		}
-    */
+			#swagger.parameters['repId'] = {
+					in: 'path',
+					description: 'Representation ID',
+					required: true,
+					type: 'integer'
+			}
+			#swagger.responses[200] = {
+					description: 'Representation',
+					schema: {
+							id: 1,
+							reference: 'BC0110001-2',
+							status: 'VALID',
+							redacted: true,
+							received: '2023-03-14T14:28:25.704Z',
+							originalRepresentation: '',
+							redactedRepresentation: '',
+							redactedBy: {},
+							contacts: [],
+							attachments: []
+					}
+			}
+	*/
 	validateApplicationId,
 	validateRepresentationId,
 	asyncHandler(getRepresentation)
@@ -147,52 +150,52 @@ router.get(
 router.post(
 	'/',
 	/*
-        #swagger.tags = ['Applications']
-        #swagger.path = '/applications/{id}/representations'
-        #swagger.description = 'Creates a representation for an application'
-        #swagger.parameters['id'] = {
-            in: 'path',
-			description: 'Application ID',
-			required: true,
-			type: 'integer'
-		}
-		#swagger.parameters['body'] = {
-            in: 'body',
-            description: 'Representation Details',
-            schema: {
-				status: 'DRAFT',
-				redacted: false,
-				received: '2023-03-14T14:28:25.704Z',
-				originalRepresentation: 'This is the representation text',
-				represented: {
-					firstName: 'Peter',
-					lastName: 'Biggins',
-					organisationName: '',
-				    jobTitle: '',
-				    email: 'peter.bigins@dummy.email',
-				    phoneNumber: '0123456789',
-				    address: {
-						addressLine1: '',
-						addressLine2: '',
-						town: '',
-						county: '',
-						postcode: '',
-						country: ''
-						},
-					type: 'PERSON',
-					under18: false
-				},
-				representative: {}
+			#swagger.tags = ['Applications']
+			#swagger.path = '/applications/{id}/representations'
+			#swagger.description = 'Creates a representation for an application'
+			#swagger.parameters['id'] = {
+					in: 'path',
+					description: 'Application ID',
+					required: true,
+					type: 'integer'
 			}
-        }
-        #swagger.responses[200] = {
-            description: 'Representation',
-            schema: {
-				id: 1,
-				status: 'DRAFT',
+			#swagger.parameters['body'] = {
+					in: 'body',
+					description: 'Representation Details',
+					schema: {
+							status: 'DRAFT',
+							redacted: false,
+							received: '2023-03-14T14:28:25.704Z',
+							originalRepresentation: 'This is the representation text',
+							represented: {
+									firstName: 'Peter',
+									lastName: 'Biggins',
+									organisationName: '',
+									jobTitle: '',
+									email: 'peter.bigins@dummy.email',
+									phoneNumber: '0123456789',
+									address: {
+											addressLine1: '',
+											addressLine2: '',
+											town: '',
+											county: '',
+											postcode: '',
+											country: ''
+											},
+									type: 'PERSON',
+									under18: false
+							},
+							representative: {}
+					}
 			}
-		}
-    */
+			#swagger.responses[200] = {
+					description: 'Representation',
+					schema: {
+							id: 1,
+							status: 'DRAFT',
+					}
+			}
+	*/
 	validateApplicationId,
 	validateCreateRepresentation,
 	asyncHandler(createRepresentation)
@@ -201,54 +204,54 @@ router.post(
 router.patch(
 	'/:repId',
 	/*
-        #swagger.tags = ['Applications']
-        #swagger.path = '/applications/{id}/representations/{repId}'
-        #swagger.description = 'Updates a representation for an application'
-        #swagger.parameters['id'] = {
-            in: 'path',
-			description: 'Application ID',
-			required: true,
-			type: 'integer'
-		}
-		#swagger.parameters['body'] = {
-            in: 'body',
-            description: 'Representation Details',
-            schema: {
-				status: 'DRAFT',
-				redacted: false,
-				redactedBy: 'A users name who has performed a redaction',
-				redactedNotes: 'A string if redacted text',
-				received: '2023-03-14T14:28:25.704Z',
-				originalRepresentation: 'This is the representation text',
-				represented: {
-					firstName: 'Peter',
-					lastName: 'Biggins',
-					organisationName: '',
-				    jobTitle: '',
-				    email: 'peter.bigins@dummy.email',
-				    phoneNumber: '0123456789',
-				    address: {
-						addressLine1: '',
-						addressLine2: '',
-						town: '',
-						county: '',
-						postcode: '',
-						country: ''
-						},
-					type: 'PERSON',
-					under18: false
-				},
-				representative: {}
+			#swagger.tags = ['Applications']
+			#swagger.path = '/applications/{id}/representations/{repId}'
+			#swagger.description = 'Updates a representation for an application'
+			#swagger.parameters['id'] = {
+					in: 'path',
+					description: 'Application ID',
+					required: true,
+					type: 'integer'
 			}
-        }
-        #swagger.responses[200] = {
-            description: 'Representation',
-            schema: {
-				id: 1,
-				status: 'DRAFT',
+			#swagger.parameters['body'] = {
+					in: 'body',
+					description: 'Representation Details',
+					schema: {
+							status: 'DRAFT',
+							redacted: false,
+							redactedBy: 'A users name who has performed a redaction',
+							redactedNotes: 'A string if redacted text',
+							received: '2023-03-14T14:28:25.704Z',
+							originalRepresentation: 'This is the representation text',
+							represented: {
+									firstName: 'Peter',
+									lastName: 'Biggins',
+									organisationName: '',
+									jobTitle: '',
+									email: 'peter.bigins@dummy.email',
+									phoneNumber: '0123456789',
+									address: {
+											addressLine1: '',
+											addressLine2: '',
+											town: '',
+											county: '',
+											postcode: '',
+											country: ''
+											},
+									type: 'PERSON',
+									under18: false
+							},
+							representative: {}
+					}
 			}
-		}
-    */
+			#swagger.responses[200] = {
+					description: 'Representation',
+					schema: {
+							id: 1,
+							status: 'DRAFT',
+					}
+			}
+	*/
 	validateApplicationId,
 	representationPatchValidator,
 	asyncHandler(patchRepresentation)

--- a/apps/api/src/server/applications/application/representations/status/status.service.js
+++ b/apps/api/src/server/applications/application/representations/status/status.service.js
@@ -1,5 +1,5 @@
 import * as representationsRepository from '../../../../repositories/representation.repository.js';
 
 export const updateStatusRepresentation = async (repId, action) => {
-	return representationsRepository.updateApplicationRepresentationStatus(repId, action);
+	return representationsRepository.updateApplicationRepresentationStatusById(repId, action);
 };

--- a/apps/api/src/server/infrastructure/topics.js
+++ b/apps/api/src/server/infrastructure/topics.js
@@ -3,3 +3,4 @@ export const NSIP_PROJECT_UPDATE = 'nsip-project-update';
 export const NSIP_DOCUMENT = 'nsip-document';
 export const NSIP_SUBSCRIPTION = 'nsip-subscription';
 export const NSIP_EXAM_TIMETABLE = 'nsip-exam-timetable';
+export const NSIP_REPRESENTATION = 'nsip-representation';

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -856,6 +856,63 @@
 				}
 			}
 		},
+		"/applications/{id}/representations/publish": {
+			"patch": {
+				"tags": ["Applications"],
+				"description": "Publishes representations on an application that are VALID or PUBLISHED with unpublishedUpdates",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"description": "Representation IDs to publish, and user performing action",
+						"required": true,
+						"schema": {
+							"type": "object",
+							"properties": {
+								"representationIds": {
+									"type": "array",
+									"example": [123, 124, 125],
+									"items": {
+										"type": "number"
+									}
+								},
+								"actionBy": {
+									"type": "string",
+									"example": "Joe Bloggs"
+								}
+							}
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Representation",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"publishedRepIds": {
+									"type": "array",
+									"example": [123, 134, 125],
+									"items": {
+										"type": "number"
+									}
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/applications/{id}/representations/{repId}/redact": {
 			"patch": {
 				"tags": ["Applications"],


### PR DESCRIPTION
## Describe your changes

ASB-1688

- adds new endpoint: `PATCH /applications/{id}/representations/publish`

this endpoint takes a list of representation IDs and publishes a message for each to the nsip-representation topic.
It then sets the status of each rep to PUBLISHED if they have not already been previously published, and for those that have, it sets the unpublishedUpdates flag to false.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
