### PR TITLE
feat(appeals/api): add appeals api endpoint to save document redaction status and received date

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -118,6 +118,7 @@ const mockAppellantCaseInvalidReasonTextDeleteMany = jest.fn().mockResolvedValue
 const mockAppellantCaseInvalidReasonTextCreateMany = jest.fn().mockResolvedValue({});
 const mockLPAQuestionnaireIncompleteReasonTextDeleteMany = jest.fn().mockResolvedValue({});
 const mockLPAQuestionnaireIncompleteReasonTextCreateMany = jest.fn().mockResolvedValue({});
+const mockDocumentRedactionStatusFindMany = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -474,6 +475,12 @@ class MockPrismaClient {
 		return {
 			deleteMany: mockLPAQuestionnaireIncompleteReasonTextDeleteMany,
 			createMany: mockLPAQuestionnaireIncompleteReasonTextCreateMany
+		};
+	}
+
+	get documentRedactionStatus() {
+		return {
+			findMany: mockDocumentRedactionStatusFindMany
 		};
 	}
 

--- a/appeals/api/src/database/migrations/20230922142342_add_document_redaction_status_and_received_date/migration.sql
+++ b/appeals/api/src/database/migrations/20230922142342_add_document_redaction_status_and_received_date/migration.sql
@@ -1,0 +1,31 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Document] ADD [documentRedactionStatusId] INT,
+[receivedAt] DATETIME2;
+
+-- CreateTable
+CREATE TABLE [dbo].[DocumentRedactionStatus] (
+    [id] INT NOT NULL IDENTITY(1,1),
+    [name] NVARCHAR(1000) NOT NULL,
+    CONSTRAINT [DocumentRedactionStatus_pkey] PRIMARY KEY CLUSTERED ([id]),
+    CONSTRAINT [DocumentRedactionStatus_name_key] UNIQUE NONCLUSTERED ([name])
+);
+
+-- AddForeignKey
+ALTER TABLE [dbo].[Document] ADD CONSTRAINT [Document_documentRedactionStatusId_fkey] FOREIGN KEY ([documentRedactionStatusId]) REFERENCES [dbo].[DocumentRedactionStatus]([id]) ON DELETE SET NULL ON UPDATE CASCADE;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -13,6 +13,7 @@ export {
 	AppellantCaseInvalidReason,
 	AppellantCaseIncompleteReasonOnAppellantCase,
 	AppellantCaseInvalidReasonOnAppellantCase,
+	DocumentRedactionStatus,
 	DocumentVersion,
 	KnowledgeOfOtherLandowners,
 	LPAQuestionnaire,

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -370,18 +370,21 @@ model Folder {
 /// This model is a central space for each document which might have several
 /// versions and can store shared metadata.
 model Document {
-  guid                     String                    @id @default(uuid())
-  name                     String
-  folderId                 Int
-  createdAt                DateTime                  @default(now())
-  isDeleted                Boolean                   @default(false)
-  latestVersionId          Int?
-  caseId                   Int
-  folder                   Folder                    @relation(fields: [folderId], references: [id])
-  documentVersion          DocumentVersion[]         @relation("VersionHistory")
-  representationAttachment RepresentationAttachment? @relation("AttachmentDocument")
-  latestDocumentVersion    DocumentVersion?          @relation("LatestVersion", fields: [guid, latestVersionId], references: [documentGuid, version], onUpdate: NoAction, onDelete: NoAction)
-  case                     Appeal                    @relation(fields: [caseId], references: [id], onUpdate: NoAction, onDelete: NoAction)
+  guid                      String                    @id @default(uuid())
+  name                      String
+  folderId                  Int
+  createdAt                 DateTime                  @default(now())
+  isDeleted                 Boolean                   @default(false)
+  latestVersionId           Int?
+  caseId                    Int
+  receivedAt                DateTime?
+  documentRedactionStatusId Int?
+  folder                    Folder                    @relation(fields: [folderId], references: [id])
+  documentVersion           DocumentVersion[]         @relation("VersionHistory")
+  representationAttachment  RepresentationAttachment? @relation("AttachmentDocument")
+  latestDocumentVersion     DocumentVersion?          @relation("LatestVersion", fields: [guid, latestVersionId], references: [documentGuid, version], onUpdate: NoAction, onDelete: NoAction)
+  case                      Appeal                    @relation(fields: [caseId], references: [id], onUpdate: NoAction, onDelete: NoAction)
+  documentRedactionStatus   DocumentRedactionStatus?  @relation(fields: [documentRedactionStatusId], references: [id])
 
   @@unique([name, folderId])
   @@unique([guid, latestVersionId])
@@ -673,4 +676,10 @@ model LPAQuestionnaireIncompleteReasonText {
   lPAQuestionnaireIncompleteReasonOnLPAQuestionnaire LPAQuestionnaireIncompleteReasonOnLPAQuestionnaire @relation(fields: [lpaQuestionnaireIncompleteReasonId, lpaQuestionnaireId], references: [lpaQuestionnaireIncompleteReasonId, lpaQuestionnaireId])
   lpaQuestionnaireIncompleteReasonId                 Int
   lpaQuestionnaireId                                 Int
+}
+
+model DocumentRedactionStatus {
+  id        Int        @id @default(autoincrement())
+  name      String     @unique
+  documents Document[]
 }

--- a/appeals/api/src/database/seed/data-static.js
+++ b/appeals/api/src/database/seed/data-static.js
@@ -16,6 +16,7 @@
  * @typedef {import('@pins/appeals.api').Schema.LPAQuestionnaireIncompleteReason} LPAQuestionnaireIncompleteReason
  * @typedef {import('@pins/appeals.api').Schema.SiteVisitType} SiteVisitType
  * @typedef {import('@pins/appeals.api').Schema.Specialism} Specialism
+ * @typedef {import('@pins/appeals.api').Schema.DocumentRedactionStatus} DocumentRedactionStatus
  */
 
 /**
@@ -309,6 +310,23 @@ export const specialisms = [
 ];
 
 /**
+ * An array of document redaction statuses.
+ *
+ * @type {Pick<DocumentRedactionStatus, 'name'>[]}
+ */
+export const documentRedactionStatuses = [
+	{
+		name: 'Redacted'
+	},
+	{
+		name: 'Unredacted'
+	},
+	{
+		name: 'No redaction required'
+	}
+];
+
+/**
  * Seed static data into the database. Does not disconnect from the database or handle errors.
  *
  * @param {import('../../server/utils/db-client/index.js').PrismaClient} databaseConnector
@@ -409,6 +427,13 @@ export async function seedStaticData(databaseConnector) {
 		await databaseConnector.specialism.upsert({
 			create: { name: specialism.name },
 			where: { name: specialism.name },
+			update: {}
+		});
+	}
+	for (const documentRedactionStatus of documentRedactionStatuses) {
+		await databaseConnector.documentRedactionStatus.upsert({
+			create: { name: documentRedactionStatus.name },
+			where: { name: documentRedactionStatus.name },
 			update: {}
 		});
 	}

--- a/appeals/api/src/server/common/validators/date-parameter.js
+++ b/appeals/api/src/server/common/validators/date-parameter.js
@@ -16,6 +16,7 @@ import { recalculateDateIfNotBusinessDay } from '#utils/business-days.js';
  * 	parameterName: string,
  *  mustBeFutureDate?: boolean,
  *  mustBeBusinessDay?: boolean,
+ *  isRequired?: boolean,
  *  customFn?: (value: any, other: {req: any}) => Error | boolean
  * }} param0
  * @returns {ValidationChain}
@@ -24,10 +25,14 @@ const validateDateParameter = ({
 	parameterName,
 	mustBeFutureDate = false,
 	mustBeBusinessDay = false,
+	isRequired = false,
 	customFn = () => true
-}) =>
-	body(parameterName)
-		.optional()
+}) => {
+	const validator = body(parameterName);
+
+	!isRequired && validator.optional();
+
+	return validator
 		.isDate()
 		.withMessage(ERROR_MUST_BE_CORRECT_DATE_FORMAT)
 		.custom((value) => (mustBeFutureDate ? dateIsAfterDate(new Date(value), new Date()) : true))
@@ -46,5 +51,6 @@ const validateDateParameter = ({
 		})
 		.custom(customFn)
 		.customSanitizer(joinDateAndTime);
+};
 
 export default validateDateParameter;

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -8,6 +8,7 @@ declare global {
 			notifyClient: NotifyClient;
 			visitType: SiteVisitType;
 			validationOutcome: ValidationOutcome;
+			documentRedactionStatusIds: number[];
 		}
 	}
 }
@@ -342,8 +343,8 @@ interface FolderInfo {
 interface DocumentInfo {
 	id: string;
 	name: string;
-	folderId: number;
-	caseId: number;
+	folderId?: number;
+	caseId?: number;
 }
 
 interface SingleSiteVisitDetailsResponse {
@@ -492,6 +493,19 @@ interface IncompleteInvalidReasonsResponse {
 	text: string[];
 }
 
+interface SingleFolderResponse {
+	id: number;
+	path: string;
+	caseId: number;
+	documents: DocumentInfo[] | null;
+}
+
+type UpdateDocumentsRequest = {
+	id: string;
+	receivedDate: string;
+	redactionStatus: number;
+}[];
+
 type ListedBuildingDetailsResponse = Pick<ListedBuildingDetails, 'listEntry'>[];
 
 type LookupTables = AppellantCaseIncompleteReason | AppellantCaseInvalidReason | ValidationOutcome;
@@ -527,6 +541,7 @@ export {
 	SingleAppealDetailsResponse,
 	SingleAppellantCaseResponse,
 	SingleAppellantResponse,
+	SingleFolderResponse,
 	SingleLPAQuestionnaireResponse,
 	SingleSiteVisitDetailsResponse,
 	TimetableDeadlineDate,
@@ -536,6 +551,7 @@ export {
 	UpdateAppellantCaseValidationOutcome,
 	UpdateAppellantCaseValidationOutcomeParams,
 	UpdateAppellantRequest,
+	UpdateDocumentsRequest,
 	UpdateLPAQuestionaireValidationOutcomeParams,
 	UpdateLPAQuestionnaireRequest,
 	UpdateTimetableRequest,

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -22,6 +22,7 @@ import { appellantCaseValidationOutcomesRoutes } from './appellant-case-validati
 import { appellantsRoutes } from './appellants/appellants.routes.js';
 import { addressesRoutes } from './addresses/addresses.routes.js';
 import { appealTimetablesRoutes } from './appeal-timetables/appeal-timetables.routes.js';
+import { documentRedactionStatusesRoutes } from './document-redaction-statuses/document-redaction-statuses.routes.js';
 
 const router = createRouter();
 
@@ -36,6 +37,7 @@ router.use(appellantCasesRoutes);
 router.use(appellantCaseValidationOutcomesRoutes);
 router.use(appellantsRoutes);
 router.use(designatedSitesRoutes);
+router.use(documentRedactionStatusesRoutes);
 router.use(documentsRoutes);
 router.use(integrationsRoutes);
 router.use(knowledgeOfOtherLandownersRoutes);

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -23,6 +23,8 @@ export const DOCUMENT_STATUS_RECEIVED = 'received';
 export const ERROR_APPEAL_ALLOCATION_LEVELS = 'Invalid allocation level';
 export const ERROR_APPEAL_ALLOCATION_SPECIALISMS = 'Invalid allocation specialism';
 export const ERROR_CANNOT_BE_EMPTY_STRING = 'Cannot be an empty string';
+export const ERROR_DOCUMENT_REDACTION_STATUSES_MUST_BE_ONE_OF =
+	'Document redaction statuses must be one of {replacement0}';
 export const ERROR_FAILED_TO_GET_DATA = 'Failed to get data';
 export const ERROR_FAILED_TO_SAVE_DATA = 'Failed to save data';
 export const ERROR_FAILED_TO_SEND_NOTIFICATION_EMAIL = 'Failed to send notification email';

--- a/appeals/api/src/server/endpoints/document-redaction-statuses/__tests__/document-redaction-statuses.test.js
+++ b/appeals/api/src/server/endpoints/document-redaction-statuses/__tests__/document-redaction-statuses.test.js
@@ -1,0 +1,47 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { documentRedactionStatuses } from '../../../tests/data.js';
+import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('document redaction statuses routes', () => {
+	describe('/appeals/document-redaction-statuses', () => {
+		describe('GET', () => {
+			test('gets document redaction statuses', async () => {
+				// @ts-ignore
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue(
+					documentRedactionStatuses
+				);
+
+				const response = await request.get('/appeals/document-redaction-statuses');
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual(documentRedactionStatuses);
+			});
+
+			test('returns an error if document redaction statuses are not found', async () => {
+				// @ts-ignore
+				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([]);
+
+				const response = await request.get('/appeals/document-redaction-statuses');
+
+				expect(response.status).toEqual(404);
+				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
+			});
+
+			test('returns an error if unable to get document redaction statuses', async () => {
+				// @ts-ignore
+				databaseConnector.documentRedactionStatus.findMany.mockImplementation(() => {
+					throw new Error(ERROR_FAILED_TO_GET_DATA);
+				});
+
+				const response = await request.get('/appeals/document-redaction-statuses');
+
+				expect(response.status).toEqual(500);
+				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/document-redaction-statuses/document-redaction-statuses.routes.js
+++ b/appeals/api/src/server/endpoints/document-redaction-statuses/document-redaction-statuses.routes.js
@@ -1,0 +1,22 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getLookupData } from '../../common/controllers/lookup-data.controller.js';
+
+const router = createRouter();
+
+router.get(
+	'/document-redaction-statuses',
+	/*
+		#swagger.tags = ['Document Redaction Statuses']
+		#swagger.path = '/appeals/document-redaction-statuses'
+		#swagger.description = 'Gets document redaction statuses'
+		#swagger.responses[200] = {
+			description: 'Document redaction statuses',
+			schema: { $ref: '#/definitions/AllDocumentRedactionStatusesResponse' },
+		}
+		#swagger.responses[400] = {}
+	 */
+	asyncHandler(getLookupData('documentRedactionStatus'))
+);
+
+export { router as documentRedactionStatusesRoutes };

--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -1,12 +1,16 @@
+import { ERROR_FAILED_TO_SAVE_DATA } from '#endpoints/constants.js';
+import logger from '#utils/logger.js';
 import * as service from './documents.service.js';
+import * as documentRepository from '#repositories/document.repository.js';
 
 /** @typedef {import('@pins/appeals/index.js').BlobInfo} BlobInfo */
 /** @typedef {import('@pins/appeals.api').Schema.Folder} Folder */
-/** @typedef {import('express').RequestHandler} RequestHandler */
+/** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
 
 /**
- * @type {RequestHandler}
+ * @param {Request} req
+ * @param {Response} res
  * @returns {Promise<Response>}
  */
 const getFolder = async (req, res) => {
@@ -18,7 +22,8 @@ const getFolder = async (req, res) => {
 };
 
 /**
- * @type {RequestHandler}
+ * @param {Request} req
+ * @param {Response} res
  * @returns {Promise<Response>}
  */
 const getDocument = async (req, res) => {
@@ -28,7 +33,8 @@ const getDocument = async (req, res) => {
 };
 
 /**
- * @type {RequestHandler}
+ * @param {Request} req
+ * @param {Response} res
  * @returns {Promise<Response>}
  */
 const addDocuments = async (req, res) => {
@@ -39,7 +45,8 @@ const addDocuments = async (req, res) => {
 };
 
 /**
- * @type {RequestHandler}
+ * @param {Request} req
+ * @param {Response} res
  * @returns {Promise<Response>}
  */
 const addDocumentVersion = async (req, res) => {
@@ -66,4 +73,23 @@ const getStorageInfo = (docs) => {
 	};
 };
 
-export { getFolder, getDocument, addDocuments, addDocumentVersion };
+/**
+ * @param {Request} req
+ * @param {Response} res
+ */
+const updateDocuments = async (req, res) => {
+	const { body } = req;
+
+	try {
+		await documentRepository.updateDocuments(body.documents);
+	} catch (error) {
+		if (error) {
+			logger.error(error);
+			return res.status(500).send({ errors: { body: ERROR_FAILED_TO_SAVE_DATA } });
+		}
+	}
+
+	res.send(body);
+};
+
+export { addDocuments, addDocumentVersion, getDocument, getFolder, updateDocuments };

--- a/appeals/api/src/server/endpoints/documents/documents.formatter.js
+++ b/appeals/api/src/server/endpoints/documents/documents.formatter.js
@@ -1,0 +1,19 @@
+/** @typedef {import('@pins/appeals.api').Schema.Folder} Folder */
+/** @typedef {import('@pins/appeals.api').Appeals.SingleFolderResponse} SingleFolderResponse */
+
+/**
+ * @param {Folder} folder
+ * @returns {SingleFolderResponse}
+ */
+const formatFolder = (folder) => ({
+	caseId: folder.caseId,
+	documents:
+		folder.documents?.map((document) => ({
+			id: document.guid,
+			name: document.name
+		})) || null,
+	id: folder.id,
+	path: folder.path
+});
+
+export { formatFolder };

--- a/appeals/api/src/server/endpoints/documents/documents.routes.js
+++ b/appeals/api/src/server/endpoints/documents/documents.routes.js
@@ -7,7 +7,8 @@ import {
 	getFolderIdValidator,
 	getDocumentIdValidator,
 	getDocumentValidator,
-	getDocumentsValidator
+	getDocumentsValidator,
+	patchDocumentsValidator
 } from './documents.validators.js';
 import * as controller from './documents.controller.js';
 
@@ -102,6 +103,30 @@ router.post(
 	validateDocumentAndAddToRequest,
 	getDocumentValidator,
 	asyncHandler(controller.addDocumentVersion)
+);
+
+router.patch(
+	'/:appealId/documents',
+	/*
+		#swagger.tags = ['Documents']
+		#swagger.path = '/appeals/{appealId}/documents'
+		#swagger.description = Updates multiple documents
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Documents to update',
+			schema: { $ref: '#/definitions/UpdateDocumentsRequest' },
+			required: true
+		}
+		#swagger.responses[200] = {
+			description: 'Documents to update',
+			schema: { $ref: '#/definitions/UpdateDocumentsResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	patchDocumentsValidator,
+	checkAppealExistsAndAddToRequest,
+	asyncHandler(controller.updateDocuments)
 );
 
 export { router as documentsRoutes };

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -5,8 +5,12 @@ export interface Folder {
 	path?: string;
 	/** @example 34 */
 	caseId?: number;
-	/** @example [] */
-	documents?: any[];
+	documents?: {
+		/** @example "987e66e0-1db4-404b-8213-8082919159e9" */
+		id?: string;
+		/** @example "right-of-way.pdf" */
+		name?: string;
+	}[];
 }
 
 export interface DocumentDetails {
@@ -1212,4 +1216,33 @@ export interface UpdateAppealTimetableResponse {
 	lpaQuestionnaireDueDate?: string;
 	/** @example "2023-08-12T01:00:00.000Z" */
 	statementReviewDate?: string;
+}
+
+export interface AllDocumentRedactionStatusesResponse {
+	/** @example 1 */
+	id?: number;
+	/** @example "Document redaction status" */
+	name?: string;
+}
+
+export interface UpdateDocumentsRequest {
+	documents?: {
+		/** @example "987e66e0-1db4-404b-8213-8082919159e9" */
+		id?: string;
+		/** @example "2023-09-23" */
+		receivedDate?: string;
+		/** @example 1 */
+		redactionStatus?: number;
+	}[];
+}
+
+export interface UpdateDocumentsResponse {
+	documents?: {
+		/** @example "987e66e0-1db4-404b-8213-8082919159e9" */
+		id?: string;
+		/** @example "2023-09-23" */
+		receivedDate?: string;
+		/** @example 1 */
+		redactionStatus?: number;
+	}[];
 }

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -624,6 +624,33 @@
 				}
 			}
 		},
+		"/appeals/document-redaction-statuses": {
+			"get": {
+				"tags": ["Document Redaction Statuses"],
+				"description": "Gets document redaction statuses",
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "Document redaction statuses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllDocumentRedactionStatusesResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/AllDocumentRedactionStatusesResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/document-folders/{folderId}": {
 			"get": {
 				"tags": ["Documents"],
@@ -830,6 +857,60 @@
 						"application/xml": {
 							"schema": {
 								"$ref": "#/components/schemas/DocumentDetails"
+							}
+						}
+					}
+				}
+			},
+			"patch": {
+				"tags": ["Documents"],
+				"description": "Updates multiple documents",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Document to update",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateDocumentsResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateDocumentsResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Document to update",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateDocumentsRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateDocumentsRequest"
 							}
 						}
 					}
@@ -1641,8 +1722,19 @@
 					},
 					"documents": {
 						"type": "array",
-						"example": [],
-						"items": {}
+						"items": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "string",
+									"example": "987e66e0-1db4-404b-8213-8082919159e9"
+								},
+								"name": {
+									"type": "string",
+									"example": "right-of-way.pdf"
+								}
+							}
+						}
 					}
 				},
 				"xml": {
@@ -4378,6 +4470,78 @@
 				},
 				"xml": {
 					"name": "UpdateAppealTimetableResponse"
+				}
+			},
+			"AllDocumentRedactionStatusesResponse": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "number",
+						"example": 1
+					},
+					"name": {
+						"type": "string",
+						"example": "Document redaction status"
+					}
+				},
+				"xml": {
+					"name": "AllDocumentRedactionStatusesResponse"
+				}
+			},
+			"UpdateDocumentsRequest": {
+				"type": "object",
+				"properties": {
+					"documents": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "string",
+									"example": "987e66e0-1db4-404b-8213-8082919159e9"
+								},
+								"receivedDate": {
+									"type": "string",
+									"example": "2023-09-23"
+								},
+								"redactionStatus": {
+									"type": "number",
+									"example": 1
+								}
+							}
+						}
+					}
+				},
+				"xml": {
+					"name": "UpdateDocumentsRequest"
+				}
+			},
+			"UpdateDocumentsResponse": {
+				"type": "object",
+				"properties": {
+					"documents": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "string",
+									"example": "987e66e0-1db4-404b-8213-8082919159e9"
+								},
+								"receivedDate": {
+									"type": "string",
+									"example": "2023-09-23"
+								},
+								"redactionStatus": {
+									"type": "number",
+									"example": 1
+								}
+							}
+						}
+					}
+				},
+				"xml": {
+					"name": "UpdateDocumentsResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/repositories/document-redaction-status.repository.js
+++ b/appeals/api/src/server/repositories/document-redaction-status.repository.js
@@ -1,0 +1,20 @@
+import { DATABASE_ORDER_BY_ASC } from '#endpoints/constants.js';
+import { databaseConnector } from '#utils/database-connector.js';
+
+/** @typedef {import('@pins/appeals.api').Schema.DocumentRedactionStatus} DocumentRedactionStatus */
+/**
+ * @typedef {import('#db-client').Prisma.PrismaPromise<T>} PrismaPromise
+ * @template T
+ */
+
+/**
+ * @returns {PrismaPromise<DocumentRedactionStatus[]>}
+ */
+const getAllDocumentRedactionStatuses = () =>
+	databaseConnector.documentRedactionStatus.findMany({
+		orderBy: {
+			id: DATABASE_ORDER_BY_ASC
+		}
+	});
+
+export default { getAllDocumentRedactionStatuses };

--- a/appeals/api/src/server/repositories/document.repository.js
+++ b/appeals/api/src/server/repositories/document.repository.js
@@ -6,6 +6,7 @@ import { databaseConnector } from '#utils/database-connector.js';
  */
 /** @typedef {import('@pins/appeals.api').Schema.Document} Document */
 /** @typedef {import('@pins/appeals.api').Schema.DocumentVersions} DocumentVersions */
+/** @typedef {import('@pins/appeals.api').Appeals.UpdateDocumentsRequest} UpdateDocumentsRequest */
 
 /**
  * @param {string} guid
@@ -66,3 +67,22 @@ export const getDocumentsInFolder = ({ folderId, skipValue, pageSize }) => {
 		include: { latestDocumentVersion: true }
 	});
 };
+
+/**
+ * @param {UpdateDocumentsRequest} data
+ * @returns
+ */
+export const updateDocuments = (data) =>
+	Promise.all(
+		data.map((document) =>
+			databaseConnector.document.update({
+				data: {
+					receivedAt: document.receivedDate,
+					documentRedactionStatusId: document.redactionStatus
+				},
+				where: {
+					guid: document.id
+				}
+			})
+		)
+	);

--- a/appeals/api/src/server/repositories/folder.repository.js
+++ b/appeals/api/src/server/repositories/folder.repository.js
@@ -12,7 +12,8 @@ import { databaseConnector } from '#utils/database-connector.js';
  */
 export const getById = (id) => {
 	return databaseConnector.folder.findUnique({
-		where: { id }
+		where: { id },
+		include: { documents: true }
 	});
 };
 

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -36,7 +36,12 @@ export const spec = {
 			id: 23,
 			path: 'appellantCase/appealStatement',
 			caseId: 34,
-			documents: []
+			documents: [
+				{
+					id: '987e66e0-1db4-404b-8213-8082919159e9',
+					name: 'right-of-way.pdf'
+				}
+			]
 		},
 		DocumentDetails: {
 			guid: 'c957e9d0-1a02-4650-acdc-f9fdd689c210',
@@ -643,6 +648,28 @@ export const spec = {
 			issueDeterminationDate: '2023-08-10T01:00:00.000Z',
 			lpaQuestionnaireDueDate: '2023-08-11T01:00:00.000Z',
 			statementReviewDate: '2023-08-12T01:00:00.000Z'
+		},
+		AllDocumentRedactionStatusesResponse: {
+			id: 1,
+			name: 'Document redaction status'
+		},
+		UpdateDocumentsRequest: {
+			documents: [
+				{
+					id: '987e66e0-1db4-404b-8213-8082919159e9',
+					receivedDate: '2023-09-23',
+					redactionStatus: 1
+				}
+			]
+		},
+		UpdateDocumentsResponse: {
+			documents: [
+				{
+					id: '987e66e0-1db4-404b-8213-8082919159e9',
+					receivedDate: '2023-09-23',
+					redactionStatus: 1
+				}
+			]
 		}
 	},
 	components: {}

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -424,6 +424,8 @@ const planningObligationStatuses = lookupListData;
 const procedureTypes = lookupListData;
 const scheduleTypes = lookupListData;
 const siteVisitTypes = lookupListData;
+const documentRedactionStatuses = lookupListData;
+const documentRedactionStatusIds = documentRedactionStatuses.map(({ id }) => id);
 
 const designatedSites = [
 	{
@@ -707,6 +709,8 @@ export {
 	baseExpectedLPAQuestionnaireResponse,
 	designatedSites,
 	document,
+	documentRedactionStatuses,
+	documentRedactionStatusIds,
 	fullPlanningAppeal,
 	fullPlanningAppealAppellantCaseIncomplete,
 	fullPlanningAppealAppellantCaseInvalid,

--- a/appeals/api/src/server/tests/documents/mocks.js
+++ b/appeals/api/src/server/tests/documents/mocks.js
@@ -2,6 +2,7 @@ const guid = '27d0fda4-8a9a-4f5a-a158-68eaea676158';
 const version = 1;
 const originalFileName = 'mydoc.pdf';
 const fileName = 'mydoc';
+const folderId = 23;
 
 export const appeal = {
 	id: 34,
@@ -25,7 +26,7 @@ export const addDocumentsRequest = {
 			documentType: 'application/pdf',
 			documentSize: 14699,
 			fileRowId: `file_row_1685470289030_16995`,
-			folderId: folder.folderId
+			folderId
 		}
 	]
 };
@@ -39,7 +40,7 @@ export const addDocumentVersionRequest = {
 		documentType: 'application/pdf',
 		documentSize: 14699,
 		fileRowId: `file_row_1685470289030_16995`,
-		folderId: folder.folderId
+		folderId
 	}
 };
 
@@ -81,4 +82,18 @@ export const blobInfo = {
 	GUID: guid,
 	documentName: fileName,
 	blobStoreUrl: `appeal/APP-Q9999-D-21-941501/${guid}/v1/${fileName}`
+};
+
+export const savedFolder = {
+	id: folderId,
+	path: 'appellant_case/appealStatement',
+	caseId: 1,
+	documents: [
+		{
+			caseId: appeal.id,
+			folderId,
+			guid,
+			name: originalFileName
+		}
+	]
 };


### PR DESCRIPTION
## Describe your changes

- Updated GET Folder endpoint to return the documents for that folder. Can be used to display a list of documents that have just been uploaded. Swagger - http://localhost:3000/api-docs/#/Documents/get_appeals__appealId__document_folders__folderId_
- Added GET Document Redaction Status endpoint to return the redaction statuses. Can be used to dynamically generate the Redaction Status radio button list. Swagger - http://localhost:3000/api-docs/#/Document%20Redaction%20Statuses/get_appeals_document_redaction_statuses
- Added PATCH Documents endpoint to save the document info. Swagger - http://localhost:3000/api-docs/#/Documents/patch_appeals__appealId__documents

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAT-491

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
