### PR TITLE
fix(applications/api): patch representation bug

### DIFF
--- a/apps/api/src/server/repositories/representation.repository.js
+++ b/apps/api/src/server/repositories/representation.repository.js
@@ -268,7 +268,13 @@ export const createApplicationRepresentation = async ({
 };
 
 export const updateApplicationRepresentation = async (
-	{ representationDetails, represented, representedAddress, representative, representativeAddress },
+	{
+		representationDetails = {},
+		represented,
+		representedAddress,
+		representative,
+		representativeAddress
+	},
 	caseId,
 	representationId
 ) => {


### PR DESCRIPTION
## Describe your changes

Some PATCH `/applications/{id}/representations/{repId}` requests were failing with error:

```javascript
{ 
    "errors": "Cannot set properties of undefined (setting 'unpublishedUpdates')" 
}
```

This was because when patching items objects that did not include `representationDetails` then this would be undefined and we would throw an error on this line:

```javascript
representationDetails.unpublishedUpdates = true
```

This PR simply adds a default value for the `representationDetails` in the `updateApplicationRepresentation` which means we don't unexpectedly throw an error when setting `representationDetails.unpublishedUpdates`.

---

Example of previously failing request
```javascript
// PATCH /applications/1/representations/363
{
  "represented": {
    "firstName": "Dante",
    "lastName": "Alighieri"
  }
}
```

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/ASB-1885

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
