### PR TITLE
feat(appeals/api): add initial appeals audit trail logging

### DIFF
--- a/appeals/api/setup-tests.js
+++ b/appeals/api/setup-tests.js
@@ -119,6 +119,8 @@ const mockAppellantCaseInvalidReasonTextCreateMany = jest.fn().mockResolvedValue
 const mockLPAQuestionnaireIncompleteReasonTextDeleteMany = jest.fn().mockResolvedValue({});
 const mockLPAQuestionnaireIncompleteReasonTextCreateMany = jest.fn().mockResolvedValue({});
 const mockDocumentRedactionStatusFindMany = jest.fn().mockResolvedValue({});
+const mockAuditTrailFindMany = jest.fn().mockResolvedValue({});
+const mockAuditTrailCreate = jest.fn().mockResolvedValue({});
 
 class MockPrismaClient {
 	get address() {
@@ -481,6 +483,13 @@ class MockPrismaClient {
 	get documentRedactionStatus() {
 		return {
 			findMany: mockDocumentRedactionStatusFindMany
+		};
+	}
+
+	get auditTrail() {
+		return {
+			findMany: mockAuditTrailFindMany,
+			create: mockAuditTrailCreate
 		};
 	}
 

--- a/appeals/api/src/database/migrations/20230928104020_add_audit_trail/migration.sql
+++ b/appeals/api/src/database/migrations/20230928104020_add_audit_trail/migration.sql
@@ -1,0 +1,49 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `azureUserId` on the `User` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[azureAdUserId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropIndex
+ALTER TABLE [dbo].[User] DROP CONSTRAINT [User_azureUserId_key];
+
+-- AlterTable
+ALTER TABLE [dbo].[User] DROP COLUMN [azureUserId];
+ALTER TABLE [dbo].[User] ADD [azureAdUserId] NVARCHAR(1000);
+
+-- CreateTable
+CREATE TABLE [dbo].[AuditTrail] (
+    [id] INT NOT NULL IDENTITY(1,1),
+    [appealId] INT NOT NULL,
+    [userId] INT NOT NULL,
+    [loggedAt] DATETIME2 NOT NULL,
+    [details] NVARCHAR(1000) NOT NULL,
+    CONSTRAINT [AuditTrail_pkey] PRIMARY KEY CLUSTERED ([id])
+);
+
+-- CreateIndex
+ALTER TABLE [dbo].[User] ADD CONSTRAINT [User_azureAdUserId_key] UNIQUE NONCLUSTERED ([azureAdUserId]);
+
+-- AddForeignKey
+ALTER TABLE [dbo].[AuditTrail] ADD CONSTRAINT [AuditTrail_appealId_fkey] FOREIGN KEY ([appealId]) REFERENCES [dbo].[Appeal]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE [dbo].[AuditTrail] ADD CONSTRAINT [AuditTrail_userId_fkey] FOREIGN KEY ([userId]) REFERENCES [dbo].[User]([id]) ON DELETE NO ACTION ON UPDATE CASCADE;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.d.ts
+++ b/appeals/api/src/database/schema.d.ts
@@ -321,3 +321,7 @@ export interface AppellantCaseInvalidReasonOnAppellantCase
 	appellantCaseInvalidReason: AppellantCaseInvalidReason;
 	appellantCaseInvalidReasonText: AppellantCaseInvalidReasonText[];
 }
+
+export interface AuditTrail extends schema.AuditTrail {
+	user: User;
+}

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -49,6 +49,7 @@ model Appeal {
   caseOfficer                  User?                 @relation("caseOfficer", fields: [caseOfficerUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   inspectorUserId              Int?
   inspector                    User?                 @relation("inspector", fields: [inspectorUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  auditTrail                   AuditTrail[]
 }
 
 /// AppealType model
@@ -344,10 +345,11 @@ model InspectorDecision {
 /// Contains information on Back Office users (PINS employees)
 model User {
   id             Int              @id @default(autoincrement())
-  azureUserId    String?          @unique
+  azureAdUserId  String?          @unique
   Representation Representation[]
   caseOfficer    Appeal[]         @relation("caseOfficer")
   inspector      Appeal[]         @relation("inspector")
+  auditTrail     AuditTrail[]
 }
 
 /// Folder model
@@ -682,4 +684,14 @@ model DocumentRedactionStatus {
   id        Int        @id @default(autoincrement())
   name      String     @unique
   documents Document[]
+}
+
+model AuditTrail {
+  id       Int      @id @default(autoincrement())
+  appealId Int
+  userId   Int
+  loggedAt DateTime
+  details  String
+  appeal   Appeal   @relation(fields: [appealId], references: [id])
+  user     User     @relation(fields: [userId], references: [id])
 }

--- a/appeals/api/src/server/common/validators/boolean-with-conditional-string-parameters.js
+++ b/appeals/api/src/server/common/validators/boolean-with-conditional-string-parameters.js
@@ -2,7 +2,7 @@ import { body } from 'express-validator';
 import validateBooleanParameter from './boolean-parameter.js';
 import validateStringParameter from './string-parameter.js';
 import { ERROR_MUST_HAVE_DETAILS, ERROR_MUST_NOT_HAVE_DETAILS } from '#endpoints/constants.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 /** @typedef {import('express-validator').ValidationChain} ValidationChain */
 
@@ -22,13 +22,13 @@ const validateBooleanWithConditionalStringParameters = (
 	body(booleanParameterName)
 		.optional()
 		.custom((value, { req }) => {
-			const errorMessageReplacements = [detailsParameterName, booleanParameterName, value];
+			const stringTokenReplacements = [detailsParameterName, booleanParameterName, value];
 
 			if (value === triggerValue && !req.body[detailsParameterName]) {
-				throw new Error(errorMessageReplacement(ERROR_MUST_HAVE_DETAILS, errorMessageReplacements));
+				throw new Error(stringTokenReplacement(ERROR_MUST_HAVE_DETAILS, stringTokenReplacements));
 			} else if (value !== triggerValue && req.body[detailsParameterName]) {
 				throw new Error(
-					errorMessageReplacement(ERROR_MUST_NOT_HAVE_DETAILS, errorMessageReplacements)
+					stringTokenReplacement(ERROR_MUST_NOT_HAVE_DETAILS, stringTokenReplacements)
 				);
 			}
 

--- a/appeals/api/src/server/common/validators/string-parameter.js
+++ b/appeals/api/src/server/common/validators/string-parameter.js
@@ -5,7 +5,7 @@ import {
 	ERROR_MUST_BE_STRING,
 	LENGTH_300
 } from '#endpoints/constants.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 /** @typedef {import('express-validator').ValidationChain} ValidationChain */
 
@@ -22,6 +22,6 @@ const validateStringParameter = (parameterName, maxLength = LENGTH_300) =>
 		.notEmpty()
 		.withMessage(ERROR_CANNOT_BE_EMPTY_STRING)
 		.isLength({ max: maxLength })
-		.withMessage(errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [maxLength]));
+		.withMessage(stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [maxLength]));
 
 export default validateStringParameter;

--- a/appeals/api/src/server/endpoints/addresses/__tests__/addresses.test.js
+++ b/appeals/api/src/server/endpoints/addresses/__tests__/addresses.test.js
@@ -9,8 +9,8 @@ import {
 	LENGTH_300,
 	LENGTH_8
 } from '../../constants.js';
-import { householdAppeal } from '#tests/data.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import { azureAdUserId, householdAppeal } from '#tests/data.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -21,9 +21,9 @@ describe('addresses routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.get(
-					`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`
-				);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
@@ -38,7 +38,9 @@ describe('addresses routes', () => {
 			});
 
 			test('returns an error if appealId is not numeric', async () => {
-				const response = await request.get(`/appeals/one/addresses/${householdAppeal.address.id}`);
+				const response = await request
+					.get(`/appeals/one/addresses/${householdAppeal.address.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -52,7 +54,9 @@ describe('addresses routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request.get(`/appeals/3/addresses/${householdAppeal.address.id}`);
+				const response = await request
+					.get(`/appeals/3/addresses/${householdAppeal.address.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -63,7 +67,9 @@ describe('addresses routes', () => {
 			});
 
 			test('returns an error if addressId is not numeric', async () => {
-				const response = await request.get(`/appeals/${householdAppeal.id}/addresses/one`);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/addresses/one`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -77,7 +83,9 @@ describe('addresses routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.get(`/appeals/${householdAppeal.id}/addresses/3`);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/addresses/3`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -112,7 +120,8 @@ describe('addresses routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.address.update).toHaveBeenCalledWith({
 					data: dataToSave,
@@ -127,7 +136,8 @@ describe('addresses routes', () => {
 			test('returns an error if appealId is not numeric', async () => {
 				const response = await request
 					.patch(`/appeals/one/addresses/${householdAppeal.address.id}`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -143,7 +153,8 @@ describe('addresses routes', () => {
 
 				const response = await request
 					.patch(`/appeals/3/addresses/${householdAppeal.address.id}`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -156,7 +167,8 @@ describe('addresses routes', () => {
 			test('returns an error if addressId is not numeric', async () => {
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/addresses/one`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -172,7 +184,8 @@ describe('addresses routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/addresses/3`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -190,7 +203,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						addressLine1: [patchBody.addressLine1]
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -208,7 +222,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						addressLine1: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -226,12 +241,13 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						addressLine1: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						addressLine1: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						addressLine1: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -244,7 +260,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						addressLine2: [patchBody.addressLine2]
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -262,7 +279,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						addressLine2: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -280,12 +298,13 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						addressLine2: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						addressLine2: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						addressLine2: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -298,7 +317,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						country: [patchBody.country]
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -316,7 +336,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						country: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -334,12 +355,13 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						country: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						country: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						country: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -352,7 +374,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						county: [patchBody.county]
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -370,7 +393,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						county: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -388,12 +412,13 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						county: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						county: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						county: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -406,7 +431,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						postcode: [patchBody.postcode]
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -424,7 +450,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						postcode: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -442,12 +469,13 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						postcode: 'A'.repeat(LENGTH_8 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						postcode: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_8])
+						postcode: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_8])
 					}
 				});
 			});
@@ -460,7 +488,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						town: [patchBody.town]
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -478,7 +507,8 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						town: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -496,12 +526,13 @@ describe('addresses routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
 					.send({
 						town: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						town: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						town: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -512,7 +543,8 @@ describe('addresses routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
-					.send({});
+					.send({})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({});
@@ -528,7 +560,8 @@ describe('addresses routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/addresses/${householdAppeal.address.id}`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.address.update).toHaveBeenCalledWith({
 					data: dataToSave,

--- a/appeals/api/src/server/endpoints/addresses/addresses.routes.js
+++ b/appeals/api/src/server/endpoints/addresses/addresses.routes.js
@@ -13,6 +13,11 @@ router.get(
 		#swagger.tags = ['Addresses']
 		#swagger.path = '/appeals/{appealId}/addresses/{addressId}'
 		#swagger.description = Gets a single address by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Gets a single address by id',
 			schema: { $ref: '#/definitions/SingleAddressResponse' }
@@ -32,6 +37,11 @@ router.patch(
 		#swagger.tags = ['Addresses']
 		#swagger.path = '/appeals/{appealId}/addresses/{addressId}'
 		#swagger.description = Updates a single address by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Address details to update',

--- a/appeals/api/src/server/endpoints/appeal-allocation/__tests__/appeal-allocation.test.js
+++ b/appeals/api/src/server/endpoints/appeal-allocation/__tests__/appeal-allocation.test.js
@@ -1,5 +1,5 @@
 import { request } from '#tests/../app-test.js';
-import { householdAppeal } from '#tests/data.js';
+import { azureAdUserId, householdAppeal } from '#tests/data.js';
 import { ERROR_APPEAL_ALLOCATION_LEVELS, ERROR_NOT_FOUND } from '#endpoints/constants.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
@@ -19,7 +19,8 @@ describe('appeal allocation routes', () => {
 				.send({
 					specialisms: [3, 4],
 					level: 32
-				});
+				})
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -38,7 +39,8 @@ describe('appeal allocation routes', () => {
 				.send({
 					specialisms: [3, 4],
 					level: 'Z'
-				});
+				})
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -59,7 +61,8 @@ describe('appeal allocation routes', () => {
 				.send({
 					specialisms: [3, 4],
 					level: 'A'
-				});
+				})
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -89,7 +92,8 @@ describe('appeal allocation routes', () => {
 				.send({
 					specialisms: [1, 2],
 					level: 'A'
-				});
+				})
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(200);
 		});

--- a/appeals/api/src/server/endpoints/appeal-allocation/appeal-allocation-routes.js
+++ b/appeals/api/src/server/endpoints/appeal-allocation/appeal-allocation-routes.js
@@ -13,6 +13,11 @@ router.get(
 		#swagger.tags = ['Appeal Allocation']
 		#swagger.path = '/appeals/appeal-allocation-specialisms'
 		#swagger.description = 'Gets the list of specialisms used for allocation'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'List of allocation specialisms',
 			schema: { $ref: '#/definitions/AllocationSpecialismsResponse' },
@@ -28,6 +33,11 @@ router.get(
 		#swagger.tags = ['Appeal Allocation']
 		#swagger.path = '/appeals/appeal-allocation-levels'
 		#swagger.description = 'Gets the list of levels and associated bands used for allocation'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'List of allocation levels',
 			schema: { $ref: '#/definitions/AllocationLevelsResponse' },
@@ -43,6 +53,11 @@ router.patch(
 		#swagger.tags = ['Appeal Allocation']
 		#swagger.path = '/appeals/{appealId}/appeal-allocation'
 		#swagger.description = 'Adds or changes allocation for an appeal'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appeal allocation',

--- a/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/__tests__/appeal-timetables.test.js
@@ -7,9 +7,9 @@ import {
 	ERROR_MUST_NOT_HAVE_TIMETABLE_DATE,
 	ERROR_NOT_FOUND
 } from '../../constants.js';
-import { fullPlanningAppeal, householdAppeal } from '#tests/data.js';
+import { azureAdUserId, fullPlanningAppeal, householdAppeal } from '#tests/data.js';
 import joinDateAndTime from '#utils/join-date-and-time.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 const futureDate = '2099-09-01';
@@ -46,7 +46,8 @@ describe('appeal timetables routes', () => {
 				const { appealTimetable, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(householdAppealRequestBody);
+					.send(householdAppealRequestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appealTimetable.update).toHaveBeenCalledWith({
 					data: householdAppealResponseBody,
@@ -65,7 +66,8 @@ describe('appeal timetables routes', () => {
 				const { appealTimetable, id } = fullPlanningAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(fullPlanningAppealRequestBody);
+					.send(fullPlanningAppealRequestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appealTimetable.update).toHaveBeenCalledWith({
 					data: fullPlanningAppealResponseBody,
@@ -83,7 +85,8 @@ describe('appeal timetables routes', () => {
 
 				const response = await request
 					.patch(`/appeals/one/appeal-timetables/${householdAppeal.appealTimetable.id}`)
-					.send(householdAppealRequestBody);
+					.send(householdAppealRequestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -100,7 +103,8 @@ describe('appeal timetables routes', () => {
 				const { appealTimetable } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/3/appeal-timetables/${appealTimetable.id}`)
-					.send(householdAppealRequestBody);
+					.send(householdAppealRequestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -116,7 +120,8 @@ describe('appeal timetables routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/appeal-timetables/one`)
-					.send(householdAppealRequestBody);
+					.send(householdAppealRequestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -133,7 +138,8 @@ describe('appeal timetables routes', () => {
 				const { id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/3`)
-					.send(householdAppealRequestBody);
+					.send(householdAppealRequestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -152,7 +158,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						finalCommentReviewDate: '05/05/2023'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -171,7 +178,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						finalCommentReviewDate: '2023-5-5'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -191,7 +199,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -211,7 +220,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -231,7 +241,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -250,7 +261,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						finalCommentReviewDate: '2099-02-30'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -270,12 +282,13 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						finalCommentReviewDate: errorMessageReplacement(ERROR_MUST_NOT_HAVE_TIMETABLE_DATE, [
+						finalCommentReviewDate: stringTokenReplacement(ERROR_MUST_NOT_HAVE_TIMETABLE_DATE, [
 							appealType.type
 						])
 					}
@@ -291,7 +304,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						issueDeterminationDate: '05/05/2023'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -310,7 +324,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						issueDeterminationDate: '2023-5-5'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -330,7 +345,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -350,7 +366,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -370,7 +387,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -389,7 +407,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						issueDeterminationDate: '2099-02-30'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -408,7 +427,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						lpaQuestionnaireDueDate: '05/05/2023'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -427,7 +447,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						lpaQuestionnaireDueDate: '2023-5-5'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -447,7 +468,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -467,7 +489,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -487,7 +510,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -506,7 +530,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						lpaQuestionnaireDueDate: '2023-02-30'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -525,7 +550,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						statementReviewDate: '05/05/2023'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -544,7 +570,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						statementReviewDate: '2023-5-5'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -564,7 +591,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -584,7 +612,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -604,7 +633,8 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -623,7 +653,8 @@ describe('appeal timetables routes', () => {
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
 					.send({
 						statementReviewDate: '2023-02-30'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -643,12 +674,13 @@ describe('appeal timetables routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						statementReviewDate: errorMessageReplacement(ERROR_MUST_NOT_HAVE_TIMETABLE_DATE, [
+						statementReviewDate: stringTokenReplacement(ERROR_MUST_NOT_HAVE_TIMETABLE_DATE, [
 							appealType.type
 						])
 					}
@@ -662,7 +694,8 @@ describe('appeal timetables routes', () => {
 				const { appealTimetable, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send({});
+					.send({})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({});
@@ -679,7 +712,8 @@ describe('appeal timetables routes', () => {
 				const { appealTimetable, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appeal-timetables/${appealTimetable.id}`)
-					.send(householdAppealRequestBody);
+					.send(householdAppealRequestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appealTimetable.update).toHaveBeenCalledWith({
 					data: householdAppealResponseBody,

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.routes.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.routes.js
@@ -13,6 +13,11 @@ router.patch(
 		#swagger.tags = ['Appeal Timetables']
 		#swagger.path = '/appeals/{appealId}/appeal-timetables/{appealTimetableId}'
 		#swagger.description = 'Updates a single appeal timetable by id'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appeal timetable details to update',

--- a/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.validators.js
+++ b/appeals/api/src/server/endpoints/appeal-timetables/appeal-timetables.validators.js
@@ -4,7 +4,7 @@ import validateIdParameter from '#common/validators/id-parameter.js';
 import validateDateParameter from '#common/validators/date-parameter.js';
 import isFPA from '#utils/is-fpa.js';
 import { ERROR_MUST_NOT_HAVE_TIMETABLE_DATE } from '#endpoints/constants.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Appeal} Appeal */
 
@@ -16,7 +16,7 @@ import errorMessageReplacement from '#utils/error-message-replacement.js';
 const validateFPATimetableDate = (value, { req }) => {
 	if (!isFPA(req.appeal.appealType)) {
 		throw new Error(
-			errorMessageReplacement(ERROR_MUST_NOT_HAVE_TIMETABLE_DATE, [req.appeal.appealType.type])
+			stringTokenReplacement(ERROR_MUST_NOT_HAVE_TIMETABLE_DATE, [req.appeal.appealType.type])
 		);
 	}
 	return true;

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -68,6 +68,7 @@ interface RepositoryGetByIdResultItem {
 	appealType: Schema.AppealType | null;
 	appellant: Schema.Appellant | null;
 	appellantCase?: Schema.AppellantCase | null;
+	auditTrail: Schema.AuditTrail[] | null;
 	caseOfficer: User | null;
 	createdAt: Date;
 	dueDate: Date | null;
@@ -484,6 +485,7 @@ interface UpdateAppealRequest {
 }
 
 interface UsersToAssign {
+	azureAdUserId: string;
 	caseOfficer?: string | null;
 	inspector?: string | null;
 }
@@ -499,6 +501,19 @@ interface SingleFolderResponse {
 	caseId: number;
 	documents: DocumentInfo[] | null;
 }
+
+interface CreateAuditTrailRequest {
+	appealId: number;
+	details: string;
+	loggedAt: Date;
+	userId: number;
+}
+
+type GetAuditTrailsResponse = {
+	azureAdUserId: string;
+	details: string;
+	loggedDate: Date;
+}[];
 
 type UpdateDocumentsRequest = {
 	id: string;
@@ -524,6 +539,7 @@ export {
 	AssignedUser,
 	BankHolidayFeedDivisions,
 	BankHolidayFeedEvents,
+	CreateAuditTrailRequest,
 	DocumentationSummary,
 	DocumentInfo,
 	FolderInfo,
@@ -541,6 +557,7 @@ export {
 	SingleAppealDetailsResponse,
 	SingleAppellantCaseResponse,
 	SingleAppellantResponse,
+	GetAuditTrailsResponse,
 	SingleFolderResponse,
 	SingleLPAQuestionnaireResponse,
 	SingleSiteVisitDetailsResponse,

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -23,9 +23,12 @@ import { appellantsRoutes } from './appellants/appellants.routes.js';
 import { addressesRoutes } from './addresses/addresses.routes.js';
 import { appealTimetablesRoutes } from './appeal-timetables/appeal-timetables.routes.js';
 import { documentRedactionStatusesRoutes } from './document-redaction-statuses/document-redaction-statuses.routes.js';
+import { auditTrailsRoutes } from './audit-trails/audit-trails.routes.js';
+import checkAzureAdUserIdHeaderExists from '#middleware/check-azure-ad-user-id-header-exists.js';
 
 const router = createRouter();
 
+router.use('/', checkAzureAdUserIdHeaderExists);
 router.use('/', initNotifyClientAndAddToRequest);
 
 router.use(addressesRoutes);
@@ -36,6 +39,7 @@ router.use(appellantCaseInvalidReasonsRoutes);
 router.use(appellantCasesRoutes);
 router.use(appellantCaseValidationOutcomesRoutes);
 router.use(appellantsRoutes);
+router.use(auditTrailsRoutes);
 router.use(designatedSitesRoutes);
 router.use(documentRedactionStatusesRoutes);
 router.use(documentsRoutes);

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -1,15 +1,20 @@
+import { jest } from '@jest/globals';
 import { request } from '../../../app-test.js';
 import {
+	AUDIT_TRAIL_ASSIGNED_CASE_OFFICER,
+	AUDIT_TRAIL_ASSIGNED_INSPECTOR,
 	ERROR_FAILED_TO_SAVE_DATA,
 	ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS,
 	ERROR_MUST_BE_CORRECT_DATE_FORMAT,
 	ERROR_MUST_BE_GREATER_THAN_ZERO,
 	ERROR_MUST_BE_NUMBER,
+	ERROR_MUST_BE_SET_AS_HEADER,
 	ERROR_MUST_BE_UUID,
 	ERROR_NOT_FOUND,
 	ERROR_PAGENUMBER_AND_PAGESIZE_ARE_REQUIRED
 } from '../../constants.js';
 import {
+	azureAdUserId,
 	fullPlanningAppeal,
 	householdAppeal,
 	householdAppealAppellantCaseIncomplete,
@@ -17,10 +22,15 @@ import {
 	otherAppeals
 } from '#tests/data.js';
 import formatAddress from '#utils/format-address.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
 describe('appeals routes', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
 	describe('/appeals', () => {
 		describe('GET', () => {
 			test('gets appeals when not given pagination params or a search term', async () => {
@@ -29,7 +39,7 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findMany.mockResolvedValue([householdAppeal, fullPlanningAppeal]);
 
-				const response = await request.get('/appeals');
+				const response = await request.get('/appeals').set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
@@ -84,7 +94,9 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findMany.mockResolvedValue([fullPlanningAppeal]);
 
-				const response = await request.get('/appeals?pageNumber=2&pageSize=1');
+				const response = await request
+					.get('/appeals?pageNumber=2&pageSize=1')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
@@ -124,7 +136,9 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findMany.mockResolvedValue([householdAppeal]);
 
-				const response = await request.get('/appeals?searchTerm=MD21');
+				const response = await request
+					.get('/appeals?searchTerm=MD21')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
@@ -183,7 +197,9 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findMany.mockResolvedValue([householdAppeal]);
 
-				const response = await request.get('/appeals?searchTerm=md21');
+				const response = await request
+					.get('/appeals?searchTerm=md21')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
@@ -242,7 +258,9 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findMany.mockResolvedValue([householdAppeal]);
 
-				const response = await request.get('/appeals?searchTerm=MD21 5XY');
+				const response = await request
+					.get('/appeals?searchTerm=MD21 5XY')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.findMany).toHaveBeenCalledWith(
 					expect.objectContaining({
@@ -296,7 +314,9 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if pageNumber is given and pageSize is not given', async () => {
-				const response = await request.get('/appeals?pageNumber=1');
+				const response = await request
+					.get('/appeals?pageNumber=1')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -307,7 +327,9 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if pageSize is given and pageNumber is not given', async () => {
-				const response = await request.get('/appeals?pageSize=1');
+				const response = await request
+					.get('/appeals?pageSize=1')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -318,7 +340,9 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if pageNumber is not numeric', async () => {
-				const response = await request.get('/appeals?pageNumber=one&pageSize=1');
+				const response = await request
+					.get('/appeals?pageNumber=one&pageSize=1')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -329,7 +353,9 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if pageNumber is less than 1', async () => {
-				const response = await request.get('/appeals?pageNumber=-1&pageSize=1');
+				const response = await request
+					.get('/appeals?pageNumber=-1&pageSize=1')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -340,7 +366,9 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if pageSize is not numeric', async () => {
-				const response = await request.get('/appeals?pageNumber=1&pageSize=one');
+				const response = await request
+					.get('/appeals?pageNumber=1&pageSize=one')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -351,7 +379,9 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if pageSize is less than 1', async () => {
-				const response = await request.get('/appeals?pageNumber=1&pageSize=-1');
+				const response = await request
+					.get('/appeals?pageNumber=1&pageSize=-1')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -362,7 +392,9 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if searchTerm is less than 2 characters', async () => {
-				const response = await request.get('/appeals?searchTerm=a');
+				const response = await request
+					.get('/appeals?searchTerm=a')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -373,12 +405,25 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if searchTerm is more than 8 characters', async () => {
-				const response = await request.get('/appeals?searchTerm=aaaaaaaaa');
+				const response = await request
+					.get('/appeals?searchTerm=aaaaaaaaa')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
 						searchTerm: ERROR_LENGTH_BETWEEN_2_AND_8_CHARACTERS
+					}
+				});
+			});
+
+			test('returns an error if azureAdUserId is not set as a header', async () => {
+				const response = await request.get('/appeals');
+
+				expect(response.status).toEqual(400);
+				expect(response.body).toEqual({
+					errors: {
+						azureAdUserId: ERROR_MUST_BE_SET_AS_HEADER
 					}
 				});
 			});
@@ -396,7 +441,9 @@ describe('appeals routes', () => {
 					.mockResolvedValueOnce(linkedAppeals)
 					.mockResolvedValueOnce(otherAppeals);
 
-				const response = await request.get(`/appeals/${householdAppeal.id}`);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
@@ -419,7 +466,7 @@ describe('appeals routes', () => {
 					appealType: householdAppeal.appealType.type,
 					appellantCaseId: 1,
 					appellantName: householdAppeal.appellant.name,
-					caseOfficer: householdAppeal.caseOfficer.azureUserId,
+					caseOfficer: householdAppeal.caseOfficer.azureAdUserId,
 					decision: householdAppeal.inspectorDecision.outcome,
 					documentationSummary: {
 						appellantCase: {
@@ -441,7 +488,7 @@ describe('appeals routes', () => {
 							hasIssues: householdAppeal.lpaQuestionnaire.doesSiteHaveHealthAndSafetyIssues
 						}
 					},
-					inspector: householdAppeal.inspector.azureUserId,
+					inspector: householdAppeal.inspector.azureAdUserId,
 					inspectorAccess: {
 						appellantCase: {
 							details: householdAppeal.appellantCase.visibilityRestrictions,
@@ -497,7 +544,9 @@ describe('appeals routes', () => {
 					.mockResolvedValueOnce(linkedAppeals)
 					.mockResolvedValueOnce([]);
 
-				const response = await request.get(`/appeals/${fullPlanningAppeal.id}`);
+				const response = await request
+					.get(`/appeals/${fullPlanningAppeal.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
@@ -522,7 +571,7 @@ describe('appeals routes', () => {
 					appealType: fullPlanningAppeal.appealType.type,
 					appellantCaseId: 1,
 					appellantName: fullPlanningAppeal.appellant.name,
-					caseOfficer: fullPlanningAppeal.caseOfficer.azureUserId,
+					caseOfficer: fullPlanningAppeal.caseOfficer.azureAdUserId,
 					decision: fullPlanningAppeal.inspectorDecision.outcome,
 					documentationSummary: {
 						appellantCase: {
@@ -544,7 +593,7 @@ describe('appeals routes', () => {
 							hasIssues: fullPlanningAppeal.lpaQuestionnaire.doesSiteHaveHealthAndSafetyIssues
 						}
 					},
-					inspector: fullPlanningAppeal.inspector.azureUserId,
+					inspector: fullPlanningAppeal.inspector.azureAdUserId,
 					inspectorAccess: {
 						appellantCase: {
 							details: fullPlanningAppeal.appellantCase.visibilityRestrictions,
@@ -589,7 +638,7 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if appealId is not numeric', async () => {
-				const response = await request.get('/appeals/one');
+				const response = await request.get('/appeals/one').set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -603,7 +652,7 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request.get('/appeals/3');
+				const response = await request.get('/appeals/3').set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -619,9 +668,12 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					startedAt: '2023-05-05'
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						startedAt: '2023-05-05'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 					data: {
@@ -644,9 +696,12 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue(householdAppeal.caseOfficer);
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					caseOfficer: householdAppeal.caseOfficer.azureUserId
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						caseOfficer: householdAppeal.caseOfficer.azureAdUserId
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 					data: {
@@ -657,9 +712,19 @@ describe('appeals routes', () => {
 						id: householdAppeal.id
 					}
 				});
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_CASE_OFFICER, [
+							householdAppeal.caseOfficer.azureAdUserId
+						]),
+						loggedAt: expect.any(Date),
+						userId: householdAppeal.caseOfficer.id
+					}
+				});
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
-					caseOfficer: householdAppeal.caseOfficer.azureUserId
+					caseOfficer: householdAppeal.caseOfficer.azureAdUserId
 				});
 			});
 
@@ -669,9 +734,12 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue(householdAppeal.caseOfficer);
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					caseOfficer: null
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						caseOfficer: null
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 					data: {
@@ -682,6 +750,7 @@ describe('appeals routes', () => {
 						id: householdAppeal.id
 					}
 				});
+				expect(databaseConnector.auditTrail.create).not.toHaveBeenCalled();
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					caseOfficer: null
@@ -694,9 +763,12 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue(householdAppeal.inspector);
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					inspector: householdAppeal.inspector.azureUserId
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						inspector: householdAppeal.inspector.azureAdUserId
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 					data: {
@@ -707,9 +779,19 @@ describe('appeals routes', () => {
 						id: householdAppeal.id
 					}
 				});
+				expect(databaseConnector.auditTrail.create).toHaveBeenCalledWith({
+					data: {
+						appealId: householdAppeal.id,
+						details: stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_INSPECTOR, [
+							householdAppeal.inspector.azureAdUserId
+						]),
+						loggedAt: expect.any(Date),
+						userId: householdAppeal.inspector.id
+					}
+				});
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
-					inspector: householdAppeal.inspector.azureUserId
+					inspector: householdAppeal.inspector.azureAdUserId
 				});
 			});
 
@@ -719,9 +801,12 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.user.upsert.mockResolvedValue(householdAppeal.inspector);
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					inspector: null
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						inspector: null
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appeal.update).toHaveBeenCalledWith({
 					data: {
@@ -732,6 +817,7 @@ describe('appeals routes', () => {
 						id: householdAppeal.id
 					}
 				});
+				expect(databaseConnector.auditTrail.create).not.toHaveBeenCalled();
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					inspector: null
@@ -739,7 +825,7 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if appealId is not numeric', async () => {
-				const response = await request.patch('/appeals/one');
+				const response = await request.patch('/appeals/one').set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -753,7 +839,9 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request.get(`/appeals/${householdAppeal.id}`);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -764,9 +852,12 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if startedAt is not in the correct format', async () => {
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					startedAt: '05/05/2023'
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						startedAt: '05/05/2023'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -777,9 +868,12 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if startedAt does not contain leading zeros', async () => {
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					startedAt: '2023-5-5'
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						startedAt: '2023-5-5'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -790,9 +884,12 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if startedAt is not a valid date', async () => {
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					startedAt: '2023-02-30'
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						startedAt: '2023-02-30'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -803,9 +900,12 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if caseOfficer is not a valid uuid', async () => {
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					caseOfficer: '1'
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						caseOfficer: '1'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -816,9 +916,12 @@ describe('appeals routes', () => {
 			});
 
 			test('returns an error if inspector is not a valid uuid', async () => {
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					inspector: '1'
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						inspector: '1'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -837,9 +940,12 @@ describe('appeals routes', () => {
 					throw new Error(ERROR_FAILED_TO_SAVE_DATA);
 				});
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({
-					startedAtDate: '2023-02-10'
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({
+						startedAtDate: '2023-02-10'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({
@@ -853,7 +959,10 @@ describe('appeals routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.update.mockResolvedValue(true);
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({});

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -5,11 +5,12 @@ import { DEFAULT_PAGE_NUMBER, DEFAULT_PAGE_SIZE, ERROR_FAILED_TO_SAVE_DATA } fro
 import { formatAppeal, formatAppeals } from './appeals.formatter.js';
 import { assignUser, assignedUserType } from './appeals.service.js';
 
-/** @typedef {import('express').RequestHandler} RequestHandler */
+/** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
 
 /**
- * @type {RequestHandler}
+ * @param {Request} req
+ * @param {Response} res
  * @returns {Promise<Response>}
  */
 const getAppeals = async (req, res) => {
@@ -35,7 +36,8 @@ const getAppeals = async (req, res) => {
 };
 
 /**
- * @type {RequestHandler}
+ * @param {Request} req
+ * @param {Response} res
  * @returns {Response}
  */
 const getAppealById = (req, res) => {
@@ -46,7 +48,8 @@ const getAppealById = (req, res) => {
 };
 
 /**
- * @type {RequestHandler}
+ * @param {Request} req
+ * @param {Response} res
  * @returns {Promise<Response>}
  */
 const updateAppealById = async (req, res) => {
@@ -56,10 +59,11 @@ const updateAppealById = async (req, res) => {
 		params
 	} = req;
 	const appealId = Number(params.appealId);
+	const azureAdUserId = String(req.get('azureAdUserId'));
 
 	try {
 		assignedUserType({ caseOfficer, inspector })
-			? await assignUser(appealId, { caseOfficer, inspector })
+			? await assignUser(appealId, { azureAdUserId, caseOfficer, inspector })
 			: await appealRepository.updateAppealById(appealId, {
 					startedAt
 			  });

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -58,7 +58,7 @@ const formatAppeal = (appeal) => {
 			appealType: appeal.appealType?.type,
 			appellantCaseId: appeal.appellantCase?.id,
 			appellantName: appeal.appellant?.name,
-			caseOfficer: appeal.caseOfficer?.azureUserId || null,
+			caseOfficer: appeal.caseOfficer?.azureAdUserId || null,
 			decision: appeal.inspectorDecision?.outcome,
 			healthAndSafety: {
 				appellantCase: {
@@ -70,7 +70,7 @@ const formatAppeal = (appeal) => {
 					hasIssues: appeal.lpaQuestionnaire?.doesSiteHaveHealthAndSafetyIssues || null
 				}
 			},
-			inspector: appeal.inspector?.azureUserId || null,
+			inspector: appeal.inspector?.azureAdUserId || null,
 			inspectorAccess: {
 				appellantCase: {
 					details: appeal.appellantCase?.visibilityRestrictions || null,

--- a/appeals/api/src/server/endpoints/appeals/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.routes.js
@@ -16,6 +16,11 @@ router.get(
 		#swagger.tags = ['Appeals']
 		#swagger.path = '/appeals'
 		#swagger.description = 'Gets requested appeals, limited to the first 30 appeals if no pagination params are given'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.parameters['pageNumber'] = {
 			in: 'query',
 			description: 'The pagination page number - required if pageSize is given',
@@ -47,6 +52,11 @@ router.get(
 		#swagger.tags = ['Appeals']
 		#swagger.path = '/appeals/{appealId}'
 		#swagger.description = Gets a single appeal by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Gets a single appeal by id',
 			schema: { $ref: '#/definitions/SingleAppealResponse' }
@@ -65,6 +75,11 @@ router.patch(
 		#swagger.tags = ['Appeals']
 		#swagger.path = '/appeals/{appealId}'
 		#swagger.description = 'Updates a single appeal by id'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appeal details to update',

--- a/appeals/api/src/server/endpoints/appeals/appeals.service.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.service.js
@@ -1,5 +1,13 @@
 import userRepository from '#repositories/user.repository.js';
 import appealRepository from '#repositories/appeal.repository.js';
+import { createAuditTrail } from '#endpoints/audit-trails/audit-trails.service.js';
+import {
+	AUDIT_TRAIL_ASSIGNED_CASE_OFFICER,
+	AUDIT_TRAIL_ASSIGNED_INSPECTOR,
+	USER_TYPE_CASE_OFFICER,
+	USER_TYPE_INSPECTOR
+} from '#endpoints/constants.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.AssignedUser} AssignedUser */
 /** @typedef {import('@pins/appeals.api').Appeals.UsersToAssign} UsersToAssign */
@@ -11,14 +19,14 @@ import appealRepository from '#repositories/appeal.repository.js';
 const hasValueOrIsNull = (value) => Boolean(value) || value === null;
 
 /**
- * @param {UsersToAssign} param0
+ * @param {Pick<UsersToAssign, 'caseOfficer' | 'inspector'>} param0
  * @returns {AssignedUser | null}
  */
 const assignedUserType = ({ caseOfficer, inspector }) => {
 	if (hasValueOrIsNull(caseOfficer)) {
-		return 'caseOfficer';
+		return USER_TYPE_CASE_OFFICER;
 	} else if (hasValueOrIsNull(inspector)) {
-		return 'inspector';
+		return USER_TYPE_INSPECTOR;
 	}
 	return null;
 };
@@ -28,18 +36,29 @@ const assignedUserType = ({ caseOfficer, inspector }) => {
  * @param {UsersToAssign} param0
  * @returns {Promise<object | null>}
  */
-const assignUser = async (id, { caseOfficer, inspector }) => {
-	const azureUserId = caseOfficer || inspector;
+const assignUser = async (id, { azureAdUserId, caseOfficer, inspector }) => {
+	const assignedUserId = caseOfficer || inspector;
 	const typeOfAssignedUser = assignedUserType({ caseOfficer, inspector });
 
 	if (typeOfAssignedUser) {
+		let details = '';
 		let userId = null;
 
-		if (azureUserId) {
-			({ id: userId } = await userRepository.findOrCreateUser(azureUserId));
+		if (assignedUserId) {
+			({ id: userId } = await userRepository.findOrCreateUser(assignedUserId));
 		}
 
-		return appealRepository.updateAppealById(id, { [typeOfAssignedUser]: userId });
+		await appealRepository.updateAppealById(id, { [typeOfAssignedUser]: userId });
+
+		if (assignedUserId) {
+			if (caseOfficer) {
+				details = stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_CASE_OFFICER, [caseOfficer]);
+			} else if (inspector) {
+				details = stringTokenReplacement(AUDIT_TRAIL_ASSIGNED_INSPECTOR, [inspector]);
+			}
+
+			await createAuditTrail({ appealId: id, details, azureAdUserId });
+		}
 	}
 
 	return null;

--- a/appeals/api/src/server/endpoints/appellant-case-incomplete-reasons/__tests__/appellant-case-incomplete-reasons.test.js
+++ b/appeals/api/src/server/endpoints/appellant-case-incomplete-reasons/__tests__/appellant-case-incomplete-reasons.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { appellantCaseIncompleteReasons } from '../../../tests/data.js';
+import { appellantCaseIncompleteReasons, azureAdUserId } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -15,7 +15,9 @@ describe('appellant case incomplete reasons routes', () => {
 					appellantCaseIncompleteReasons
 				);
 
-				const response = await request.get('/appeals/appellant-case-incomplete-reasons');
+				const response = await request
+					.get('/appeals/appellant-case-incomplete-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(appellantCaseIncompleteReasons);
@@ -25,7 +27,9 @@ describe('appellant case incomplete reasons routes', () => {
 				// @ts-ignore
 				databaseConnector.appellantCaseIncompleteReason.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/appellant-case-incomplete-reasons');
+				const response = await request
+					.get('/appeals/appellant-case-incomplete-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -37,7 +41,9 @@ describe('appellant case incomplete reasons routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/appellant-case-incomplete-reasons');
+				const response = await request
+					.get('/appeals/appellant-case-incomplete-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/appellant-case-incomplete-reasons/appellant-case-incomplete-reasons.routes.js
+++ b/appeals/api/src/server/endpoints/appellant-case-incomplete-reasons/appellant-case-incomplete-reasons.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Appellant Case Incomplete Reasons']
 		#swagger.path = '/appeals/appellant-case-incomplete-reasons'
 		#swagger.description = 'Gets appellant case incomplete reasons'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Appellant case incomplete reasons',
 			schema: { $ref: '#/definitions/AllAppellantCaseIncompleteReasonsResponse' },

--- a/appeals/api/src/server/endpoints/appellant-case-invalid-reasons/__tests__/appellant-case-invalid-reasons.test.js
+++ b/appeals/api/src/server/endpoints/appellant-case-invalid-reasons/__tests__/appellant-case-invalid-reasons.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { appellantCaseInvalidReasons } from '../../../tests/data.js';
+import { appellantCaseInvalidReasons, azureAdUserId } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -15,7 +15,9 @@ describe('appellant case invalid reasons routes', () => {
 					appellantCaseInvalidReasons
 				);
 
-				const response = await request.get('/appeals/appellant-case-invalid-reasons');
+				const response = await request
+					.get('/appeals/appellant-case-invalid-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(appellantCaseInvalidReasons);
@@ -25,7 +27,9 @@ describe('appellant case invalid reasons routes', () => {
 				// @ts-ignore
 				databaseConnector.appellantCaseInvalidReason.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/appellant-case-invalid-reasons');
+				const response = await request
+					.get('/appeals/appellant-case-invalid-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -37,7 +41,9 @@ describe('appellant case invalid reasons routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/appellant-case-invalid-reasons');
+				const response = await request
+					.get('/appeals/appellant-case-invalid-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/appellant-case-invalid-reasons/appellant-case-invalid-reasons.routes.js
+++ b/appeals/api/src/server/endpoints/appellant-case-invalid-reasons/appellant-case-invalid-reasons.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Appellant Case Invalid Reasons']
 		#swagger.path = '/appeals/appellant-case-invalid-reasons'
 		#swagger.description = 'Gets appellant case invalid reasons'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Appellant case invalid reasons',
 			schema: { $ref: '#/definitions/AllAppellantCaseInvalidReasonsResponse' },

--- a/appeals/api/src/server/endpoints/appellant-case-validation-outcomes/__tests__/appellant-case-validation-outcomes.test.js
+++ b/appeals/api/src/server/endpoints/appellant-case-validation-outcomes/__tests__/appellant-case-validation-outcomes.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { appellantCaseValidationOutcomes } from '../../../tests/data.js';
+import { appellantCaseValidationOutcomes, azureAdUserId } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -15,7 +15,9 @@ describe('appellant case validation outcomes routes', () => {
 					appellantCaseValidationOutcomes
 				);
 
-				const response = await request.get('/appeals/appellant-case-validation-outcomes');
+				const response = await request
+					.get('/appeals/appellant-case-validation-outcomes')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(appellantCaseValidationOutcomes);
@@ -25,7 +27,9 @@ describe('appellant case validation outcomes routes', () => {
 				// @ts-ignore
 				databaseConnector.appellantCaseValidationOutcome.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/appellant-case-validation-outcomes');
+				const response = await request
+					.get('/appeals/appellant-case-validation-outcomes')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -37,7 +41,9 @@ describe('appellant case validation outcomes routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/appellant-case-validation-outcomes');
+				const response = await request
+					.get('/appeals/appellant-case-validation-outcomes')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/appellant-case-validation-outcomes/appellant-case-validation-outcomes.routes.js
+++ b/appeals/api/src/server/endpoints/appellant-case-validation-outcomes/appellant-case-validation-outcomes.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Appellant Case Validation Outcomes']
 		#swagger.path = '/appeals/appellant-case-validation-outcomes'
 		#swagger.description = 'Gets appellant case validation outcomes'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Appellant case validation outcomes',
 			schema: { $ref: '#/definitions/AllAppellantCaseValidationOutcomesResponse' },

--- a/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/__tests__/appellant-cases.test.js
@@ -32,6 +32,7 @@ import {
 	appellantCaseIncompleteReasons,
 	appellantCaseInvalidReasons,
 	appellantCaseValidationOutcomes,
+	azureAdUserId,
 	baseExpectedAppellantCaseResponse,
 	fullPlanningAppeal,
 	fullPlanningAppealAppellantCaseIncomplete,
@@ -46,7 +47,7 @@ import joinDateAndTime from '#utils/join-date-and-time.js';
 import { calculateTimetable } from '../../../utils/business-days.js';
 import config from '../../../config/config.js';
 import { NotifyClient } from 'notifications-node-client';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
 const startedAt = new Date(joinDateAndTime(format(new Date(), DEFAULT_DATE_FORMAT_DATABASE)));
@@ -66,7 +67,9 @@ describe('appellant cases routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 				const { appellantCase, id } = householdAppeal;
-				const response = await request.get(`/appeals/${id}/appellant-cases/${appellantCase.id}`);
+				const response = await request
+					.get(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(baseExpectedAppellantCaseResponse(householdAppeal));
@@ -78,9 +81,11 @@ describe('appellant cases routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppealAppellantCaseValid);
 
 				const { appellantCase } = householdAppealAppellantCaseValid;
-				const response = await request.get(
-					`/appeals/${householdAppealAppellantCaseValid.id}/appellant-cases/${appellantCase.id}`
-				);
+				const response = await request
+					.get(
+						`/appeals/${householdAppealAppellantCaseValid.id}/appellant-cases/${appellantCase.id}`
+					)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(
@@ -96,9 +101,11 @@ describe('appellant cases routes', () => {
 				);
 
 				const { appellantCase } = householdAppealAppellantCaseIncomplete;
-				const response = await request.get(
-					`/appeals/${householdAppealAppellantCaseIncomplete.id}/appellant-cases/${appellantCase.id}`
-				);
+				const response = await request
+					.get(
+						`/appeals/${householdAppealAppellantCaseIncomplete.id}/appellant-cases/${appellantCase.id}`
+					)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(
@@ -112,9 +119,11 @@ describe('appellant cases routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppealAppellantCaseInvalid);
 
 				const { appellantCase } = householdAppealAppellantCaseInvalid;
-				const response = await request.get(
-					`/appeals/${householdAppealAppellantCaseInvalid.id}/appellant-cases/${appellantCase.id}`
-				);
+				const response = await request
+					.get(
+						`/appeals/${householdAppealAppellantCaseInvalid.id}/appellant-cases/${appellantCase.id}`
+					)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(
@@ -128,9 +137,9 @@ describe('appellant cases routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(fullPlanningAppeal);
 
 				const { appellantCase } = fullPlanningAppeal;
-				const response = await request.get(
-					`/appeals/${fullPlanningAppeal.id}/appellant-cases/${appellantCase.id}`
-				);
+				const response = await request
+					.get(`/appeals/${fullPlanningAppeal.id}/appellant-cases/${appellantCase.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(baseExpectedAppellantCaseResponse(fullPlanningAppeal));
@@ -144,9 +153,11 @@ describe('appellant cases routes', () => {
 				);
 
 				const { appellantCase } = fullPlanningAppealAppellantCaseIncomplete;
-				const response = await request.get(
-					`/appeals/${fullPlanningAppealAppellantCaseIncomplete.id}/appellant-cases/${appellantCase.id}`
-				);
+				const response = await request
+					.get(
+						`/appeals/${fullPlanningAppealAppellantCaseIncomplete.id}/appellant-cases/${appellantCase.id}`
+					)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(
@@ -162,9 +173,11 @@ describe('appellant cases routes', () => {
 				);
 
 				const { appellantCase } = fullPlanningAppealAppellantCaseInvalid;
-				const response = await request.get(
-					`/appeals/${fullPlanningAppealAppellantCaseInvalid.id}/appellant-cases/${appellantCase.id}`
-				);
+				const response = await request
+					.get(
+						`/appeals/${fullPlanningAppealAppellantCaseInvalid.id}/appellant-cases/${appellantCase.id}`
+					)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(
@@ -174,7 +187,9 @@ describe('appellant cases routes', () => {
 
 			test('returns an error if appealId is not numeric', async () => {
 				const { appellantCase } = householdAppeal;
-				const response = await request.get(`/appeals/one/appellant-cases/${appellantCase.id}`);
+				const response = await request
+					.get(`/appeals/one/appellant-cases/${appellantCase.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -189,7 +204,9 @@ describe('appellant cases routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
 				const { appellantCase } = householdAppeal;
-				const response = await request.get(`/appeals/3/appellant-cases/${appellantCase.id}`);
+				const response = await request
+					.get(`/appeals/3/appellant-cases/${appellantCase.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -201,7 +218,9 @@ describe('appellant cases routes', () => {
 
 			test('returns an error if appellantCaseId is not numeric', async () => {
 				const { id } = householdAppeal;
-				const response = await request.get(`/appeals/${id}/appellant-cases/one`);
+				const response = await request
+					.get(`/appeals/${id}/appellant-cases/one`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -216,7 +235,9 @@ describe('appellant cases routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 				const { id } = householdAppeal;
-				const response = await request.get(`/appeals/${id}/appellant-cases/3`);
+				const response = await request
+					.get(`/appeals/${id}/appellant-cases/3`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -257,7 +278,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -316,7 +338,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -392,7 +415,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -465,7 +489,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -550,7 +575,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -616,7 +642,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -698,7 +725,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -753,7 +781,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -792,7 +821,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -856,7 +886,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase } = fullPlanningAppeal;
 				const response = await request
 					.patch(`/appeals/${fullPlanningAppeal.id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -918,7 +949,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase } = fullPlanningAppeal;
 				const response = await request
 					.patch(`/appeals/${fullPlanningAppeal.id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -954,7 +986,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase } = fullPlanningAppeal;
 				const response = await request
 					.patch(`/appeals/${fullPlanningAppeal.id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -989,7 +1022,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase } = fullPlanningAppeal;
 				const response = await request
 					.patch(`/appeals/${fullPlanningAppeal.id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1028,7 +1062,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase } = fullPlanningAppeal;
 				const response = await request
 					.patch(`/appeals/${fullPlanningAppeal.id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1044,7 +1079,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/one/appellant-cases/${appellantCase.id}`)
 					.send({
 						validationOutcome: 'Valid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1063,7 +1099,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/3/appellant-cases/${appellantCase.id}`)
 					.send({
 						validationOutcome: 'Valid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -1075,9 +1112,12 @@ describe('appellant cases routes', () => {
 
 			test('returns an error if appellantCaseId is not numeric', async () => {
 				const { id } = householdAppeal;
-				const response = await request.patch(`/appeals/${id}/appellant-cases/one`).send({
-					validationOutcome: 'Valid'
-				});
+				const response = await request
+					.patch(`/appeals/${id}/appellant-cases/one`)
+					.send({
+						validationOutcome: 'Valid'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1092,9 +1132,12 @@ describe('appellant cases routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 				const { id } = householdAppeal;
-				const response = await request.patch(`/appeals/${id}/appellant-cases/3`).send({
-					validationOutcome: 'Valid'
-				});
+				const response = await request
+					.patch(`/appeals/${id}/appellant-cases/3`)
+					.send({
+						validationOutcome: 'Valid'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -1112,7 +1155,8 @@ describe('appellant cases routes', () => {
 						appealDueDate: '05/05/2023',
 						incompleteReasons: [{ id: 1 }],
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1130,7 +1174,8 @@ describe('appellant cases routes', () => {
 						appealDueDate: '2023-5-5',
 						incompleteReasons: [{ id: 1 }],
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1151,7 +1196,8 @@ describe('appellant cases routes', () => {
 				};
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1169,7 +1215,8 @@ describe('appellant cases routes', () => {
 						appealDueDate: '2023-02-30',
 						incompleteReasons: [{ id: 1 }],
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1185,7 +1232,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1201,7 +1249,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						validationOutcome: 'Invalid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1218,7 +1267,8 @@ describe('appellant cases routes', () => {
 					.send({
 						incompleteReasons: 1,
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1235,7 +1285,8 @@ describe('appellant cases routes', () => {
 					.send({
 						invalidReasons: 1,
 						validationOutcome: 'Invalid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1252,7 +1303,8 @@ describe('appellant cases routes', () => {
 					.send({
 						incompleteReasons: [],
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1269,7 +1321,8 @@ describe('appellant cases routes', () => {
 					.send({
 						invalidReasons: [],
 						validationOutcome: 'Invalid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1297,7 +1350,8 @@ describe('appellant cases routes', () => {
 					.send({
 						incompleteReasons: [{ id: 1 }, { id: 10 }],
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -1325,7 +1379,8 @@ describe('appellant cases routes', () => {
 					.send({
 						invalidReasons: [{ id: 1 }, { id: 10 }],
 						validationOutcome: 'Invalid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -1346,7 +1401,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						validationOutcome: 'Complete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1364,7 +1420,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1387,7 +1444,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1404,7 +1462,8 @@ describe('appellant cases routes', () => {
 					.send({
 						incompleteReasons: [{ id: 1 }, { id: 2 }],
 						validationOutcome: 'Valid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1426,7 +1485,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1449,7 +1509,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1466,7 +1527,8 @@ describe('appellant cases routes', () => {
 					.send({
 						invalidReasons: [{ id: 1 }, { id: 2 }],
 						validationOutcome: 'Valid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1485,7 +1547,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						applicantFirstName: ['Fiona']
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1504,7 +1567,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						applicantFirstName: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1523,12 +1587,13 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						applicantFirstName: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						applicantFirstName: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						applicantFirstName: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -1542,7 +1607,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						applicantSurname: ['Burgess']
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1561,7 +1627,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						applicantSurname: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1580,12 +1647,13 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						applicantSurname: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						applicantSurname: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						applicantSurname: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -1599,7 +1667,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						isSiteFullyOwned: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1619,7 +1688,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1641,7 +1711,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1666,7 +1737,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1689,7 +1761,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1712,7 +1785,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1735,7 +1809,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1758,7 +1833,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1781,7 +1857,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1800,7 +1877,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						isSitePartiallyOwned: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1820,7 +1898,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1840,7 +1919,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1863,7 +1943,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1886,7 +1967,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1909,7 +1991,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1932,7 +2015,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1955,7 +2039,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1978,7 +2063,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -1997,7 +2083,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						areAllOwnersKnown: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2017,7 +2104,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2037,7 +2125,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2060,7 +2149,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2083,7 +2173,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2106,7 +2197,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2129,7 +2221,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2152,7 +2245,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2175,7 +2269,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2194,7 +2289,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						hasAttemptedToIdentifyOwners: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2216,7 +2312,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						hasAttemptedToIdentifyOwners: true
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2238,7 +2335,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						hasAttemptedToIdentifyOwners: false
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2263,7 +2361,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2286,7 +2385,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2309,7 +2409,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2332,7 +2433,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2355,7 +2457,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2378,7 +2481,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2397,7 +2501,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						hasAdvertisedAppeal: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2417,7 +2522,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2437,7 +2543,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2460,7 +2567,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2483,7 +2591,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2506,7 +2615,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2529,7 +2639,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2552,7 +2663,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2575,7 +2687,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2594,7 +2707,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						isSiteVisibleFromPublicRoad: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2614,7 +2728,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2635,7 +2750,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2658,7 +2774,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2683,7 +2800,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2706,7 +2824,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2731,7 +2850,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2754,7 +2874,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2779,7 +2900,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2798,7 +2920,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						visibilityRestrictions: ['The site is behind a tall hedge']
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2817,7 +2940,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						visibilityRestrictions: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2836,12 +2960,13 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						visibilityRestrictions: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						visibilityRestrictions: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [
+						visibilityRestrictions: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [
 							LENGTH_300
 						])
 					}
@@ -2857,12 +2982,13 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						isSiteVisibleFromPublicRoad: false
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						isSiteVisibleFromPublicRoad: errorMessageReplacement(ERROR_MUST_HAVE_DETAILS, [
+						isSiteVisibleFromPublicRoad: stringTokenReplacement(ERROR_MUST_HAVE_DETAILS, [
 							'visibilityRestrictions',
 							'isSiteVisibleFromPublicRoad',
 							false
@@ -2881,12 +3007,13 @@ describe('appellant cases routes', () => {
 					.send({
 						isSiteVisibleFromPublicRoad: true,
 						visibilityRestrictions: 'The site is behind a tall hedge'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						isSiteVisibleFromPublicRoad: errorMessageReplacement(ERROR_MUST_NOT_HAVE_DETAILS, [
+						isSiteVisibleFromPublicRoad: stringTokenReplacement(ERROR_MUST_NOT_HAVE_DETAILS, [
 							'visibilityRestrictions',
 							'isSiteVisibleFromPublicRoad',
 							true
@@ -2904,7 +3031,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						hasHealthAndSafetyIssues: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2925,7 +3053,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2945,7 +3074,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2970,7 +3100,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -2993,7 +3124,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -3018,7 +3150,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -3041,7 +3174,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -3066,7 +3200,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -3089,7 +3224,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					where: { id: appellantCase.id },
@@ -3108,7 +3244,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						healthAndSafetyIssues: ['There is no mobile reception at the site']
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3127,7 +3264,8 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						healthAndSafetyIssues: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3146,14 +3284,13 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						healthAndSafetyIssues: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						healthAndSafetyIssues: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [
-							LENGTH_300
-						])
+						healthAndSafetyIssues: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -3168,12 +3305,13 @@ describe('appellant cases routes', () => {
 					.send({
 						hasHealthAndSafetyIssues: false,
 						healthAndSafetyIssues: 'There is no mobile reception at the site'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						hasHealthAndSafetyIssues: errorMessageReplacement(ERROR_MUST_NOT_HAVE_DETAILS, [
+						hasHealthAndSafetyIssues: stringTokenReplacement(ERROR_MUST_NOT_HAVE_DETAILS, [
 							'healthAndSafetyIssues',
 							'hasHealthAndSafetyIssues',
 							false
@@ -3191,12 +3329,13 @@ describe('appellant cases routes', () => {
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
 					.send({
 						hasHealthAndSafetyIssues: true
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						hasHealthAndSafetyIssues: errorMessageReplacement(ERROR_MUST_HAVE_DETAILS, [
+						hasHealthAndSafetyIssues: stringTokenReplacement(ERROR_MUST_HAVE_DETAILS, [
 							'healthAndSafetyIssues',
 							'hasHealthAndSafetyIssues',
 							true
@@ -3212,7 +3351,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send({});
+					.send({})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({});
@@ -3232,7 +3372,8 @@ describe('appellant cases routes', () => {
 				const { appellantCase, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/appellant-cases/${appellantCase.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellantCase.update).toHaveBeenCalledWith({
 					data: body,

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.routes.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.routes.js
@@ -19,6 +19,11 @@ router.get(
 		#swagger.tags = ['Appellant Cases']
 		#swagger.path = '/appeals/{appealId}/appellant-cases/{appellantCaseId}'
 		#swagger.description = Gets a single appellant case for an appeal by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Gets a single appellant case for an appeal by id',
 			schema: { $ref: '#/definitions/SingleAppellantCaseResponse' }
@@ -38,6 +43,11 @@ router.patch(
 		#swagger.tags = ['Appellant Cases']
 		#swagger.path = '/appeals/{appealId}/appellant-cases/{appellantCaseId}'
 		#swagger.description = Updates a single appellant case for an appeal by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appellant case details to update',

--- a/appeals/api/src/server/endpoints/appellants/__tests__/appellants.test.js
+++ b/appeals/api/src/server/endpoints/appellants/__tests__/appellants.test.js
@@ -8,8 +8,8 @@ import {
 	ERROR_NOT_FOUND,
 	LENGTH_300
 } from '../../constants.js';
-import { householdAppeal } from '#tests/data.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import { azureAdUserId, householdAppeal } from '#tests/data.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -20,9 +20,9 @@ describe('appellants routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.get(
-					`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`
-				);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
@@ -35,9 +35,9 @@ describe('appellants routes', () => {
 			});
 
 			test('returns an error if appealId is not numeric', async () => {
-				const response = await request.get(
-					`/appeals/one/appellants/${householdAppeal.appellant.id}`
-				);
+				const response = await request
+					.get(`/appeals/one/appellants/${householdAppeal.appellant.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -51,7 +51,9 @@ describe('appellants routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request.get(`/appeals/3/appellants/${householdAppeal.appellant.id}`);
+				const response = await request
+					.get(`/appeals/3/appellants/${householdAppeal.appellant.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -62,7 +64,9 @@ describe('appellants routes', () => {
 			});
 
 			test('returns an error if appellantId is not numeric', async () => {
-				const response = await request.get(`/appeals/${householdAppeal.id}/appellants/one`);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/appellants/one`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -76,7 +80,9 @@ describe('appellants routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.get(`/appeals/${householdAppeal.id}/appellants/3`);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/appellants/3`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -98,7 +104,8 @@ describe('appellants routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellant.update).toHaveBeenCalledWith({
 					data: patchBody,
@@ -113,7 +120,8 @@ describe('appellants routes', () => {
 			test('returns an error if appealId is not numeric', async () => {
 				const response = await request
 					.patch(`/appeals/one/appellants/${householdAppeal.appellant.id}`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -129,7 +137,8 @@ describe('appellants routes', () => {
 
 				const response = await request
 					.patch(`/appeals/3/appellants/${householdAppeal.appellant.id}`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -142,7 +151,8 @@ describe('appellants routes', () => {
 			test('returns an error if appellantId is not numeric', async () => {
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/appellants/one`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -158,7 +168,8 @@ describe('appellants routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/appellants/3`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -176,7 +187,8 @@ describe('appellants routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
 					.send({
 						name: [patchBody.name]
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -194,7 +206,8 @@ describe('appellants routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
 					.send({
 						name: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -212,12 +225,13 @@ describe('appellants routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
 					.send({
 						name: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						name: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						name: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -228,7 +242,8 @@ describe('appellants routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
-					.send({});
+					.send({})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({});
@@ -244,7 +259,8 @@ describe('appellants routes', () => {
 
 				const response = await request
 					.patch(`/appeals/${householdAppeal.id}/appellants/${householdAppeal.appellant.id}`)
-					.send(patchBody);
+					.send(patchBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.appellant.update).toHaveBeenCalledWith({
 					data: patchBody,

--- a/appeals/api/src/server/endpoints/appellants/appellants.routes.js
+++ b/appeals/api/src/server/endpoints/appellants/appellants.routes.js
@@ -13,6 +13,11 @@ router.get(
 		#swagger.tags = ['Appellants']
 		#swagger.path = '/appeals/{appealId}/appellants/{appellantId}'
 		#swagger.description = Gets a single appellant by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Gets a single appellant by id',
 			schema: { $ref: '#/definitions/SingleAppellantResponse' }
@@ -32,6 +37,11 @@ router.patch(
 		#swagger.tags = ['Appellants']
 		#swagger.path = '/appeals/{appealId}/appellants/{appellantId}'
 		#swagger.description = Updates a single appellant by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appellant details to update',

--- a/appeals/api/src/server/endpoints/audit-trails/__tests__/audit-trails.test.js
+++ b/appeals/api/src/server/endpoints/audit-trails/__tests__/audit-trails.test.js
@@ -1,0 +1,46 @@
+import supertest from 'supertest';
+import { app } from '../../../app-test.js';
+import { azureAdUserId, householdAppeal } from '../../../tests/data.js';
+
+const { databaseConnector } = await import('../../../utils/database-connector.js');
+const request = supertest(app);
+
+describe('audit trails routes', () => {
+	describe('/appeals/:appealId/audit-trails', () => {
+		describe('GET', () => {
+			test('gets audit trail entries', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const { auditTrail, id } = householdAppeal;
+				const response = await request
+					.get(`/appeals/${id}/audit-trails`)
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual([
+					{
+						azureAdUserId: auditTrail[0].user.azureAdUserId,
+						details: auditTrail[0].details,
+						loggedDate: auditTrail[0].loggedAt
+					}
+				]);
+			});
+
+			test('returns an empty array if audit trail entries are not found', async () => {
+				householdAppeal.auditTrail = [];
+
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+
+				const { id } = householdAppeal;
+				const response = await request
+					.get(`/appeals/${id}/audit-trails`)
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(200);
+				expect(response.body).toEqual([]);
+			});
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/audit-trails/audit-trails.controller.js
+++ b/appeals/api/src/server/endpoints/audit-trails/audit-trails.controller.js
@@ -1,0 +1,18 @@
+import { formatAuditTrail } from './audit-trails.formatter.js';
+
+/** @typedef {import('express').Request} Request */
+/** @typedef {import('express').Response} Response */
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Response}
+ */
+const getAuditTrailById = (req, res) => {
+	const { auditTrail } = req.appeal;
+	const formattedAuditTrail = formatAuditTrail(auditTrail);
+
+	return res.send(formattedAuditTrail);
+};
+
+export { getAuditTrailById };

--- a/appeals/api/src/server/endpoints/audit-trails/audit-trails.formatter.js
+++ b/appeals/api/src/server/endpoints/audit-trails/audit-trails.formatter.js
@@ -1,0 +1,17 @@
+/** @typedef {import('@pins/appeals.api').Schema.AuditTrail} AuditTrail */
+/** @typedef {import('@pins/appeals.api').Appeals.GetAuditTrailsResponse} GetAuditTrailsResponse */
+
+/**
+ * @param {AuditTrail[] | null} auditTrail
+ * @returns {GetAuditTrailsResponse | []}
+ */
+const formatAuditTrail = (auditTrail) =>
+	auditTrail
+		? auditTrail.map(({ details, loggedAt, user }) => ({
+				azureAdUserId: user.azureAdUserId,
+				details,
+				loggedDate: loggedAt
+		  }))
+		: [];
+
+export { formatAuditTrail };

--- a/appeals/api/src/server/endpoints/audit-trails/audit-trails.routes.js
+++ b/appeals/api/src/server/endpoints/audit-trails/audit-trails.routes.js
@@ -1,0 +1,32 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import { getAuditTrailById } from './audit-trails.controller.js';
+import checkAppealExistsAndAddToRequest from '#middleware/check-appeal-exists-and-add-to-request.js';
+import { getAuditTrailValidator } from './audit-trails.validators.js';
+
+const router = createRouter();
+
+router.get(
+	'/:appealId/audit-trails',
+	/*
+		#swagger.tags = ['Audit Trails']
+		#swagger.path = '/appeals/{appealId}/audit-trails'
+		#swagger.description = Gets audit trail entries for an appeal by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.responses[200] = {
+			description: 'Gets audit trail entries for an appeal by id',
+			schema: { $ref: '#/definitions/GetAuditTrailsResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	getAuditTrailValidator,
+	checkAppealExistsAndAddToRequest,
+	asyncHandler(getAuditTrailById)
+);
+
+export { router as auditTrailsRoutes };

--- a/appeals/api/src/server/endpoints/audit-trails/audit-trails.service.js
+++ b/appeals/api/src/server/endpoints/audit-trails/audit-trails.service.js
@@ -1,0 +1,22 @@
+import auditTrailRepository from '#repositories/audit-trail.repository.js';
+import userRepository from '#repositories/user.repository.js';
+
+/**
+ * @param {*} param0
+ */
+const createAuditTrail = async ({ appealId, details, azureAdUserId }) => {
+	if (azureAdUserId) {
+		const { id: userId } = await userRepository.findOrCreateUser(azureAdUserId);
+
+		if (userId) {
+			await auditTrailRepository.createAuditTrail({
+				appealId,
+				details,
+				loggedAt: new Date(),
+				userId
+			});
+		}
+	}
+};
+
+export { createAuditTrail };

--- a/appeals/api/src/server/endpoints/audit-trails/audit-trails.validators.js
+++ b/appeals/api/src/server/endpoints/audit-trails/audit-trails.validators.js
@@ -1,0 +1,10 @@
+import { composeMiddleware } from '@pins/express';
+import { validationErrorHandler } from '#middleware/error-handler.js';
+import validateIdParameter from '#common/validators/id-parameter.js';
+
+const getAuditTrailValidator = composeMiddleware(
+	validateIdParameter('appealId'),
+	validationErrorHandler
+);
+
+export { getAuditTrailValidator };

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -6,9 +6,15 @@ export const VALIDATION_OUTCOME_VALID = 'Valid';
 export const APPEAL_TYPE_SHORTHAND_FPA = 'FPA';
 export const APPEAL_TYPE_SHORTHAND_HAS = 'HAS';
 
+export const AUDIT_TRAIL_ASSIGNED_CASE_OFFICER =
+	'The case officer {replacement0} was added to the team';
+export const AUDIT_TRAIL_ASSIGNED_INSPECTOR =
+	'The inspector {replacement0} was assigned to the team';
+
 export const BANK_HOLIDAY_FEED_DIVISION_ENGLAND = 'england-and-wales';
 
 export const DATABASE_ORDER_BY_ASC = 'asc';
+export const DATABASE_ORDER_BY_DESC = 'desc';
 
 export const DEFAULT_DATE_FORMAT_DATABASE = 'yyyy-MM-dd';
 export const DEFAULT_DATE_FORMAT_DISPLAY = 'dd LLL yyyy';
@@ -46,6 +52,7 @@ export const ERROR_MUST_BE_IN_FUTURE = 'Must be in the future';
 export const ERROR_MUST_BE_INCOMPLETE_INVALID_REASON =
 	'Must be an array of objects containing a required id number parameter and an optional text string array parameter containing 10 or less items';
 export const ERROR_MUST_BE_NUMBER = 'Must be a number';
+export const ERROR_MUST_BE_SET_AS_HEADER = 'Must be set as a header';
 export const ERROR_MUST_BE_STRING = 'Must be a string';
 export const ERROR_MUST_BE_UUID = 'Must be a uuid';
 export const ERROR_MUST_BE_VALID_FILEINFO = 'Must be a valid file';
@@ -89,3 +96,6 @@ export const STATE_TARGET_READY_TO_START = 'ready_to_start';
 export const STATE_TARGET_STATEMENT_REVIEW = 'statement_review';
 
 export const STATE_TYPE_FINAL = 'final';
+
+export const USER_TYPE_CASE_OFFICER = 'caseOfficer';
+export const USER_TYPE_INSPECTOR = 'inspector';

--- a/appeals/api/src/server/endpoints/designated-sites/__tests__/designated-sites.test.js
+++ b/appeals/api/src/server/endpoints/designated-sites/__tests__/designated-sites.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { designatedSites } from '../../../tests/data.js';
+import { azureAdUserId, designatedSites } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -13,7 +13,9 @@ describe('designated sites routes', () => {
 				// @ts-ignore
 				databaseConnector.designatedSite.findMany.mockResolvedValue(designatedSites);
 
-				const response = await request.get('/appeals/designated-sites');
+				const response = await request
+					.get('/appeals/designated-sites')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(designatedSites);
@@ -23,7 +25,9 @@ describe('designated sites routes', () => {
 				// @ts-ignore
 				databaseConnector.designatedSite.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/designated-sites');
+				const response = await request
+					.get('/appeals/designated-sites')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -35,7 +39,9 @@ describe('designated sites routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/designated-sites');
+				const response = await request
+					.get('/appeals/designated-sites')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/designated-sites/designated-sites.routes.js
+++ b/appeals/api/src/server/endpoints/designated-sites/designated-sites.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Designated Sites']
 		#swagger.path = '/appeals/designated-sites'
 		#swagger.description = 'Gets designated sites'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Designated sites',
 			schema: { $ref: '#/definitions/AllDesignatedSitesResponse' },

--- a/appeals/api/src/server/endpoints/document-redaction-statuses/__tests__/document-redaction-statuses.test.js
+++ b/appeals/api/src/server/endpoints/document-redaction-statuses/__tests__/document-redaction-statuses.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { documentRedactionStatuses } from '../../../tests/data.js';
+import { azureAdUserId, documentRedactionStatuses } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -15,7 +15,9 @@ describe('document redaction statuses routes', () => {
 					documentRedactionStatuses
 				);
 
-				const response = await request.get('/appeals/document-redaction-statuses');
+				const response = await request
+					.get('/appeals/document-redaction-statuses')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(documentRedactionStatuses);
@@ -25,7 +27,9 @@ describe('document redaction statuses routes', () => {
 				// @ts-ignore
 				databaseConnector.documentRedactionStatus.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/document-redaction-statuses');
+				const response = await request
+					.get('/appeals/document-redaction-statuses')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -37,7 +41,9 @@ describe('document redaction statuses routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/document-redaction-statuses');
+				const response = await request
+					.get('/appeals/document-redaction-statuses')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/document-redaction-statuses/document-redaction-statuses.routes.js
+++ b/appeals/api/src/server/endpoints/document-redaction-statuses/document-redaction-statuses.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Document Redaction Statuses']
 		#swagger.path = '/appeals/document-redaction-statuses'
 		#swagger.description = 'Gets document redaction statuses'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Document redaction statuses',
 			schema: { $ref: '#/definitions/AllDocumentRedactionStatusesResponse' },

--- a/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
+++ b/appeals/api/src/server/endpoints/documents/__tests__/documents.test.js
@@ -18,6 +18,7 @@ import * as service from '../documents.service.js';
 import * as controller from '../documents.controller.js';
 import { request } from '../../../app-test.js';
 import {
+	azureAdUserId,
 	documentRedactionStatuses,
 	documentRedactionStatusIds,
 	householdAppeal
@@ -30,7 +31,7 @@ import {
 	ERROR_MUST_BE_UUID,
 	ERROR_NOT_FOUND
 } from '#endpoints/constants.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 const { default: got } = await import('got');
@@ -41,9 +42,9 @@ describe('/appeals/:appealId/document-folders/:folderId', () => {
 			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 			databaseConnector.folder.findUnique.mockResolvedValue(savedFolder);
 
-			const response = await request.get(
-				`/appeals/${householdAppeal.id}/document-folders/${savedFolder.id}`
-			);
+			const response = await request
+				.get(`/appeals/${householdAppeal.id}/document-folders/${savedFolder.id}`)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(200);
 			expect(response.body).toEqual({
@@ -90,7 +91,8 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(databaseConnector.document.update).toHaveBeenCalledTimes(2);
 			expect(databaseConnector.document.update).toHaveBeenCalledWith({
@@ -129,7 +131,10 @@ describe('/appeals/:appealId/documents', () => {
 		});
 
 		test('returns an error if appealId is not numeric', async () => {
-			const response = await request.patch('/appeals/one/documents').send(requestBody);
+			const response = await request
+				.patch('/appeals/one/documents')
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -143,7 +148,10 @@ describe('/appeals/:appealId/documents', () => {
 			// @ts-ignore
 			databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-			const response = await request.patch('/appeals/3/documents').send(requestBody);
+			const response = await request
+				.patch('/appeals/3/documents')
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(404);
 			expect(response.body).toEqual({
@@ -160,7 +168,8 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -177,7 +186,8 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -194,7 +204,8 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -211,7 +222,8 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -228,7 +240,8 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -245,7 +258,8 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
@@ -265,12 +279,13 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					documents: errorMessageReplacement(ERROR_DOCUMENT_REDACTION_STATUSES_MUST_BE_ONE_OF, [
+					documents: stringTokenReplacement(ERROR_DOCUMENT_REDACTION_STATUSES_MUST_BE_ONE_OF, [
 						documentRedactionStatusIds.join(', ')
 					])
 				}
@@ -287,12 +302,13 @@ describe('/appeals/:appealId/documents', () => {
 
 			const response = await request
 				.patch(`/appeals/${householdAppeal.id}/documents`)
-				.send(requestBody);
+				.send(requestBody)
+				.set('azureAdUserId', azureAdUserId);
 
 			expect(response.status).toEqual(400);
 			expect(response.body).toEqual({
 				errors: {
-					documents: errorMessageReplacement(ERROR_DOCUMENT_REDACTION_STATUSES_MUST_BE_ONE_OF, [
+					documents: stringTokenReplacement(ERROR_DOCUMENT_REDACTION_STATUSES_MUST_BE_ONE_OF, [
 						documentRedactionStatusIds.join(', ')
 					])
 				}

--- a/appeals/api/src/server/endpoints/documents/documents.routes.js
+++ b/appeals/api/src/server/endpoints/documents/documents.routes.js
@@ -20,6 +20,11 @@ router.get(
 		#swagger.tags = ['Documents']
 		#swagger.path = '/appeals/{appealId}/document-folders/{folderId}'
 		#swagger.description = Returns the contents of a single appeal folder, by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Returns the contents of a single appeal folder, by id',
 			schema: { $ref: '#/definitions/Folder' }
@@ -39,6 +44,11 @@ router.get(
 		#swagger.tags = ['Documents']
 		#swagger.path = '/appeals/{appealId}/documents/{documentId}'
 		#swagger.description = Returns the contents of the appeal folders
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Gets all the documents for a specific appeal by id',
 			schema: { $ref: '#/definitions/DocumentDetails' }
@@ -59,6 +69,11 @@ router.post(
 		#swagger.tags = ['Documents']
 		#swagger.path = '/appeals/{appealId}/documents'
 		#swagger.description = Upload documents to a case
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appeal documents to post',
@@ -84,6 +99,11 @@ router.post(
 		#swagger.tags = ['Documents']
 		#swagger.path = '/appeals/{appealId}/documents/{documentId}'
 		#swagger.description = Add a new version of a document
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Appeal documents to post',
@@ -111,6 +131,11 @@ router.patch(
 		#swagger.tags = ['Documents']
 		#swagger.path = '/appeals/{appealId}/documents'
 		#swagger.description = Updates multiple documents
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Documents to update',

--- a/appeals/api/src/server/endpoints/documents/documents.validators.js
+++ b/appeals/api/src/server/endpoints/documents/documents.validators.js
@@ -10,7 +10,7 @@ import {
 	ERROR_MUST_BE_VALID_FILEINFO
 } from '#endpoints/constants.js';
 import validateDateParameter from '#common/validators/date-parameter.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 import { getDocumentRedactionStatusIds } from './documents.service.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateDocumentsRequest} UpdateDocumentsRequest */
@@ -27,7 +27,7 @@ const validateDocumentRedactionStatusIds = async (documents) => {
 
 	if (!hasValidStatusIds) {
 		throw new Error(
-			errorMessageReplacement(ERROR_DOCUMENT_REDACTION_STATUSES_MUST_BE_ONE_OF, [
+			stringTokenReplacement(ERROR_DOCUMENT_REDACTION_STATUSES_MUST_BE_ONE_OF, [
 				redactionStatusIds.join(', ')
 			])
 		);

--- a/appeals/api/src/server/endpoints/knowledge-of-other-landowners/__tests__/knowledge-of-other-landowners.test.js
+++ b/appeals/api/src/server/endpoints/knowledge-of-other-landowners/__tests__/knowledge-of-other-landowners.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { knowledgeOfOtherLandowners } from '../../../tests/data.js';
+import { azureAdUserId, knowledgeOfOtherLandowners } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -15,7 +15,9 @@ describe('knowledge of other landowners routes', () => {
 					knowledgeOfOtherLandowners
 				);
 
-				const response = await request.get('/appeals/knowledge-of-other-landowners');
+				const response = await request
+					.get('/appeals/knowledge-of-other-landowners')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(knowledgeOfOtherLandowners);
@@ -25,7 +27,9 @@ describe('knowledge of other landowners routes', () => {
 				// @ts-ignore
 				databaseConnector.knowledgeOfOtherLandowners.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/knowledge-of-other-landowners');
+				const response = await request
+					.get('/appeals/knowledge-of-other-landowners')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -37,7 +41,9 @@ describe('knowledge of other landowners routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/knowledge-of-other-landowners');
+				const response = await request
+					.get('/appeals/knowledge-of-other-landowners')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/knowledge-of-other-landowners/knowledge-of-other-landowners.routes.js
+++ b/appeals/api/src/server/endpoints/knowledge-of-other-landowners/knowledge-of-other-landowners.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Knowledge Of Other Landowners']
 		#swagger.path = '/appeals/knowledge-of-other-landowners'
 		#swagger.description = 'Gets knowledge of other landowners values'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Knowledge of other landowners values',
 			schema: { $ref: '#/definitions/AllKnowledgeOfOtherLandownersResponse' },

--- a/appeals/api/src/server/endpoints/lpa-notification-methods/__tests__/lpa-notification-methods.test.js
+++ b/appeals/api/src/server/endpoints/lpa-notification-methods/__tests__/lpa-notification-methods.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { lpaNotificationMethods } from '../../../tests/data.js';
+import { azureAdUserId, lpaNotificationMethods } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -13,7 +13,9 @@ describe('lpa notification methods routes', () => {
 				// @ts-ignore
 				databaseConnector.lPANotificationMethods.findMany.mockResolvedValue(lpaNotificationMethods);
 
-				const response = await request.get('/appeals/lpa-notification-methods');
+				const response = await request
+					.get('/appeals/lpa-notification-methods')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(lpaNotificationMethods);
@@ -23,7 +25,9 @@ describe('lpa notification methods routes', () => {
 				// @ts-ignore
 				databaseConnector.lPANotificationMethods.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/lpa-notification-methods');
+				const response = await request
+					.get('/appeals/lpa-notification-methods')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -35,7 +39,9 @@ describe('lpa notification methods routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/lpa-notification-methods');
+				const response = await request
+					.get('/appeals/lpa-notification-methods')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/lpa-notification-methods/lpa-notification-methods.routes.js
+++ b/appeals/api/src/server/endpoints/lpa-notification-methods/lpa-notification-methods.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['LPA Notification Methods']
 		#swagger.path = '/appeals/lpa-notification-methods'
 		#swagger.description = 'Gets LPA notification methods'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'LPA notification methods',
 			schema: { $ref: '#/definitions/AllLPANotificationMethodsResponse' },

--- a/appeals/api/src/server/endpoints/lpa-questionnaire-incomplete-reasons/__tests__/lpa-questionnaire-incomplete-reasons.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaire-incomplete-reasons/__tests__/lpa-questionnaire-incomplete-reasons.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { lpaQuestionnaireIncompleteReasons } from '../../../tests/data.js';
+import { azureAdUserId, lpaQuestionnaireIncompleteReasons } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -15,7 +15,9 @@ describe('lpa questionnaire incomplete reasons routes', () => {
 					lpaQuestionnaireIncompleteReasons
 				);
 
-				const response = await request.get('/appeals/lpa-questionnaire-incomplete-reasons');
+				const response = await request
+					.get('/appeals/lpa-questionnaire-incomplete-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(lpaQuestionnaireIncompleteReasons);
@@ -25,7 +27,9 @@ describe('lpa questionnaire incomplete reasons routes', () => {
 				// @ts-ignore
 				databaseConnector.lPAQuestionnaireIncompleteReason.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/lpa-questionnaire-incomplete-reasons');
+				const response = await request
+					.get('/appeals/lpa-questionnaire-incomplete-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -37,7 +41,9 @@ describe('lpa questionnaire incomplete reasons routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/lpa-questionnaire-incomplete-reasons');
+				const response = await request
+					.get('/appeals/lpa-questionnaire-incomplete-reasons')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/lpa-questionnaire-incomplete-reasons/lpa-questionnaire-incomplete-reasons.routes.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaire-incomplete-reasons/lpa-questionnaire-incomplete-reasons.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['LPA Questionnaire Incomplete Reasons']
 		#swagger.path = '/appeals/lpa-questionnaire-incomplete-reasons'
 		#swagger.description = 'Gets LPA questionnaire incomplete reasons'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'LPA questionnaire incomplete reasons',
 			schema: { $ref: '#/definitions/AllLPAQuestionnaireIncompleteReasonsResponse' },

--- a/appeals/api/src/server/endpoints/lpa-questionnaire-validation-outcomes/__tests__/lpa-questionnaire-validation-outcomes.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaire-validation-outcomes/__tests__/lpa-questionnaire-validation-outcomes.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { lpaQuestionnaireValidationOutcomes } from '../../../tests/data.js';
+import { azureAdUserId, lpaQuestionnaireValidationOutcomes } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -15,7 +15,9 @@ describe('lpa questionnaire validation outcomes routes', () => {
 					lpaQuestionnaireValidationOutcomes
 				);
 
-				const response = await request.get('/appeals/lpa-questionnaire-validation-outcomes');
+				const response = await request
+					.get('/appeals/lpa-questionnaire-validation-outcomes')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(lpaQuestionnaireValidationOutcomes);
@@ -25,7 +27,9 @@ describe('lpa questionnaire validation outcomes routes', () => {
 				// @ts-ignore
 				databaseConnector.lPAQuestionnaireValidationOutcome.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/lpa-questionnaire-validation-outcomes');
+				const response = await request
+					.get('/appeals/lpa-questionnaire-validation-outcomes')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -37,7 +41,9 @@ describe('lpa questionnaire validation outcomes routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/lpa-questionnaire-validation-outcomes');
+				const response = await request
+					.get('/appeals/lpa-questionnaire-validation-outcomes')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/lpa-questionnaire-validation-outcomes/lpa-questionnaire-validation-outcomes.routes.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaire-validation-outcomes/lpa-questionnaire-validation-outcomes.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['LPA Questionnaire Validation Outcomes']
 		#swagger.path = '/appeals/lpa-questionnaire-validation-outcomes'
 		#swagger.description = 'Gets LPA questionnaire validation outcomes'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'LPA questionnaire validation outcomes',
 			schema: { $ref: '#/definitions/AllLPAQuestionnaireValidationOutcomesResponse' },

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/__tests__/lpa-questionnaires.test.js
@@ -26,6 +26,7 @@ import {
 	STATE_TARGET_STATEMENT_REVIEW
 } from '../../constants.js';
 import {
+	azureAdUserId,
 	baseExpectedLPAQuestionnaireResponse,
 	fullPlanningAppeal,
 	householdAppeal,
@@ -36,7 +37,7 @@ import {
 	otherAppeals
 } from '../../../tests/data.js';
 import createManyToManyRelationData from '#utils/create-many-to-many-relation-data.js';
-import errorMessageReplacement from '#utils/error-message-replacement.js';
+import stringTokenReplacement from '#utils/string-token-replacement.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -54,9 +55,9 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.appeal.findMany.mockResolvedValue(otherAppeals);
 
 				const { id, lpaQuestionnaire } = householdAppeal;
-				const response = await request.get(
-					`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`
-				);
+				const response = await request
+					.get(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(baseExpectedLPAQuestionnaireResponse(householdAppeal));
@@ -71,9 +72,9 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.appeal.findMany.mockResolvedValue(otherAppeals);
 
 				const { id, lpaQuestionnaire } = householdAppealLPAQuestionnaireComplete;
-				const response = await request.get(
-					`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`
-				);
+				const response = await request
+					.get(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(
@@ -90,9 +91,9 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.appeal.findMany.mockResolvedValue(otherAppeals);
 
 				const { id, lpaQuestionnaire } = householdAppealLPAQuestionnaireIncomplete;
-				const response = await request.get(
-					`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`
-				);
+				const response = await request
+					.get(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(
@@ -101,9 +102,9 @@ describe('lpa questionnaires routes', () => {
 			});
 
 			test('returns an error if appealId is not numeric', async () => {
-				const response = await request.get(
-					`/appeals/one/lpa-questionnaires/${householdAppeal.lpaQuestionnaire.id}`
-				);
+				const response = await request
+					.get(`/appeals/one/lpa-questionnaires/${householdAppeal.lpaQuestionnaire.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -118,7 +119,9 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
 				const { lpaQuestionnaire } = householdAppeal;
-				const response = await request.get(`/appeals/3/lpa-questionnaires/${lpaQuestionnaire.id}`);
+				const response = await request
+					.get(`/appeals/3/lpa-questionnaires/${lpaQuestionnaire.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -130,7 +133,9 @@ describe('lpa questionnaires routes', () => {
 
 			test('returns an error if lpaQuestionnaireId is not numeric', async () => {
 				const { id } = householdAppeal;
-				const response = await request.get(`/appeals/${id}/lpa-questionnaires/one`);
+				const response = await request
+					.get(`/appeals/${id}/lpa-questionnaires/one`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -145,7 +150,9 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 				const { id } = householdAppeal;
-				const response = await request.get(`/appeals/${id}/lpa-questionnaires/3`);
+				const response = await request
+					.get(`/appeals/${id}/lpa-questionnaires/3`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -183,7 +190,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -234,7 +242,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = fullPlanningAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -279,7 +288,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -327,7 +337,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -375,7 +386,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -423,7 +435,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -471,7 +484,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -528,7 +542,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -614,7 +629,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -707,7 +723,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {
@@ -759,7 +776,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/one/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						validationOutcome: 'Complete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -778,7 +796,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/3/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						validationOutcome: 'Complete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -790,9 +809,12 @@ describe('lpa questionnaires routes', () => {
 
 			test('returns an error if lpaQuestionnaireId is not numeric', async () => {
 				const { id } = householdAppeal;
-				const response = await request.patch(`/appeals/${id}/lpa-questionnaires/one`).send({
-					validationOutcome: 'Complete'
-				});
+				const response = await request
+					.patch(`/appeals/${id}/lpa-questionnaires/one`)
+					.send({
+						validationOutcome: 'Complete'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -807,9 +829,12 @@ describe('lpa questionnaires routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 				const { id } = householdAppeal;
-				const response = await request.patch(`/appeals/${id}/lpa-questionnaires/3`).send({
-					validationOutcome: 'Complete'
-				});
+				const response = await request
+					.patch(`/appeals/${id}/lpa-questionnaires/3`)
+					.send({
+						validationOutcome: 'Complete'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -831,7 +856,9 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
+
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
@@ -854,7 +881,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -874,7 +902,8 @@ describe('lpa questionnaires routes', () => {
 					.send({
 						incompleteReasons: [{ id: 1 }],
 						validationOutcome: 'Complete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -894,7 +923,8 @@ describe('lpa questionnaires routes', () => {
 					.send({
 						lpaQuestionnaireDueDate: '2099-06-22',
 						validationOutcome: 'Complete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -913,7 +943,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -931,7 +962,8 @@ describe('lpa questionnaires routes', () => {
 						incompleteReasons: [{ id: 1 }],
 						lpaQuestionnaireDueDate: '05/05/2099',
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -949,7 +981,8 @@ describe('lpa questionnaires routes', () => {
 						incompleteReasons: [{ id: 1 }],
 						lpaQuestionnaireDueDate: '2099-5-5',
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -969,7 +1002,8 @@ describe('lpa questionnaires routes', () => {
 						incompleteReasons: [{ id: 1 }],
 						lpaQuestionnaireDueDate: '2023-06-04',
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -987,7 +1021,8 @@ describe('lpa questionnaires routes', () => {
 						incompleteReasons: [{ id: 1 }],
 						lpaQuestionnaireDueDate: '2099-02-30',
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1008,7 +1043,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						validationOutcome: 'invalid'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1037,7 +1073,8 @@ describe('lpa questionnaires routes', () => {
 						incompleteReasons: [{ id: 1 }, { id: 10 }],
 						lpaQuestionnaireDueDate: '2099-06-22',
 						validationOutcome: 'Incomplete'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -1056,7 +1093,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						isListedBuilding: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1076,7 +1114,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1098,7 +1137,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1123,7 +1163,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1146,7 +1187,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1169,7 +1211,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1192,7 +1235,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1215,7 +1259,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1238,7 +1283,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1257,7 +1303,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						doesAffectAListedBuilding: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1277,7 +1324,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1299,7 +1347,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1324,7 +1373,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1347,7 +1397,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1370,7 +1421,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1393,7 +1445,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1416,7 +1469,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1439,7 +1493,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1458,7 +1513,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						doesAffectAScheduledMonument: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1478,12 +1534,14 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
 					data: body
 				});
+
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
 					doesAffectAScheduledMonument: true
@@ -1500,7 +1558,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1525,7 +1584,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1548,7 +1608,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1571,7 +1632,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1594,7 +1656,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1617,7 +1680,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1640,7 +1704,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1659,7 +1724,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						isConservationArea: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1679,7 +1745,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1701,7 +1768,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1726,7 +1794,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1749,7 +1818,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1772,7 +1842,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1795,7 +1866,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1818,7 +1890,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1841,7 +1914,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1860,7 +1934,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						hasProtectedSpecies: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -1880,7 +1955,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1902,7 +1978,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1927,7 +2004,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1950,7 +2028,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1973,7 +2052,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -1996,7 +2076,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2019,7 +2100,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2042,7 +2124,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2061,7 +2144,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						isTheSiteWithinAnAONB: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2081,7 +2165,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2103,7 +2188,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2128,7 +2214,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2151,7 +2238,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2174,7 +2262,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2197,7 +2286,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2220,7 +2310,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2243,7 +2334,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2262,7 +2354,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						hasTreePreservationOrder: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2282,7 +2375,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2304,7 +2398,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2329,7 +2424,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2352,7 +2448,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2375,7 +2472,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2398,7 +2496,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2421,7 +2520,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2444,7 +2544,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2463,7 +2564,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						isGypsyOrTravellerSite: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2483,7 +2585,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2505,7 +2608,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2530,7 +2634,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2553,7 +2658,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2576,7 +2682,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2599,7 +2706,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2622,7 +2730,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2645,7 +2754,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2664,7 +2774,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						isPublicRightOfWay: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2684,7 +2795,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2706,7 +2818,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2731,7 +2844,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2754,7 +2868,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2777,7 +2892,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2800,7 +2916,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2823,7 +2940,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2846,7 +2964,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2865,7 +2984,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						isEnvironmentalStatementRequired: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -2885,7 +3005,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2907,7 +3028,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2932,7 +3054,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2955,7 +3078,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -2978,7 +3102,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3001,7 +3126,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3024,7 +3150,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3047,7 +3174,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3066,7 +3194,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						hasCompletedAnEnvironmentalStatement: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3086,7 +3215,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3108,7 +3238,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3133,7 +3264,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3156,7 +3288,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3179,7 +3312,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3202,7 +3336,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3225,7 +3360,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3248,7 +3384,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3267,7 +3404,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						includesScreeningOption: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3287,7 +3425,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3309,7 +3448,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3334,7 +3474,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3357,7 +3498,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3380,7 +3522,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3403,7 +3546,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3426,7 +3570,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3449,7 +3594,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3468,7 +3614,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						meetsOrExceedsThresholdOrCriteriaInColumn2: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3488,7 +3635,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3510,7 +3658,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3535,7 +3684,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3558,7 +3708,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3581,7 +3732,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3604,7 +3756,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3627,7 +3780,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3650,7 +3804,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3676,7 +3831,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(
 					databaseConnector.designatedSitesOnLPAQuestionnaires.createMany
@@ -3707,7 +3863,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(
 					databaseConnector.designatedSitesOnLPAQuestionnaires.createMany
@@ -3731,7 +3888,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						designatedSites: 1
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3751,7 +3909,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3770,7 +3929,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						designatedSites: []
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3796,7 +3956,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -3822,7 +3983,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3850,7 +4012,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: householdAppeal.lpaQuestionnaire.id },
@@ -3874,7 +4037,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -3900,7 +4064,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -3919,9 +4084,10 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						isSensitiveArea: 'yes'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
-				// expect(response.status).toEqual(400);
+				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
 						isSensitiveArea: ERROR_MUST_BE_BOOLEAN
@@ -3940,7 +4106,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: lpaQuestionnaire.id },
@@ -3960,7 +4127,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: lpaQuestionnaire.id },
@@ -3985,7 +4153,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: lpaQuestionnaire.id },
@@ -4008,7 +4177,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: lpaQuestionnaire.id },
@@ -4033,7 +4203,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: lpaQuestionnaire.id },
@@ -4056,7 +4227,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: lpaQuestionnaire.id },
@@ -4081,7 +4253,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: lpaQuestionnaire.id },
@@ -4104,7 +4277,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(requestBody);
+					.send(requestBody)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					where: { id: lpaQuestionnaire.id },
@@ -4123,7 +4297,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						sensitiveAreaDetails: ['The area is liable to flooding']
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -4142,7 +4317,8 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						sensitiveAreaDetails: ''
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -4161,12 +4337,13 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						sensitiveAreaDetails: 'A'.repeat(LENGTH_300 + 1)
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						sensitiveAreaDetails: errorMessageReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
+						sensitiveAreaDetails: stringTokenReplacement(ERROR_MAX_LENGTH_CHARACTERS, [LENGTH_300])
 					}
 				});
 			});
@@ -4181,12 +4358,13 @@ describe('lpa questionnaires routes', () => {
 					.send({
 						isSensitiveArea: false,
 						sensitiveAreaDetails: 'The area is liable to flooding'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						isSensitiveArea: errorMessageReplacement(ERROR_MUST_NOT_HAVE_DETAILS, [
+						isSensitiveArea: stringTokenReplacement(ERROR_MUST_NOT_HAVE_DETAILS, [
 							'sensitiveAreaDetails',
 							'isSensitiveArea',
 							false
@@ -4204,12 +4382,13 @@ describe('lpa questionnaires routes', () => {
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
 					.send({
 						isSensitiveArea: true
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
 					errors: {
-						isSensitiveArea: errorMessageReplacement(ERROR_MUST_HAVE_DETAILS, [
+						isSensitiveArea: stringTokenReplacement(ERROR_MUST_HAVE_DETAILS, [
 							'sensitiveAreaDetails',
 							'isSensitiveArea',
 							true
@@ -4225,7 +4404,8 @@ describe('lpa questionnaires routes', () => {
 				const { lpaQuestionnaire, id } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send({});
+					.send({})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({});
@@ -4253,7 +4433,8 @@ describe('lpa questionnaires routes', () => {
 				const { id, lpaQuestionnaire } = householdAppeal;
 				const response = await request
 					.patch(`/appeals/${id}/lpa-questionnaires/${lpaQuestionnaire.id}`)
-					.send(body);
+					.send(body)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.lPAQuestionnaire.update).toHaveBeenCalledWith({
 					data: {

--- a/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.routes.js
+++ b/appeals/api/src/server/endpoints/lpa-questionnaires/lpa-questionnaires.routes.js
@@ -22,6 +22,11 @@ router.get(
 		#swagger.tags = ['LPA Questionnaires']
 		#swagger.path = '/appeals/{appealId}/lpa-questionnaires/{lpaQuestionnaireId}'
 		#swagger.description = Gets a single LPA questionnaire for an appeal by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Gets a single LPA questionnaire for an appeal by id',
 			schema: { $ref: '#/definitions/SingleLPAQuestionnaireResponse' }
@@ -41,6 +46,11 @@ router.patch(
 		#swagger.tags = ['LPA Questionnaires']
 		#swagger.path = '/appeals/{appealId}/lpa-questionnaires/{lpaQuestionnaireId}'
 		#swagger.description = Updates a single LPA questionnaire for an appeal by id
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'LPA questionnaire details to update',

--- a/appeals/api/src/server/endpoints/planning-obligation-statuses/__tests__/planning-obligation-statuses.test.js
+++ b/appeals/api/src/server/endpoints/planning-obligation-statuses/__tests__/planning-obligation-statuses.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { planningObligationStatuses } from '../../../tests/data.js';
+import { azureAdUserId, planningObligationStatuses } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -15,7 +15,9 @@ describe('planning obligation statuses routes', () => {
 					planningObligationStatuses
 				);
 
-				const response = await request.get('/appeals/planning-obligation-statuses');
+				const response = await request
+					.get('/appeals/planning-obligation-statuses')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(planningObligationStatuses);
@@ -25,7 +27,9 @@ describe('planning obligation statuses routes', () => {
 				// @ts-ignore
 				databaseConnector.planningObligationStatus.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/planning-obligation-statuses');
+				const response = await request
+					.get('/appeals/planning-obligation-statuses')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -37,7 +41,9 @@ describe('planning obligation statuses routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/planning-obligation-statuses');
+				const response = await request
+					.get('/appeals/planning-obligation-statuses')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/planning-obligation-statuses/planning-obligation-statuses.routes.js
+++ b/appeals/api/src/server/endpoints/planning-obligation-statuses/planning-obligation-statuses.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Planning Obligation Statuses']
 		#swagger.path = '/appeals/planning-obligation-statuses'
 		#swagger.description = 'Gets planning obligation statuses'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Planning obligation statuses',
 			schema: { $ref: '#/definitions/AllPlanningObligationStatusesResponse' },

--- a/appeals/api/src/server/endpoints/procedure-types/__tests__/procedure-types.test.js
+++ b/appeals/api/src/server/endpoints/procedure-types/__tests__/procedure-types.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { procedureTypes } from '../../../tests/data.js';
+import { azureAdUserId, procedureTypes } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -13,7 +13,9 @@ describe('procedure types routes', () => {
 				// @ts-ignore
 				databaseConnector.procedureType.findMany.mockResolvedValue(procedureTypes);
 
-				const response = await request.get('/appeals/procedure-types');
+				const response = await request
+					.get('/appeals/procedure-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(procedureTypes);
@@ -23,7 +25,9 @@ describe('procedure types routes', () => {
 				// @ts-ignore
 				databaseConnector.procedureType.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/procedure-types');
+				const response = await request
+					.get('/appeals/procedure-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -35,7 +39,9 @@ describe('procedure types routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/procedure-types');
+				const response = await request
+					.get('/appeals/procedure-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/procedure-types/procedure-types.routes.js
+++ b/appeals/api/src/server/endpoints/procedure-types/procedure-types.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Procedure Types']
 		#swagger.path = '/appeals/procedure-types'
 		#swagger.description = 'Gets procedure types'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Procedure types',
 			schema: { $ref: '#/definitions/AllProcedureTypesResponse' },

--- a/appeals/api/src/server/endpoints/schedule-types/__tests__/schedule-types.test.js
+++ b/appeals/api/src/server/endpoints/schedule-types/__tests__/schedule-types.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { scheduleTypes } from '../../../tests/data.js';
+import { azureAdUserId, scheduleTypes } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -13,7 +13,9 @@ describe('schedule types routes', () => {
 				// @ts-ignore
 				databaseConnector.scheduleType.findMany.mockResolvedValue(scheduleTypes);
 
-				const response = await request.get('/appeals/schedule-types');
+				const response = await request
+					.get('/appeals/schedule-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(scheduleTypes);
@@ -23,7 +25,9 @@ describe('schedule types routes', () => {
 				// @ts-ignore
 				databaseConnector.scheduleType.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/schedule-types');
+				const response = await request
+					.get('/appeals/schedule-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -35,7 +39,9 @@ describe('schedule types routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/schedule-types');
+				const response = await request
+					.get('/appeals/schedule-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/schedule-types/schedule-types.routes.js
+++ b/appeals/api/src/server/endpoints/schedule-types/schedule-types.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Schedule Types']
 		#swagger.path = '/appeals/schedule-types'
 		#swagger.description = 'Gets schedule types'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Schedule types',
 			schema: { $ref: '#/definitions/AllScheduleTypesResponse' },

--- a/appeals/api/src/server/endpoints/site-visit-types/__tests__/site-visit-types.test.js
+++ b/appeals/api/src/server/endpoints/site-visit-types/__tests__/site-visit-types.test.js
@@ -1,6 +1,6 @@
 import supertest from 'supertest';
 import { app } from '../../../app-test.js';
-import { siteVisitTypes } from '../../../tests/data.js';
+import { azureAdUserId, siteVisitTypes } from '../../../tests/data.js';
 import { ERROR_FAILED_TO_GET_DATA, ERROR_NOT_FOUND } from '../../constants.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
@@ -13,7 +13,9 @@ describe('site visit types routes', () => {
 				// @ts-ignore
 				databaseConnector.siteVisitType.findMany.mockResolvedValue(siteVisitTypes);
 
-				const response = await request.get('/appeals/site-visit-types');
+				const response = await request
+					.get('/appeals/site-visit-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual(siteVisitTypes);
@@ -23,7 +25,9 @@ describe('site visit types routes', () => {
 				// @ts-ignore
 				databaseConnector.siteVisitType.findMany.mockResolvedValue([]);
 
-				const response = await request.get('/appeals/site-visit-types');
+				const response = await request
+					.get('/appeals/site-visit-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({ errors: ERROR_NOT_FOUND });
@@ -35,7 +39,9 @@ describe('site visit types routes', () => {
 					throw new Error(ERROR_FAILED_TO_GET_DATA);
 				});
 
-				const response = await request.get('/appeals/site-visit-types');
+				const response = await request
+					.get('/appeals/site-visit-types')
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(500);
 				expect(response.body).toEqual({ errors: ERROR_FAILED_TO_GET_DATA });

--- a/appeals/api/src/server/endpoints/site-visit-types/site-visit-types.routes.js
+++ b/appeals/api/src/server/endpoints/site-visit-types/site-visit-types.routes.js
@@ -10,6 +10,11 @@ router.get(
 		#swagger.tags = ['Site Visit Types']
 		#swagger.path = '/appeals/site-visit-types'
 		#swagger.description = 'Gets site visit types'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Site visit types',
 			schema: { $ref: '#/definitions/AllSiteVisitTypesResponse' },

--- a/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
+++ b/appeals/api/src/server/endpoints/site-visits/__tests__/site-visits.test.js
@@ -10,7 +10,7 @@ import {
 	SITE_VISIT_TYPE_UNACCOMPANIED,
 	STATE_TARGET_ISSUE_DETERMINATION
 } from '../../constants.js';
-import { householdAppeal as householdAppealData } from '../../../tests/data.js';
+import { azureAdUserId, householdAppeal as householdAppealData } from '../../../tests/data.js';
 
 const { databaseConnector } = await import('../../../utils/database-connector.js');
 
@@ -32,9 +32,12 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitType: siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitType: siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
 					data: {
@@ -59,12 +62,15 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: siteVisit.visitDate.split('T')[0],
-					visitEndTime: siteVisit.visitEndTime,
-					visitStartTime: siteVisit.visitStartTime,
-					visitType: siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						visitEndTime: siteVisit.visitEndTime,
+						visitStartTime: siteVisit.visitStartTime,
+						visitType: siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
 					data: {
@@ -102,12 +108,15 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: siteVisit.visitDate.split('T')[0],
-					visitEndTime: '9:00',
-					visitStartTime: '7:00',
-					visitType: siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						visitEndTime: '9:00',
+						visitStartTime: '7:00',
+						visitType: siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
 					data: {
@@ -143,12 +152,15 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: siteVisit.visitDate.split('T')[0],
-					visitEndTime: '18:00',
-					visitStartTime: '16:00',
-					visitType: siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						visitType: siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
 					data: {
@@ -178,10 +190,13 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.siteVisitType.findUnique.mockResolvedValue(siteVisit.siteVisitType);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: siteVisit.visitDate.split('T')[0],
-					visitType: siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: siteVisit.visitDate.split('T')[0],
+						visitType: siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
 					data: {
@@ -198,9 +213,12 @@ describe('site visit routes', () => {
 			});
 
 			test('returns an error if appealId is not numeric', async () => {
-				const response = await request.post('/appeals/one/site-visits').send({
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post('/appeals/one/site-visits')
+					.send({
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -214,9 +232,12 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -230,9 +251,12 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitType: 123
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitType: 123
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -248,9 +272,12 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.siteVisitType.findUnique.mockResolvedValue(null);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitType: 'access not required'
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitType: 'access not required'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -264,11 +291,14 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitEndTime: '18:00',
-					visitStartTime: '16:00',
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -282,11 +312,14 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: '2023-12-07',
-					visitStartTime: '16:00',
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: '2023-12-07',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -300,11 +333,14 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: '2023-12-07',
-					visitEndTime: '16:00',
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: '2023-12-07',
+						visitEndTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -318,12 +354,15 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: '07/12/2023',
-					visitEndTime: '18:00',
-					visitStartTime: '16:00',
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: '07/12/2023',
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -337,12 +376,15 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: '56/12/2023',
-					visitEndTime: '18:00',
-					visitStartTime: '16:00',
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: '56/12/2023',
+						visitEndTime: '18:00',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -356,12 +398,15 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: '2023-07-12',
-					visitEndTime: '56:00',
-					visitStartTime: '16:00',
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: '2023-07-12',
+						visitEndTime: '56:00',
+						visitStartTime: '16:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -375,12 +420,15 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: '2023-07-12',
-					visitEndTime: '18:00',
-					visitStartTime: '56:00',
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: '2023-07-12',
+						visitEndTime: '18:00',
+						visitStartTime: '56:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -394,12 +442,15 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.post(`/appeals/${householdAppeal.id}/site-visits`).send({
-					visitDate: '2023-07-12',
-					visitEndTime: '16:00',
-					visitStartTime: '18:00',
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/site-visits`)
+					.send({
+						visitDate: '2023-07-12',
+						visitEndTime: '16:00',
+						visitStartTime: '18:00',
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -418,9 +469,9 @@ describe('site visit routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
 				const { siteVisit } = householdAppeal;
-				const response = await request.get(
-					`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`
-				);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
@@ -434,7 +485,7 @@ describe('site visit routes', () => {
 			});
 
 			test('returns an error if appealId is not numeric', async () => {
-				const response = await request.get('/appeals/one');
+				const response = await request.get('/appeals/one').set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -448,7 +499,7 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(null);
 
-				const response = await request.get('/appeals/3');
+				const response = await request.get('/appeals/3').set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -462,7 +513,9 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.get(`/appeals/${householdAppeal.id}/site-visits/one`);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/site-visits/one`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -476,7 +529,9 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.get(`/appeals/${householdAppeal.id}/site-visits/2`);
+				const response = await request
+					.get(`/appeals/${householdAppeal.id}/site-visits/2`)
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -500,7 +555,8 @@ describe('site visit routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/site-visits/${siteVisit.id}`)
 					.send({
 						visitType: siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.update).toHaveBeenCalledWith({
 					where: { id: siteVisit.id },
@@ -532,7 +588,8 @@ describe('site visit routes', () => {
 						visitEndTime: siteVisit.visitEndTime,
 						visitStartTime: siteVisit.visitStartTime,
 						visitType: siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.update).toHaveBeenCalledWith({
 					where: { id: siteVisit.id },
@@ -577,7 +634,8 @@ describe('site visit routes', () => {
 						visitEndTime: '3:00',
 						visitStartTime: '1:00',
 						visitType: siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.update).toHaveBeenCalledWith({
 					where: { id: siteVisit.id },
@@ -620,7 +678,8 @@ describe('site visit routes', () => {
 						visitEndTime: '18:00',
 						visitStartTime: '16:00',
 						visitType: siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.update).toHaveBeenCalledWith({
 					where: { id: siteVisit.id },
@@ -655,7 +714,8 @@ describe('site visit routes', () => {
 					.send({
 						visitDate: siteVisit.visitDate.split('T')[0],
 						visitType: siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(databaseConnector.siteVisit.create).toHaveBeenCalledWith({
 					data: {
@@ -676,7 +736,8 @@ describe('site visit routes', () => {
 					.patch(`/appeals/one/site-visits/${householdAppeal.siteVisit.id}`)
 					.send({
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -694,7 +755,8 @@ describe('site visit routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
 					.send({
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -712,7 +774,8 @@ describe('site visit routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/site-visits/one`)
 					.send({
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -726,9 +789,12 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}/site-visits/2`).send({
-					visitType: householdAppeal.siteVisit.siteVisitType.name
-				});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}/site-visits/2`)
+					.send({
+						visitType: householdAppeal.siteVisit.siteVisitType.name
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(404);
 				expect(response.body).toEqual({
@@ -746,7 +812,8 @@ describe('site visit routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
 					.send({
 						visitType: 123
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -766,7 +833,8 @@ describe('site visit routes', () => {
 					.patch(`/appeals/${householdAppeal.id}/site-visits/${householdAppeal.siteVisit.id}`)
 					.send({
 						visitType: 'access not required'
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -786,7 +854,8 @@ describe('site visit routes', () => {
 						visitEndTime: '18:00',
 						visitStartTime: '16:00',
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -806,7 +875,8 @@ describe('site visit routes', () => {
 						visitDate: '2023-12-07',
 						visitStartTime: '16:00',
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -826,7 +896,8 @@ describe('site visit routes', () => {
 						visitDate: '2023-12-07',
 						visitEndTime: '16:00',
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -847,7 +918,8 @@ describe('site visit routes', () => {
 						visitEndTime: '18:00',
 						visitStartTime: '16:00',
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -868,7 +940,8 @@ describe('site visit routes', () => {
 						visitEndTime: '18:00',
 						visitStartTime: '16:00',
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -889,7 +962,8 @@ describe('site visit routes', () => {
 						visitEndTime: '56:00',
 						visitStartTime: '16:00',
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -910,7 +984,8 @@ describe('site visit routes', () => {
 						visitEndTime: '18:00',
 						visitStartTime: '56:00',
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -931,7 +1006,8 @@ describe('site visit routes', () => {
 						visitEndTime: '16:00',
 						visitStartTime: '18:00',
 						visitType: householdAppeal.siteVisit.siteVisitType.name
-					});
+					})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(400);
 				expect(response.body).toEqual({
@@ -945,7 +1021,10 @@ describe('site visit routes', () => {
 				// @ts-ignore
 				databaseConnector.appeal.update.mockResolvedValue(householdAppeal);
 
-				const response = await request.patch(`/appeals/${householdAppeal.id}`).send({});
+				const response = await request
+					.patch(`/appeals/${householdAppeal.id}`)
+					.send({})
+					.set('azureAdUserId', azureAdUserId);
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({});

--- a/appeals/api/src/server/endpoints/site-visits/site-visits.routes.js
+++ b/appeals/api/src/server/endpoints/site-visits/site-visits.routes.js
@@ -19,6 +19,11 @@ router.post(
 		#swagger.tags = ['Site Visits']
 		#swagger.path = '/appeals/{appealId}/site-visits'
 		#swagger.description = 'Creates a single site visit'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Site visit details to create',
@@ -48,6 +53,11 @@ router.get(
 		#swagger.tags = ['Site Visits']
 		#swagger.path = '/appeals/{appealId}/site-visits/{siteVisitId}'
 		#swagger.description = 'Gets a single site visit by id'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.responses[200] = {
 			description: 'Gets a single site visit by id',
 			schema: { $ref: '#/definitions/SingleSiteVisitResponse' }
@@ -67,6 +77,11 @@ router.patch(
 		#swagger.tags = ['Site Visits']
 		#swagger.path = '/appeals/{appealId}/site-visits/{siteVisitId}'
 		#swagger.description = 'Updates a single site visit by id'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
 		#swagger.requestBody = {
 			in: 'body',
 			description: 'Site visit details to create',

--- a/appeals/api/src/server/middleware/check-azure-ad-user-id-header-exists.js
+++ b/appeals/api/src/server/middleware/check-azure-ad-user-id-header-exists.js
@@ -1,0 +1,25 @@
+import { ERROR_MUST_BE_SET_AS_HEADER } from '#endpoints/constants.js';
+
+/** @typedef {import('express').Request} Request */
+/** @typedef {import('express').Response} Response */
+/** @typedef {import('express').NextFunction} NextFunction */
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @param {NextFunction} next
+ * @returns {Response | void}
+ */
+const checkAzureAdUserIdHeaderExists = (req, res, next) => {
+	if (!req.get('azureAdUserId')) {
+		return res.status(400).send({
+			errors: {
+				azureAdUserId: ERROR_MUST_BE_SET_AS_HEADER
+			}
+		});
+	}
+
+	next();
+};
+
+export default checkAzureAdUserIdHeaderExists;

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -1246,3 +1246,12 @@ export interface UpdateDocumentsResponse {
 		redactionStatus?: number;
 	}[];
 }
+
+export type GetAuditTrailsResponse = {
+	/** @example "f7ea429b-65d8-4c44-8fc2-7f1a34069855" */
+	azureAdUserId?: string;
+	/** @example "the case officer 13de469c-8de6-4908-97cd-330ea73df618 was added to the team" */
+	details?: string;
+	/** @example "2023-09-26T16:22:20.688Z" */
+	loggedDate?: string;
+}[];

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -35,6 +35,15 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {
@@ -77,6 +86,15 @@
 						"name": "addressId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -144,6 +162,15 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {
@@ -195,7 +222,17 @@
 			"get": {
 				"tags": ["Appeal Allocation"],
 				"description": "Gets the list of specialisms used for allocation",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "List of allocation specialisms",
@@ -222,7 +259,17 @@
 			"get": {
 				"tags": ["Appeal Allocation"],
 				"description": "Gets the list of levels and associated bands used for allocation",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "List of allocation levels",
@@ -254,6 +301,15 @@
 						"name": "appealId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -302,7 +358,17 @@
 			"get": {
 				"tags": ["Appellant Case Incomplete Reasons"],
 				"description": "Gets appellant case incomplete reasons",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Appellant case incomplete reasons",
@@ -329,7 +395,17 @@
 			"get": {
 				"tags": ["Appellant Case Invalid Reasons"],
 				"description": "Gets appellant case invalid reasons",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Appellant case invalid reasons",
@@ -369,6 +445,15 @@
 						"name": "appellantCaseId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -414,6 +499,15 @@
 						"name": "appellantCaseId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -465,7 +559,17 @@
 			"get": {
 				"tags": ["Appellant Case Validation Outcomes"],
 				"description": "Gets appellant case validation outcomes",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Appellant case validation outcomes",
@@ -505,6 +609,15 @@
 						"name": "appellantId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -553,6 +666,15 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {
@@ -597,11 +719,69 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/audit-trails": {
+			"get": {
+				"tags": ["Audit Trails"],
+				"description": "Gets audit trail entries for an appeal by id",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Gets audit trail entries for an appeal by id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/GetAuditTrailsResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/GetAuditTrailsResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				}
+			}
+		},
 		"/appeals/designated-sites": {
 			"get": {
 				"tags": ["Designated Sites"],
 				"description": "Gets designated sites",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Designated sites",
@@ -628,7 +808,17 @@
 			"get": {
 				"tags": ["Document Redaction Statuses"],
 				"description": "Gets document redaction statuses",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Document redaction statuses",
@@ -668,6 +858,15 @@
 						"name": "folderId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -718,6 +917,15 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {
@@ -760,6 +968,15 @@
 						"name": "documentId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -819,6 +1036,15 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {
@@ -873,11 +1099,20 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {
 					"200": {
-						"description": "Document to update",
+						"description": "Documents to update",
 						"content": {
 							"application/json": {
 								"schema": {
@@ -900,7 +1135,7 @@
 				},
 				"requestBody": {
 					"in": "body",
-					"description": "Document to update",
+					"description": "Documents to update",
 					"required": true,
 					"content": {
 						"application/json": {
@@ -1062,7 +1297,17 @@
 			"get": {
 				"tags": ["Knowledge Of Other Landowners"],
 				"description": "Gets knowledge of other landowners values",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Knowledge of other landowners values",
@@ -1089,7 +1334,17 @@
 			"get": {
 				"tags": ["LPA Notification Methods"],
 				"description": "Gets LPA notification methods",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "LPA notification methods",
@@ -1116,7 +1371,17 @@
 			"get": {
 				"tags": ["LPA Questionnaire Incomplete Reasons"],
 				"description": "Gets LPA questionnaire incomplete reasons",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "LPA questionnaire incomplete reasons",
@@ -1156,6 +1421,15 @@
 						"name": "lpaQuestionnaireId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -1201,6 +1475,15 @@
 						"name": "lpaQuestionnaireId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -1252,7 +1535,17 @@
 			"get": {
 				"tags": ["LPA Questionnaire Validation Outcomes"],
 				"description": "Gets LPA questionnaire validation outcomes",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "LPA questionnaire validation outcomes",
@@ -1279,7 +1572,17 @@
 			"get": {
 				"tags": ["Planning Obligation Statuses"],
 				"description": "Gets planning obligation statuses",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Planning obligation statuses",
@@ -1306,7 +1609,17 @@
 			"get": {
 				"tags": ["Procedure Types"],
 				"description": "Gets procedure types",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Procedure types",
@@ -1333,7 +1646,17 @@
 			"get": {
 				"tags": ["Schedule Types"],
 				"description": "Gets schedule types",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Schedule types",
@@ -1365,6 +1688,15 @@
 						"name": "appealId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -1432,6 +1764,15 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {
@@ -1477,6 +1818,15 @@
 						"name": "siteVisitId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -1531,7 +1881,17 @@
 			"get": {
 				"tags": ["Site Visit Types"],
 				"description": "Gets site visit types",
-				"parameters": [],
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "Site visit types",
@@ -1559,6 +1919,15 @@
 				"tags": ["Appeals"],
 				"description": "Gets requested appeals, limited to the first 30 appeals if no pagination params are given",
 				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					},
 					{
 						"name": "pageNumber",
 						"in": "query",
@@ -1621,6 +1990,15 @@
 						"schema": {
 							"type": "string"
 						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
 					}
 				],
 				"responses": {
@@ -1655,6 +2033,15 @@
 						"name": "appealId",
 						"in": "path",
 						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
 						"schema": {
 							"type": "string"
 						}
@@ -4542,6 +4929,29 @@
 				},
 				"xml": {
 					"name": "UpdateDocumentsResponse"
+				}
+			},
+			"GetAuditTrailsResponse": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"azureAdUserId": {
+							"type": "string",
+							"example": "f7ea429b-65d8-4c44-8fc2-7f1a34069855"
+						},
+						"details": {
+							"type": "string",
+							"example": "the case officer 13de469c-8de6-4908-97cd-330ea73df618 was added to the team"
+						},
+						"loggedDate": {
+							"type": "string",
+							"example": "2023-09-26T16:22:20.688Z"
+						}
+					}
+				},
+				"xml": {
+					"name": "GetAuditTrailsResponse"
 				}
 			}
 		}

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -1,6 +1,7 @@
 import { getSkipValue } from '#utils/database-pagination.js';
 import { databaseConnector } from '#utils/database-connector.js';
 import { hasValueOrIsNull } from '#endpoints/appeals/appeals.service.js';
+import { DATABASE_ORDER_BY_DESC } from '#endpoints/constants.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetAllResultItem} RepositoryGetAllResultItem */
 /** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetByIdResultItem} RepositoryGetByIdResultItem */
@@ -107,6 +108,14 @@ const getAppealById = async (id) => {
 			},
 			appealTimetable: true,
 			appealType: true,
+			auditTrail: {
+				include: {
+					user: true
+				},
+				orderBy: {
+					loggedAt: DATABASE_ORDER_BY_DESC
+				}
+			},
 			caseOfficer: true,
 			inspector: true,
 			inspectorDecision: true,

--- a/appeals/api/src/server/repositories/audit-trail.repository.js
+++ b/appeals/api/src/server/repositories/audit-trail.repository.js
@@ -1,0 +1,23 @@
+import { databaseConnector } from '#utils/database-connector.js';
+
+/** @typedef {import('@pins/appeals.api').Appeals.CreateAuditTrailRequest} CreateAuditTrailRequest */
+/**
+ * @typedef {import('#db-client').Prisma.PrismaPromise<T>} PrismaPromise
+ * @template T
+ */
+
+/**
+ * @param {CreateAuditTrailRequest} param0
+ * @returns {PrismaPromise<object>}
+ */
+const createAuditTrail = ({ appealId, details, loggedAt, userId }) =>
+	databaseConnector.auditTrail.create({
+		data: {
+			appealId,
+			details,
+			loggedAt,
+			userId
+		}
+	});
+
+export default { createAuditTrail };

--- a/appeals/api/src/server/repositories/user.repository.js
+++ b/appeals/api/src/server/repositories/user.repository.js
@@ -7,17 +7,17 @@ import { databaseConnector } from '#utils/database-connector.js';
  */
 
 /**
- * @param {string} azureUserId
+ * @param {string} azureAdUserId
  * @returns {PrismaPromise<User>}
  */
-const findOrCreateUser = (azureUserId) =>
+const findOrCreateUser = (azureAdUserId) =>
 	databaseConnector.user.upsert({
 		where: {
-			azureUserId
+			azureAdUserId
 		},
 		update: {},
 		create: {
-			azureUserId
+			azureAdUserId
 		}
 	});
 

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -670,7 +670,14 @@ export const spec = {
 					redactionStatus: 1
 				}
 			]
-		}
+		},
+		GetAuditTrailsResponse: [
+			{
+				azureAdUserId: 'f7ea429b-65d8-4c44-8fc2-7f1a34069855',
+				details: 'The case officer 13de469c-8de6-4908-97cd-330ea73df618 was added to the team',
+				loggedDate: '2023-09-26T16:22:20.688Z'
+			}
+		]
 	},
 	components: {}
 };

--- a/appeals/api/src/server/tests/data.js
+++ b/appeals/api/src/server/tests/data.js
@@ -14,6 +14,8 @@ import formatNeighbouringSiteContacts from '#utils/format-neighbouring-site-cont
 /** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetByIdResultItem} RepositoryGetByIdResultItem */
 /** @typedef {import('@pins/appeals.api').Appeals.SingleLPAQuestionnaireResponse} SingleLPAQuestionnaireResponse */
 
+const azureAdUserId = '6f930ec9-7f6f-448c-bb50-b3b898035959';
+
 const householdAppeal = {
 	id: 1,
 	reference: 'APP/Q9999/D/21/1345264',
@@ -83,14 +85,23 @@ const householdAppeal = {
 		},
 		visibilityRestrictions: 'The site is behind a tall hedge'
 	},
+	auditTrail: [
+		{
+			details: 'The case officer 13de469c-8de6-4908-97cd-330ea73df618 was added to the team',
+			loggedAt: new Date().toISOString(),
+			user: {
+				azureAdUserId
+			}
+		}
+	],
 	caseOfficer: {
 		id: 1,
-		azureUserId: 'a8973f33-4d2e-486b-87b0-d068343ad9eb'
+		azureAdUserId: 'a8973f33-4d2e-486b-87b0-d068343ad9eb'
 	},
 	dueDate: '2023-08-10T01:00:00.000Z',
 	inspector: {
 		id: 2,
-		azureUserId: 'e8f89175-d02c-4a60-870e-dc954d5b530a'
+		azureAdUserId: 'e8f89175-d02c-4a60-870e-dc954d5b530a'
 	},
 	inspectorDecision: {
 		outcome: 'Not issued yet'
@@ -426,6 +437,7 @@ const scheduleTypes = lookupListData;
 const siteVisitTypes = lookupListData;
 const documentRedactionStatuses = lookupListData;
 const documentRedactionStatusIds = documentRedactionStatuses.map(({ id }) => id);
+const auditTrails = lookupListData;
 
 const designatedSites = [
 	{
@@ -705,6 +717,8 @@ export {
 	appellantCaseIncompleteReasons,
 	appellantCaseInvalidReasons,
 	appellantCaseValidationOutcomes,
+	auditTrails,
+	azureAdUserId,
 	baseExpectedAppellantCaseResponse,
 	baseExpectedLPAQuestionnaireResponse,
 	designatedSites,

--- a/appeals/api/src/server/utils/string-token-replacement.js
+++ b/appeals/api/src/server/utils/string-token-replacement.js
@@ -3,7 +3,7 @@
  * @param {Array<string | number>} replacements
  * @returns {string}
  */
-const errorMessageReplacement = (errorMessage, replacements) =>
+const stringTokenReplacement = (errorMessage, replacements) =>
 	replacements
 		.map((replacement) => String(replacement))
 		.reduce(
@@ -12,4 +12,4 @@ const errorMessageReplacement = (errorMessage, replacements) =>
 			errorMessage
 		);
 
-export default errorMessageReplacement;
+export default stringTokenReplacement;


### PR DESCRIPTION
## Describe your changes

- Add Audit Trail database table
- Add service to log Audit Trail logs
- Add GET Audit Trail endpoint, returning logs ordered by date desc
- Mandate `azureAdUserId` header value to be set for all API endpoints
- Rename `errorMessageReplacement` to `stringTokenReplacement` as it's not just used for error messages now

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
