### PR TITLE
fix(applications/web): remove &nbsp; from copied update content

### DIFF
--- a/apps/web/src/client/components/html-content-editor/html-content-editor.js
+++ b/apps/web/src/client/components/html-content-editor/html-content-editor.js
@@ -59,7 +59,6 @@ function initHtmlContentEditor() {
 				return;
 			}
 			const showWarning = text.length > parseInt(limit);
-			console.log('showWanring', { showWarning, length: text.length, limit: parseInt(limit) });
 			charCountWarning.style.setProperty('display', showWarning ? 'block' : 'none', 'important');
 		}
 

--- a/apps/web/src/server/applications/case/project-updates/project-updates.mapper.js
+++ b/apps/web/src/server/applications/case/project-updates/project-updates.mapper.js
@@ -20,7 +20,8 @@ export function bodyToCreateRequest(body) {
 export function bodyToUpdateRequest(body) {
 	const content = decodeURI(body.backOfficeProjectUpdateContent)
 		.replaceAll('<p><br></p>', '<br>')
-		.replaceAll('<br>', '<br />');
+		.replaceAll('<br>', '<br />')
+		.replaceAll('&nbsp;', ' '); // these are sometimes included when copy+pasting in an update
 
 	return {
 		htmlContent: content,


### PR DESCRIPTION
## Describe your changes

Copy+pasted update content could fail the sanitisation check, so strip out `&nbsp;` from copied content.

## Issue ticket number and link

[ASB-1929](https://pins-ds.atlassian.net/jira/software/c/projects/ASB/boards/166?selectedIssue=ASB-1929)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[ASB-1929]: https://pins-ds.atlassian.net/browse/ASB-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ