### PR TITLE
feat: ensure required config is set at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ apps/api> npm run db:seed
 Ensure a database is running and setup, then:
 
 1. `apps/api` requires an `.env` file with a `DATABASE_URL` entry, as per [Database Environment Setup](#environment-setup)
-2. `apps/web` requires a `.env.local` file, copying `.env.development` gives a good starting point, but `SESSION_SECRET=anyValue` needs adding to it
+2. `apps/web` requires a `.env` file, copying `.env.example` gives a good starting point and should work
 
 To run the apps, the recommended option is to have 2 terminals, one running the api, and one running the web app:
 

--- a/appeals/web/.env.development
+++ b/appeals/web/.env.development
@@ -29,10 +29,8 @@ AUTH_DISABLED_GROUP_IDS=*
 
 APPEALS_CASE_OFFICER_GROUP_ID=appeals_case_officer
 APPEALS_INSPECTOR_GROUP_ID=appeals_inspector
-APPEALS_VALIDATION_OFFICER_GROUP_ID=appeals_validation_officer
-APPLICATIONS_CASE_ADMIN_OFFICER_GROUP_ID=applications_case_admin_officer
-APPLICATIONS_CASETEAM_GROUP_ID=applications_case_team
-APPLICATIONS_INSPECTOR_GROUP_ID=applications_inspector
+APPEALS_LEGAL_TEAM_GROUP_ID=appeals_legal_team
+APPEALS_CS_TEAM_GROUP_ID=appeals_cs_team
 
 
 ## HTTP #######################################################################

--- a/appeals/web/.env.example
+++ b/appeals/web/.env.example
@@ -1,69 +1,55 @@
-## MSAL #######################################################################
+# Example .env file for local development (auth disabled)
 
-# The unique application (client) uuid assigned to the web app by Azure AD when
-# the app was registered.
+## Auth #######################################################################
+
 # AUTH_CLIENT_ID=
-
-# The tenant uuid used by the MSAL authority (which is a url that indicates a
-# directory that MSAL can request tokens from).
-# AUTH_TENANT_ID=
-
-# This secret is provided by the Azure AD during app registration.
 # AUTH_CLIENT_SECRET=
+# AUTH_TENANT_ID=
 
 # A flag to indicate whether integration with MSAL is disabled on this
 # environment. This is only used during development. When true, the MSAL client
 # configuration data (above) is not required.
-# AUTH_DISABLED=true
+AUTH_DISABLED=true
 
 # When auth is disabled (see above), a list of comma-delimited group ids can
 # be provided to simulate a user's account. The wildcard '*' will simulate the
 # user being a member of all groups belonging to the web app.
-# AUTH_DISABLED_GROUP_IDS=*
+AUTH_DISABLED_GROUP_IDS=*
 
-
-## ACTIVE DIRECTORY ###########################################################
-
-# The uuids of the groups within Azure AD that users are assigned to for
-# accessing the different domains.
-
-# APPEALS_CASEOFFICER_GROUP_ID=
-# APPEALS_INSPECTOR_GROUP_ID=
-# APPEALS_VALIDATIONOFFICER_GROUP_ID=
-# APPLICATIONS_CASE_ADMIN_OFFICER_GROUP_ID=
-# APPLICATIONS_CASETEAM_GROUP_ID=
-# APPLICATIONS_INSPECTOR_GROUP_ID=
-
+APPEALS_CASE_OFFICER_GROUP_ID=appeals_case_officer
+APPEALS_INSPECTOR_GROUP_ID=appeals_inspector
+APPEALS_LEGAL_TEAM_GROUP_ID=appeals_legal_team
+APPEALS_CS_TEAM_GROUP_ID=appeals_cs_team
 
 ## HTTP #######################################################################
 
-# The api hostame
-# API_HOST=http://localhost:3000
+API_HOST=http://localhost:3000
+APP_HOSTNAME=localhost:8080
 
-# Enable the https protocol for the web server.
-# HTTPS_ENABLED=false
+HTTPS_ENABLED=false
 
-# The web server port when running under http protocol.
-# HTTP_PORT=8080
-
-# The web server port when running under https protocol.
+HTTP_PORT=8080
 # HTTPS_PORT=3443
 
-# The path to the SSL certificate file – required when https is enabled.
+# The path to the SSL cert & key files – required when https is enabled.
 # SSL_CERT_FILE=
-
-# The path to the SSL certificate key file – required when https is enabled.
 # SSL_KEY_FILE=
-
 
 ## LOGGING ####################################################################
 
 # The logging level for the server.log
 # Options: trace, debug, info, warn, error, fatal, silent
-# LOG_LEVEL_FILE=debug
+LOG_LEVEL_FILE=debug
 
 # The logging level for the stdout.
 # Options: trace, debug, info, warn, error, fatal, silent
-# LOG_LEVEL_STDOUT=info
-# AZURE_BLOB_STORE_HOST=https://127.0.0.1:10000/
-# AZURE_BLOB_DEFAULT_CONTAINER=document-service-uploads
+LOG_LEVEL_STDOUT=debug
+
+## General  ####################################################################
+
+# Blob store host - used for CSP and file downloads
+AZURE_BLOB_STORE_HOST=any
+AZURE_BLOB_STORE_HOST=https://127.0.0.1:10000/devstoreaccount1
+AZURE_BLOB_DEFAULT_CONTAINER=document-service-uploads
+
+SESSION_SECRET=SomeSecretHere

--- a/appeals/web/.env.test
+++ b/appeals/web/.env.test
@@ -29,11 +29,8 @@ AUTH_CLIENT_SECRET=auth_client_secret
 
 APPEALS_CASE_OFFICER_GROUP_ID=appeals_case_officer
 APPEALS_INSPECTOR_GROUP_ID=appeals_inspector
-APPEALS_VALIDATION_OFFICER_GROUP_ID=appeals_validation_officer
-APPLICATIONS_CASE_ADMIN_OFFICER_GROUP_ID=applications_case_admin_officer
-APPLICATIONS_CASETEAM_GROUP_ID=applications_case_team
-APPLICATIONS_INSPECTOR_GROUP_ID=applications_inspector
-
+APPEALS_LEGAL_TEAM_GROUP_ID=appeals_legal_team
+APPEALS_CS_TEAM_GROUP_ID=appeals_cs_team
 
 ## HTTP #######################################################################
 APP_HOSTNAME=localhost:8080

--- a/appeals/web/.env.test
+++ b/appeals/web/.env.test
@@ -36,7 +36,7 @@ APPLICATIONS_INSPECTOR_GROUP_ID=applications_inspector
 
 
 ## HTTP #######################################################################
-
+APP_HOSTNAME=localhost:8080
 # The api hostame
 API_HOST=http://test
 

--- a/appeals/web/environment/base-config.js
+++ b/appeals/web/environment/base-config.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import url from 'node:url';
 import { baseSchema } from './schema.js';
 
-const __dirname = url.fileURLToPath(import.meta.url);
+const __dirname = path.basename(url.fileURLToPath(import.meta.url));
 
 /**
  * @typedef {import('./config.js').BaseEnvironmentConfig} BaseEnvironmentConfig

--- a/appeals/web/environment/base-config.js
+++ b/appeals/web/environment/base-config.js
@@ -1,0 +1,61 @@
+import { loadEnvironment } from '@pins/platform';
+import path from 'node:path';
+import url from 'node:url';
+import { baseSchema } from './schema.js';
+
+const __dirname = url.fileURLToPath(import.meta.url);
+
+/**
+ * @typedef {import('./config.js').BaseEnvironmentConfig} BaseEnvironmentConfig
+ */
+
+/**
+ * Returns validated base configuration from the given environment settings.
+ *
+ * @param {Record<string, string | undefined>} environment
+ * @returns {BaseEnvironmentConfig}
+ * @throws {Error}
+ */
+export function baseConfigFromEnvironment(environment) {
+	const cwd = path.join(__dirname, '..'); // web folder
+
+	const env = environment.NODE_ENV;
+	const config = {
+		bundleAnalyzer: false, // TODO: load this from environment?
+		buildDir: path.join(cwd, '.build'),
+		cwd,
+		env,
+		isProduction: env === 'production',
+		isDevelopment: env === 'development' || env === 'local',
+		isTest: env === 'test',
+		isRelease: environment.APP_RELEASE
+	};
+
+	const { value: validatedConfig, error } = baseSchema.validate(config);
+
+	if (error) {
+		throw new Error(`loadBaseConfig validation error: ${error.message}`);
+	}
+	return validatedConfig;
+}
+
+/**
+ * Loaded config, it only needs loading once
+ * @type {BaseEnvironmentConfig|undefined}
+ */
+let baseConfig;
+
+/**
+ * Load environment settings, and returns validated base config.
+ *
+ * @returns {BaseEnvironmentConfig}
+ */
+export function loadBaseConfig() {
+	if (baseConfig !== undefined) {
+		return baseConfig;
+	}
+	const environment = loadEnvironment(process.env.NODE_ENV);
+	const config = baseConfigFromEnvironment(environment);
+	baseConfig = config;
+	return config;
+}

--- a/appeals/web/environment/config.d.ts
+++ b/appeals/web/environment/config.d.ts
@@ -1,6 +1,25 @@
 import { LevelWithSilent } from 'pino';
 
-export interface EnvironmentConfig {
+/**
+ * Configuration required for bundling or build steps, not running the application.
+ * Loaded from the process environment, and .env files.
+ */
+export interface BaseEnvironmentConfig {
+	buildDir: string;
+	bundleAnalyzer: boolean;
+	cwd: string;
+	env: 'development' | 'test' | 'production' | 'local';
+	isProduction: boolean;
+	isDevelopment: boolean;
+	isTest: boolean;
+	isRelease?: boolean;
+}
+
+/**
+ * Configuration required for running the application.
+ * Loaded from the process environment, and .env files.
+ */
+export interface EnvironmentConfig extends BaseEnvironmentConfig {
 	// The web application hostname (e.g. back-office-dev.planninginspectorate.gov.uk)
 	appHostname: string;
 	apiUrl: string;
@@ -12,20 +31,12 @@ export interface EnvironmentConfig {
 	blobStorageDefaultContainer: string;
 	blobEmulatorSasUrl: string;
 	useBlobEmulator: boolean;
-	bundleAnalyzer: boolean;
-	buildDir: string;
 	cwd: string;
-	env: 'development' | 'test' | 'production' | 'local';
-	isProduction: boolean;
-	isDevelopment: boolean;
-	isTest: boolean;
-	isRelease?: boolean;
 	logLevelFile: LevelWithSilent;
 	logLevelStdOut: LevelWithSilent;
 	msal: {
 		authority: string;
 		clientId: string;
-		apiClientId: string;
 		clientSecret: string;
 		redirectUri: string;
 		logoutUri: string;
@@ -48,6 +59,7 @@ export interface EnvironmentConfig {
 	};
 }
 
-const config: EnvironmentConfig;
+export function loadConfig(): EnvironmentConfig;
 
+const config: EnvironmentConfig;
 export default config;

--- a/appeals/web/environment/config.js
+++ b/appeals/web/environment/config.js
@@ -1,73 +1,106 @@
 import { loadEnvironment } from '@pins/platform';
 import path from 'node:path';
-import url from 'node:url';
 import schema from './schema.js';
+import { baseConfigFromEnvironment } from './base-config.js';
 
-const environment = loadEnvironment(process.env.NODE_ENV);
+/**
+ * @typedef {import('./config.js').EnvironmentConfig} EnvironmentConfig
+ */
 
-const { value: validatedConfig, error } = schema.validate({
-	appHostname: environment.APP_HOSTNAME,
-	apiUrl: environment.API_HOST,
-	authDisabled: environment.AUTH_DISABLED,
-	authRedirectPath: environment.AUTH_REDIRECT_PATH || '/auth/redirect',
-	blobStorageUrl: environment.AZURE_BLOB_STORE_HOST,
-	blobStorageDefaultContainer: environment.AZURE_BLOB_DEFAULT_CONTAINER,
-	blobEmulatorSasUrl: environment.AZURE_BLOB_EMULATOR_SAS_HOST,
-	useBlobEmulator: environment.AZURE_BLOB_USE_EMULATOR,
-	env: environment.NODE_ENV,
-	isRelease: environment.APP_RELEASE,
-	logLevelFile: environment.LOG_LEVEL_FILE,
-	logLevelStdOut: environment.LOG_LEVEL_STDOUT,
-	msal: {
-		clientId: environment.AUTH_CLIENT_ID,
-		clientSecret: environment.AUTH_CLIENT_SECRET,
-		apiClientId: environment.AUTH_CLIENT_BACKEND_API_ID,
-		tenantId: environment.AUTH_TENANT_ID
-	},
-	serverPort: environment.HTTPS_ENABLED === 'true' ? environment.HTTPS_PORT : environment.HTTP_PORT,
-	serverProtocol: environment.HTTPS_ENABLED === 'true' ? 'https' : 'http',
-	sessionSecret: environment.SESSION_SECRET,
-	sslCertificateFile: environment.SSL_CERT_FILE,
-	sslCertificateKeyFile: environment.SSL_KEY_FILE,
-	referenceData: {
-		appeals: {
-			caseOfficerGroupId: environment.APPEALS_CASE_OFFICER_GROUP_ID,
-			inspectorGroupId: environment.APPEALS_INSPECTOR_GROUP_ID,
-			legalGroupId: environment.APPEALS_LEGAL_TEAM_GROUP_ID,
-			customerServiceGroupId: environment.APPEALS_CS_TEAM_GROUP_ID
-		}
-	},
-	// flag name convention: featureFlag[ jira number ][ferature shoret description]
-	// set Feature Flag default val here [default: false] - will be overwritted by values cming from the .env file
-	featureFlags: {
-		featureFlagBoas1TestFeature: !environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE
-			? false
-			: environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
+/**
+ * Loaded config, it only needs loading once
+ * @type {EnvironmentConfig|undefined}
+ */
+let loadedConfig;
+
+/**
+ * Load environment settings, and returns validated config.
+ *
+ * @returns {EnvironmentConfig}
+ */
+export function loadConfig() {
+	if (loadedConfig) {
+		return loadedConfig;
 	}
-});
+	const environment = loadEnvironment(process.env.NODE_ENV);
+	const baseConfig = baseConfigFromEnvironment(environment);
+	// defaults where needed
+	const {
+		API_HOST,
+		APP_HOSTNAME,
+		APPEALS_CASE_OFFICER_GROUP_ID,
+		APPEALS_INSPECTOR_GROUP_ID,
+		APPEALS_LEGAL_TEAM_GROUP_ID,
+		APPEALS_CS_TEAM_GROUP_ID,
+		AUTH_CLIENT_ID = '*',
+		AUTH_CLIENT_SECRET = '*',
+		AUTH_DISABLED_GROUP_IDS = '',
+		AUTH_DISABLED,
+		AUTH_REDIRECT_PATH = '/auth/redirect',
+		AUTH_TENANT_ID = '*',
+		AZURE_BLOB_STORE_HOST,
+		AZURE_BLOB_DEFAULT_CONTAINER,
+		AZURE_BLOB_EMULATOR_SAS_HOST,
+		AZURE_BLOB_USE_EMULATOR,
+		FEATURE_FLAG_BOAS_1_TEST_FEATURE,
+		HTTP_PORT = 8080,
+		HTTPS_ENABLED,
+		HTTPS_PORT,
+		LOG_LEVEL_FILE,
+		LOG_LEVEL_STDOUT,
+		SESSION_SECRET,
+		SSL_CERT_FILE,
+		SSL_KEY_FILE
+	} = environment;
 
-if (error) {
-	throw new Error(`Env validation error: ${error.message}`);
+	const config = {
+		...baseConfig,
+		appHostname: APP_HOSTNAME,
+		apiUrl: API_HOST,
+		authDisabled: AUTH_DISABLED,
+		authDisabledGroupIds: AUTH_DISABLED_GROUP_IDS.split(','),
+		authRedirectPath: AUTH_REDIRECT_PATH,
+		blobStorageUrl: AZURE_BLOB_STORE_HOST,
+		blobStorageDefaultContainer: AZURE_BLOB_DEFAULT_CONTAINER,
+		blobEmulatorSasUrl: AZURE_BLOB_EMULATOR_SAS_HOST,
+		useBlobEmulator: AZURE_BLOB_USE_EMULATOR,
+		logLevelFile: LOG_LEVEL_FILE,
+		logLevelStdOut: LOG_LEVEL_STDOUT,
+		msal: {
+			clientId: AUTH_CLIENT_ID,
+			clientSecret: AUTH_CLIENT_SECRET,
+			authority: `https://login.microsoftonline.com/${AUTH_TENANT_ID}`,
+			logoutUri: 'https://login.microsoftonline.com/common/oauth2/v2.0/logout'
+		},
+		serverPort: HTTPS_ENABLED === 'true' ? HTTPS_PORT : HTTP_PORT,
+		serverProtocol: HTTPS_ENABLED === 'true' ? 'https' : 'http',
+		sessionSecret: SESSION_SECRET,
+		sslCertificateFile: SSL_CERT_FILE,
+		sslCertificateKeyFile: SSL_KEY_FILE,
+		referenceData: {
+			appeals: {
+				caseOfficerGroupId: APPEALS_CASE_OFFICER_GROUP_ID,
+				inspectorGroupId: APPEALS_INSPECTOR_GROUP_ID,
+				legalGroupId: APPEALS_LEGAL_TEAM_GROUP_ID,
+				customerServiceGroupId: APPEALS_CS_TEAM_GROUP_ID
+			}
+		},
+		// flag name convention: featureFlag[ jira number ][ferature shoret description]
+		// set Feature Flag default val here [default: false] - will be overwritted by values cming from the .env file
+		featureFlags: {
+			featureFlagBoas1TestFeature: FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
+		},
+		tmpDir: path.join(baseConfig.cwd, '.tmp')
+	};
+
+	const { value: validatedConfig, error } = schema.validate(config);
+
+	if (error) {
+		throw new Error(`loadConfig validation error: ${error.message}`);
+	}
+
+	loadedConfig = validatedConfig;
+	return validatedConfig;
 }
 
-const cwd = url.fileURLToPath(new URL('..', import.meta.url));
-const { AUTH_DISABLED_GROUP_IDS = '' } = environment;
-const { msal, ...config } = validatedConfig;
-const { clientId = '*', tenantId = '*', clientSecret = '*' } = msal;
-
-export default {
-	...config,
-	authDisabledGroupIds: AUTH_DISABLED_GROUP_IDS.split(','),
-	buildDir: path.join(cwd, '.build'),
-	cwd,
-	isProduction: validatedConfig.env === 'production',
-	isDevelopment: validatedConfig.env === 'development' || validatedConfig.env === 'local',
-	isTest: validatedConfig.env === 'test',
-	msal: {
-		clientId,
-		clientSecret,
-		authority: `https://login.microsoftonline.com/${tenantId}`,
-		logoutUri: 'https://login.microsoftonline.com/common/oauth2/v2.0/logout'
-	},
-	tmpDir: path.join(cwd, '.tmp')
-};
+export default loadConfig();

--- a/appeals/web/environment/schema.js
+++ b/appeals/web/environment/schema.js
@@ -2,39 +2,60 @@ import joi from 'joi';
 
 const logLevel = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'];
 
-export default joi.object({
-	appHostname: joi.string(),
-	apiUrl: joi.string().uri(),
-	authDisabled: joi.boolean().optional(),
-	authRedirectPath: joi.string(),
-	blobStorageUrl: joi.string(),
-	blobEmulatorSasUrl: joi.string(),
-	blobStorageDefaultContainer: joi.string(),
-	useBlobEmulator: joi.boolean().optional(),
-	env: joi.string().valid('development', 'production', 'test', 'local'),
-	isRelease: joi.boolean().optional(),
-	logLevelFile: joi.string().valid(...logLevel),
-	logLevelStdOut: joi.string().valid(...logLevel),
-	msal: joi.object({
-		clientId: joi.string(),
-		clientSecret: joi.string(),
-		tenantId: joi.string(),
-		apiClientId: joi.string()
-	}),
-	serverProtocol: joi.string().valid('http', 'https'),
-	serverPort: joi.number(),
-	sessionSecret: joi
-		.string()
-		.when('env', { is: 'test', then: joi.optional(), otherwise: joi.optional() }),
-	sslCertificateFile: joi.string(),
-	sslCertificateKeyFile: joi.string(),
-	referenceData: joi.object({
-		appeals: joi.object({
-			caseOfficerGroupId: joi.string(),
-			inspectorGroupId: joi.string(),
-			legalGroupId: joi.string(),
-			customerServiceGroupId: joi.string()
-		})
-	}),
-	featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean())
-});
+export const baseSchema = joi
+	.object({
+		buildDir: joi.string(),
+		bundleAnalyzer: joi.boolean(),
+		cwd: joi.string(),
+		env: joi.string().valid('development', 'production', 'test', 'local'),
+		isProduction: joi.boolean(),
+		isDevelopment: joi.boolean(),
+		isTest: joi.boolean(),
+		isRelease: joi.boolean().optional()
+	})
+	.options({ presence: 'required' }); // all required by default
+
+export default baseSchema
+	.append({
+		appHostname: joi.string(),
+		apiUrl: joi.string().uri(),
+		authDisabled: joi.boolean().optional(),
+		authDisabledGroupIds: joi.array().optional(),
+		authRedirectPath: joi.string(),
+		blobStorageUrl: joi.string(),
+		blobEmulatorSasUrl: joi.string().when('useBlobEmulator', { not: 'true', then: joi.optional() }),
+		blobStorageDefaultContainer: joi.string(),
+		useBlobEmulator: joi.boolean().optional(),
+		logLevelFile: joi.string().valid(...logLevel),
+		logLevelStdOut: joi.string().valid(...logLevel),
+		msal: joi
+			.object({
+				authority: joi.string(),
+				clientId: joi.string(),
+				clientSecret: joi.string(),
+				logoutUri: joi.string()
+			})
+			.options({ presence: 'required' }),
+		serverProtocol: joi.string().valid('http', 'https'),
+		serverPort: joi.number(),
+		sessionSecret: joi.string().when('env', { is: 'test', then: joi.optional() }),
+		sslCertificateFile: joi.string().when('serverProtocol', { is: 'http', then: joi.optional() }),
+		sslCertificateKeyFile: joi
+			.string()
+			.when('serverProtocol', { is: 'http', then: joi.optional() }),
+		tmpDir: joi.string(),
+		referenceData: joi
+			.object({
+				appeals: joi
+					.object({
+						caseOfficerGroupId: joi.string(),
+						inspectorGroupId: joi.string(),
+						legalGroupId: joi.string(),
+						customerServiceGroupId: joi.string()
+					})
+					.options({ presence: 'required' })
+			})
+			.options({ presence: 'required' }),
+		featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean())
+	})
+	.options({ presence: 'required' }); // all required by default

--- a/appeals/web/scripts/rollup/bundle-js.js
+++ b/appeals/web/scripts/rollup/bundle-js.js
@@ -10,12 +10,12 @@ import fs from 'node:fs';
 import { rollup } from 'rollup';
 import iife from 'rollup-plugin-iife';
 import { visualizer } from 'rollup-plugin-visualizer';
-import config from '../../environment/config.js';
+import { loadBaseConfig } from '@pins/applications.web/environment/base-config.js';
 import { getLogger } from './get-logger.js';
 import { minifySource } from './minify-js.js';
 import { buildVirtualJSON } from './rollup-plugin-virtual-json.js';
 
-const { buildDir, env, bundleAnalyzer, isProduction, isRelease } = config;
+const { buildDir, env, bundleAnalyzer, isProduction, isRelease } = loadBaseConfig();
 const logger = getLogger({ scope: 'JS' });
 
 process.on('unhandledRejection', (reason, p) => {

--- a/appeals/web/scripts/rollup/compile-css.js
+++ b/appeals/web/scripts/rollup/compile-css.js
@@ -1,4 +1,4 @@
-import config from '@pins/appeals.web/environment/config.js';
+import { loadBaseConfig } from '@pins/applications.web/environment/base-config.js';
 import autoprefixer from 'autoprefixer';
 import kleur from 'kleur';
 import fs from 'node:fs';
@@ -12,7 +12,7 @@ import { hashForContent } from './hash.js';
 /** @typedef {import('source-map-js').RawSourceMap} RawSourceMap */
 /** @typedef {import('postcss').SourceMap} SourceMap */
 
-const { buildDir, isProduction, isRelease } = config;
+const { buildDir, isProduction, isRelease } = loadBaseConfig();
 const logger = getLogger({ scope: 'Sass' });
 
 const appDirectory = fs.realpathSync(process.cwd());

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,64 +1,52 @@
-## MSAL #######################################################################
+# Example .env file for local development (auth disabled)
 
-# The unique application (client) uuid assigned to the web app by Azure AD when
-# the app was registered.
+## Auth #######################################################################
+
 # AUTH_CLIENT_ID=
-
-# The tenant uuid used by the MSAL authority (which is a url that indicates a
-# directory that MSAL can request tokens from).
-# AUTH_TENANT_ID=
-
-# This secret is provided by the Azure AD during app registration.
 # AUTH_CLIENT_SECRET=
+# AUTH_TENANT_ID=
 
 # A flag to indicate whether integration with MSAL is disabled on this
 # environment. This is only used during development. When true, the MSAL client
 # configuration data (above) is not required.
-# AUTH_DISABLED=true
+AUTH_DISABLED=true
 
 # When auth is disabled (see above), a list of comma-delimited group ids can
 # be provided to simulate a user's account. The wildcard '*' will simulate the
 # user being a member of all groups belonging to the web app.
-# AUTH_DISABLED_GROUP_IDS=*
+AUTH_DISABLED_GROUP_IDS=*
 
-
-## ACTIVE DIRECTORY ###########################################################
-
-# The uuids of the groups within Azure AD that users are assigned to for
-# accessing the different domains.
-
-# APPLICATIONS_CASE_ADMIN_OFFICER_GROUP_ID=
-# APPLICATIONS_CASETEAM_GROUP_ID=
-# APPLICATIONS_INSPECTOR_GROUP_ID=
-
+APPLICATIONS_CASE_ADMIN_OFFICER_GROUP_ID=applications_case_admin_officer
+APPLICATIONS_CASETEAM_GROUP_ID=applications_case_team
+APPLICATIONS_INSPECTOR_GROUP_ID=applications_inspector
 
 ## HTTP #######################################################################
 
-# The api hostame
-# API_HOST=http://localhost:3000
+API_HOST=http://localhost:3000
+APP_HOSTNAME=localhost:8080
 
-# Enable the https protocol for the web server.
-# HTTPS_ENABLED=false
+HTTPS_ENABLED=false
 
-# The web server port when running under http protocol.
-# HTTP_PORT=8080
-
-# The web server port when running under https protocol.
+HTTP_PORT=8080
 # HTTPS_PORT=3443
 
-# The path to the SSL certificate file – required when https is enabled.
+# The path to the SSL cert & key files – required when https is enabled.
 # SSL_CERT_FILE=
-
-# The path to the SSL certificate key file – required when https is enabled.
 # SSL_KEY_FILE=
-
 
 ## LOGGING ####################################################################
 
 # The logging level for the server.log
 # Options: trace, debug, info, warn, error, fatal, silent
-# LOG_LEVEL_FILE=debug
+LOG_LEVEL_FILE=debug
 
 # The logging level for the stdout.
 # Options: trace, debug, info, warn, error, fatal, silent
-# LOG_LEVEL_STDOUT=info
+LOG_LEVEL_STDOUT=debug
+
+## General  ####################################################################
+
+# Blob store host - used for CSP and file downloads
+AZURE_BLOB_STORE_HOST=any
+
+SESSION_SECRET=SomeSecretHere

--- a/apps/web/.env.test
+++ b/apps/web/.env.test
@@ -85,3 +85,4 @@ DOCUMENT_STORAGE_CONNECTION_STRING=AccountName=devstoreaccount1;AccountKey=Eby8v
 
 # The web hostname
 APP_HOSTNAME=localhost:8080
+AZURE_BLOB_STORE_HOST=any

--- a/apps/web/environment/base-config.js
+++ b/apps/web/environment/base-config.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 import url from 'node:url';
 import { baseSchema } from './schema.js';
 
-const __dirname = url.fileURLToPath(import.meta.url);
+const __dirname = path.basename(url.fileURLToPath(import.meta.url));
 
 /**
  * @typedef {import('./config.js').BaseEnvironmentConfig} BaseEnvironmentConfig

--- a/apps/web/environment/base-config.js
+++ b/apps/web/environment/base-config.js
@@ -1,0 +1,61 @@
+import { loadEnvironment } from '@pins/platform';
+import path from 'node:path';
+import url from 'node:url';
+import { baseSchema } from './schema.js';
+
+const __dirname = url.fileURLToPath(import.meta.url);
+
+/**
+ * @typedef {import('./config.js').BaseEnvironmentConfig} BaseEnvironmentConfig
+ */
+
+/**
+ * Returns validated base configuration from the given environment settings.
+ *
+ * @param {Record<string, string | undefined>} environment
+ * @returns {BaseEnvironmentConfig}
+ * @throws {Error}
+ */
+export function baseConfigFromEnvironment(environment) {
+	const cwd = path.join(__dirname, '..'); // web folder
+
+	const env = environment.NODE_ENV;
+	const config = {
+		bundleAnalyzer: false, // TODO: load this from environment?
+		buildDir: path.join(cwd, '.build'),
+		cwd,
+		env,
+		isProduction: env === 'production',
+		isDevelopment: env === 'development' || env === 'local',
+		isTest: env === 'test',
+		isRelease: environment.APP_RELEASE
+	};
+
+	const { value: validatedConfig, error } = baseSchema.validate(config);
+
+	if (error) {
+		throw new Error(`loadBaseConfig validation error: ${error.message}`);
+	}
+	return validatedConfig;
+}
+
+/**
+ * Loaded config, it only needs loading once
+ * @type {BaseEnvironmentConfig|undefined}
+ */
+let baseConfig;
+
+/**
+ * Load environment settings, and returns validated base config.
+ *
+ * @returns {BaseEnvironmentConfig}
+ */
+export function loadBaseConfig() {
+	if (baseConfig !== undefined) {
+		return baseConfig;
+	}
+	const environment = loadEnvironment(process.env.NODE_ENV);
+	const config = baseConfigFromEnvironment(environment);
+	baseConfig = config;
+	return config;
+}

--- a/apps/web/environment/config.d.ts
+++ b/apps/web/environment/config.d.ts
@@ -1,6 +1,25 @@
 import { LevelWithSilent } from 'pino';
 
-export interface EnvironmentConfig {
+/**
+ * Configuration required for bundling or build steps, not running the application.
+ * Loaded from the process environment, and .env files.
+ */
+export interface BaseEnvironmentConfig {
+	buildDir: string;
+	bundleAnalyzer: boolean;
+	cwd: string;
+	env: 'development' | 'test' | 'production' | 'local';
+	isProduction: boolean;
+	isDevelopment: boolean;
+	isTest: boolean;
+	isRelease?: boolean;
+}
+
+/**
+ * Configuration required for running the application.
+ * Loaded from the process environment, and .env files.
+ */
+export interface EnvironmentConfig extends BaseEnvironmentConfig {
 	// The web application hostname (e.g. back-office-dev.planninginspectorate.gov.uk)
 	appHostname: string;
 	apiUrl: string;
@@ -9,20 +28,12 @@ export interface EnvironmentConfig {
 	// redirect path for MSAL auth, defaults to /auth/redirect
 	authRedirectPath: string;
 	blobStorageUrl: string;
-	bundleAnalyzer: boolean;
-	buildDir: string;
 	cwd: string;
-	env: 'development' | 'test' | 'production' | 'local';
-	isProduction: boolean;
-	isDevelopment: boolean;
-	isTest: boolean;
-	isRelease?: boolean;
 	logLevelFile: LevelWithSilent;
 	logLevelStdOut: LevelWithSilent;
 	msal: {
 		authority: string;
 		clientId: string;
-		apiClientId: string;
 		clientSecret: string;
 		redirectUri: string;
 		logoutUri: string;
@@ -45,6 +56,7 @@ export interface EnvironmentConfig {
 	};
 }
 
-const config: EnvironmentConfig;
+export function loadConfig(): EnvironmentConfig;
 
+const config: EnvironmentConfig;
 export default config;

--- a/apps/web/environment/config.js
+++ b/apps/web/environment/config.js
@@ -1,69 +1,98 @@
 import { loadEnvironment } from '@pins/platform';
 import path from 'node:path';
-import url from 'node:url';
 import schema from './schema.js';
+import { baseConfigFromEnvironment } from './base-config.js';
 
-const environment = loadEnvironment(process.env.NODE_ENV);
+/**
+ * @typedef {import('./config.js').EnvironmentConfig} EnvironmentConfig
+ */
 
-const { value: validatedConfig, error } = schema.validate({
-	appHostname: environment.APP_HOSTNAME,
-	apiUrl: environment.API_HOST,
-	authDisabled: environment.AUTH_DISABLED,
-	authRedirectPath: environment.AUTH_REDIRECT_PATH || '/auth/redirect',
-	blobStorageUrl: environment.AZURE_BLOB_STORE_HOST,
-	env: environment.NODE_ENV,
-	isRelease: environment.APP_RELEASE,
-	logLevelFile: environment.LOG_LEVEL_FILE,
-	logLevelStdOut: environment.LOG_LEVEL_STDOUT,
-	msal: {
-		clientId: environment.AUTH_CLIENT_ID,
-		clientSecret: environment.AUTH_CLIENT_SECRET,
-		apiClientId: environment.AUTH_CLIENT_BACKEND_API_ID,
-		tenantId: environment.AUTH_TENANT_ID
-	},
-	serverPort: environment.HTTPS_ENABLED === 'true' ? environment.HTTPS_PORT : environment.HTTP_PORT,
-	serverProtocol: environment.HTTPS_ENABLED === 'true' ? 'https' : 'http',
-	sessionSecret: environment.SESSION_SECRET,
-	sslCertificateFile: environment.SSL_CERT_FILE,
-	sslCertificateKeyFile: environment.SSL_KEY_FILE,
-	referenceData: {
-		applications: {
-			caseAdminOfficerGroupId: environment.APPLICATIONS_CASE_ADMIN_OFFICER_GROUP_ID,
-			caseTeamGroupId: environment.APPLICATIONS_CASETEAM_GROUP_ID,
-			inspectorGroupId: environment.APPLICATIONS_INSPECTOR_GROUP_ID
-		}
-	},
-	// flag name convention: featureFlag[ jira number ][ferature shoret description]
-	// set Feature Flag default val here [default: false] - will be overwritted by values cming from the .env file
-	featureFlags: {
-		featureFlagBoas1TestFeature: !environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE
-			? false
-			: environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
+/**
+ * Loaded config, it only needs loading once
+ * @type {EnvironmentConfig|undefined}
+ */
+let loadedConfig;
+
+/**
+ * Load environment settings, and returns validated config.
+ *
+ * @returns {EnvironmentConfig}
+ */
+export function loadConfig() {
+	if (loadedConfig) {
+		return loadedConfig;
 	}
-});
+	const environment = loadEnvironment(process.env.NODE_ENV);
+	const baseConfig = baseConfigFromEnvironment(environment);
+	// defaults where needed
+	const {
+		API_HOST,
+		APP_HOSTNAME,
+		APPLICATIONS_CASE_ADMIN_OFFICER_GROUP_ID,
+		APPLICATIONS_CASETEAM_GROUP_ID,
+		APPLICATIONS_INSPECTOR_GROUP_ID,
+		AUTH_CLIENT_ID = '*',
+		AUTH_CLIENT_SECRET = '*',
+		AUTH_DISABLED_GROUP_IDS = '',
+		AUTH_DISABLED,
+		AUTH_REDIRECT_PATH = '/auth/redirect',
+		AUTH_TENANT_ID = '*',
+		AZURE_BLOB_STORE_HOST,
+		FEATURE_FLAG_BOAS_1_TEST_FEATURE,
+		HTTP_PORT = 8080,
+		HTTPS_ENABLED,
+		HTTPS_PORT,
+		LOG_LEVEL_FILE,
+		LOG_LEVEL_STDOUT,
+		SESSION_SECRET,
+		SSL_CERT_FILE,
+		SSL_KEY_FILE
+	} = environment;
 
-if (error) {
-	throw new Error(`Env validation error: ${error.message}`);
+	const config = {
+		...baseConfig,
+		appHostname: APP_HOSTNAME,
+		apiUrl: API_HOST,
+		authDisabled: AUTH_DISABLED,
+		authDisabledGroupIds: AUTH_DISABLED_GROUP_IDS.split(','),
+		authRedirectPath: AUTH_REDIRECT_PATH,
+		blobStorageUrl: AZURE_BLOB_STORE_HOST,
+		logLevelFile: LOG_LEVEL_FILE,
+		logLevelStdOut: LOG_LEVEL_STDOUT,
+		msal: {
+			clientId: AUTH_CLIENT_ID,
+			clientSecret: AUTH_CLIENT_SECRET,
+			authority: `https://login.microsoftonline.com/${AUTH_TENANT_ID}`,
+			logoutUri: 'https://login.microsoftonline.com/common/oauth2/v2.0/logout'
+		},
+		serverPort: HTTPS_ENABLED === 'true' ? HTTPS_PORT : HTTP_PORT,
+		serverProtocol: HTTPS_ENABLED === 'true' ? 'https' : 'http',
+		sessionSecret: SESSION_SECRET,
+		sslCertificateFile: SSL_CERT_FILE,
+		sslCertificateKeyFile: SSL_KEY_FILE,
+		referenceData: {
+			applications: {
+				caseAdminOfficerGroupId: APPLICATIONS_CASE_ADMIN_OFFICER_GROUP_ID,
+				caseTeamGroupId: APPLICATIONS_CASETEAM_GROUP_ID,
+				inspectorGroupId: APPLICATIONS_INSPECTOR_GROUP_ID
+			}
+		},
+		// flag name convention: featureFlag[ jira number ][ferature shoret description]
+		// set Feature Flag default val here [default: false] - will be overwritted by values cming from the .env file
+		featureFlags: {
+			featureFlagBoas1TestFeature: FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
+		},
+		tmpDir: path.join(baseConfig.cwd, '.tmp')
+	};
+
+	const { value: validatedConfig, error } = schema.validate(config);
+
+	if (error) {
+		throw new Error(`loadConfig validation error: ${error.message}`);
+	}
+
+	loadedConfig = validatedConfig;
+	return validatedConfig;
 }
 
-const cwd = url.fileURLToPath(new URL('..', import.meta.url));
-const { AUTH_DISABLED_GROUP_IDS = '' } = environment;
-const { msal, ...config } = validatedConfig;
-const { clientId = '*', tenantId = '*', clientSecret = '*' } = msal;
-
-export default {
-	...config,
-	authDisabledGroupIds: AUTH_DISABLED_GROUP_IDS.split(','),
-	buildDir: path.join(cwd, '.build'),
-	cwd,
-	isProduction: validatedConfig.env === 'production',
-	isDevelopment: validatedConfig.env === 'development' || validatedConfig.env === 'local',
-	isTest: validatedConfig.env === 'test',
-	msal: {
-		clientId,
-		clientSecret,
-		authority: `https://login.microsoftonline.com/${tenantId}`,
-		logoutUri: 'https://login.microsoftonline.com/common/oauth2/v2.0/logout'
-	},
-	tmpDir: path.join(cwd, '.tmp')
-};
+export default loadConfig();

--- a/apps/web/environment/schema.js
+++ b/apps/web/environment/schema.js
@@ -2,35 +2,56 @@ import joi from 'joi';
 
 const logLevel = ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'];
 
-export default joi.object({
-	appHostname: joi.string(),
-	apiUrl: joi.string().uri(),
-	authDisabled: joi.boolean().optional(),
-	authRedirectPath: joi.string(),
-	blobStorageUrl: joi.string(),
-	env: joi.string().valid('development', 'production', 'test', 'local'),
-	isRelease: joi.boolean().optional(),
-	logLevelFile: joi.string().valid(...logLevel),
-	logLevelStdOut: joi.string().valid(...logLevel),
-	msal: joi.object({
-		clientId: joi.string(),
-		clientSecret: joi.string(),
-		tenantId: joi.string(),
-		apiClientId: joi.string()
-	}),
-	serverProtocol: joi.string().valid('http', 'https'),
-	serverPort: joi.number(),
-	sessionSecret: joi
-		.string()
-		.when('env', { is: 'test', then: joi.optional(), otherwise: joi.optional() }),
-	sslCertificateFile: joi.string(),
-	sslCertificateKeyFile: joi.string(),
-	referenceData: joi.object({
-		applications: joi.object({
-			caseAdminOfficerGroupId: joi.string(),
-			caseTeamGroupId: joi.string(),
-			inspectorGroupId: joi.string()
-		})
-	}),
-	featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean())
-});
+export const baseSchema = joi
+	.object({
+		buildDir: joi.string(),
+		bundleAnalyzer: joi.boolean(),
+		cwd: joi.string(),
+		env: joi.string().valid('development', 'production', 'test', 'local'),
+		isProduction: joi.boolean(),
+		isDevelopment: joi.boolean(),
+		isTest: joi.boolean(),
+		isRelease: joi.boolean().optional()
+	})
+	.options({ presence: 'required' }); // all required by default
+
+export default baseSchema
+	.append({
+		appHostname: joi.string(),
+		apiUrl: joi.string().uri(),
+		authDisabled: joi.boolean().optional(),
+		authDisabledGroupIds: joi.array().optional(),
+		authRedirectPath: joi.string(),
+		blobStorageUrl: joi.string(),
+		logLevelFile: joi.string().valid(...logLevel),
+		logLevelStdOut: joi.string().valid(...logLevel),
+		msal: joi
+			.object({
+				authority: joi.string(),
+				clientId: joi.string(),
+				clientSecret: joi.string(),
+				logoutUri: joi.string()
+			})
+			.options({ presence: 'required' }),
+		serverProtocol: joi.string().valid('http', 'https'),
+		serverPort: joi.number(),
+		sessionSecret: joi.string().when('env', { is: 'test', then: joi.optional() }),
+		sslCertificateFile: joi.string().when('serverProtocol', { is: 'http', then: joi.optional() }),
+		sslCertificateKeyFile: joi
+			.string()
+			.when('serverProtocol', { is: 'http', then: joi.optional() }),
+		tmpDir: joi.string(),
+		referenceData: joi
+			.object({
+				applications: joi
+					.object({
+						caseAdminOfficerGroupId: joi.string(),
+						caseTeamGroupId: joi.string(),
+						inspectorGroupId: joi.string()
+					})
+					.options({ presence: 'required' })
+			})
+			.options({ presence: 'required' }),
+		featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean())
+	})
+	.options({ presence: 'required' }); // all required by default

--- a/apps/web/scripts/rollup/bundle-js.js
+++ b/apps/web/scripts/rollup/bundle-js.js
@@ -10,12 +10,12 @@ import fs from 'node:fs';
 import { rollup } from 'rollup';
 import iife from 'rollup-plugin-iife';
 import { visualizer } from 'rollup-plugin-visualizer';
-import config from '../../environment/config.js';
+import { loadBaseConfig } from '@pins/applications.web/environment/base-config.js';
 import { getLogger } from './get-logger.js';
 import { minifySource } from './minify-js.js';
 import { buildVirtualJSON } from './rollup-plugin-virtual-json.js';
 
-const { buildDir, env, bundleAnalyzer, isProduction, isRelease } = config;
+const { buildDir, env, bundleAnalyzer, isProduction, isRelease } = loadBaseConfig();
 const logger = getLogger({ scope: 'JS' });
 
 process.on('unhandledRejection', (reason, p) => {

--- a/apps/web/scripts/rollup/compile-css.js
+++ b/apps/web/scripts/rollup/compile-css.js
@@ -1,4 +1,4 @@
-import config from '@pins/applications.web/environment/config.js';
+import { loadBaseConfig } from '@pins/applications.web/environment/base-config.js';
 import autoprefixer from 'autoprefixer';
 import kleur from 'kleur';
 import fs from 'node:fs';
@@ -12,7 +12,7 @@ import { hashForContent } from './hash.js';
 /** @typedef {import('source-map-js').RawSourceMap} RawSourceMap */
 /** @typedef {import('postcss').SourceMap} SourceMap */
 
-const { buildDir, isProduction, isRelease } = config;
+const { buildDir, isProduction, isRelease } = loadBaseConfig();
 const logger = getLogger({ scope: 'Sass' });
 
 const appDirectory = fs.realpathSync(process.cwd());


### PR DESCRIPTION
## Describe your changes

By default `joi` treats all fields as optional, so if some environment configuration is missing there no immediate error.

Instead fields that are required are treated as such, with an error on startup. For example if missing the `web` session secret, the error would be:

```
throw new Error(`loadConfig validation error: ${error.message}`);
                      ^
Error: loadConfig validation error: "sessionSecret" is required
```

Changes:

- create baseConfig for web, used for build steps only
- set all fields to required in the config schema
- update `.env.example` to be a working example for local development

## Issue ticket number and link

[BOAS-1098](https://pins-ds.atlassian.net/browse/BOAS-1098)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1098]: https://pins-ds.atlassian.net/browse/BOAS-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ