### PR TITLE
fix(web/applications): only refresh s51 title page if title isn't unique

### DIFF
--- a/apps/web/src/server/applications/case/s51/applications-s51.controller.js
+++ b/apps/web/src/server/applications/case/s51/applications-s51.controller.js
@@ -153,10 +153,13 @@ export async function postApplicationsCaseEditS51Item({ body, params }, response
 
 	if (step === 'title' && body.title) {
 		const { errors } = await checkS51NameIsUnique(caseId, body.title);
-		return response.render(`applications/case-s51/properties/edit/s51-edit-${step}`, {
-			adviceId,
-			errors
-		});
+
+		if (errors) {
+			return response.render(`applications/case-s51/properties/edit/s51-edit-${step}`, {
+				adviceId,
+				errors
+			});
+		}
 	}
 
 	const { errors } = await updateS51Advice(caseId, Number(adviceId), payload);


### PR DESCRIPTION
## Describe your changes

There is currently a logic error that blocks you from updated the title of an S51 item. This is the correct logic.

Tested locally

## Issue ticket number and link

[BOAS-1207](https://pins-ds.atlassian.net/browse/BOAS-1207)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1207]: https://pins-ds.atlassian.net/browse/BOAS-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ