### PR TITLE
feat(web): provide feedback to the user when duplicates return

### DIFF
--- a/apps/web/src/client/components/file-uploader/_server-actions.js
+++ b/apps/web/src/client/components/file-uploader/_server-actions.js
@@ -46,11 +46,17 @@ const serverActions = (uploadForm) => {
 		})
 			.then((response) => response.json())
 			.then((uploadsInfos) => {
-				if (uploadsInfos.failedDocuments) {
+				if (uploadsInfos.failedDocuments || uploadsInfos.duplicates) {
 					const failedDocuments = /** @type {string[]} */ (uploadsInfos.failedDocuments);
+					const duplicates = /** @type {string[]} */ (uploadsInfos.duplicates);
 
 					failedUploads.push(
 						...failedDocuments.map((name, idx) => ({
+							message: 'CONFLICT',
+							name,
+							fileRowId: `failedUpload${idx}`
+						})),
+						...duplicates.map((name, idx) => ({
 							message: 'CONFLICT',
 							name,
 							fileRowId: `failedUpload${idx}`


### PR DESCRIPTION
## Describe your changes

Currently when duplicates are found, the new file is not created, but it isn't clear to the user that this has happened. This change should display the error when this happens.

It's difficult to test locally because uploading files crashes the app. Will need to check it's working in dev once merged.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
