### PR TITLE
feat(api): publish event when unpublishing representation

### DIFF
--- a/apps/api/src/message-schemas/events/nsip-document.schema.json
+++ b/apps/api/src/message-schemas/events/nsip-document.schema.json
@@ -15,7 +15,7 @@
 	"properties": {
 		"documentId": {
 			"type": "string",
-			"examples": ["ID23343453"],
+			"examples": ["01c958f2-4e9f-4ce2-adf9-81038702cafa"],
 			"description": "The unique identifier for the file. This will be different to documentReference"
 		},
 		"caseId": {
@@ -29,7 +29,7 @@
 		},
 		"documentReference": {
 			"type": "string",
-			"examples": ["EN010120_1"],
+			"examples": ["WA0110015-000002"],
 			"description": "Reference used throughout ODT <CaseRef>-<SequenceNo>"
 		},
 		"version": {

--- a/apps/api/src/message-schemas/events/nsip-representation.schema.json
+++ b/apps/api/src/message-schemas/events/nsip-representation.schema.json
@@ -12,7 +12,7 @@
 	],
 	"properties": {
 		"representationId": {
-			"type": "string"
+			"type": "number"
 		},
 		"referenceId": {
 			"examples": ["TR043003-000010"],
@@ -24,6 +24,11 @@
 		},
 		"caseRef": {
 			"type": "string"
+		},
+		"caseId": {
+			"type": "number",
+			"examples": [1242],
+			"description": "The unique identifier within the Back Office. This is not the same as the case reference"
 		},
 		"status": {
 			"type": "string",

--- a/apps/api/src/server/applications/application/representations/publish/__tests__/publish-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/publish/__tests__/publish-representation.test.js
@@ -1,8 +1,8 @@
-import { request } from '../../../../app-test.js';
-import { eventClient } from '../../../../infrastructure/event-client.js';
+import { request } from '#app-test';
+import { eventClient } from '#infrastructure/event-client.js';
 import { jest } from '@jest/globals';
 
-const { databaseConnector } = await import('../../../../utils/database-connector.js');
+const { databaseConnector } = await import('#utils/database-connector.js');
 
 const representations = [
 	{
@@ -132,6 +132,7 @@ const expectedEventPayload = [
 			}
 		],
 		caseRef: 'BC0110001',
+		caseId: 151,
 		dateReceived: '2023-08-11T10:52:56.516Z',
 		examinationLibraryRef: '',
 		originalRepresentation: 'some rep text secret stuff',
@@ -160,6 +161,7 @@ const expectedEventPayload = [
 	{
 		attachments: [],
 		caseRef: 'BC0110001',
+		caseId: 151,
 		dateReceived: '2023-08-11T10:52:56.516Z',
 		examinationLibraryRef: '',
 		originalRepresentation: 'some words',

--- a/apps/api/src/server/applications/application/representations/publish/publish.service.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.service.js
@@ -2,7 +2,10 @@ import * as representationsRepository from '#repositories/representation.reposit
 import { eventClient } from '#infrastructure/event-client.js';
 import { NSIP_REPRESENTATION } from '#infrastructure/topics.js';
 import { EventType } from '@pins/event-client';
-import { buildNsipRepresentationPayload } from './representation.js';
+import {
+	buildNsipRepresentationPayload,
+	buildNsipRepresentationStatusUpdatePayload
+} from './representation.js';
 import { setRepresentationsAsPublished } from '#repositories/representation.repository.js';
 
 export const publishCaseRepresentations = async (caseId, representationIds, actionBy) => {
@@ -18,3 +21,10 @@ export const publishCaseRepresentations = async (caseId, representationIds, acti
 
 	return representations;
 };
+
+export const publishRepresentationStatusUpdate = async (representation, newStatus) =>
+	eventClient.sendEvents(
+		NSIP_REPRESENTATION,
+		buildNsipRepresentationStatusUpdatePayload(representation, newStatus),
+		EventType.Update
+	);

--- a/apps/api/src/server/applications/application/representations/publish/representation.js
+++ b/apps/api/src/server/applications/application/representations/publish/representation.js
@@ -1,9 +1,15 @@
+/**
+ *
+ * @param {Representation} representation
+ * @returns {{representationType: *, attachments: *, representationId: *, originalRepresentation: *, representationFrom: *, examinationLibraryRef: string, referenceId: *, caseRef: *, dateReceived: *, caseId: *, represented: ({}|{firstName: *, lastName: *, under18: *, organisationName: *, emailAddress: *, telephone: *, id: *, contactMethod: *}), representative: ({}|{firstName: *, lastName: *, under18: *, organisationName: *, emailAddress: *, telephone: *, id: *, contactMethod: *}), registerFor: *, status: *}|{caseRef: *, representationType: *, attachments: *, representationId: *, redacted, redactedRepresentation, dateReceived: *, caseId: *, originalRepresentation: *, examinationLibraryRef: string, referenceId: *, status: *}|{redactedBy, redactedNotes, caseRef: *, representationType: *, attachments: *, representationId: *, dateReceived: *, caseId: *, originalRepresentation: *, examinationLibraryRef: string, referenceId: *, status: *}}
+ */
 export const buildNsipRepresentationPayload = (representation) => {
 	let nsipRepresentation = {
 		representationId: representation.id,
 		referenceId: representation.reference,
 		examinationLibraryRef: '',
 		caseRef: representation.case.reference,
+		caseId: representation.caseId,
 		status: representation.status,
 		originalRepresentation: representation.originalRepresentation,
 		representationType: representation.type,
@@ -42,6 +48,20 @@ export const buildNsipRepresentationPayload = (representation) => {
 	}
 
 	return nsipRepresentation;
+};
+
+/**
+ *
+ * @param {Prisma.RepresentationSelect} representation
+ * @param {string} newStatus
+ * @returns {{}|{representationId, status}}
+ */
+export const buildNsipRepresentationStatusUpdatePayload = (representation, newStatus) => {
+	if (!representation) return {};
+	return {
+		representationId: representation.id,
+		status: newStatus
+	};
 };
 
 const buildNsipInterestedPartyPayload = (representationContact) => {

--- a/apps/api/src/server/applications/application/representations/publishable/__tests__/publishable-representations.test.js
+++ b/apps/api/src/server/applications/application/representations/publishable/__tests__/publishable-representations.test.js
@@ -1,6 +1,6 @@
-import { request } from '../../../../app-test.js';
+import { request } from '#app-test';
 
-const { databaseConnector } = await import('../../../../utils/database-connector.js');
+const { databaseConnector } = await import('#utils/database-connector.js');
 
 const representations = [
 	{

--- a/apps/api/src/server/applications/application/representations/representaions.service.js
+++ b/apps/api/src/server/applications/application/representations/representaions.service.js
@@ -15,7 +15,7 @@ export const getCaseRepresentations = async (caseId, pagination, filterAndSort) 
  *
  * @param {number} caseId
  * @param {number} repId
- * @returns {Promise<object>}
+ * @returns {Promise<Prisma.RepresentationSelect>}
  */
 export const getCaseRepresentation = async (caseId, repId) => {
 	return representationsRepository.getById(Number(repId), Number(caseId));

--- a/apps/api/src/server/applications/application/representations/status/status.service.js
+++ b/apps/api/src/server/applications/application/representations/status/status.service.js
@@ -1,5 +1,18 @@
 import * as representationsRepository from '../../../../repositories/representation.repository.js';
+import { publishRepresentationStatusUpdate } from '../publish/publish.service.js';
 
 export const updateStatusRepresentation = async (repId, action) => {
-	return representationsRepository.updateApplicationRepresentationStatusById(repId, action);
+	const representation = await representationsRepository.getFirstById(repId);
+
+	const previousStatus = representation.status;
+	const newStatus = action.status;
+	const unpublished = previousStatus === 'PUBLISHED' && newStatus !== 'PUBLISHED';
+
+	if (unpublished) await publishRepresentationStatusUpdate(representation, newStatus);
+
+	return representationsRepository.updateApplicationRepresentationStatusById(
+		representation,
+		action,
+		unpublished
+	);
 };

--- a/apps/api/src/server/repositories/__tests__/representation.repository.test.js
+++ b/apps/api/src/server/repositories/__tests__/representation.repository.test.js
@@ -433,6 +433,70 @@ describe('Representation repository', () => {
 	});
 
 	describe('getById', () => {
+		const expectedSelect = {
+			id: true,
+			reference: true,
+			status: true,
+			redacted: true,
+			received: true,
+			originalRepresentation: true,
+			redactedRepresentation: true,
+			type: true,
+			user: {
+				select: {
+					azureReference: true
+				}
+			},
+			contacts: {
+				select: {
+					id: true,
+					type: true,
+					firstName: true,
+					lastName: true,
+					organisationName: true,
+					jobTitle: true,
+					under18: true,
+					email: true,
+					contactMethod: true,
+					phoneNumber: true,
+					address: {
+						select: {
+							addressLine1: true,
+							addressLine2: true,
+							town: true,
+							county: true,
+							postcode: true,
+							country: true
+						}
+					}
+				}
+			},
+			representationActions: {
+				select: {
+					actionBy: true,
+					actionDate: true,
+					invalidReason: true,
+					notes: true,
+					previousRedactStatus: true,
+					previousStatus: true,
+					redactStatus: true,
+					referredTo: true,
+					status: true,
+					type: true
+				},
+				orderBy: {
+					actionDate: 'desc'
+				}
+			},
+			attachments: {
+				select: {
+					Document: true,
+					documentGuid: true,
+					id: true
+				}
+			}
+		};
+
 		it('finds a representation by id', async () => {
 			databaseConnector.representation.findMany.mockResolvedValue(existingRepresentations);
 
@@ -440,69 +504,7 @@ describe('Representation repository', () => {
 
 			expect(representation).toEqual(existingRepresentations[0]);
 			expect(databaseConnector.representation.findMany).toHaveBeenCalledWith({
-				select: {
-					id: true,
-					reference: true,
-					status: true,
-					redacted: true,
-					received: true,
-					originalRepresentation: true,
-					redactedRepresentation: true,
-					type: true,
-					user: {
-						select: {
-							azureReference: true
-						}
-					},
-					contacts: {
-						select: {
-							id: true,
-							type: true,
-							firstName: true,
-							lastName: true,
-							organisationName: true,
-							jobTitle: true,
-							under18: true,
-							email: true,
-							contactMethod: true,
-							phoneNumber: true,
-							address: {
-								select: {
-									addressLine1: true,
-									addressLine2: true,
-									town: true,
-									county: true,
-									postcode: true,
-									country: true
-								}
-							}
-						}
-					},
-					representationActions: {
-						select: {
-							actionBy: true,
-							actionDate: true,
-							invalidReason: true,
-							notes: true,
-							previousRedactStatus: true,
-							previousStatus: true,
-							redactStatus: true,
-							referredTo: true,
-							status: true,
-							type: true
-						},
-						orderBy: {
-							actionDate: 'desc'
-						}
-					},
-					attachments: {
-						select: {
-							Document: true,
-							documentGuid: true,
-							id: true
-						}
-					}
-				},
+				select: expectedSelect,
 				where: {
 					id: 1
 				}
@@ -516,74 +518,35 @@ describe('Representation repository', () => {
 
 			expect(representation).toEqual(existingRepresentations[0]);
 			expect(databaseConnector.representation.findMany).toHaveBeenCalledWith({
-				select: {
-					id: true,
-					reference: true,
-					status: true,
-					redacted: true,
-					received: true,
-					originalRepresentation: true,
-					redactedRepresentation: true,
-					type: true,
-					user: {
-						select: {
-							azureReference: true
-						}
-					},
-					contacts: {
-						select: {
-							id: true,
-							type: true,
-							firstName: true,
-							lastName: true,
-							organisationName: true,
-							jobTitle: true,
-							under18: true,
-							email: true,
-							contactMethod: true,
-							phoneNumber: true,
-							address: {
-								select: {
-									addressLine1: true,
-									addressLine2: true,
-									town: true,
-									county: true,
-									postcode: true,
-									country: true
-								}
-							}
-						}
-					},
-					representationActions: {
-						select: {
-							actionBy: true,
-							actionDate: true,
-							invalidReason: true,
-							notes: true,
-							previousRedactStatus: true,
-							previousStatus: true,
-							redactStatus: true,
-							referredTo: true,
-							status: true,
-							type: true
-						},
-						orderBy: {
-							actionDate: 'desc'
-						}
-					},
-					attachments: {
-						select: {
-							Document: true,
-							documentGuid: true,
-							id: true
-						}
-					}
-				},
+				select: expectedSelect,
 				where: {
 					case: {
 						id: 2
 					},
 					id: 1
+				}
+			});
+		});
+	});
+
+	describe('getFirstById', () => {
+		it('finds first representation by id', async () => {
+			await representationRepository.getFirstById(1);
+
+			expect(databaseConnector.representation.findFirst).toHaveBeenCalledWith({
+				where: {
+					id: 1
+				}
+			});
+		});
+
+		it('finds first representation by id and caseId', async () => {
+			await representationRepository.getFirstById(1, 2);
+
+			expect(databaseConnector.representation.findFirst).toHaveBeenCalledWith({
+				where: {
+					id: 1,
+					caseId: 2
 				}
 			});
 		});


### PR DESCRIPTION
## Describe your changes

ASB-1742

A change to the `PATCH /applications/{id}/representations/{repId}/status` endpoint:

When changing the status of a `Representation` from `PUBLISHED` to another value:
1. publish a `Update` event to the `nsip-representations` topic containing the `Representation` details. 
2. also set the `unpublishedUpdates` flag to `false`.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
