### PR TITLE
fix(tooling): fix prisma version to 4.16.1

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -37,7 +37,7 @@
     "@pins/event-client": "^0.0.0",
     "@pins/express": "^0.0.0",
     "@pins/platform": "^0.0.0",
-    "@prisma/client": "^4.16.1",
+    "@prisma/client": "4.16.1",
     "@supercharge/promise-pool": "^2.4.0",
     "body-parser": "1.20.0",
     "c8": "^7.11.3",
@@ -76,7 +76,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "jest-mock-extended": "^3.0.1",
     "nodemon": "^2.0.18",
-    "prisma": "^4.16.1",
+    "prisma": "4.16.1",
     "rimraf": "^3.0.2",
     "supertest": "6.2.3",
     "swagger-autogen": "^2.21.4"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,7 +38,7 @@
     "@pins/event-client": "^0.0.0",
     "@pins/express": "^0.0.0",
     "@pins/platform": "^0.0.0",
-    "@prisma/client": "^4.16.1",
+    "@prisma/client": "4.16.1",
     "@supercharge/promise-pool": "^2.4.0",
     "body-parser": "1.20.0",
     "c8": "^7.11.3",
@@ -78,7 +78,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "jest-mock-extended": "^3.0.1",
     "nodemon": "^2.0.18",
-    "prisma": "^4.16.1",
+    "prisma": "4.16.1",
     "rimraf": "^3.0.2",
     "supertest": "6.2.3",
     "swagger-autogen": "^2.21.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"typescript": "^4.6.4"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"appeals/api": {
@@ -50,7 +50,7 @@
 				"@pins/event-client": "^0.0.0",
 				"@pins/express": "^0.0.0",
 				"@pins/platform": "^0.0.0",
-				"@prisma/client": "^4.16.1",
+				"@prisma/client": "4.16.1",
 				"@supercharge/promise-pool": "^2.4.0",
 				"body-parser": "1.20.0",
 				"c8": "^7.11.3",
@@ -89,13 +89,13 @@
 				"jest-environment-jsdom": "^29.3.1",
 				"jest-mock-extended": "^3.0.1",
 				"nodemon": "^2.0.18",
-				"prisma": "^4.16.1",
+				"prisma": "4.16.1",
 				"rimraf": "^3.0.2",
 				"supertest": "6.2.3",
 				"swagger-autogen": "^2.21.4"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"appeals/api/node_modules/@jest/console": {
@@ -1645,7 +1645,7 @@
 				"terser": "^5.13.1"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"appeals/web/node_modules/@jest/console": {
@@ -2833,7 +2833,7 @@
 				"@pins/event-client": "^0.0.0",
 				"@pins/express": "^0.0.0",
 				"@pins/platform": "^0.0.0",
-				"@prisma/client": "^4.16.1",
+				"@prisma/client": "4.16.1",
 				"@supercharge/promise-pool": "^2.4.0",
 				"body-parser": "1.20.0",
 				"c8": "^7.11.3",
@@ -2873,13 +2873,13 @@
 				"jest-environment-jsdom": "^29.3.1",
 				"jest-mock-extended": "^3.0.1",
 				"nodemon": "^2.0.18",
-				"prisma": "^4.16.1",
+				"prisma": "4.16.1",
 				"rimraf": "^3.0.2",
 				"supertest": "6.2.3",
 				"swagger-autogen": "^2.21.4"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"apps/api-testing": {
@@ -4497,7 +4497,7 @@
 				"swagger-autogen": "^2.21.1"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"apps/document-storage/node_modules/@jest/console": {
@@ -6005,7 +6005,7 @@
 				"jest": "^29.4.1"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"apps/functions/document-check/node_modules/@jest/console": {
@@ -7108,7 +7108,7 @@
 				"jest": "^29.4.1"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"apps/functions/document-publish/node_modules/@jest/console": {
@@ -8233,7 +8233,7 @@
 				"@azure/functions": "^3.5.0"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"apps/functions/odw-integration/node_modules/@azure/functions": {
@@ -8398,7 +8398,7 @@
 				"terser": "^5.13.1"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"apps/web/node_modules/cookie": {
@@ -35031,7 +35031,7 @@
 				"type-fest": "^2.12.2"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"packages/appeals/node_modules/type-fest": {
@@ -35052,7 +35052,7 @@
 				"type-fest": "^2.12.2"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"packages/applications/node_modules/type-fest": {
@@ -35075,7 +35075,7 @@
 				"@azure/storage-blob": "^12.12.0"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"packages/eslint": {
@@ -35111,7 +35111,7 @@
 				"@azure/service-bus": "^7.7.3"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"packages/express": {
@@ -35129,7 +35129,7 @@
 				"@types/multer": "^1.4.7"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"packages/platform": {
@@ -35150,7 +35150,7 @@
 				"type-fest": "^2.12.2"
 			},
 			"engines": {
-				"node": ">=16.14.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"packages/platform/node_modules/type-fest": {
@@ -38444,7 +38444,7 @@
 				"@pins/event-client": "^0.0.0",
 				"@pins/express": "^0.0.0",
 				"@pins/platform": "^0.0.0",
-				"@prisma/client": "^4.16.1",
+				"@prisma/client": "4.16.1",
 				"@supercharge/promise-pool": "^2.4.0",
 				"@types/express": "^4.17.13",
 				"@types/express-pino-logger": "^4.0.3",
@@ -38478,7 +38478,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"prisma": "^4.16.1",
+				"prisma": "4.16.1",
 				"rhea": "3.0.1",
 				"rimraf": "^3.0.2",
 				"supertest": "6.2.3",
@@ -40625,7 +40625,7 @@
 				"@pins/event-client": "^0.0.0",
 				"@pins/express": "^0.0.0",
 				"@pins/platform": "^0.0.0",
-				"@prisma/client": "^4.16.1",
+				"@prisma/client": "4.16.1",
 				"@supercharge/promise-pool": "^2.4.0",
 				"@types/express": "^4.17.13",
 				"@types/express-pino-logger": "^4.0.3",
@@ -40659,7 +40659,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"prisma": "^4.16.1",
+				"prisma": "4.16.1",
 				"rhea": "3.0.1",
 				"rimraf": "^3.0.2",
 				"sanitize-html": "^2.11.0",


### PR DESCRIPTION
## Describe your changes

We need prisma to be 4.16.1 - see comment in https://github.com/Planning-Inspectorate/back-office/pull/1204
We had ^4.16.1 which would allow 4.16.2

## Issue ticket number and link

N/A

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
