### PR TITLE
chore(appeals/api): trying to fix DB seed

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -25,7 +25,7 @@
     "db:migrate:prod": "npx prisma migrate deploy",
     "db:push": "npx prisma db push --accept-data-loss",
     "db:reset": "npx prisma migrate reset --force",
-    "db:seed": "npm run prisma-generate && npx prisma db seed",
+    "db:seed": "npm run prisma-generate && cross-env NODE_ENV=development node src/database/seed/seed-development.js",
     "db:seed:prod": "npm run prisma-generate && cross-env NODE_ENV=production node src/database/seed/seed-production.js",
     "prisma:format": "npx prisma format",
     "prisma-generate": "npx prisma generate",

--- a/appeals/api/src/database/seed/seed-clear.js
+++ b/appeals/api/src/database/seed/seed-clear.js
@@ -73,6 +73,7 @@ export async function deleteAllRecords(databaseConnector) {
 	await deleteDocuments;
 
 	await databaseConnector.$transaction([
+		deleteAudits,
 		deleteUsers,
 		deleteAppealAllocationLevels,
 		deleteAppealSpecialisms,
@@ -95,7 +96,6 @@ export async function deleteAllRecords(databaseConnector) {
 		deleteAppealTimetable,
 		deleteAddresses,
 		deleteInspectorDecision,
-		deleteAudits,
 		deleteFolders,
 		deleteAppeals,
 		deleteAppellant,

--- a/appeals/api/src/database/seed/seed-clear.js
+++ b/appeals/api/src/database/seed/seed-clear.js
@@ -69,6 +69,10 @@ export async function deleteAllRecords(databaseConnector) {
 	// delete document versions, documents, and THEN the folders.  Has to be in this order for integrity constraints
 	// TODO: Currently an issue with cyclic references, hence this hack to clear the latestVersionId
 	await databaseConnector.$queryRawUnsafe(`UPDATE Document SET latestVersionId = NULL;`);
+	// delete references to users on appeals
+	await databaseConnector.$queryRawUnsafe(
+		`UPDATE Appeal SET inspectorUserId = NULL, caseOfficerUserId = NULL;`
+	);
 	await deleteDocumentsVersions;
 	await deleteDocuments;
 


### PR DESCRIPTION
Changed npm script to run the db:seed
Update appeals to remove user refs when seeding
Delete audit data before users when seeding

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
