### PR TITLE
feat(api): set unpublishedUpdates when deleting contact from published representation

### DIFF
--- a/apps/api/src/server/applications/application/representations/contacts/__tests___/delete-contact.test.js
+++ b/apps/api/src/server/applications/application/representations/contacts/__tests___/delete-contact.test.js
@@ -10,21 +10,53 @@ const existingRepresentations = [
 		status: 'VALID',
 		redacted: true,
 		received: '2023-03-14T14:28:25.704Z'
+	},
+	{
+		id: 2,
+		representationId: 200,
+		reference: 'BC0110001-3',
+		status: 'PUBLISHED',
+		redacted: true,
+		received: '2023-03-14T14:28:25.704Z',
+		unpublishedUpdates: false
 	}
 ];
 
 describe('Delete Application Representation Contact', () => {
 	beforeAll(() => {
-		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[0]);
 		databaseConnector.representation.findMany.mockResolvedValue(existingRepresentations);
 	});
 
 	it('Delete representation contact', async () => {
+		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[0]);
 		databaseConnector.representationContact.delete.mockResolvedValue();
+
+		const response = await request
+			.delete('/applications/1/representations/2/contacts/1')
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual({
+			contactId: '1'
+		});
+	});
+
+	it('Delete published representation contact', async () => {
+		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[1]);
+		databaseConnector.representationContact.delete.mockResolvedValue();
+
 		const response = await request
 			.delete('/applications/1/representations/1/contacts/1')
 			.set('Content-Type', 'application/json')
 			.set('Accept', 'application/json');
+
+		expect(databaseConnector.representation.update).toHaveBeenCalledWith({
+			where: { id: 2 },
+			data: {
+				unpublishedUpdates: true
+			}
+		});
 
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual({


### PR DESCRIPTION
## Describe your changes

ASB-1737

Set `unpublishedUpdates` to `true` when deleting Contact from Representation that has been published (`status = 'PUBLISHED'`)

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
