### PR TITLE
fix(web): arrange site visit unaccompanied visit type should not require times

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
@@ -1049,7 +1049,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                 <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="visit-type" name="visit-type" type="radio"
-                        value="unaccompanied" checked>
+                        value="unaccompanied">
                         <label class="govuk-label govuk-radios__label" for="visit-type">Unaccompanied</label>
                     </div>
                     <div class="govuk-radios__item">
@@ -1059,7 +1059,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                     </div>
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="visit-type-3" name="visit-type"
-                        type="radio" value="accompanied">
+                        type="radio" value="accompanied" checked>
                         <label class="govuk-label govuk-radios__label" for="visit-type-3">Accompanied</label>
                     </div>
                 </div>
@@ -1167,7 +1167,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                 <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="visit-type" name="visit-type" type="radio"
-                        value="unaccompanied" checked>
+                        value="unaccompanied">
                         <label class="govuk-label govuk-radios__label" for="visit-type">Unaccompanied</label>
                     </div>
                     <div class="govuk-radios__item">
@@ -1177,7 +1177,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                     </div>
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="visit-type-3" name="visit-type"
-                        type="radio" value="accompanied">
+                        type="radio" value="accompanied" checked>
                         <label class="govuk-label govuk-radios__label" for="visit-type-3">Accompanied</label>
                     </div>
                 </div>
@@ -1285,7 +1285,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                 <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="visit-type" name="visit-type" type="radio"
-                        value="unaccompanied" checked>
+                        value="unaccompanied">
                         <label class="govuk-label govuk-radios__label" for="visit-type">Unaccompanied</label>
                     </div>
                     <div class="govuk-radios__item">
@@ -1295,7 +1295,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                     </div>
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="visit-type-3" name="visit-type"
-                        type="radio" value="accompanied">
+                        type="radio" value="accompanied" checked>
                         <label class="govuk-label govuk-radios__label" for="visit-type-3">Accompanied</label>
                     </div>
                 </div>
@@ -1403,7 +1403,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                 <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="visit-type" name="visit-type" type="radio"
-                        value="unaccompanied" checked>
+                        value="unaccompanied">
                         <label class="govuk-label govuk-radios__label" for="visit-type">Unaccompanied</label>
                     </div>
                     <div class="govuk-radios__item">
@@ -1413,7 +1413,7 @@ exports[`site-visit POST /site-visit/schedule-visit should re-render the schedul
                     </div>
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="visit-type-3" name="visit-type"
-                        type="radio" value="accompanied">
+                        type="radio" value="accompanied" checked>
                         <label class="govuk-label govuk-radios__label" for="visit-type-3">Accompanied</label>
                     </div>
                 </div>

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/site-visit.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/site-visit.test.js
@@ -175,7 +175,7 @@ describe('site-visit', () => {
 
 		it('should re-render the schedule visit page with the expected error message if visit start time hour is invalid', async () => {
 			const response = await request.post(`${baseUrl}/1${siteVisitPath}${scheduleVisitPath}`).send({
-				'visit-type': 'unaccompanied',
+				'visit-type': 'accompanied',
 				'visit-date-day': '1',
 				'visit-date-month': '1',
 				'visit-date-year': '2023',
@@ -192,7 +192,7 @@ describe('site-visit', () => {
 
 		it('should re-render the schedule visit page with the expected error message if visit start time minute is invalid', async () => {
 			const response = await request.post(`${baseUrl}/1${siteVisitPath}${scheduleVisitPath}`).send({
-				'visit-type': 'unaccompanied',
+				'visit-type': 'accompanied',
 				'visit-date-day': '1',
 				'visit-date-month': '1',
 				'visit-date-year': '2023',
@@ -209,7 +209,7 @@ describe('site-visit', () => {
 
 		it('should re-render the schedule visit page with the expected error message if visit end time hour is invalid', async () => {
 			const response = await request.post(`${baseUrl}/1${siteVisitPath}${scheduleVisitPath}`).send({
-				'visit-type': 'unaccompanied',
+				'visit-type': 'accompanied',
 				'visit-date-day': '1',
 				'visit-date-month': '1',
 				'visit-date-year': '2023',
@@ -226,7 +226,7 @@ describe('site-visit', () => {
 
 		it('should re-render the schedule visit page with the expected error message if visit end time minute is invalid', async () => {
 			const response = await request.post(`${baseUrl}/1${siteVisitPath}${scheduleVisitPath}`).send({
-				'visit-type': 'unaccompanied',
+				'visit-type': 'accompanied',
 				'visit-date-day': '1',
 				'visit-date-month': '1',
 				'visit-date-year': '2023',
@@ -243,7 +243,7 @@ describe('site-visit', () => {
 
 		it('should redirect to the site visit scheduled confirmation page if all required fields are populated and valid', async () => {
 			const response = await request.post(`${baseUrl}/1${siteVisitPath}${scheduleVisitPath}`).send({
-				'visit-type': 'unaccompanied',
+				'visit-type': 'accompanied',
 				'visit-date-day': '1',
 				'visit-date-month': '1',
 				'visit-date-year': '2023',
@@ -251,6 +251,21 @@ describe('site-visit', () => {
 				'visit-start-time-minute': '00',
 				'visit-end-time-hour': '11',
 				'visit-end-time-minute': '30'
+			});
+
+			expect(response.statusCode).toBe(302);
+		});
+
+		it('should redirect to the site visit scheduled confirmation page if visit type is unaccompanied and start and end times are not populated but all other required fields are populated and valid', async () => {
+			const response = await request.post(`${baseUrl}/1${siteVisitPath}${scheduleVisitPath}`).send({
+				'visit-type': 'unaccompanied',
+				'visit-date-day': '1',
+				'visit-date-month': '1',
+				'visit-date-year': '2023',
+				'visit-start-time-hour': '',
+				'visit-start-time-minute': '',
+				'visit-end-time-hour': '',
+				'visit-end-time-minute': ''
 			});
 
 			expect(response.statusCode).toBe(302);

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/site-visit.validators.js
@@ -8,5 +8,19 @@ export const validateSiteVisitType = createValidator(
 );
 
 export const validateVisitDate = createDateInputValidator('visit-date', 'visit date');
-export const validateVisitStartTime = createTimeInputValidator('visit-start-time', 'start time');
-export const validateVisitEndTime = createTimeInputValidator('visit-end-time', 'end time');
+export const validateVisitStartTime = createTimeInputValidator(
+	'visit-start-time',
+	'start time',
+	// @ts-ignore
+	(value, { req }) => {
+		return req.body['visit-type'] !== 'unaccompanied';
+	}
+);
+export const validateVisitEndTime = createTimeInputValidator(
+	'visit-end-time',
+	'end time',
+	// @ts-ignore
+	(value, { req }) => {
+		return req.body['visit-type'] !== 'unaccompanied';
+	}
+);

--- a/appeals/web/src/server/lib/validators/time-input.validator.js
+++ b/appeals/web/src/server/lib/validators/time-input.validator.js
@@ -4,10 +4,14 @@ import { capitalize } from 'lodash-es';
 
 export const createTimeInputValidator = (
 	fieldNamePrefix = 'time',
-	messageFieldNamePrefix = 'time'
+	messageFieldNamePrefix = 'time',
+	// @ts-ignore
+	// eslint-disable-next-line no-unused-vars
+	continueValidationCondition = (value) => true
 ) =>
 	createValidator(
 		body(`${fieldNamePrefix}-hour`)
+			.if(continueValidationCondition)
 			.trim()
 			.notEmpty()
 			.withMessage(
@@ -32,6 +36,7 @@ export const createTimeInputValidator = (
 				)
 			),
 		body(`${fieldNamePrefix}-minute`)
+			.if(continueValidationCondition)
 			.trim()
 			.notEmpty()
 			.withMessage(


### PR DESCRIPTION
arrange site visit unaccompanied visit type should not require times

## Describe your changes

Update validation for set site visit route to make start and end times optional for unaccompanied visit type

## Issue ticket number and link

BOAT-424

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
