### PR TITLE
feat(web/applications): change to a PUBLISHED tag in after publishing

### DIFF
--- a/apps/web/src/server/views/applications/case/overview.njk
+++ b/apps/web/src/server/views/applications/case/overview.njk
@@ -13,6 +13,16 @@
       {% set applicantFirstWebsiteValue = '<a class="govuk-link" href="//' + applicantFirstWebsite + '">' + applicantFirstWebsite + '</a>' %}
   {% endif %}
   <h2 class="govuk-heading-m">Overview</h2>
+  {% set publishedTag %}
+    {% if case.publishedDate %}
+      <strong class="govuk-tag govuk-tag--green">PUBLISHED</strong>
+      &nbsp;
+      <span class="govuk-body-s colour--secondary">Last updated {{ case.publishedDate | datestamp({format: 'h:mma dd MMM yyyy'}) }}</span>
+    {% else %}
+      <strong class="govuk-tag govuk-tag--grey">NOT PUBLISHED</strong>
+    {% endif %}
+  {% endset %}
+
   {{ govukSummaryList({
     rows: [
       {
@@ -33,7 +43,7 @@
       },
       {
         key: { text: "Project page" },
-        value: { html:  '<strong class="govuk-tag govuk-tag--grey">NOT PUBLISHED</strong>' }
+        value: { html: publishedTag }
       }
     ]
   }) }}


### PR DESCRIPTION
## Describe your changes

Currently the overview page continues to show `NOT PUBLISHED` after publishing the case. This change introduces a green `PUBLISHED` tag and the datetime at which the case was published.

## Issue ticket number and link

[BOAS-1195](https://pins-ds.atlassian.net/browse/BOAS-1195)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1195]: https://pins-ds.atlassian.net/browse/BOAS-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ