### PR TITLE
feat(api): setting representation unpublishedupdates flag when updating rep

### DIFF
--- a/apps/api/src/server/applications/application/representations/__tests__/patch-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/patch-representation.test.js
@@ -5,10 +5,19 @@ const { databaseConnector } = await import('../../../../utils/database-connector
 const existingRepresentations = [
 	{
 		id: 1,
-		representationId: 200,
+		caseId: 200,
 		reference: 'BC0110001-2',
 		status: 'VALID',
 		redacted: true,
+		received: '2023-03-14T14:28:25.704Z'
+	},
+	{
+		id: 2,
+		caseId: 200,
+		reference: 'BC0110001-3',
+		status: 'PUBLISHED',
+		redacted: true,
+		unpublishedUpdates: false,
 		received: '2023-03-14T14:28:25.704Z'
 	}
 ];
@@ -139,6 +148,29 @@ describe('Patch Application Representation', () => {
 		expect(response.body).toEqual({
 			id: 1,
 			status: 'VALID'
+		});
+	});
+
+	it('Patch published representation - set unpublishedUpdates', async () => {
+		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[1]);
+
+		const response = await request
+			.patch('/applications/1/representations/2')
+			.send({ originalRepresentation: 'Updated original rep' })
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		expect(databaseConnector.representation.update).toHaveBeenCalledWith({
+			data: {
+				originalRepresentation: 'Updated original rep',
+				unpublishedUpdates: true
+			},
+			where: { id: 2 }
+		});
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual({
+			id: 2,
+			status: 'PUBLISHED'
 		});
 	});
 });

--- a/apps/api/src/server/applications/application/representations/attachment/__tests__/delete-attachment.test.js
+++ b/apps/api/src/server/applications/application/representations/attachment/__tests__/delete-attachment.test.js
@@ -5,22 +5,32 @@ const { databaseConnector } = await import('../../../../../utils/database-connec
 const existingRepresentations = [
 	{
 		id: 1,
-		representationId: 200,
+		caseId: 200,
 		reference: 'BC0110001-2',
 		status: 'VALID',
 		redacted: true,
 		received: '2023-03-14T14:28:25.704Z',
 		attachment: [{ id: 1 }]
+	},
+	{
+		id: 2,
+		caseId: 200,
+		reference: 'BC0110001-3',
+		status: 'PUBLISHED',
+		redacted: true,
+		received: '2023-03-14T14:28:25.704Z',
+		unpublishedUpdates: false,
+		attachment: [{ id: 2 }]
 	}
 ];
 
 describe('Delete Application Representation Attachment', () => {
 	beforeAll(() => {
-		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[0]);
 		databaseConnector.representation.findMany.mockResolvedValue(existingRepresentations);
 	});
 
 	it('Delete Representation Attachment', async () => {
+		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[0]);
 		databaseConnector.representationAttachment.delete.mockResolvedValue({ id: '1' });
 		databaseConnector.document.update.mockResolvedValue({ id: '1' });
 		const response = await request
@@ -31,6 +41,29 @@ describe('Delete Application Representation Attachment', () => {
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual({
 			attachmentId: '1'
+		});
+	});
+
+	it('Delete Published Representation Attachment', async () => {
+		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[1]);
+		databaseConnector.representationAttachment.delete.mockResolvedValue({ id: '2' });
+		databaseConnector.document.update.mockResolvedValue({ id: '2' });
+
+		const response = await request
+			.delete('/applications/1/representations/2/attachment/2')
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		expect(databaseConnector.representation.update).toHaveBeenCalledWith({
+			where: { id: 2 },
+			data: {
+				unpublishedUpdates: true
+			}
+		});
+
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual({
+			attachmentId: '2'
 		});
 	});
 });

--- a/apps/api/src/server/applications/application/representations/attachment/__tests__/post-attachment.test.js
+++ b/apps/api/src/server/applications/application/representations/attachment/__tests__/post-attachment.test.js
@@ -5,22 +5,32 @@ const { databaseConnector } = await import('../../../../../utils/database-connec
 const existingRepresentations = [
 	{
 		id: 1,
-		representationId: 200,
+		caseId: 200,
 		reference: 'BC0110001-2',
 		status: 'VALID',
 		redacted: true,
+		received: '2023-03-14T14:28:25.704Z'
+	},
+	{
+		id: 2,
+		caseId: 200,
+		reference: 'BC0110001-3',
+		status: 'PUBLISHED',
+		redacted: true,
+		unpublishedUpdates: false,
 		received: '2023-03-14T14:28:25.704Z'
 	}
 ];
 
 describe('Post Application Representation Attachment', () => {
 	beforeAll(() => {
-		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[0]);
 		databaseConnector.representation.findMany.mockResolvedValue(existingRepresentations);
 	});
 
 	it('Post Representation Attachment', async () => {
+		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[0]);
 		databaseConnector.representationAttachment.create.mockResolvedValue({ id: '1' });
+
 		const response = await request
 			.post('/applications/1/representations/1/attachment')
 			.send({
@@ -32,6 +42,31 @@ describe('Post Application Representation Attachment', () => {
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual({
 			attachmentId: '1'
+		});
+	});
+
+	it('Post Published Representation Attachment', async () => {
+		databaseConnector.representation.findFirst.mockResolvedValue(existingRepresentations[1]);
+		databaseConnector.representationAttachment.create.mockResolvedValue({ id: '2' });
+
+		const response = await request
+			.post('/applications/1/representations/2/attachment')
+			.send({
+				documentId: '1'
+			})
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		expect(databaseConnector.representation.update).toHaveBeenCalledWith({
+			where: { id: 2 },
+			data: {
+				unpublishedUpdates: true
+			}
+		});
+
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual({
+			attachmentId: '2'
 		});
 	});
 });

--- a/apps/api/src/server/applications/application/representations/attachment/attachment.controller.js
+++ b/apps/api/src/server/applications/application/representations/attachment/attachment.controller.js
@@ -33,7 +33,7 @@ export const addRepresentationAttachment = async ({ params, body }, response) =>
 
 /**
  *
- * @type {import("express").RequestHandler<{id: number}, ?, import("@pins/applications").deleteRepresentationAttachment>}
+ * @type {import("express").RequestHandler<{repId: number, attachmentId: number}, ?, import("@pins/applications").deleteRepresentationAttachment>}
  */
 export const deleteRepresentationAttachment = async ({ params }, response) => {
 	const { repId, attachmentId } = params;

--- a/apps/api/src/server/applications/application/representations/attachment/attachment.controller.js
+++ b/apps/api/src/server/applications/application/representations/attachment/attachment.controller.js
@@ -36,10 +36,10 @@ export const addRepresentationAttachment = async ({ params, body }, response) =>
  * @type {import("express").RequestHandler<{id: number}, ?, import("@pins/applications").deleteRepresentationAttachment>}
  */
 export const deleteRepresentationAttachment = async ({ params }, response) => {
-	const { attachmentId } = params;
+	const { repId, attachmentId } = params;
 
 	try {
-		const { id } = await deleteAttachmentRepresentation(Number(attachmentId));
+		const { id } = await deleteAttachmentRepresentation(Number(repId), Number(attachmentId));
 		return response.send({ attachmentId: id });
 	} catch (error) {
 		if (error instanceof Prisma.PrismaClientKnownRequestError) {

--- a/apps/api/src/server/applications/application/representations/attachment/attachment.service.js
+++ b/apps/api/src/server/applications/application/representations/attachment/attachment.service.js
@@ -4,6 +4,6 @@ export const addAttachmentRepresentation = async (repId, documentId) => {
 	return representationsRepository.addApplicationRepresentationAttachment(repId, documentId);
 };
 
-export const deleteAttachmentRepresentation = async (attachmentId) => {
-	return representationsRepository.deleteApplicationRepresentationAttachment(attachmentId);
+export const deleteAttachmentRepresentation = async (repId, attachmentId) => {
+	return representationsRepository.deleteApplicationRepresentationAttachment(repId, attachmentId);
 };

--- a/apps/api/src/server/repositories/representation.repository.js
+++ b/apps/api/src/server/repositories/representation.repository.js
@@ -257,6 +257,8 @@ export const updateApplicationRepresentation = async (
 	if (!response)
 		throw new Error(`Representation Id ${representationId} does not belong to case Id ${caseId}`);
 
+	if (response.status === 'PUBLISHED') representationDetails.unpublishedUpdates = true;
+
 	const whereIsRepresented = {
 		OR: [
 			{
@@ -386,10 +388,10 @@ export const updateApplicationRepresentationRedaction = async (
 		where: { id: representationId, caseId }
 	});
 
-	if (response.status === 'PUBLISHED') representation.unpublishedUpdates = true;
-
 	if (!response)
 		throw new Error(`Representation Id ${representationId} does not belong to case Id ${caseId}`);
+
+	if (response.status === 'PUBLISHED') representation.unpublishedUpdates = true;
 
 	if (!isEmpty(representation)) {
 		await databaseConnector.representation.update({


### PR DESCRIPTION
## Describe your changes

ASB-1741, ASB-1743, ASB-1732

Set `unpublishedUpdates` to `true` when updating a Representation that has already been published (`status = 'PUBLISHED'`)

1. 48892fa8 - when calling `PATCH /representation/:repid`
2. 1e8ebf98 - `POST /representation/:repid/attachment`
3. 7a83971b - `DELETE /representation/:repid/attachment/:id`

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
