### PR TITLE
fix(api): appellant case and lpaq incomplete flows - should not be able to enter past dates

### DIFF
--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -6,6 +6,7 @@ import {
 	DEFAULT_DATE_FORMAT_DATABASE,
 	DEFAULT_DATE_FORMAT_DISPLAY,
 	DEFAULT_TIMESTAMP_TIME,
+	ERROR_MUST_BE_IN_FUTURE,
 	ERROR_CANNOT_BE_EMPTY_STRING,
 	ERROR_FAILED_TO_SAVE_DATA,
 	ERROR_INVALID_APPELLANT_CASE_VALIDATION_OUTCOME,
@@ -251,7 +252,7 @@ describe('appellant cases routes', () => {
 				);
 
 				const body = {
-					appealDueDate: '2023-07-14',
+					appealDueDate: '2099-07-14',
 					incompleteReasons: [1, 2, 3],
 					validationOutcome: 'Incomplete',
 					otherNotValidReasons: 'Another reason'
@@ -696,6 +697,28 @@ describe('appellant cases routes', () => {
 				expect(response.body).toEqual({
 					errors: {
 						appealDueDate: ERROR_MUST_BE_CORRECT_DATE_FORMAT
+					}
+				});
+			});
+
+			test('returns an error if appealDueDate is in the past', async () => {
+				jest.useFakeTimers().setSystemTime(new Date('2023-06-05'));
+
+				const { appellantCase, id } = householdAppeal;
+				const body = {
+					appealDueDate: '2023-06-04',
+					incompleteReasons: [1, 2, 3],
+					validationOutcome: 'Incomplete',
+					otherNotValidReasons: 'Another reason'
+				};
+				const response = await request
+					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
+					.send(body);
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						appealDueDate: ERROR_MUST_BE_IN_FUTURE
 					}
 				});
 			});

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.validators.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.validators.js
@@ -8,9 +8,11 @@ import {
 	ERROR_ONLY_FOR_INVALID_VALIDATION_OUTCOME,
 	ERROR_VALID_VALIDATION_OUTCOME_NO_REASONS,
 	ERROR_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED,
+	ERROR_MUST_BE_IN_FUTURE,
 	MAX_LENGTH_4000
 } from '../constants.js';
 import { isOutcomeIncomplete, isOutcomeInvalid } from '#utils/check-validation-outcome.js';
+import { dateIsAfterDate } from '#utils/date-comparison.js';
 import validateDateParameter from '#common/validators/date-parameter.js';
 import validateIdParameter from '#common/validators/id-parameter.js';
 import validateNumberArrayParameter from '#common/validators/number-array-parameter.js';
@@ -37,6 +39,10 @@ const patchAppellantCaseValidator = composeMiddleware(
 		) => {
 			if (value && !isOutcomeIncomplete(req.body.validationOutcome)) {
 				throw new Error(ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME);
+			}
+
+			if (value && !dateIsAfterDate(new Date(value), new Date())) {
+				throw new Error(ERROR_MUST_BE_IN_FUTURE);
 			}
 
 			return value;

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -67,6 +67,7 @@ export const ERROR_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED =
 	'Validation outcome reasons are required when validationOutcome is Incomplete or Invalid';
 export const ERROR_LPA_QUESTIONNAIRE_VALID_VALIDATION_OUTCOME_REASONS_REQUIRED =
 	'Validation outcome reasons are required when validationOutcome is Incomplete';
+export const ERROR_MUST_BE_IN_FUTURE = 'Must be in the future';
 
 export const MAX_LENGTH_8 = 8;
 export const MAX_LENGTH_300 = 300;

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -10,6 +10,7 @@ import {
 	ERROR_MUST_BE_ARRAY_OF_NUMBERS,
 	ERROR_MUST_BE_BOOLEAN,
 	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
+	ERROR_MUST_BE_IN_FUTURE,
 	ERROR_MUST_BE_NUMBER,
 	ERROR_MUST_BE_STRING,
 	ERROR_MUST_CONTAIN_AT_LEAST_1_VALUE,
@@ -273,7 +274,7 @@ describe('lpa questionnaires routes', () => {
 
 				const body = {
 					incompleteReasons: [1, 2, 3],
-					lpaQuestionnaireDueDate: '2023-06-21',
+					lpaQuestionnaireDueDate: '2099-06-22',
 					otherNotValidReasons: 'Another incomplete reason',
 					validationOutcome: 'incomplete'
 				};
@@ -305,7 +306,7 @@ describe('lpa questionnaires routes', () => {
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					...body,
-					lpaQuestionnaireDueDate: '2023-06-21T01:00:00.000Z'
+					lpaQuestionnaireDueDate: '2099-06-22T01:00:00.000Z'
 				});
 			});
 
@@ -323,7 +324,7 @@ describe('lpa questionnaires routes', () => {
 
 				const body = {
 					incompleteReasons: [1, 2, 3],
-					lpaQuestionnaireDueDate: '2023-04-29',
+					lpaQuestionnaireDueDate: '2025-08-23',
 					otherNotValidReasons: 'Another incomplete reason',
 					validationOutcome: 'incomplete'
 				};
@@ -355,7 +356,7 @@ describe('lpa questionnaires routes', () => {
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					...body,
-					lpaQuestionnaireDueDate: '2023-05-02T01:00:00.000Z'
+					lpaQuestionnaireDueDate: '2025-08-26T01:00:00.000Z'
 				});
 			});
 
@@ -373,7 +374,7 @@ describe('lpa questionnaires routes', () => {
 
 				const body = {
 					incompleteReasons: [1, 2, 3],
-					lpaQuestionnaireDueDate: '2023-04-07',
+					lpaQuestionnaireDueDate: '2025-04-18',
 					otherNotValidReasons: 'Another incomplete reason',
 					validationOutcome: 'incomplete'
 				};
@@ -405,7 +406,7 @@ describe('lpa questionnaires routes', () => {
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					...body,
-					lpaQuestionnaireDueDate: '2023-04-11T01:00:00.000Z'
+					lpaQuestionnaireDueDate: '2025-04-22T01:00:00.000Z'
 				});
 			});
 
@@ -423,7 +424,7 @@ describe('lpa questionnaires routes', () => {
 
 				const body = {
 					incompleteReasons: [1, 2, 3],
-					lpaQuestionnaireDueDate: '2023-12-25',
+					lpaQuestionnaireDueDate: '2024-12-25',
 					otherNotValidReasons: 'Another incomplete reason',
 					validationOutcome: 'incomplete'
 				};
@@ -455,7 +456,7 @@ describe('lpa questionnaires routes', () => {
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					...body,
-					lpaQuestionnaireDueDate: '2023-12-27T01:00:00.000Z'
+					lpaQuestionnaireDueDate: '2024-12-27T01:00:00.000Z'
 				});
 			});
 
@@ -473,7 +474,7 @@ describe('lpa questionnaires routes', () => {
 
 				const body = {
 					incompleteReasons: [1, 2, 3],
-					lpaQuestionnaireDueDate: '2023-06-21',
+					lpaQuestionnaireDueDate: '2099-06-22',
 					otherNotValidReasons: 'Another incomplete reason',
 					validationOutcome: 'Incomplete'
 				};
@@ -505,7 +506,7 @@ describe('lpa questionnaires routes', () => {
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					...body,
-					lpaQuestionnaireDueDate: '2023-06-21T01:00:00.000Z'
+					lpaQuestionnaireDueDate: '2099-06-22T01:00:00.000Z'
 				});
 			});
 
@@ -581,7 +582,7 @@ describe('lpa questionnaires routes', () => {
 
 				const body = {
 					incompleteReasons: ['1', '2', '3'],
-					lpaQuestionnaireDueDate: '2023-06-21',
+					lpaQuestionnaireDueDate: '2099-06-22',
 					otherNotValidReasons: 'Another incomplete reason',
 					validationOutcome: 'incomplete'
 				};
@@ -613,6 +614,26 @@ describe('lpa questionnaires routes', () => {
 				expect(response.body).toEqual({
 					errors: {
 						incompleteReasons: ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME
+					}
+				});
+			});
+
+			test('returns an error if validationOutcome is Complete and lpaQuestionnaireDueDate is given', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const { id, lpaQuestionnaire } = householdAppeal;
+				const response = await request
+					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
+					.send({
+						lpaQuestionnaireDueDate: '2099-06-22',
+						validationOutcome: 'Complete'
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						lpaQuestionnaireDueDate: ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME
 					}
 				});
 			});
@@ -706,7 +727,7 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						incompleteReasons: [1],
-						lpaQuestionnaireDueDate: '05/05/2023',
+						lpaQuestionnaireDueDate: '05/05/2099',
 						validationOutcome: 'Incomplete'
 					});
 
@@ -724,7 +745,7 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						incompleteReasons: [1],
-						lpaQuestionnaireDueDate: '2023-5-5',
+						lpaQuestionnaireDueDate: '2099-5-5',
 						validationOutcome: 'Incomplete'
 					});
 
@@ -736,13 +757,33 @@ describe('lpa questionnaires routes', () => {
 				});
 			});
 
+			test('returns an error if lpaQuestionnaireDueDate is in the past', async () => {
+				jest.useFakeTimers().setSystemTime(new Date('2023-06-05'));
+
+				const { id, lpaQuestionnaire } = householdAppeal;
+				const response = await request
+					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
+					.send({
+						incompleteReasons: [1],
+						lpaQuestionnaireDueDate: '2023-06-04',
+						validationOutcome: 'Incomplete'
+					});
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						lpaQuestionnaireDueDate: ERROR_MUST_BE_IN_FUTURE
+					}
+				});
+			});
+
 			test('returns an error if lpaQuestionnaireDueDate is not a valid date', async () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						incompleteReasons: [1],
-						lpaQuestionnaireDueDate: '2023-02-30',
+						lpaQuestionnaireDueDate: '2099-02-30',
 						validationOutcome: 'Incomplete'
 					});
 
@@ -764,7 +805,6 @@ describe('lpa questionnaires routes', () => {
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
-						lpaQuestionnaireDueDate: '2023-06-21',
 						validationOutcome: 'invalid'
 					});
 
@@ -793,7 +833,7 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						incompleteReasons: [1, 3],
-						lpaQuestionnaireDueDate: '2023-06-21',
+						lpaQuestionnaireDueDate: '2099-06-22',
 						validationOutcome: 'Incomplete'
 					});
 
@@ -822,7 +862,7 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						incompleteReasons: [1, 2],
-						lpaQuestionnaireDueDate: '2023-06-21',
+						lpaQuestionnaireDueDate: '2099-06-22',
 						otherNotValidReasons: 'Another incomplete reason',
 						validationOutcome: 'Incomplete'
 					});
@@ -852,7 +892,7 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						incompleteReasons: [1, 10],
-						lpaQuestionnaireDueDate: '2023-06-21',
+						lpaQuestionnaireDueDate: '2099-06-22',
 						validationOutcome: 'Incomplete'
 					});
 

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.validators.js
@@ -7,9 +7,11 @@ import {
 	ERROR_MUST_BE_STRING,
 	ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME,
 	ERROR_VALID_VALIDATION_OUTCOME_NO_REASONS,
+	ERROR_MUST_BE_IN_FUTURE,
 	MAX_LENGTH_4000
 } from '../constants.js';
 import { isOutcomeIncomplete, isOutcomeInvalid } from '#utils/check-validation-outcome.js';
+import { dateIsAfterDate } from '#utils/date-comparison.js';
 import validateDateParameter from '#common/validators/date-parameter.js';
 import validateIdParameter from '#common/validators/id-parameter.js';
 import validateNumberArrayParameter from '#common/validators/number-array-parameter.js';
@@ -67,7 +69,23 @@ const patchLPAQuestionnaireValidator = composeMiddleware(
 
 			return value;
 		}),
-	validateDateParameter('lpaQuestionnaireDueDate'),
+	validateDateParameter(
+		'lpaQuestionnaireDueDate',
+		(
+			/** @type {any} */ value,
+			/** @type {{ req: { body: { validationOutcome: string } } }} */ { req }
+		) => {
+			if (value && !isOutcomeIncomplete(req.body.validationOutcome)) {
+				throw new Error(ERROR_ONLY_FOR_INCOMPLETE_VALIDATION_OUTCOME);
+			}
+
+			if (value && !dateIsAfterDate(new Date(value), new Date())) {
+				throw new Error(ERROR_MUST_BE_IN_FUTURE);
+			}
+
+			return value;
+		}
+	),
 	validateBooleanParameter('isListedBuilding'),
 	validateBooleanParameter('doesAffectAListedBuilding'),
 	validateBooleanParameter('doesAffectAScheduledMonument'),

--- a/appeals/api/src/server/utils/__tests__/date-comparison.test.js
+++ b/appeals/api/src/server/utils/__tests__/date-comparison.test.js
@@ -1,0 +1,15 @@
+import { dateIsAfterDate } from '#utils/date-comparison.js';
+
+describe('date is after date', () => {
+	test('returns false if date is before afterDate', () => {
+		expect(dateIsAfterDate(new Date('January 1, 2023'), new Date('January 2, 2023'))).toBe(false);
+	});
+
+	test('returns false if date is same as afterDate', () => {
+		expect(dateIsAfterDate(new Date('January 1, 2023'), new Date('January 1, 2023'))).toBe(false);
+	});
+
+	test('returns true if date is after afterDate', () => {
+		expect(dateIsAfterDate(new Date('January 2, 2023'), new Date('January 1, 2023'))).toBe(true);
+	});
+});

--- a/appeals/api/src/server/utils/date-comparison.js
+++ b/appeals/api/src/server/utils/date-comparison.js
@@ -1,0 +1,9 @@
+/**
+ *
+ * @param {Date} date
+ * @param {Date} afterDate
+ * @returns {boolean}
+ */
+export const dateIsAfterDate = (date, afterDate) => {
+	return date.getTime() > afterDate.getTime();
+};


### PR DESCRIPTION
## Describe your changes

API updates to disallow updated due dates which are in the past for lpaq and appellant case incomplete flows

## Issue ticket number and link

BOAT-445

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
