### PR TITLE
feat(functions): populate document metadata after successful creation

### DIFF
--- a/apps/functions/deadline-submissions/deadline-submission-command/__tests__/deadline-submission-command.test.js
+++ b/apps/functions/deadline-submissions/deadline-submission-command/__tests__/deadline-submission-command.test.js
@@ -12,6 +12,7 @@ describe('deadline-submission-command', () => {
 		api.getCaseID = jest.fn().mockResolvedValue(1);
 		api.getFolderID = jest.fn().mockResolvedValue(1);
 		api.lineItemExists = jest.fn().mockResolvedValue(true);
+		api.populateDocumentMetadata = jest.fn();
 
 		eventClient.publishFailureEvent = mockSendEvents;
 
@@ -34,7 +35,7 @@ describe('deadline-submission-command', () => {
 	test('Success', async () => {
 		const mockSubmitDocument = jest.fn().mockResolvedValue({
 			privateBlobContainer: 'test-container',
-			documents: [{ blobStoreUrl: '/test/blob/url' }]
+			documents: [{ blobStoreUrl: '/application/blob/url/1' }]
 		});
 		api.submitDocument = mockSubmitDocument;
 

--- a/apps/functions/deadline-submissions/deadline-submission-command/back-office-api-client.js
+++ b/apps/functions/deadline-submissions/deadline-submission-command/back-office-api-client.js
@@ -122,9 +122,35 @@ async function lineItemExists(caseID, timetableItemName, lineItem) {
 	return _lineItem !== null;
 }
 
+/**
+ *
+ * @param {number} caseID
+ * @param {{ documentGuid: string, documentName: string, userName: string, deadline: string, submissionType: string, representative?: string }} _
+ * */
+async function populateDocumentMetadata(
+	caseID,
+	{ documentGuid, documentName, userName, deadline, submissionType, representative }
+) {
+	await got.post(
+		`https://${config.apiHost}/applications/${caseID}/documents/${documentGuid}/metadata`,
+		{
+			json: {
+				version: 1,
+				documentGuid,
+				fileName: documentName,
+				author: userName,
+				representative,
+				filter1: deadline,
+				filter2: submissionType
+			}
+		}
+	);
+}
+
 export default {
 	getCaseID,
 	getFolderID,
 	lineItemExists,
-	submitDocument
+	submitDocument,
+	populateDocumentMetadata
 };

--- a/apps/functions/deadline-submissions/deadline-submission-command/index.js
+++ b/apps/functions/deadline-submissions/deadline-submission-command/index.js
@@ -49,13 +49,23 @@ export default async function (context, msg) {
 
 	const { blobStoreUrl } = documents[0];
 	const destinationName = blobStoreUrl.startsWith('/') ? blobStoreUrl.slice(1) : blobStoreUrl;
+	const match = blobStoreUrl.match(/^\/application\/.+\/(.+)\/1$/);
 
 	const successful = await blob.copyFile(
 		{ containerName: submissionsContainer, blobName: sourceBlobName },
 		{ containerName: privateBlobContainer, blobName: destinationName }
 	);
 
-	if (!successful) {
+	if (successful) {
+		await api.populateDocumentMetadata(caseID, {
+			documentGuid: match[1],
+			documentName: msg.documentName,
+			userName: msg.name,
+			deadline: msg.deadline,
+			submissionType: msg.submissionType,
+			representative: msg.interestedPartyReference
+		});
+	} else {
 		await events.publishFailureEvent(context, {
 			deadline: msg.deadline,
 			submissionType: msg.submissionType,

--- a/apps/functions/deadline-submissions/deadline-submission-command/index.js
+++ b/apps/functions/deadline-submissions/deadline-submission-command/index.js
@@ -9,23 +9,19 @@ const { submissionsContainer } = config;
  *
  * @param {import('@azure/functions').Context} context
  * @param {import('@pins/api/src/message-schemas/commands/new-deadline-submission').DeadlineSubmission} msg
+ * @returns {Promise<string | null>}
  */
-export default async function (context, msg) {
-	context.log('Handle new deadline submission', msg);
-
+async function run(context, msg) {
 	const caseID = await api.getCaseID(msg.caseReference);
 	if (!caseID) {
-		// TODO: Publish failure message to service bus
-		context.log.error(`No case found with reference: ${msg.caseReference}`);
-		return;
+		throw new Error(`No case found with reference: ${msg.caseReference}`);
 	}
 
 	const entitiesExist = await api.lineItemExists(caseID, msg.deadline, msg.submissionType);
 	if (!entitiesExist) {
-		context.log.error(
-			`Timetable item "${msg.deadline}" or line item "${msg.msg.submissionType}" could not be found`
+		throw new Error(
+			`Timetable item "${msg.deadline}" or line item "${msg.submissionType}" could not be found`
 		);
-		return;
 	}
 
 	const sourceBlobName = `${msg.blobGuid}/${msg.documentName}`;
@@ -43,29 +39,52 @@ export default async function (context, msg) {
 	});
 
 	if (documents.length === 0) {
-		context.log.error('No documents to process in response from API');
-		return;
+		throw new Error('No documents to process in response from API');
 	}
 
 	const { blobStoreUrl } = documents[0];
 	const destinationName = blobStoreUrl.startsWith('/') ? blobStoreUrl.slice(1) : blobStoreUrl;
+
 	const match = blobStoreUrl.match(/^\/application\/.+\/(.+)\/1$/);
+	if (!match) {
+		throw new Error(`RegEx match failed for blob store URL: ${blobStoreUrl}`);
+	}
 
 	const successful = await blob.copyFile(
 		{ containerName: submissionsContainer, blobName: sourceBlobName },
 		{ containerName: privateBlobContainer, blobName: destinationName }
 	);
 
-	if (successful) {
-		await api.populateDocumentMetadata(caseID, {
-			documentGuid: match[1],
-			documentName: msg.documentName,
-			userName: msg.name,
-			deadline: msg.deadline,
-			submissionType: msg.submissionType,
-			representative: msg.interestedPartyReference
-		});
-	} else {
+	if (!successful) {
+		return null;
+	}
+
+	await api.populateDocumentMetadata(caseID, {
+		documentGuid: match[1],
+		documentName: msg.documentName,
+		userName: msg.name,
+		deadline: msg.deadline,
+		submissionType: msg.submissionType,
+		representative: msg.interestedPartyReference
+	});
+
+	return documents[0].blobStoreUrl;
+}
+
+/**
+ *
+ * @param {import('@azure/functions').Context} context
+ * @param {import('@pins/api/src/message-schemas/commands/new-deadline-submission').DeadlineSubmission} msg
+ */
+export default async function (context, msg) {
+	context.log('Handle new deadline submission', msg);
+
+	let blobStoreUrl = null;
+	try {
+		blobStoreUrl = await run(context, msg);
+	} catch (err) {
+		context.log(err);
+
 		await events.publishFailureEvent(context, {
 			deadline: msg.deadline,
 			submissionType: msg.submissionType,
@@ -75,8 +94,8 @@ export default async function (context, msg) {
 	}
 
 	context.log(
-		successful
-			? `Successfully copied blob ${msg.blobGuid} from submissions to uploads store with name ${documents[0].blobStoreUrl}`
+		blobStoreUrl
+			? `Successfully copied blob ${msg.blobGuid} from submissions to uploads store with name ${blobStoreUrl}`
 			: `Failed to copy blob ${msg.blobGuid} from submissions to uploads store`
 	);
 }


### PR DESCRIPTION
## Describe your changes

Populate document metadata after creating the document from an FO submission. This is needed for display on the front end.

Tested locally.

## Issue ticket number and link

[BOAS-960](https://pins-ds.atlassian.net/browse/BOAS-960)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-960]: https://pins-ds.atlassian.net/browse/BOAS-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ