### PR TITLE
fix(appeals/api): add address and appellant ids to the get appellant case api endpoint

### DIFF
--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -207,7 +207,7 @@ describe('appeal timetables routes', () => {
 
 				const { appealTimetable, id } = fullPlanningAppeal;
 				const body = {
-					finalCommentReviewDate: '2023-09-02'
+					finalCommentReviewDate: '2099-09-19'
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
@@ -227,7 +227,7 @@ describe('appeal timetables routes', () => {
 
 				const { appealTimetable, id } = fullPlanningAppeal;
 				const body = {
-					finalCommentReviewDate: '2023-12-25'
+					finalCommentReviewDate: '2025-12-25'
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
@@ -249,7 +249,7 @@ describe('appeal timetables routes', () => {
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
-						finalCommentReviewDate: '2023-02-30'
+						finalCommentReviewDate: '2099-02-30'
 					});
 
 				expect(response.status).toEqual(400);
@@ -346,7 +346,7 @@ describe('appeal timetables routes', () => {
 
 				const { appealTimetable, id } = householdAppeal;
 				const body = {
-					issueDeterminationDate: '2023-09-02'
+					issueDeterminationDate: '2099-09-19'
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
@@ -366,7 +366,7 @@ describe('appeal timetables routes', () => {
 
 				const { appealTimetable, id } = householdAppeal;
 				const body = {
-					issueDeterminationDate: '2023-12-25'
+					issueDeterminationDate: '2025-12-25'
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
@@ -388,7 +388,7 @@ describe('appeal timetables routes', () => {
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
-						issueDeterminationDate: '2023-02-30'
+						issueDeterminationDate: '2099-02-30'
 					});
 
 				expect(response.status).toEqual(400);
@@ -463,7 +463,7 @@ describe('appeal timetables routes', () => {
 
 				const { appealTimetable, id } = householdAppeal;
 				const body = {
-					lpaQuestionnaireDueDate: '2023-09-02'
+					lpaQuestionnaireDueDate: '2099-09-19'
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
@@ -483,7 +483,7 @@ describe('appeal timetables routes', () => {
 
 				const { appealTimetable, id } = householdAppeal;
 				const body = {
-					lpaQuestionnaireDueDate: '2023-12-25'
+					lpaQuestionnaireDueDate: '2025-12-25'
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
@@ -580,7 +580,7 @@ describe('appeal timetables routes', () => {
 
 				const { appealTimetable, id } = fullPlanningAppeal;
 				const body = {
-					statementReviewDate: '2023-09-02'
+					statementReviewDate: '2099-09-19'
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
@@ -600,7 +600,7 @@ describe('appeal timetables routes', () => {
 
 				const { appealTimetable, id } = fullPlanningAppeal;
 				const body = {
-					statementReviewDate: '2023-12-25'
+					statementReviewDate: '2025-12-25'
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -34,6 +34,7 @@ interface LinkedAppeal {
 }
 
 interface AppealSite {
+	addressId?: number;
 	addressLine1?: string;
 	addressLine2?: string;
 	town?: string;
@@ -238,8 +239,9 @@ interface SingleAppellantCaseResponse {
 	appealSite: AppealSite;
 	appellantCaseId: number;
 	appellant: {
-		name: string | null;
+		appellantId: number;
 		company: string | null;
+		name: string | null;
 	};
 	applicant: {
 		firstName: string | null;
@@ -247,8 +249,8 @@ interface SingleAppellantCaseResponse {
 	};
 	planningApplicationReference: string;
 	developmentDescription?: {
-		isCorrect: boolean | null;
 		details: string | null;
+		isCorrect: boolean | null;
 	};
 	documents: {
 		appealStatement: FolderInfo | {};

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
@@ -28,11 +28,15 @@ const formatAppellantCase = (appeal, folders = null) => {
 			}),
 			appealId: appeal.id,
 			appealReference: appeal.reference,
-			appealSite: formatAddress(appeal.address),
+			appealSite: {
+				addressId: appeal.address.id,
+				...formatAddress(appeal.address)
+			},
 			appellantCaseId: appellantCase.id,
 			appellant: {
-				company: appeal.appellant?.company || null,
-				name: appeal.appellant?.name || null
+				appellantId: appeal.appellant.id,
+				company: appeal.appellant.company || null,
+				name: appeal.appellant.name || null
 			},
 			applicant: {
 				firstName: appellantCase.applicantFirstName,

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -2129,6 +2129,10 @@
 					"appealSite": {
 						"type": "object",
 						"properties": {
+							"addressId": {
+								"type": "number",
+								"example": 1
+							},
 							"addressLine1": {
 								"type": "string",
 								"example": "21 The Pavement"
@@ -2150,13 +2154,17 @@
 					"appellant": {
 						"type": "object",
 						"properties": {
-							"name": {
-								"type": "string",
-								"example": "Roger Simmons"
+							"appellantId": {
+								"type": "number",
+								"example": 1
 							},
 							"company": {
 								"type": "string",
 								"example": "Roger Simmons Ltd"
+							},
+							"name": {
+								"type": "string",
+								"example": "Roger Simmons"
 							}
 						}
 					},
@@ -2176,13 +2184,13 @@
 					"developmentDescription": {
 						"type": "object",
 						"properties": {
-							"isCorrect": {
-								"type": "boolean",
-								"example": false
-							},
 							"details": {
 								"type": "string",
 								"example": "A new extension has been added at the back"
+							},
+							"isCorrect": {
+								"type": "boolean",
+								"example": false
 							}
 						}
 					},

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -207,22 +207,24 @@ const document = {
 			appealId: 1,
 			appealReference: 'APP/Q9999/D/21/965625',
 			appealSite: {
+				addressId: 1,
 				addressLine1: '21 The Pavement',
 				county: 'Wandsworth',
 				postCode: 'SW4 0HY'
 			},
 			appellantCaseId: 1,
 			appellant: {
-				name: 'Roger Simmons',
-				company: 'Roger Simmons Ltd'
+				appellantId: 1,
+				company: 'Roger Simmons Ltd',
+				name: 'Roger Simmons'
 			},
 			applicant: {
 				firstName: 'Fiona',
 				surname: 'Burgess'
 			},
 			developmentDescription: {
-				isCorrect: false,
-				details: 'A new extension has been added at the back'
+				details: 'A new extension has been added at the back',
+				isCorrect: false
 			},
 			documents: {
 				appealStatement: {

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -590,16 +590,18 @@ const baseExpectedAppellantCaseResponse = (appeal) => ({
 	appealId: appeal.id,
 	appealReference: appeal.reference,
 	appealSite: {
-		addressLine1: appeal.address?.addressLine1,
-		addressLine2: appeal.address?.addressLine2,
-		town: appeal.address?.town,
-		county: appeal.address?.county,
-		postCode: appeal.address?.postcode
+		addressId: appeal.address.id,
+		addressLine1: appeal.address.addressLine1,
+		addressLine2: appeal.address.addressLine2,
+		town: appeal.address.town,
+		county: appeal.address.county,
+		postCode: appeal.address.postcode
 	},
 	appellantCaseId: appeal.appellantCase?.id,
 	appellant: {
-		name: appeal.appellant?.name,
-		company: appeal.appellant?.company
+		appellantId: appeal.appellant.id,
+		company: appeal.appellant?.company,
+		name: appeal.appellant?.name
 	},
 	applicant: {
 		firstName: appeal.appellantCase?.applicantFirstName,
@@ -607,8 +609,8 @@ const baseExpectedAppellantCaseResponse = (appeal) => ({
 	},
 	...(isFPA(appeal.appealType) && {
 		developmentDescription: {
-			isCorrect: appeal.appellantCase?.isDevelopmentDescriptionStillCorrect,
-			details: appeal.appellantCase?.newDevelopmentDescription
+			details: appeal.appellantCase?.newDevelopmentDescription,
+			isCorrect: appeal.appellantCase?.isDevelopmentDescriptionStillCorrect
 		}
 	}),
 	documents: {


### PR DESCRIPTION
## Describe your changes

Update the Appeals GET Appellant Case API endpoint to return `appellantId` and `addressId` to enable these values to be passed to the relevant Change page so they can be used to save the updated data.

Also updated some dates in the Timetable tests to put them more in the future to prevent false-positive failures for a while longer.

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-427

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
