### PR TITLE
fix(web/applications): render proper error on S51 status change

### DIFF
--- a/apps/web/src/server/applications/case/s51/applications-s51.service.js
+++ b/apps/web/src/server/applications/case/s51/applications-s51.service.js
@@ -65,19 +65,13 @@ export const updateS51Advice = async (caseId, adviceId, payload) => {
  * @returns {Promise<{newS51Advice?: S51Advice, errors?: ValidationErrors}>}
  * */
 export const updateS51AdviceStatus = async (caseId, payload) => {
-	let response;
-
 	try {
-		response = await patch(`applications/${caseId}/s51-advice/`, { json: payload });
+		return await patch(`applications/${caseId}/s51-advice/`, { json: payload });
 	} catch (/** @type {*} */ error) {
-		pino.error(`[API] ${error?.response?.body?.errors?.message || 'Unknown error'}`);
+		pino.error(`[API] ${error?.response?.body?.errors || 'Unknown error'}`);
 
-		response = new Promise((resolve) => {
-			resolve({ errors: 'An error occurred, please try again later' });
-		});
+		return { errors: error?.response?.body?.errors };
 	}
-
-	return response;
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

Render the proper error from the API when trying to change the status of an S51 item that is already published.

Tested locally.

## Issue ticket number and link

[BOAS-1204](https://pins-ds.atlassian.net/browse/BOAS-1204)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1204]: https://pins-ds.atlassian.net/browse/BOAS-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ