### PR TITLE
feat(appeals/web): adding additional read-only groups to AD config

### DIFF
--- a/appeals/web/environment/config.js
+++ b/appeals/web/environment/config.js
@@ -33,7 +33,8 @@ const { value: validatedConfig, error } = schema.validate({
 		appeals: {
 			caseOfficerGroupId: environment.APPEALS_CASE_OFFICER_GROUP_ID,
 			inspectorGroupId: environment.APPEALS_INSPECTOR_GROUP_ID,
-			validationOfficerGroupId: environment.APPEALS_VALIDATION_OFFICER_GROUP_ID
+			legalGroupId: environment.APPEALS_LEGAL_TEAM_GROUP_ID,
+			customerServiceGroupId: environment.APPEALS_CS_TEAM_GROUP_ID
 		}
 	},
 	// flag name convention: featureFlag[ jira number ][ferature shoret description]

--- a/appeals/web/environment/schema.js
+++ b/appeals/web/environment/schema.js
@@ -32,12 +32,8 @@ export default joi.object({
 		appeals: joi.object({
 			caseOfficerGroupId: joi.string(),
 			inspectorGroupId: joi.string(),
-			validationOfficerGroupId: joi.string()
-		}),
-		applications: joi.object({
-			caseAdminOfficerGroupId: joi.string(),
-			caseTeamGroupId: joi.string(),
-			inspectorGroupId: joi.string()
+			legalGroupId: joi.string(),
+			customerServiceGroupId: joi.string()
 		})
 	}),
 	featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean())


### PR DESCRIPTION
Added new legal and customer service AD groups to the app configuration. Users in these groups will have a read-only view of the appeal data.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
