### PR TITLE
Feature/boas 1220 subscriptions

### DIFF
--- a/apps/api/src/server/applications/subscriptions/__tests__/subscriptions.test.js
+++ b/apps/api/src/server/applications/subscriptions/__tests__/subscriptions.test.js
@@ -12,11 +12,11 @@ import { typesError } from '../subscriptions.validators.js';
  */
 
 describe('subscriptions', () => {
-	describe('get', () => {
+	describe('get (uses post)', () => {
 		const tests = [
 			{
 				name: 'should check all required fields',
-				query: {},
+				body: {},
 				want: {
 					status: 400,
 					body: {
@@ -29,7 +29,7 @@ describe('subscriptions', () => {
 			},
 			{
 				name: 'should allow a valid request',
-				query: {
+				body: {
 					caseReference: '5123',
 					emailAddress: 'hello.world@example.com'
 				},
@@ -41,7 +41,7 @@ describe('subscriptions', () => {
 			},
 			{
 				name: 'should return a subscription',
-				query: {
+				body: {
 					caseReference: '1234',
 					emailAddress: 'hello.world@example.com'
 				},
@@ -63,17 +63,13 @@ describe('subscriptions', () => {
 			}
 		];
 
-		it.each(tests)('$name', async ({ query, subscription, want }) => {
+		it.each(tests)('$name', async ({ body, subscription, want }) => {
 			databaseConnector.subscription.findUnique.mockReset();
 			if (subscription !== undefined) {
 				databaseConnector.subscription.findUnique.mockResolvedValueOnce(subscription);
 			}
 			// action
-			let queryStr = '';
-			for (const [k, v] of Object.entries(query)) {
-				queryStr += `${k}=${encodeURIComponent(v)}&`;
-			}
-			const response = await request.get(`/applications/subscriptions?${queryStr}`);
+			const response = await request.post(`/applications/subscriptions`).send(body);
 
 			// checks
 			expect(response.body).toEqual(want.body);

--- a/apps/api/src/server/applications/subscriptions/subscriptions.controller.js
+++ b/apps/api/src/server/applications/subscriptions/subscriptions.controller.js
@@ -51,12 +51,10 @@ export async function listSubscriptions(req, res) {
  * @throws {Error}
  * @returns {Promise<void>}
  */
-export async function getSubscription(request, response) {
-	const { query } = request;
-
+export async function getSubscription({ body }, response) {
 	// we're expecting strings here, not other possible types (e.g. string[])
-	const caseReference = String(query.caseReference);
-	const emailAddress = String(query.emailAddress);
+	const caseReference = String(body.caseReference);
+	const emailAddress = String(body.emailAddress);
 
 	try {
 		const res = await subscriptionRepository.findUnique(caseReference, emailAddress);

--- a/apps/api/src/server/applications/subscriptions/subscriptions.routes.js
+++ b/apps/api/src/server/applications/subscriptions/subscriptions.routes.js
@@ -16,20 +16,20 @@ import { validatePaginationParameters } from '#middleware/pagination-validation.
 
 const router = createRouter();
 
-router.get(
+router.post(
 	'/',
 	/*
         #swagger.tags = ['Applications']
         #swagger.path = '/applications/subscriptions'
         #swagger.description = 'Get a subscription'
         #swagger.parameters['caseReference'] = {
-            in: 'query',
+            in: 'body',
             description: 'subscription caseReference',
             schema: { type: 'string' },
             required: true
         }
         #swagger.parameters['emailAddress'] = {
-            in: 'query',
+            in: 'body',
             description: 'subscription emailAddress',
             schema: { type: 'string' },
             required: true

--- a/apps/api/src/server/applications/subscriptions/subscriptions.validators.js
+++ b/apps/api/src/server/applications/subscriptions/subscriptions.validators.js
@@ -6,8 +6,8 @@ const typesList = Subscription.TypeList.map((t) => `'${t}'`).join(', ');
 export const typesError = `type must be one of ${typesList}`;
 
 export const validateGetSubscription = composeMiddleware(
-	query('caseReference').notEmpty().withMessage(`caseReference is required`),
-	query('emailAddress').notEmpty().withMessage(`emailAddress is required`),
+	body('caseReference').notEmpty().withMessage(`caseReference is required`),
+	body('emailAddress').notEmpty().withMessage(`emailAddress is required`),
 	validationErrorHandler
 );
 

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -3445,13 +3445,13 @@
 			}
 		},
 		"/applications/subscriptions": {
-			"get": {
+			"post": {
 				"tags": ["Applications"],
 				"description": "Get a subscription",
 				"parameters": [
 					{
 						"name": "caseReference",
-						"in": "query",
+						"in": "body",
 						"description": "subscription caseReference",
 						"schema": {
 							"type": "string"
@@ -3460,7 +3460,7 @@
 					},
 					{
 						"name": "emailAddress",
-						"in": "query",
+						"in": "body",
 						"description": "subscription emailAddress",
 						"schema": {
 							"type": "string"

--- a/apps/functions/handle-subscriptions/handle-subscription-command/back-office-api-client.js
+++ b/apps/functions/handle-subscriptions/handle-subscription-command/back-office-api-client.js
@@ -1,6 +1,5 @@
 import got from 'got';
 import config from './config.js';
-import querystring from 'querystring';
 
 /**
  *
@@ -9,8 +8,11 @@ import querystring from 'querystring';
  * @returns {Promise<{id: number}|null>}
  */
 function getSubscription(caseReference, emailAddress) {
-	const query = querystring.stringify({ caseReference, emailAddress });
-	return got.get(`https://${config.API_HOST}/applications/subscriptions/?${query}`).json();
+	return got
+		.post(`https://${config.API_HOST}/applications/subscriptions/`, {
+			json: { caseReference, emailAddress }
+		})
+		.json();
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

Changes `getSubscription` endpoint to a POST so that we don't end up caching the email address parameter.

* feat(api/applications): change get-subscription endpoint to POST
* refactor(api/applications): use BackOfficeAppError in get subscriptions
* chore(api/applications): regenerate swagger docs
* feat(functions): call new POST endpoint in handleSubscriptions

Tested locally.

## Issue ticket number and link

[BOAS-1220](https://pins-ds.atlassian.net/browse/BOAS-1220)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1220]: https://pins-ds.atlassian.net/browse/BOAS-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ