### PR TITLE
fix(api/applications): add missing tables to seed script (boas-1216)

### DIFF
--- a/apps/api/src/database/seed/seed-clear.js
+++ b/apps/api/src/database/seed/seed-clear.js
@@ -1,6 +1,8 @@
 import { truncateTable } from '../prisma.truncate.js';
 
 /**
+ * Seeding function to clear down a database, deletes all cases, documents, records, reference tables, etc
+ *
  * @param {import('@prisma/client').PrismaClient} databaseConnector
  */
 export async function deleteAllRecords(databaseConnector) {
@@ -13,12 +15,16 @@ export async function deleteAllRecords(databaseConnector) {
 	const deleteGridReference = databaseConnector.gridReference.deleteMany();
 	const deleteDocuments = databaseConnector.document.deleteMany();
 	const deleteDocumentsVersions = databaseConnector.documentVersion.deleteMany();
+	const deleteDocumentActivityLog = databaseConnector.documentActivityLog.deleteMany();
+	const deletes51Advice = databaseConnector.s51Advice.deleteMany();
+	const deletes51AdviceDocument = databaseConnector.s51AdviceDocument.deleteMany();
 	const deleteFolders = databaseConnector.folder.deleteMany();
 	const deleteRepresentationContact = databaseConnector.representationContact.deleteMany();
 	const deleteRepresentationAttachment = databaseConnector.representationAttachment.deleteMany();
 	const deleteRepresentation = databaseConnector.representation.deleteMany();
 	const deleteRepresentationAction = databaseConnector.representationAction.deleteMany();
 	const deleteProjectUpdates = databaseConnector.projectUpdate.deleteMany();
+	const deleteExaminationTimetable = databaseConnector.examinationTimetable.deleteMany();
 
 	// and reference data tables
 	const deleteSubSector = databaseConnector.subSector.deleteMany();
@@ -27,21 +33,26 @@ export async function deleteAllRecords(databaseConnector) {
 	const deleteZoomLevel = databaseConnector.zoomLevel.deleteMany();
 	const deleteExaminationTimetableType = databaseConnector.examinationTimetableItem.deleteMany();
 
-	// Truncate calls on data tables
+	// start deleting ...
 	await deleteRepresentationAttachment;
 	await deleteRepresentationAction;
 	await deleteRepresentationContact;
 	await deleteRepresentation;
 
-	// delete document versions, documents, and THEN the folders.  Has to be in this order for integrity constraints
+	// delete S51 advice documents, S51 Advice, document Activity logs, document versions, documents, and THEN the folders.
+	// Has to be in this order for integrity constraints
+	await deletes51AdviceDocument;
+	await deletes51Advice;
 	// TODO: Currently an issue with cyclic references, hence this hack to clear the latestVersionId
 	await databaseConnector.$queryRawUnsafe(`UPDATE Document SET latestVersionId = NULL;`);
+	await deleteDocumentActivityLog;
 	await deleteDocumentsVersions;
 	await deleteDocuments;
 
-	// truncate tables
+	// truncate / delete tables
 	await truncateTable('RegionsOnApplicationDetails');
 	await truncateTable('ExaminationTimetableItem');
+	await deleteExaminationTimetable;
 
 	await deleteLowestFolders(databaseConnector);
 	await deleteLowestFolders(databaseConnector);


### PR DESCRIPTION
## Describe your changes

Fix to make seeding script work again.  Specifically, deleting of certain new tables: 
- DocumentActivityLog
- S51Advice
- S51AdviceDocument
- ExaminationTimetable

## BOAS-1216 Add missing tables to seed script
https://pins-ds.atlassian.net/browse/BOAS-1216

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
