### PR TITLE
fix(web): disallow file downloads before virus check

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -223,28 +223,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-3\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"3\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-3\\">4 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/3/version//preview\\">4 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">4 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-3 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/3/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -259,28 +249,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-5\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"5\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-5\\">6 Magna aliqua Ut enim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/5/version//preview\\">6 Magna aliqua Ut enim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">6 Magna aliqua Ut enim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/5/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-5 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/5/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -295,18 +275,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-7\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"7\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-7\\">8 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">8 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -314,23 +284,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/7/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-7 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/7/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-8\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"8\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-8\\">9 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">9 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -338,69 +297,38 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/8/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-8 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/8/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-9\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"9\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-9\\">10 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/9/version//preview\\">10 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">10 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/9/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-9 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/9/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-10\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"10\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-10\\">11 Aliqua Ut enim ad minim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/10/version//preview\\">11 Aliqua Ut enim ad minim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">11 Aliqua Ut enim ad minim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/10/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-10 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/10/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-11\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"11\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-11\\">12 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">12 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Ut labore</p>
@@ -408,33 +336,22 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-11 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/11/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-12\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"12\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-12\\">13 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/12/version//preview\\">13 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">13 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/12/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-12 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/12/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -449,41 +366,21 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-14\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"14\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-14\\">15 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/14/version//preview\\">15 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">15 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/14/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-14 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/14/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-15\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"15\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-15\\">16 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">16 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -491,10 +388,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/15/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-15 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/15/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -509,97 +405,57 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-17\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"17\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-17\\">18 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/17/version//preview\\">18 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">18 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/17/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-17 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/17/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-18\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"18\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-18\\">19 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/18/version//preview\\">19 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">19 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/18/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-18 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/18/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-19\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"19\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-19\\">20 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/19/version//preview\\">20 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">20 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/19/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-19 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/19/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-20\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"20\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-20\\">21 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/20/version//preview\\">21 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">21 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/20/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-20 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/20/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -614,18 +470,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-22\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"22\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-22\\">23 Nisi ut aliquip ex ea commodo</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">23 Nisi ut aliquip ex ea commodo</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -633,46 +479,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/22/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-22 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/22/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-23\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"23\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-23\\">24 Incididunt ut labore et</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/23/version//preview\\">24 Incididunt ut labore et</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">24 Incididunt ut labore et</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/23/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-23 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/23/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-24\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"24\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-24\\">25 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">25 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -680,10 +505,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/24/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-24 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/24/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -698,74 +522,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-26\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"26\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-26\\">27 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/26/version//preview\\">27 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">27 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/26/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-26 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/26/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-27\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"27\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-27\\">28 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/27/version//preview\\">28 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">28 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/27/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-27 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/27/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-28\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"28\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-28\\">29 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/28/version//preview\\">29 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">29 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/28/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-28 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/28/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1039,28 +833,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-3\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"3\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-3\\">4 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/3/version//preview\\">4 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">4 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-3 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/3/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1075,28 +859,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-5\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"5\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-5\\">6 Magna aliqua Ut enim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/5/version//preview\\">6 Magna aliqua Ut enim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">6 Magna aliqua Ut enim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/5/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-5 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/5/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1111,18 +885,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-7\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"7\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-7\\">8 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">8 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -1130,23 +894,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/7/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-7 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/7/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-8\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"8\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-8\\">9 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">9 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -1154,69 +907,38 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/8/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-8 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/8/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-9\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"9\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-9\\">10 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/9/version//preview\\">10 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">10 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/9/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-9 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/9/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-10\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"10\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-10\\">11 Aliqua Ut enim ad minim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/10/version//preview\\">11 Aliqua Ut enim ad minim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">11 Aliqua Ut enim ad minim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/10/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-10 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/10/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-11\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"11\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-11\\">12 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">12 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Ut labore</p>
@@ -1224,33 +946,22 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-11 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/11/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-12\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"12\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-12\\">13 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/12/version//preview\\">13 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">13 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/12/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-12 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/12/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1265,41 +976,21 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-14\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"14\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-14\\">15 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/14/version//preview\\">15 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">15 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/14/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-14 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/14/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-15\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"15\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-15\\">16 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">16 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -1307,10 +998,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/15/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-15 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/15/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1325,97 +1015,57 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-17\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"17\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-17\\">18 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/17/version//preview\\">18 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">18 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/17/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-17 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/17/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-18\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"18\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-18\\">19 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/18/version//preview\\">19 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">19 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/18/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-18 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/18/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-19\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"19\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-19\\">20 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/19/version//preview\\">20 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">20 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/19/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-19 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/19/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-20\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"20\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-20\\">21 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/20/version//preview\\">21 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">21 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/20/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-20 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/20/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1430,18 +1080,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-22\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"22\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-22\\">23 Nisi ut aliquip ex ea commodo</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">23 Nisi ut aliquip ex ea commodo</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -1449,46 +1089,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/22/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-22 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/22/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-23\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"23\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-23\\">24 Incididunt ut labore et</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/23/version//preview\\">24 Incididunt ut labore et</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">24 Incididunt ut labore et</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/23/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-23 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/23/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-24\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"24\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-24\\">25 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">25 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -1496,10 +1115,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/24/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-24 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/24/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1514,74 +1132,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-26\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"26\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-26\\">27 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/26/version//preview\\">27 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">27 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/26/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-26 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/26/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-27\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"27\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-27\\">28 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/27/version//preview\\">28 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">28 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/27/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-27 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/27/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-28\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"28\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-28\\">29 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/28/version//preview\\">29 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">29 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/28/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-28 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/28/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1596,28 +1184,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-30\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"30\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-30\\">31 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/30/version//preview\\">31 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">31 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/30/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-30 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/30/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1632,74 +1210,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-32\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"32\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-32\\">33 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/32/version//preview\\">33 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">33 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/32/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-32 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/32/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-33\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"33\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-33\\">34 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/33/version//preview\\">34 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">34 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/33/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-33 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/33/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-34\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"34\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-34\\">35 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/34/version//preview\\">35 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">35 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/34/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-34 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/34/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1714,18 +1262,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-36\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"36\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-36\\">37 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">37 Elit sed do</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -1733,10 +1271,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/36/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-36 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/36/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -1777,18 +1314,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-40\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"40\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-40\\">41 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">41 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -1796,46 +1323,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/40/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-40 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/40/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-41\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"41\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-41\\">42 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/41/version//preview\\">42 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">42 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/41/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-41 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/41/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-42\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"42\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-42\\">43 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">43 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -1843,23 +1349,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/42/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-42 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/42/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-43\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"43\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-43\\">44 Ipsum dolor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">44 Ipsum dolor</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -1867,23 +1362,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/43/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-43 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/43/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-44\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"44\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-44\\">45 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">45 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -1891,46 +1375,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/44/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-44 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/44/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-45\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"45\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-45\\">46 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/45/version//preview\\">46 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">46 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/45/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-45 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/45/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-46\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"46\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-46\\">47 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">47 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -1938,46 +1401,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/46/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-46 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/46/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-47\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"47\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-47\\">48 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/47/version//preview\\">48 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">48 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/47/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-47 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/47/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-48\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"48\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-48\\">49 Sit amet</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">49 Sit amet</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -1985,10 +1427,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/48/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-48 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/48/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -2284,28 +1725,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                                 <p>Select all documents on page</p>
                             </td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-30\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"30\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-30\\">31 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/30/version//preview\\">31 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">31 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/30/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-30 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/30/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -2320,74 +1751,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-32\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"32\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-32\\">33 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/32/version//preview\\">33 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">33 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/32/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-32 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/32/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-33\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"33\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-33\\">34 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/33/version//preview\\">34 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">34 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/33/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-33 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/33/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-34\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"34\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-34\\">35 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/34/version//preview\\">35 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">35 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/34/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-34 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/34/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -2402,18 +1803,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-36\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"36\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-36\\">37 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">37 Elit sed do</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -2421,10 +1812,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/36/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-36 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/36/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -2465,18 +1855,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-40\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"40\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-40\\">41 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">41 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -2484,46 +1864,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/40/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-40 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/40/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-41\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"41\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-41\\">42 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/41/version//preview\\">42 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">42 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/41/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-41 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/41/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-42\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"42\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-42\\">43 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">43 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -2531,23 +1890,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/42/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-42 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/42/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-43\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"43\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-43\\">44 Ipsum dolor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">44 Ipsum dolor</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -2555,23 +1903,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/43/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-43 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/43/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-44\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"44\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-44\\">45 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">45 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -2579,46 +1916,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/44/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-44 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/44/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-45\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"45\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-45\\">46 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/45/version//preview\\">46 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">46 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/45/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-45 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/45/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-46\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"46\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-46\\">47 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">47 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -2626,46 +1942,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/46/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-46 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/46/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-47\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"47\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-47\\">48 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/47/version//preview\\">48 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">48 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/47/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-47 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/47/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-48\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"48\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-48\\">49 Sit amet</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">49 Sit amet</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -2673,10 +1968,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/48/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-48 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/48/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -2691,41 +1985,21 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-50\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"50\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-50\\">51 Incididunt ut labore et</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/50/version//preview\\">51 Incididunt ut labore et</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.2 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">51 Incididunt ut labore et</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.2 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/50/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-50 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/50/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-51\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"51\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-51\\">52 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">52 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -2733,10 +2007,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/51/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-51 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/51/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -2751,64 +2024,34 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-53\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"53\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-53\\">54 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/53/version//preview\\">54 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">54 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/53/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-53 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/53/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-54\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"54\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-54\\">55 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/54/version//preview\\">55 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">55 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/54/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-54 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/54/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-55\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"55\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-55\\">56 Amet consectetur</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">56 Amet consectetur</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -2816,23 +2059,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/55/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-55 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/55/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-56\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"56\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-56\\">57 Laboris nisi ut aliquip ex ea</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">57 Laboris nisi ut aliquip ex ea</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -2840,10 +2072,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/56/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-56 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/56/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3230,28 +2461,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-3\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"3\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-3\\">4 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/3/version//preview\\">4 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">4 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-3 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/3/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3266,28 +2487,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-5\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"5\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-5\\">6 Magna aliqua Ut enim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/5/version//preview\\">6 Magna aliqua Ut enim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">6 Magna aliqua Ut enim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/5/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-5 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/5/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3302,18 +2513,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-7\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"7\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-7\\">8 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">8 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -3321,23 +2522,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/7/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-7 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/7/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-8\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"8\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-8\\">9 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">9 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -3345,69 +2535,38 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/8/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-8 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/8/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-9\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"9\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-9\\">10 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/9/version//preview\\">10 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">10 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/9/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-9 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/9/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-10\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"10\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-10\\">11 Aliqua Ut enim ad minim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/10/version//preview\\">11 Aliqua Ut enim ad minim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">11 Aliqua Ut enim ad minim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/10/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-10 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/10/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-11\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"11\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-11\\">12 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">12 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Ut labore</p>
@@ -3415,33 +2574,22 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-11 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/11/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-12\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"12\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-12\\">13 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/12/version//preview\\">13 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">13 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/12/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-12 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/12/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3456,41 +2604,21 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-14\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"14\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-14\\">15 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/14/version//preview\\">15 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">15 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/14/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-14 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/14/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-15\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"15\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-15\\">16 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">16 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -3498,10 +2626,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/15/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-15 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/15/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3516,97 +2643,57 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-17\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"17\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-17\\">18 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/17/version//preview\\">18 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">18 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/17/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-17 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/17/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-18\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"18\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-18\\">19 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/18/version//preview\\">19 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">19 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/18/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-18 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/18/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-19\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"19\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-19\\">20 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/19/version//preview\\">20 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">20 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/19/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-19 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/19/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-20\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"20\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-20\\">21 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/20/version//preview\\">21 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">21 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/20/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-20 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/20/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3621,18 +2708,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-22\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"22\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-22\\">23 Nisi ut aliquip ex ea commodo</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">23 Nisi ut aliquip ex ea commodo</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -3640,46 +2717,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/22/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-22 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/22/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-23\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"23\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-23\\">24 Incididunt ut labore et</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/23/version//preview\\">24 Incididunt ut labore et</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">24 Incididunt ut labore et</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/23/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-23 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/23/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-24\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"24\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-24\\">25 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">25 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -3687,10 +2743,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/24/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-24 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/24/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3705,74 +2760,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-26\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"26\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-26\\">27 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/26/version//preview\\">27 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">27 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/26/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-26 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/26/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-27\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"27\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-27\\">28 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/27/version//preview\\">28 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">28 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/27/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-27 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/27/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-28\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"28\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-28\\">29 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/28/version//preview\\">29 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">29 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/28/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-28 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/28/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3787,28 +2812,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-30\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"30\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-30\\">31 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/30/version//preview\\">31 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">31 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/30/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-30 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/30/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3823,74 +2838,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-32\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"32\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-32\\">33 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/32/version//preview\\">33 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">33 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/32/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-32 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/32/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-33\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"33\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-33\\">34 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/33/version//preview\\">34 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">34 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/33/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-33 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/33/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-34\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"34\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-34\\">35 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/34/version//preview\\">35 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">35 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/34/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-34 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/34/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3905,18 +2890,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-36\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"36\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-36\\">37 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">37 Elit sed do</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -3924,10 +2899,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/36/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-36 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/36/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -3968,18 +2942,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-40\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"40\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-40\\">41 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">41 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -3987,46 +2951,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/40/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-40 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/40/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-41\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"41\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-41\\">42 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/41/version//preview\\">42 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">42 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/41/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-41 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/41/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-42\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"42\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-42\\">43 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">43 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -4034,23 +2977,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/42/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-42 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/42/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-43\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"43\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-43\\">44 Ipsum dolor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">44 Ipsum dolor</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -4058,23 +2990,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/43/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-43 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/43/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-44\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"44\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-44\\">45 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">45 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -4082,46 +3003,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/44/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-44 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/44/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-45\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"45\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-45\\">46 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/45/version//preview\\">46 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">46 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/45/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-45 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/45/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-46\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"46\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-46\\">47 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">47 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -4129,46 +3029,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/46/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-46 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/46/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-47\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"47\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-47\\">48 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/47/version//preview\\">48 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">48 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/47/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-47 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/47/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-48\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"48\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-48\\">49 Sit amet</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">49 Sit amet</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -4176,10 +3055,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/48/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-48 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/48/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -4461,28 +3339,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-3\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"3\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-3\\">4 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/3/version//preview\\">4 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">4 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-3 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/3/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -4497,28 +3365,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-5\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"5\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-5\\">6 Magna aliqua Ut enim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/5/version//preview\\">6 Magna aliqua Ut enim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">6 Magna aliqua Ut enim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/5/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-5 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/5/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -4533,18 +3391,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-7\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"7\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-7\\">8 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">8 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -4552,23 +3400,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/7/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-7 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/7/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-8\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"8\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-8\\">9 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">9 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -4576,69 +3413,38 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/8/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-8 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/8/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-9\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"9\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-9\\">10 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/9/version//preview\\">10 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">10 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/9/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-9 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/9/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-10\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"10\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-10\\">11 Aliqua Ut enim ad minim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/10/version//preview\\">11 Aliqua Ut enim ad minim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">11 Aliqua Ut enim ad minim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/10/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-10 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/10/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-11\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"11\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-11\\">12 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">12 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Ut labore</p>
@@ -4646,33 +3452,22 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-11 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/11/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-12\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"12\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-12\\">13 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/12/version//preview\\">13 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">13 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/12/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-12 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/12/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -4687,41 +3482,21 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-14\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"14\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-14\\">15 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/14/version//preview\\">15 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">15 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/14/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-14 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/14/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-15\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"15\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-15\\">16 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">16 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -4729,10 +3504,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/15/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-15 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/15/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -4747,97 +3521,57 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-17\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"17\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-17\\">18 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/17/version//preview\\">18 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">18 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/17/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-17 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/17/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-18\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"18\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-18\\">19 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/18/version//preview\\">19 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">19 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/18/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-18 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/18/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-19\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"19\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-19\\">20 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/19/version//preview\\">20 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">20 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/19/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-19 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/19/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-20\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"20\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-20\\">21 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/20/version//preview\\">21 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">21 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/20/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-20 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/20/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -4852,18 +3586,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-22\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"22\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-22\\">23 Nisi ut aliquip ex ea commodo</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">23 Nisi ut aliquip ex ea commodo</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -4871,46 +3595,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/22/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-22 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/22/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-23\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"23\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-23\\">24 Incididunt ut labore et</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/23/version//preview\\">24 Incididunt ut labore et</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">24 Incididunt ut labore et</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/23/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-23 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/23/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-24\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"24\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-24\\">25 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">25 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -4918,10 +3621,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/24/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-24 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/24/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -4936,74 +3638,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-26\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"26\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-26\\">27 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/26/version//preview\\">27 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">27 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/26/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-26 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/26/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-27\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"27\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-27\\">28 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/27/version//preview\\">28 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">28 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/27/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-27 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/27/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-28\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"28\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-28\\">29 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/28/version//preview\\">29 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">29 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/28/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-28 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/28/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5018,28 +3690,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-30\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"30\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-30\\">31 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/30/version//preview\\">31 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">31 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/30/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-30 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/30/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5054,74 +3716,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-32\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"32\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-32\\">33 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/32/version//preview\\">33 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">33 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/32/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-32 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/32/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-33\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"33\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-33\\">34 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/33/version//preview\\">34 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">34 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/33/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-33 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/33/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-34\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"34\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-34\\">35 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/34/version//preview\\">35 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">35 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/34/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-34 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/34/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5136,18 +3768,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-36\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"36\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-36\\">37 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">37 Elit sed do</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -5155,10 +3777,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/36/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-36 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/36/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5199,18 +3820,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-40\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"40\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-40\\">41 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">41 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -5218,46 +3829,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/40/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-40 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/40/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-41\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"41\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-41\\">42 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/41/version//preview\\">42 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">42 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/41/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-41 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/41/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-42\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"42\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-42\\">43 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">43 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -5265,23 +3855,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/42/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-42 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/42/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-43\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"43\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-43\\">44 Ipsum dolor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">44 Ipsum dolor</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -5289,23 +3868,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/43/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-43 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/43/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-44\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"44\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-44\\">45 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">45 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -5313,46 +3881,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/44/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-44 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/44/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-45\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"45\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-45\\">46 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/45/version//preview\\">46 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">46 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/45/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-45 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/45/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-46\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"46\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-46\\">47 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">47 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -5360,46 +3907,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/46/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-46 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/46/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-47\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"47\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-47\\">48 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/47/version//preview\\">48 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">48 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/47/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-47 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/47/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-48\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"48\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-48\\">49 Sit amet</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">49 Sit amet</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -5407,10 +3933,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/48/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-48 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/48/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5690,28 +4215,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-3\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"3\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-3\\">4 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/3/version//preview\\">4 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">4 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-3 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/3/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5726,28 +4241,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-5\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"5\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-5\\">6 Magna aliqua Ut enim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/5/version//preview\\">6 Magna aliqua Ut enim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">6 Magna aliqua Ut enim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/5/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-5 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/5/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5762,18 +4267,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-7\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"7\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-7\\">8 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">8 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -5781,23 +4276,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/7/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-7 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/7/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-8\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"8\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-8\\">9 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">9 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -5805,69 +4289,38 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/8/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-8 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/8/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-9\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"9\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-9\\">10 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/9/version//preview\\">10 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">10 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/9/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-9 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/9/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-10\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"10\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-10\\">11 Aliqua Ut enim ad minim</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/10/version//preview\\">11 Aliqua Ut enim ad minim</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">11 Aliqua Ut enim ad minim</p>
+                                <p class=\\"file-info colour--secondary\\">From: Eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/10/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-10 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/10/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-11\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"11\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-11\\">12 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">12 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Ut labore</p>
@@ -5875,33 +4328,22 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-11 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/11/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-12\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"12\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-12\\">13 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/12/version//preview\\">13 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">13 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/12/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-12 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/12/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5916,41 +4358,21 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-14\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"14\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-14\\">15 Do eiusmod tempor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/14/version//preview\\">15 Do eiusmod tempor</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">15 Do eiusmod tempor</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.2 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/14/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-14 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/14/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-15\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"15\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-15\\">16 Lorem ipsum</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">16 Lorem ipsum</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -5958,10 +4380,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/15/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-15 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/15/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -5976,97 +4397,57 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-17\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"17\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-17\\">18 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/17/version//preview\\">18 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">18 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/17/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-17 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/17/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-18\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"18\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-18\\">19 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/18/version//preview\\">19 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">19 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/18/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-18 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/18/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-19\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"19\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-19\\">20 Eiusmod tempor incididunt</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/19/version//preview\\">20 Eiusmod tempor incididunt</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">20 Eiusmod tempor incididunt</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 3.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/19/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-19 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/19/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-20\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"20\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-20\\">21 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/20/version//preview\\">21 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">21 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.7 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/20/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-20 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/20/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -6081,18 +4462,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-22\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"22\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-22\\">23 Nisi ut aliquip ex ea commodo</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">23 Nisi ut aliquip ex ea commodo</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -6100,46 +4471,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/22/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-22 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/22/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-23\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"23\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-23\\">24 Incididunt ut labore et</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/23/version//preview\\">24 Incididunt ut labore et</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Elit sed</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">24 Incididunt ut labore et</p>
+                                <p class=\\"file-info colour--secondary\\">From: Elit sed</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.1 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/23/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-23 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/23/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-24\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"24\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-24\\">25 Ullamco laboris nisi ut aliquip ex</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">25 Ullamco laboris nisi ut aliquip ex</p>
                                 <p class=\\"file-info colour--secondary\\">From: Labore et</p>
@@ -6147,10 +4497,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Published</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/24/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-24 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/24/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Published</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -6165,74 +4514,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-26\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"26\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-26\\">27 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/26/version//preview\\">27 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">27 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/26/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-26 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/26/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-27\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"27\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-27\\">28 Labore et dolore magna</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/27/version//preview\\">28 Labore et dolore magna</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">28 Labore et dolore magna</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.8 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/27/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-27 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/27/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-28\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"28\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-28\\">29 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/28/version//preview\\">29 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">29 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/28/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-28 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/28/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -6247,28 +4566,18 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-30\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"30\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-30\\">31 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/30/version//preview\\">31 Elit sed do</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">31 Elit sed do</p>
+                                <p class=\\"file-info colour--secondary\\">From: Adipiscing elit</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 2.5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Ready to publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/30/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-30 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/30/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Ready to publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -6283,74 +4592,44 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-32\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"32\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-32\\">33 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/32/version//preview\\">33 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">33 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/32/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-32 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/32/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-33\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"33\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-33\\">34 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/33/version//preview\\">34 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">34 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.3 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/33/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-33 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/33/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-34\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"34\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-34\\">35 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/34/version//preview\\">35 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">35 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.6 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/34/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-34 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/34/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -6365,18 +4644,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-36\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"36\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-36\\">37 Elit sed do</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">37 Elit sed do</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -6384,10 +4653,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/36/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-36 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/36/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>
@@ -6428,18 +4696,8 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-40\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"40\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-40\\">41 Dolor sit</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">41 Dolor sit</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -6447,46 +4705,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/40/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-40 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/40/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-41\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"41\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-41\\">42 Ut labore et dolore</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/41/version//preview\\">42 Ut labore et dolore</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Sed do</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">42 Ut labore et dolore</p>
+                                <p class=\\"file-info colour--secondary\\">From: Sed do</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: PDF, 4.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Do not publish</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/41/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-41 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/41/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Do not publish</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-42\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"42\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-42\\">43 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">43 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -6494,23 +4731,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/42/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-42 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/42/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-43\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"43\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-43\\">44 Ipsum dolor</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">44 Ipsum dolor</p>
                                 <p class=\\"file-info colour--secondary\\">From: Sit amet</p>
@@ -6518,23 +4744,12 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/43/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-43 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/43/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-44\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"44\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-44\\">45 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">45 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -6542,46 +4757,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/44/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-44 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/44/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-45\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"45\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-45\\">46 Dolore magna aliqua Ut</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/45/version//preview\\">46 Dolore magna aliqua Ut</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">46 Dolore magna aliqua Ut</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5.4 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/45/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-45 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/45/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-46\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"46\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-46\\">47 Consectetur adipiscing</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">47 Consectetur adipiscing</p>
                                 <p class=\\"file-info colour--secondary\\">From: Consectetur adipiscing</p>
@@ -6589,46 +4783,25 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Unchecked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/46/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-46 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/46/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unchecked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-47\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"47\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-47\\">48 Et dolore magna aliqua</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s govuk-!-font-weight-bold\\" href=\\"/documents/123/download/47/version//preview\\">48 Et dolore magna aliqua</a>
-                                <p                                 class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
-                                    <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
+                                <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">48 Et dolore magna aliqua</p>
+                                <p class=\\"file-info colour--secondary\\">From: Do eiusmod</p>
+                                <p class=\\"file-info colour--secondary\\">File type and size: JPG, 5 MB</p>
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Unredacted</td>
-                            <td class=\\"govuk-table__cell\\">Unpublished</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/47/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-47 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/47/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Unpublished</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
-                        <tr class=\\"govuk-table__row  \\">
-                            <td class=\\"govuk-table__cell\\">
-                                <div class=\\"govuk-form-group\\">
-                                    <div class=\\"govuk-checkboxes\\" data-module=\\"govuk-checkboxes\\">
-                                        <div class=\\"govuk-checkboxes__item\\">
-                                            <input class=\\"govuk-checkboxes__input\\" id=\\"checkbox-id-48\\" name=\\"selectedFilesIds[]\\"
-                                            type=\\"checkbox\\" value=\\"48\\">
-                                            <label class=\\"govuk-label govuk-checkboxes__label\\" for=\\"checkbox-id-48\\">49 Sit amet</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </td>
+                        <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
+                            <td class=\\"govuk-table__cell\\"></td>
                             <td class=\\"govuk-table__cell\\">
                                 <p class=\\"govuk-body-s govuk-!-font-weight-bold\\">49 Sit amet</p>
                                 <p class=\\"file-info colour--secondary\\">From: Amet consectetur</p>
@@ -6636,10 +4809,9 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             </td>
                             <td class=\\"govuk-table__cell\\">01/12/2022</td>
                             <td class=\\"govuk-table__cell\\">Redacted</td>
-                            <td class=\\"govuk-table__cell\\">Checked</td>
-                            <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link govuk-body-s\\" href=\\"/applications-service/case/123/project-documentation/21/document/48/properties\\">View/Edit properties</a>
-                                <a                                 data-action=download-48 class=\\"govuk-link govuk-body-s\\" href=\\"/documents/123/download/48/version//\\">Download</a>
+                            <td class=\\"govuk-table__cell\\"><strong class=\\"govuk-tag\\"> Checked</strong>
                             </td>
+                            <td class=\\"govuk-table__cell\\"></td>
                         </tr>
                         <tr class=\\"govuk-table__row govuk-table__row--disabled \\">
                             <td class=\\"govuk-table__cell\\"></td>

--- a/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
+++ b/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
@@ -197,7 +197,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -214,7 +214,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -231,7 +231,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -248,14 +248,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Magna aliqua Ut enim</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Magna aliqua Ut enim</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -264,7 +265,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -281,7 +282,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -298,7 +299,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -315,7 +316,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -332,14 +333,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Aliqua Ut enim ad minim</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Aliqua Ut enim ad minim</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -348,7 +350,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -365,7 +367,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -382,7 +384,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -399,7 +401,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -416,7 +418,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -433,7 +435,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -450,14 +452,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Dolore magna aliqua Ut</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Dolore magna aliqua Ut</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -466,14 +469,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Eiusmod tempor incididunt</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -482,14 +486,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Eiusmod tempor incididunt</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -498,14 +503,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Labore et dolore magna</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Labore et dolore magna</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -514,7 +520,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -639,7 +645,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -656,7 +662,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -673,7 +679,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -690,14 +696,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Magna aliqua Ut enim</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Magna aliqua Ut enim</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -706,7 +713,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -723,7 +730,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -740,7 +747,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -757,7 +764,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -774,14 +781,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Aliqua Ut enim ad minim</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Aliqua Ut enim ad minim</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -790,7 +798,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -807,7 +815,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -824,7 +832,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -841,7 +849,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -858,7 +866,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -875,7 +883,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
@@ -892,14 +900,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Dolore magna aliqua Ut</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Dolore magna aliqua Ut</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -908,14 +917,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Eiusmod tempor incididunt</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -924,14 +934,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Eiusmod tempor incididunt</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -940,14 +951,15 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>
                                 </tr>
                                 <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Labore et dolore magna</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">Labore et dolore magna</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 8.5 KB</p>
                                     </td>
                                     <td class=\\"govuk-table__cell\\">
                                         <p>07/03/2023</p>
@@ -956,7 +968,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
                                         <p><strong class=\\"govuk-tag\\"> Awaiting upload</strong>
                                         </p>
                                     </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                    <td class=\\"govuk-table__cell\\"><span></span>
                                     </td>
                                     <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/delete/1'>Delete</a>
                                     </td>

--- a/apps/web/src/server/views/applications/case-documentation/documentation-table.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-table.njk
@@ -60,7 +60,7 @@
 				</td>
 			</tr>
 			{% for item in items.items %}
-				{% set isNotDisabled = item.publishedStatus !== 'awaiting_upload' and item.publishedStatus !== 'awaiting_virus_check' and item.publishedStatus !== 'failed_virus_check' %}
+        {% set isNotDisabled = item.virusCheckStatus === 'scanned' %}
 
 				<tr class="govuk-table__row {{ "" if isNotDisabled else "govuk-table__row--disabled" }} {{ "govuk-table__row--failed" if item.failed else "" }}">
 					<td class="govuk-table__cell">

--- a/apps/web/src/server/views/applications/case-s51/properties/tab-attachments.component.njk
+++ b/apps/web/src/server/views/applications/case-s51/properties/tab-attachments.component.njk
@@ -8,7 +8,7 @@
 		{% set name %}
 
 		{% set isPreviewPossible = (attachment.documentType === 'application/pdf' or attachment.documentType === 'image/jpeg' or attachment.documentType === 'image/png') %}
-		{% set isAttachmentSafe = (attachment.status === 'awaiting_upload') %}
+		{% set isAttachmentSafe = attachment.status === 'scanned' %}
 
 		{% if isPreviewPossible and isAttachmentSafe %}
 			<a class="govuk-link font-weight--700" href="{{ 'document-download'|url({caseId: caseId, documentGuid: attachment.documentGuid, version: attachment.version, isPreviewActive: true}) }}">{{ attachment.documentName }}</a>
@@ -31,10 +31,13 @@
 		{% endset %}
 
 		{% set download %}
-		<a class='govuk-link' href="{{ 'document-download'|url({caseId: caseId, documentGuid: attachment.documentGuid, version: attachment.version}) }}">
-				Download
-			</a>
-
+      {% if isAttachmentSafe %}
+        <a class='govuk-link' href="{{ 'document-download'|url({caseId: caseId, documentGuid: attachment.documentGuid, version: attachment.version}) }}">
+          Download
+        </a>
+      {% else %}
+        <span></span>
+      {% endif %}
 		{% endset %}
 
 		{% set delete %}


### PR DESCRIPTION
## Describe your changes

Only allow downloading documents after they've passed the virus scan step.

## Issue ticket number and link

[BOAS-1117](https://pins-ds.atlassian.net/browse/BOAS-1117)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1117]: https://pins-ds.atlassian.net/browse/BOAS-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ