### PR TITLE
fix(appeals/api): add site visit fields to the get appeal endpoint

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -223,7 +223,10 @@ interface SingleAppealDetailsResponse {
 	planningApplicationReference: string;
 	procedureType: string | null;
 	siteVisit: {
+		siteVisitId: number | null;
 		visitDate: Date | null;
+		visitStartTime: string | null;
+		visitEndTime: string | null;
 		visitType: string | null;
 	};
 	startedAt: Date | null;
@@ -290,10 +293,6 @@ interface SingleAppellantCaseResponse {
 		isFullyOwned: boolean | null;
 		isPartiallyOwned: boolean | null;
 		knowsOtherLandowners: string | null;
-	};
-	siteVisit: {
-		siteVisitId: number | null;
-		visitType: string | null;
 	};
 	validation: ValidationOutcomeResponse | null;
 	visibility: {

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -478,7 +478,10 @@ describe('appeals routes', () => {
 					planningApplicationReference: householdAppeal.planningApplicationReference,
 					procedureType: householdAppeal.lpaQuestionnaire.procedureType.name,
 					siteVisit: {
+						siteVisitId: householdAppeal.siteVisit.id,
 						visitDate: householdAppeal.siteVisit.visitDate,
+						visitStartTime: householdAppeal.siteVisit.visitStartTime,
+						visitEndTime: householdAppeal.siteVisit.visitEndTime,
 						visitType: householdAppeal.siteVisit.siteVisitType.name
 					},
 					startedAt: householdAppeal.startedAt.toISOString()
@@ -575,7 +578,10 @@ describe('appeals routes', () => {
 					planningApplicationReference: fullPlanningAppeal.planningApplicationReference,
 					procedureType: fullPlanningAppeal.lpaQuestionnaire.procedureType.name,
 					siteVisit: {
+						siteVisitId: fullPlanningAppeal.siteVisit.id,
 						visitDate: fullPlanningAppeal.siteVisit.visitDate,
+						visitStartTime: fullPlanningAppeal.siteVisit.visitStartTime,
+						visitEndTime: fullPlanningAppeal.siteVisit.visitEndTime,
 						visitType: fullPlanningAppeal.siteVisit.siteVisitType.name
 					},
 					startedAt: fullPlanningAppeal.startedAt.toISOString()

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -98,7 +98,10 @@ const formatAppeal = (appeal) => {
 			planningApplicationReference: appeal.planningApplicationReference,
 			procedureType: appeal.lpaQuestionnaire?.procedureType?.name || null,
 			siteVisit: {
+				siteVisitId: appeal.siteVisit?.id || null,
 				visitDate: appeal.siteVisit?.visitDate || null,
+				visitStartTime: appeal.siteVisit?.visitStartTime || null,
+				visitEndTime: appeal.siteVisit?.visitEndTime || null,
 				visitType: appeal.siteVisit?.siteVisitType?.name || null
 			},
 			startedAt: appeal.startedAt,

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
@@ -14,7 +14,7 @@ import { mapFoldersLayoutForAppealSection } from '../documents/documents.mapper.
  * @returns {SingleAppellantCaseResponse | void}
  */
 const formatAppellantCase = (appeal, folders = null) => {
-	const { appellantCase, siteVisit } = appeal;
+	const { appellantCase } = appeal;
 
 	if (appellantCase) {
 		return {
@@ -79,10 +79,6 @@ const formatAppellantCase = (appeal, folders = null) => {
 				isFullyOwned: appellantCase.isSiteFullyOwned,
 				isPartiallyOwned: appellantCase.isSitePartiallyOwned,
 				knowsOtherLandowners: appellantCase.knowledgeOfOtherLandowners?.name || null
-			},
-			siteVisit: {
-				siteVisitId: siteVisit?.id || null,
-				visitType: siteVisit?.siteVisitType?.name || null
 			},
 			validation: formatValidationOutcomeResponse(
 				appellantCase.appellantCaseValidationOutcome?.name,

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -230,8 +230,14 @@ export interface SingleAppealResponse {
 	/** @example "Written" */
 	procedureType?: string;
 	siteVisit?: {
+		/** @example 1 */
+		siteVisitId?: number;
 		/** @example "2022-03-31T12:00:00.000Z" */
 		visitDate?: string;
+		/** @example "10:00" */
+		visitStartTime?: string;
+		/** @example "12:00" */
+		visitEndTime?: string;
 		/** @example "Accompanied" */
 		visitType?: string;
 	};
@@ -366,12 +372,6 @@ export interface SingleAppellantCaseResponse {
 		isPartiallyOwned?: boolean;
 		/** @example "Some" */
 		knowsOtherLandowners?: string;
-	};
-	siteVisit?: {
-		/** @example 1 */
-		siteVisitId?: number;
-		/** @example "Accompanied" */
-		visitType?: string;
 	};
 	validation?: {
 		/** @example "Incomplete" */

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -2063,9 +2063,21 @@
 					"siteVisit": {
 						"type": "object",
 						"properties": {
+							"siteVisitId": {
+								"type": "number",
+								"example": 1
+							},
 							"visitDate": {
 								"type": "string",
 								"example": "2022-03-31T12:00:00.000Z"
+							},
+							"visitStartTime": {
+								"type": "string",
+								"example": "10:00"
+							},
+							"visitEndTime": {
+								"type": "string",
+								"example": "12:00"
 							},
 							"visitType": {
 								"type": "string",
@@ -2355,19 +2367,6 @@
 							"knowsOtherLandowners": {
 								"type": "string",
 								"example": "Some"
-							}
-						}
-					},
-					"siteVisit": {
-						"type": "object",
-						"properties": {
-							"siteVisitId": {
-								"type": "number",
-								"example": 1
-							},
-							"visitType": {
-								"type": "string",
-								"example": "Accompanied"
 							}
 						}
 					},

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -186,7 +186,10 @@ export const spec = {
 			planningApplicationReference: '48269/APP/2021/1482',
 			procedureType: 'Written',
 			siteVisit: {
+				siteVisitId: 1,
 				visitDate: '2022-03-31T12:00:00.000Z',
+				visitStartTime: '10:00',
+				visitEndTime: '12:00',
 				visitType: 'Accompanied'
 			},
 			startedAt: '2022-05-17T23:00:00.000Z',
@@ -271,10 +274,6 @@ export const spec = {
 				isFullyOwned: false,
 				isPartiallyOwned: true,
 				knowsOtherLandowners: 'Some'
-			},
-			siteVisit: {
-				siteVisitId: 1,
-				visitType: 'Accompanied'
 			},
 			validation: {
 				outcome: 'Incomplete',

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -672,10 +672,6 @@ const baseExpectedAppellantCaseResponse = (appeal) => ({
 		isPartiallyOwned: appeal.appellantCase?.isSitePartiallyOwned,
 		knowsOtherLandowners: appeal.appellantCase?.knowledgeOfOtherLandowners.name
 	},
-	siteVisit: {
-		siteVisitId: appeal.siteVisit?.id,
-		visitType: appeal.siteVisit?.siteVisitType.name
-	},
 	validation: formatValidationOutcomeResponse(
 		appeal.appellantCase?.appellantCaseValidationOutcome?.name,
 		appeal.appellantCase?.appellantCaseIncompleteReasonsOnAppellantCases,


### PR DESCRIPTION
## Describe your changes

The Site Visit details are displayed on the Case Details page not the Appellant Case page so we need to ensure that this data is available in the UI.

- Remove the Site Visit data from the GET Appellant Case API endpoint
- Add Site Visit data to the GET Appeal API endpoint

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-539

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
