### PR TITLE
fix(api): representations publishing endpoint fixes

### DIFF
--- a/apps/api/src/server/applications/application/representations/publish/publish.controller.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.controller.js
@@ -7,7 +7,11 @@ export const publishRepresentations = async ({ params, body }, response) => {
 		body.actionBy
 	);
 
-	const publishedRepIds = publishedRepresentations.map((rep) => rep.id);
-
-	return response.status(200).json({ publishedRepIds });
+	if (publishedRepresentations.length > 0) {
+		return response
+			.status(200)
+			.json({ publishedRepIds: publishedRepresentations.map((rep) => rep.id) });
+	} else {
+		return response.status(400).json({ errors: { message: 'unable to publish representations' } });
+	}
 };

--- a/apps/api/src/server/applications/application/representations/publish/publish.route.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.route.js
@@ -33,6 +33,10 @@ router.patch(
 							publishedRepIds: [123, 134, 125]
 					}
 			}
+			#swagger.responses[400] = {
+				description: 'Error: Bad Request',
+				schema: { $ref: '#/definitions/GeneralError' }
+			}
 	 */
 	validateApplicationId,
 	validatePublishRepresentations,

--- a/apps/api/src/server/applications/application/representations/publish/publish.service.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.service.js
@@ -14,10 +14,16 @@ export const publishCaseRepresentations = async (caseId, representationIds, acti
 		representationIds
 	);
 
-	const nsipRepresentationsPayload = representations.map(buildNsipRepresentationPayload);
-	await eventClient.sendEvents(NSIP_REPRESENTATION, nsipRepresentationsPayload, EventType.Publish);
+	if (representations.length > 0) {
+		const nsipRepresentationsPayload = representations.map(buildNsipRepresentationPayload);
+		await eventClient.sendEvents(
+			NSIP_REPRESENTATION,
+			nsipRepresentationsPayload,
+			EventType.Publish
+		);
 
-	await setRepresentationsAsPublished(representations, actionBy);
+		await setRepresentationsAsPublished(representations, actionBy);
+	}
 
 	return representations;
 };

--- a/apps/api/src/server/applications/application/representations/publishable/__tests__/publishable-representations.test.js
+++ b/apps/api/src/server/applications/application/representations/publishable/__tests__/publishable-representations.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { request } from '#app-test';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
@@ -43,10 +44,18 @@ const representations = [
 ];
 
 describe('Get Publishable Representations', () => {
-	it('returns publiable representations for given case ids', async () => {
+	afterEach(() => jest.clearAllMocks());
+
+	it('returns publishable representations for given case id', async () => {
 		databaseConnector.representation.findMany.mockResolvedValue(representations);
 
 		const response = await request.get('/applications/1/representations/publishable');
+
+		expect(databaseConnector.representation.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				orderBy: [{ status: 'desc' }, { reference: 'asc' }]
+			})
+		);
 
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual({

--- a/apps/api/src/server/repositories/representation.repository.js
+++ b/apps/api/src/server/repositories/representation.repository.js
@@ -746,7 +746,8 @@ export const getPublishableRepresentations = async (caseId) =>
 		where: {
 			caseId,
 			OR: [{ status: 'PUBLISHED', unpublishedUpdates: true }, { status: 'VALID' }]
-		}
+		},
+		orderBy: [{ status: 'desc' }, { reference: 'asc' }]
 	});
 
 /**


### PR DESCRIPTION
## Describe your changes

- Fixes ASB-1838: return publishable reps in desired sort order (by status, then reference)
- Fixes ASB-1843: return 400 error if no rep ids are publishable, and do not publish message to message queue

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
