### PR TITLE
fix(appeals/api): add a default value for test_mailbox env var

### DIFF
--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -57,7 +57,7 @@ const { value, error } = schema.validate({
 				id: '3b4b74b4-b604-411b-9c98-5be2c6f3bdfd'
 			}
 		},
-		testMailbox: environment.TEST_MAILBOX
+		testMailbox: environment.TEST_MAILBOX || 'test@example.com'
 	},
 	bankHolidayFeed: {
 		hostname: 'https://www.gov.uk/bank-holidays.json'


### PR DESCRIPTION
## Describe your changes

Add a default value for `TEST_MAILBOX` env var.

This should fix the issue of the seeding failing in the pipeline because it can't find the TEST_MAILBOX env var.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
