### PR TITLE
fix(appeals/api): allow unaccompanied site visits to be saved without a visit time

### DIFF
--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -47,7 +47,7 @@ export const ERROR_MUST_CONTAIN_AT_LEAST_1_VALUE = 'Must contain at least one va
 export const ERROR_MUST_HAVE_DETAILS =
 	'Must have {replacement0} when {replacement1} is {replacement2}';
 export const ERROR_MUST_NOT_CONTAIN_VALIDATION_OUTCOME_REASONS =
-	'Must not be included when invalidReasons or incompleteReasons does not contain Other';
+	'Must not be given when invalidReasons or incompleteReasons does not contain Other';
 export const ERROR_MUST_NOT_HAVE_DETAILS =
 	'Must not have {replacement0} when {replacement1} is {replacement2}';
 export const ERROR_NOT_FOUND = 'Not found';
@@ -74,6 +74,8 @@ export const MAX_LENGTH_300 = 300;
 export const MAX_LENGTH_4000 = 4000;
 
 export const NODE_ENV_PRODUCTION = 'production';
+
+export const SITE_VISIT_TYPE_UNACCOMPANIED = 'Unaccompanied';
 
 export const STATE_TARGET_ARRANGE_SITE_VISIT = 'arrange_site_visit';
 export const STATE_TARGET_COMPLETE = 'complete';

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -7,13 +7,21 @@ import {
 	ERROR_NOT_FOUND,
 	ERROR_SITE_VISIT_REQUIRED_FIELDS,
 	ERROR_START_TIME_MUST_BE_EARLIER_THAN_END_TIME,
+	SITE_VISIT_TYPE_UNACCOMPANIED,
 	STATE_TARGET_ISSUE_DETERMINATION
 } from '../../constants.js';
-import { householdAppeal } from '../../../tests/data.js';
+import { householdAppeal as householdAppealData } from '../../../tests/data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
 
 describe('site visit routes', () => {
+	/** @type {typeof householdAppealData} */
+	let householdAppeal;
+
+	beforeEach(() => {
+		householdAppeal = JSON.parse(JSON.stringify(householdAppealData));
+	});
+
 	describe('/:appealId/site-visits', () => {
 		describe('POST', () => {
 			test('creates a site visit without updating the status', async () => {
@@ -160,6 +168,35 @@ describe('site visit routes', () => {
 				});
 			});
 
+			test('creates an Unaccompanied site visit without time fields', async () => {
+				const { siteVisit } = householdAppeal;
+
+				siteVisit.siteVisitType.name = SITE_VISIT_TYPE_UNACCOMPANIED;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
+					visitDate: siteVisit.visitDate.split('T')[0],
+					visitType: siteVisit.siteVisitType.name
+				});
+
+				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						visitDate: siteVisit.visitDate,
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
 			test('returns an error if appealId is not numeric', async () => {
 				const response = await request.post('/appeals/one/site-visits').send({
 					visitType: householdAppeal.siteVisit.siteVisitType.name
@@ -223,7 +260,7 @@ describe('site visit routes', () => {
 				});
 			});
 
-			test('returns an error if visitDate is not given when visitEndTime and visitStartTime are given', async () => {
+			test('returns an error if visitType is not Unaccompanied and visitDate is not given when visitEndTime and visitStartTime are given', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
@@ -241,7 +278,7 @@ describe('site visit routes', () => {
 				});
 			});
 
-			test('returns an error if visitEndTime is not given when visitDate and visitStartTime are given', async () => {
+			test('returns an error if visitType is not Unaccompanied and visitEndTime is not given when visitDate and visitStartTime are given', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
@@ -259,7 +296,7 @@ describe('site visit routes', () => {
 				});
 			});
 
-			test('returns an error if visitStartTime is not given when visitDate and visitEndTime are given', async () => {
+			test('returns an error if visitType is not Unaccompanied and visitStartTime is not given when visitDate and visitEndTime are given', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
@@ -603,6 +640,37 @@ describe('site visit routes', () => {
 				});
 			});
 
+			test('updates an Unaccompanied site visit without time fields', async () => {
+				const { siteVisit } = householdAppeal;
+
+				siteVisit.siteVisitType.name = SITE_VISIT_TYPE_UNACCOMPANIED;
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
+
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						visitType: siteVisit.siteVisitType.name
+					});
+
+				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						visitDate: siteVisit.visitDate,
+						siteVisitTypeId: siteVisit.siteVisitType.id
+					}
+				});
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual({
+					visitDate: siteVisit.visitDate,
+					visitType: siteVisit.siteVisitType.name
+				});
+			});
+
 			test('returns an error if appealId is not numeric', async () => {
 				const response = await request
 					.patch(`/appeals/one/site-visits/${householdAppeal.siteVisit.id}`)
@@ -708,7 +776,7 @@ describe('site visit routes', () => {
 				});
 			});
 
-			test('returns an error if visitDate is not given when visitEndTime and visitStartTime are given', async () => {
+			test('returns an error if visitType is not Unaccompanied and visitDate is not given when visitEndTime and visitStartTime are given', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
@@ -728,7 +796,7 @@ describe('site visit routes', () => {
 				});
 			});
 
-			test('returns an error if visitEndTime is not given when visitDate and visitStartTime are given', async () => {
+			test('returns an error if visitType is not Unaccompanied and visitEndTime is not given when visitDate and visitStartTime are given', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
@@ -748,7 +816,7 @@ describe('site visit routes', () => {
 				});
 			});
 
-			test('returns an error if visitStartTime is not given when visitDate and visitEndTime are given', async () => {
+			test('returns an error if visitType is not Unaccompanied and visitStartTime is not given when visitDate and visitEndTime are given', async () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.validators.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.validators.js
@@ -7,10 +7,19 @@ import validateTimeParameter from '#common/validators/time-parameter.js';
 import validateTimeRangeParameters from '#common/validators/time-range-parameters.js';
 import {
 	ERROR_INVALID_SITE_VISIT_TYPE,
-	ERROR_SITE_VISIT_REQUIRED_FIELDS
+	ERROR_SITE_VISIT_REQUIRED_FIELDS,
+	SITE_VISIT_TYPE_UNACCOMPANIED
 } from '#endpoints/constants.js';
+import checkStringsMatch from '#utils/check-strings-match.js';
 
 /** @typedef {import('express-validator').ValidationChain} ValidationChain */
+
+/**
+ * @param {string} visitType
+ * @returns {boolean}
+ */
+const isVisitUnaccompanied = (visitType) =>
+	checkStringsMatch(visitType, SITE_VISIT_TYPE_UNACCOMPANIED);
 
 /**
  * @param {boolean} isRequired
@@ -29,11 +38,13 @@ const validateSiteVisitType = (isRequired = false) => {
 };
 
 const validateSiteVisitRequiredDateTimeFields = param('appealId').custom((value, { req }) => {
-	const { visitDate, visitEndTime, visitStartTime } = req.body;
+	const { visitDate, visitEndTime, visitStartTime, visitType } = req.body;
 
-	if (visitDate || visitStartTime || visitEndTime) {
-		if (!visitDate || !visitStartTime || !visitEndTime) {
-			throw new Error(ERROR_SITE_VISIT_REQUIRED_FIELDS);
+	if (!isVisitUnaccompanied(visitType)) {
+		if (visitDate || visitStartTime || visitEndTime) {
+			if (!visitDate || !visitStartTime || !visitEndTime) {
+				throw new Error(ERROR_SITE_VISIT_REQUIRED_FIELDS);
+			}
 		}
 	}
 

--- a/appeals/api/src/server/utils/check-strings-match.js
+++ b/appeals/api/src/server/utils/check-strings-match.js
@@ -1,0 +1,9 @@
+/**
+ * @param {string} stringA
+ * @param {string} stringB
+ * @returns {boolean}
+ */
+const checkStringsMatch = (stringA, stringB) =>
+	String(stringA).toLowerCase() === String(stringB).toLowerCase();
+
+export default checkStringsMatch;

--- a/appeals/api/src/server/utils/check-validation-outcome.js
+++ b/appeals/api/src/server/utils/check-validation-outcome.js
@@ -3,34 +3,27 @@ import {
 	VALIDATION_OUTCOME_INVALID,
 	VALIDATION_OUTCOME_VALID
 } from '#endpoints/constants.js';
-
-/**
- * @param {string} validationOutcomeParameter
- * @param {string} validationOutcomeConstant
- * @returns {boolean}
- */
-const compareValidationOutcome = (validationOutcomeParameter, validationOutcomeConstant) =>
-	validationOutcomeParameter.toLowerCase() === validationOutcomeConstant.toLowerCase();
+import checkStringsMatch from './check-strings-match.js';
 
 /**
  * @param {string} validationOutcome
  * @returns {boolean}
  */
 const isOutcomeIncomplete = (validationOutcome) =>
-	compareValidationOutcome(validationOutcome, VALIDATION_OUTCOME_INCOMPLETE);
+	checkStringsMatch(validationOutcome, VALIDATION_OUTCOME_INCOMPLETE);
 
 /**
  * @param {string} validationOutcome
  * @returns {boolean}
  */
 const isOutcomeInvalid = (validationOutcome) =>
-	compareValidationOutcome(validationOutcome, VALIDATION_OUTCOME_INVALID);
+	checkStringsMatch(validationOutcome, VALIDATION_OUTCOME_INVALID);
 
 /**
  * @param {string} validationOutcome
  * @returns {boolean}
  */
 const isOutcomeValid = (validationOutcome) =>
-	compareValidationOutcome(validationOutcome, VALIDATION_OUTCOME_VALID);
+	checkStringsMatch(validationOutcome, VALIDATION_OUTCOME_VALID);
 
 export { isOutcomeIncomplete, isOutcomeInvalid, isOutcomeValid };


### PR DESCRIPTION
## Describe your changes

Updated the Appeals Site Visit POST/PATCH API endpoints to allow unaccompanied site visits to be saved without a visit time.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-488

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
