### PR TITLE
fix(web/applications): fix exam timetable display no items (boas-1200)

### DIFF
--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
@@ -80,7 +80,7 @@ export const uniqueTimeTableTypes = {
 export async function viewApplicationsCaseTimetableList(_, response) {
 	const examinationTimetable = await getCaseTimetableItems(response.locals.caseId);
 	const timetableItemsViewData = examinationTimetable?.items?.map(getTimetableRows) ?? [];
-	const republishStatus = examinationTimetable.items.some(
+	const republishStatus = examinationTimetable.items?.some(
 		(item) => item.createdAt > examinationTimetable.publishedAt
 	);
 


### PR DESCRIPTION
## Describe your changes

Examination timetable page crashes if there are no exam timetable items on that case.  Fixed.

## BOAS-1200 Fix Exam Timetable Display when no items
https://pins-ds.atlassian.net/browse/BOAS-1200

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
