### PR TITLE
Feature/boas 1143 api check s51 advice title unique

### DIFF
--- a/apps/api/src/server/applications/s51advice/__tests__/s51-advice.test.js
+++ b/apps/api/src/server/applications/s51advice/__tests__/s51-advice.test.js
@@ -301,4 +301,32 @@ describe('Test S51 advice API', () => {
 		expect(databaseConnector.s51Advice.findUnique).toHaveBeenCalledTimes(1);
 		expect(databaseConnector.s51Advice.update).toHaveBeenCalledTimes(1);
 	});
+
+	// Tests for the title unique HEAD checks
+	test('Is s51 title unique - HEAD returns 200 success if S51 title is unique to the case', async () => {
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
+		databaseConnector.s51Advice.findMany.mockResolvedValue({});
+		const resp = await request.head('/applications/1/s51-advice/title-unique/Advice 12').send();
+		expect(resp.status).toEqual(200);
+	});
+
+	test('Is s51 title unique - HEAD returns 404 error if S51 title is already used in the case', async () => {
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
+		databaseConnector.s51Advice.findMany.mockResolvedValue(s51AdvicesOnCase1);
+		const resp = await request.head('/applications/1/s51-advice/title-unique/Advice 1').send();
+		expect(resp.status).toEqual(400);
+	});
+
+	test('Is s51 title unique - whitespace is ignored in the test, also case-insensitive', async () => {
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
+		databaseConnector.s51Advice.findMany.mockResolvedValue(s51AdvicesOnCase1);
+		const resp = await request.head('/applications/1/s51-advice/title-unique/  ADVICE 1  ').send();
+		expect(resp.status).toEqual(400);
+	});
+
+	test('Is s51 title unique - HEAD returns 400 error if case id is invalid', async () => {
+		databaseConnector.case.findUnique.mockResolvedValue(null);
+		const resp = await request.head('/applications/999/s51-advice/title-unique/Advice 1').send();
+		expect(resp.status).toEqual(404);
+	});
 });

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -418,10 +418,10 @@ export const getReadyToPublishAdvices = async ({ params: { id }, body }, respons
 };
 
 /**
- * 
- * @param {*} body 
- * @param {*} response 
- * @returns 
+ *
+ * @param {*} body
+ * @param {*} response
+ * @returns
  */
 export const removePublishItemFromQueue = async ({ body }, response) => {
 	const adviceId = Number(body.adviceId);
@@ -438,3 +438,19 @@ export const removePublishItemFromQueue = async ({ body }, response) => {
 
 	response.send(updatedS51Advice);
 }
+
+/**
+ * Checks whether passed s51 title is unique to this case. Test is case-insensitive, and search string is trimmed.
+ *
+ * @type {import('express').RequestHandler<{id: number, title: string}, any, any, any>}
+ */
+export const verifyS51TitleIsUnique = async ({ params }, response) => {
+	const { id, title } = params;
+	const existingAdvice = await s51AdviceRepository.getS51AdviceManyByTitle(id, title.trim());
+
+	if (existingAdvice && existingAdvice.length > 0) {
+		throw new BackOfficeAppError(`Title already exists`, 400);
+	}
+
+	response.send({ title: title.trim() });
+};

--- a/apps/api/src/server/applications/s51advice/s51-advice.routes.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.routes.js
@@ -328,7 +328,7 @@ router.head(
             schema: null
         }
 		#swagger.responses[404] = {
-            description: 'Error: Not Found',
+            description: 'Error: Not Found - invalid case id',
 			schema: null
         }
 

--- a/apps/api/src/server/applications/s51advice/s51-advice.routes.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.routes.js
@@ -9,7 +9,8 @@ import {
 	updateManyS51Advices,
 	updateS51Advice,
 	getReadyToPublishAdvices,
-    removePublishItemFromQueue
+    removePublishItemFromQueue,
+	verifyS51TitleIsUnique
 } from './s51-advice.controller.js';
 import {
 	validateCreateS51Advice,
@@ -298,6 +299,42 @@ router.post(
 		}
     */
 	asyncHandler(removePublishItemFromQueue)
+);
+
+router.head(
+	'/:id/s51-advice/title-unique/:title',
+	/*
+        #swagger.tags = ['Applications']
+        #swagger.path = '/applications/{id}/s51-advice/title-unique/{title}'
+        #swagger.description = 'Checks whether an S51 title is unique to this case'
+         #swagger.parameters['id'] = {
+            in: 'path',
+			description: 'Application case ID',
+			required: true,
+			type: 'integer'
+        }
+        #swagger.parameters['title'] = {
+            in: 'path',
+			description: 'S51 Title',
+			required: true,
+			type: 'string'
+        }
+        #swagger.responses[200] = {
+            description: 'valid unique S51 Advice title',
+            schema: null
+        }
+		#swagger.responses[400] = {
+            description: 'Error: Bad Request - title is not unique',
+            schema: null
+        }
+		#swagger.responses[404] = {
+            description: 'Error: Not Found',
+			schema: null
+        }
+
+    */
+	validateApplicationId,
+	asyncHandler(verifyS51TitleIsUnique)
 );
 
 export { router as s51AdviceRoutes };

--- a/apps/api/src/server/repositories/s51-advice.repository.js
+++ b/apps/api/src/server/repositories/s51-advice.repository.js
@@ -191,3 +191,22 @@ export const getS51AdviceCountInByPublishStatus = (caseId) => {
 		}
 	});
 };
+};
+
+/**
+ * Finds all matching S51 advice records by title on a case.
+ * Can be used to check if a given S51 Title is unique to this case
+ *
+ * @param {number} caseId
+ * @param {string} title
+ * @returns {Promise<import('@pins/applications.api').Schema.S51Advice[] | null>}
+ */
+export const getS51AdviceManyByTitle = (caseId, title) => {
+	const s51advice = databaseConnector.s51Advice.findMany({
+		where: {
+			caseId,
+			title
+		}
+	});
+	return s51advice;
+};

--- a/apps/api/src/server/repositories/s51-advice.repository.js
+++ b/apps/api/src/server/repositories/s51-advice.repository.js
@@ -191,7 +191,6 @@ export const getS51AdviceCountInByPublishStatus = (caseId) => {
 		}
 	});
 };
-};
 
 /**
  * Finds all matching S51 advice records by title on a case.

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -3089,6 +3089,42 @@
 				"responses": {}
 			}
 		},
+		"/applications/{id}/s51-advice/title-unique/{title}": {
+			"head": {
+				"tags": ["Applications"],
+				"description": "Checks whether an S51 title is unique to this case",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application case ID"
+					},
+					{
+						"name": "title",
+						"in": "path",
+						"required": true,
+						"type": "string",
+						"description": "S51 Title"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "valid unique S51 Advice title",
+						"schema": null
+					},
+					"400": {
+						"description": "Error: Bad Request - title is not unique",
+						"schema": null
+					},
+					"404": {
+						"description": "Error: Not Found - invalid case id",
+						"schema": null
+					}
+				}
+			}
+		},
 		"/applications/subscriptions": {
 			"get": {
 				"tags": ["Applications"],


### PR DESCRIPTION
## Describe your changes

new endpoint `HEAD /applications/1/s51-advice/title-unique/`
to test whether a given S51 Advice Title is unique (ie not already in used on this case).

returns Status Code:
- 200 if it is unique (not already in use)
- 400 if it is not unique (already in use)
- 404 if the application id is invalid

Note: the test is case-insensitive, and leading and trailing spaces are trimmed and ignored - so '  ADVICE 1  ' will match to 'advice 1'

## S51 Advice API to check advice title is unique to case
https://pins-ds.atlassian.net/browse/BOAS-1143
(part of ticket BOAS-1082)


## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
