### PR TITLE
feat(api/applications): s51 advice delete api part 2 (boas-1163)

### DIFF
--- a/apps/api/src/server/repositories/s51-advice.repository.js
+++ b/apps/api/src/server/repositories/s51-advice.repository.js
@@ -168,7 +168,7 @@ export const getPublishedAdvicesByIds = (s51AdviceIds) => {
 };
 
 /**
- * Filter S51 advice table to retrieve documents by 'ready-to-publish' status
+ * Filter S51 advice table to retrieve documents by 'ready-to-publish' status, ignoring deleted advice
  *
  * @param {{skipValue: number, pageSize: number, caseId: number, documentVersion?: number}} params
  * @returns {import('@prisma/client').PrismaPromise<import('@pins/applications.api').Schema.S51Advice[]>}
@@ -184,7 +184,8 @@ export const getReadyToPublishAdvices = ({ skipValue, pageSize, caseId }) => {
 		],
 		where: {
 			caseId,
-			publishedStatus: 'ready_to_publish'
+			publishedStatus: 'ready_to_publish',
+			isDeleted: false
 		},
 		include: {
 			S51AdviceDocument: true
@@ -193,7 +194,7 @@ export const getReadyToPublishAdvices = ({ skipValue, pageSize, caseId }) => {
 };
 
 /**
- * Returns total number of S51 advice by published status (ready-to-publish)
+ * Returns total number of S51 advice by published status (ready-to-publish), ignoring deleted advice
  *
  * @param {number} caseId
  * @returns {import('@prisma/client').PrismaPromise<number>}
@@ -202,7 +203,8 @@ export const getS51AdviceCountInByPublishStatus = (caseId) => {
 	return databaseConnector.s51Advice.count({
 		where: {
 			caseId,
-			publishedStatus: 'ready_to_publish'
+			publishedStatus: 'ready_to_publish',
+			isDeleted: false
 		}
 	});
 };


### PR DESCRIPTION
## Describe your changes

Addition to 1st PR for BOAS-1163 to also ignore deleted advice on the api that gets advice in the ready-to-publish queue

## BOAS-1163 S51 Advice Delete API - part 2
https://pins-ds.atlassian.net/browse/BOAS-1163


## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
