### PR TITLE
chore(appeals): moved static config to constants

### DIFF
--- a/appeals/api/package.json
+++ b/appeals/api/package.json
@@ -25,7 +25,7 @@
     "db:migrate:prod": "npx prisma migrate deploy",
     "db:push": "npx prisma db push --accept-data-loss",
     "db:reset": "npx prisma migrate reset --force",
-    "db:seed": "npm run prisma-generate && cross-env NODE_ENV=development node src/database/seed/seed-development.js",
+    "db:seed": "npm run prisma-generate && npx prisma db seed",
     "db:seed:prod": "npm run prisma-generate && cross-env NODE_ENV=production node src/database/seed/seed-production.js",
     "prisma:format": "npx prisma format",
     "prisma-generate": "npx prisma generate",

--- a/appeals/api/src/server/config/config.js
+++ b/appeals/api/src/server/config/config.js
@@ -30,24 +30,6 @@ const { value, error } = schema.validate({
 			: environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
 	},
 	serviceBusEnabled: environment.SERVICE_BUS_ENABLED && environment.SERVICE_BUS_ENABLED === 'true',
-	timetable: {
-		FPA: {
-			lpaQuestionnaireDueDate: {
-				daysFromStartDate: 5
-			},
-			statementReviewDate: {
-				daysFromStartDate: 25
-			},
-			finalCommentReviewDate: {
-				daysFromStartDate: 35
-			}
-		},
-		HAS: {
-			lpaQuestionnaireDueDate: {
-				daysFromStartDate: 5
-			}
-		}
-	},
 	govNotify: {
 		api: {
 			key: environment.GOV_NOTIFY_API_KEY
@@ -71,31 +53,7 @@ const { value, error } = schema.validate({
 		{ level: 'F', band: 1 },
 		{ level: 'G', band: 1 },
 		{ level: 'H', band: 1 }
-	],
-	appealFolderPaths: [
-		// path in the format of {stage}/{documentType}
-		'appellant_case/applicationForm',
-		'appellant_case/decisionLetter',
-		'appellant_case/designAndAccessStatement',
-		'appellant_case/planningObligation',
-		'appellant_case/plansDrawingsSupportingDocuments',
-		'appellant_case/separateOwnershipCertificate',
-		'appellant_case/newSupportingDocuments',
-		'appellant_case/appealStatement',
-		// LPA questionnaire folders
-		'lpa_questionnaire/conservationAreaMap',
-		'lpa_questionnaire/notifyingParties',
-		'lpa_questionnaire/siteNotices',
-		'lpa_questionnaire/lettersToNeighbours',
-		'lpa_questionnaire/pressAdvert',
-		'lpa_questionnaire/representations',
-		'lpa_questionnaire/officersReport'
-	],
-	appealStages: {
-		// stage mapping for ODW
-		appellantCase: 'appellant_case',
-		lpaQuestionnaire: 'lpa_questionnaire'
-	}
+	]
 });
 
 if (error) {

--- a/appeals/api/src/server/config/schema.js
+++ b/appeals/api/src/server/config/schema.js
@@ -22,24 +22,6 @@ export default joi
 		cwd: joi.string(),
 		featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean()),
 		serviceBusEnabled: joi.boolean().optional(),
-		timetable: joi.object({
-			FPA: joi.object({
-				lpaQuestionnaireDueDate: joi.object({
-					daysFromStartDate: joi.number()
-				}),
-				statementReviewDate: joi.object({
-					daysFromStartDate: joi.number()
-				}),
-				finalCommentReviewDate: joi.object({
-					daysFromStartDate: joi.number()
-				})
-			}),
-			HAS: joi.object({
-				lpaQuestionnaireDueDate: joi.object({
-					daysFromStartDate: joi.number()
-				})
-			})
-		}),
 		govNotify: joi
 			.object({
 				api: joi.object({
@@ -64,11 +46,6 @@ export default joi
 				level: joi.string(),
 				band: joi.number()
 			})
-		),
-		appealFolderPaths: joi.array().items(joi.string()),
-		appealStages: joi.object({
-			appellantCase: joi.string(),
-			lpaQuestionnaire: joi.string()
-		})
+		)
 	})
 	.options({ presence: 'required' }); // required by default;

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.controller.js
@@ -1,7 +1,7 @@
 import { getFoldersForAppeal } from '#endpoints/documents/documents.service.js';
 import appellantCaseRepository from '#repositories/appellant-case.repository.js';
 import logger from '#utils/logger.js';
-import config from '#config/config.js';
+import { CONFIG_APPEAL_STAGES } from '#endpoints/constants.js';
 import { ERROR_FAILED_TO_SAVE_DATA } from '../constants.js';
 import { formatAppellantCase } from './appellant-cases.formatter.js';
 import { updateAppellantCaseValidationOutcome } from './appellant-cases.service.js';
@@ -15,7 +15,7 @@ import { updateAppellantCaseValidationOutcome } from './appellant-cases.service.
  */
 const getAppellantCaseById = async (req, res) => {
 	const { appeal } = req;
-	const folders = await getFoldersForAppeal(appeal, config.appealStages.appellantCase);
+	const folders = await getFoldersForAppeal(appeal, CONFIG_APPEAL_STAGES.appellantCase);
 	const formattedAppeal = formatAppellantCase(appeal, folders);
 
 	return res.send(formattedAppeal);

--- a/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
+++ b/appeals/api/src/server/endpoints/appellant-cases/appellant-cases.formatter.js
@@ -1,8 +1,8 @@
-import config from '#config/config.js';
 import formatAddress from '#utils/format-address.js';
 import formatValidationOutcomeResponse from '#utils/format-validation-outcome-response.js';
 import isFPA from '#utils/is-fpa.js';
 import { mapFoldersLayoutForAppealSection } from '../documents/documents.mapper.js';
+import { CONFIG_APPEAL_STAGES } from '#endpoints/constants.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetByIdResultItem} RepositoryGetByIdResultItem */
 /** @typedef {import('@pins/appeals.api').Appeals.SingleAppellantCaseResponse} SingleAppellantCaseResponse */
@@ -115,7 +115,7 @@ const formatFoldersAndDocuments = (appeal, folders) => {
 	};
 
 	if (folders) {
-		mapFoldersLayoutForAppealSection(config.appealStages.appellantCase, folderLayout, folders);
+		mapFoldersLayoutForAppealSection(CONFIG_APPEAL_STAGES.appellantCase, folderLayout, folders);
 	}
 
 	return { documents: folderLayout };

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -103,3 +103,49 @@ export const USER_TYPE_INSPECTOR = 'inspector';
 export const AUDIT_TRAIL_SYSTEM_UUID = '00000000-0000-0000-0000-000000000000';
 export const AUDIT_TRAIL_APPELLANT_IMPORT_MSG = 'The Appellant case was received';
 export const AUDIT_TRAIL_LPAQ_IMPORT_MSG = 'The LPA questionnaire was received';
+
+// Static config
+export const CONFIG_APPEAL_TIMETABLE = {
+	FPA: {
+		lpaQuestionnaireDueDate: {
+			daysFromStartDate: 5
+		},
+		statementReviewDate: {
+			daysFromStartDate: 25
+		},
+		finalCommentReviewDate: {
+			daysFromStartDate: 35
+		}
+	},
+	HAS: {
+		lpaQuestionnaireDueDate: {
+			daysFromStartDate: 5
+		}
+	}
+};
+
+export const CONFIG_APPEAL_FOLDER_PATHS = [
+	// path in the format of {stage}/{documentType}
+	'appellant_case/applicationForm',
+	'appellant_case/decisionLetter',
+	'appellant_case/designAndAccessStatement',
+	'appellant_case/planningObligation',
+	'appellant_case/plansDrawingsSupportingDocuments',
+	'appellant_case/separateOwnershipCertificate',
+	'appellant_case/newSupportingDocuments',
+	'appellant_case/appealStatement',
+	// LPA questionnaire folders
+	'lpa_questionnaire/conservationAreaMap',
+	'lpa_questionnaire/notifyingParties',
+	'lpa_questionnaire/siteNotices',
+	'lpa_questionnaire/lettersToNeighbours',
+	'lpa_questionnaire/pressAdvert',
+	'lpa_questionnaire/representations',
+	'lpa_questionnaire/officersReport'
+];
+
+export const CONFIG_APPEAL_STAGES = {
+	// stage mapping for ODW
+	appellantCase: 'appellant_case',
+	lpaQuestionnaire: 'lpa_questionnaire'
+};

--- a/appeals/api/src/server/endpoints/documents/documents.mapper.js
+++ b/appeals/api/src/server/endpoints/documents/documents.mapper.js
@@ -1,4 +1,4 @@
-import config from '#config/config.js';
+import { CONFIG_APPEAL_FOLDER_PATHS } from '#endpoints/constants.js';
 
 /** @typedef {import('@pins/appeals.api').Schema.Folder} Folder */
 /** @typedef {import('@pins/appeals/index.js').MappedDocument} MappedDocument */
@@ -82,7 +82,8 @@ export const mapCaseReferenceForStorageUrl = (caseReference) => {
  * @returns {Folder[]}
  */
 export const mapDefaultCaseFolders = (caseId) => {
-	return config.appealFolderPaths.map((/** @type {string} */ path) => {
+	// @ts-ignore
+	return CONFIG_APPEAL_FOLDER_PATHS.map((/** @type {string} */ path) => {
 		return {
 			caseId,
 			path

--- a/appeals/api/src/server/utils/business-days.js
+++ b/appeals/api/src/server/utils/business-days.js
@@ -1,7 +1,10 @@
 import { add, addBusinessDays, isAfter, isBefore, isWeekend, parseISO, sub } from 'date-fns';
 import fetch from 'node-fetch';
 import config from '../config/config.js';
-import { BANK_HOLIDAY_FEED_DIVISION_ENGLAND } from '#endpoints/constants.js';
+import {
+	CONFIG_APPEAL_TIMETABLE,
+	BANK_HOLIDAY_FEED_DIVISION_ENGLAND
+} from '#endpoints/constants.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.BankHolidayFeedEvents} BankHolidayFeedEvents */
 /** @typedef {import('@pins/appeals.api').Appeals.BankHolidayFeedDivisions} BankHolidayFeedDivisions */
@@ -123,7 +126,8 @@ const recalculateDateIfNotBusinessDay = async (date) => {
  */
 const calculateTimetable = async (appealType, startedAt) => {
 	if (startedAt) {
-		const appealTimetableConfig = config.timetable[appealType];
+		// @ts-ignore
+		const appealTimetableConfig = CONFIG_APPEAL_TIMETABLE[appealType];
 
 		if (appealTimetableConfig) {
 			const bankHolidays = await fetchBankHolidaysForDivision();


### PR DESCRIPTION
Moves the following config settings to static constants:
- AppealTimetable
- AppealFolderPaths
- AppealStages

Reverted the npm script for db:seed

Unit tests ok, db:seed ok locally.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
