### PR TITLE
fix(web/applications): display document author on delete page

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -6710,7 +6710,7 @@ exports[`applications documentation Document properties delete page If the user 
                 <tbody class=\\"govuk-table__body\\">
                     <tr class=\\"govuk-table__row\\">
                         <td class=\\"govuk-table__cell\\">12 Ullamco laboris nisi ut</td>
-                        <td class=\\"govuk-table__cell\\"></td>
+                        <td class=\\"govuk-table__cell\\">Tempor incididunt</td>
                     </tr>
                 </tbody>
             </table>
@@ -6743,7 +6743,7 @@ exports[`applications documentation Document properties delete page If the user 
                 <tbody class=\\"govuk-table__body\\">
                     <tr class=\\"govuk-table__row\\">
                         <td class=\\"govuk-table__cell\\">4 Elit sed</td>
-                        <td class=\\"govuk-table__cell\\"></td>
+                        <td class=\\"govuk-table__cell\\">Consectetur adipiscing</td>
                     </tr>
                 </tbody>
             </table>

--- a/apps/web/src/server/views/applications/case-documentation/documentation-delete.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-delete.njk
@@ -60,7 +60,7 @@
 							html: fileNameHtml
 						},
 						{
-							text: documentationFile.from
+							text: documentationFile.author
 						}
 					]
 				]


### PR DESCRIPTION
## Describe your changes

Use the `author` property on the document to fill the `From` column on the delete page.

## Issue ticket number and link

[BOAS-1159](https://pins-ds.atlassian.net/browse/BOAS-1159)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1159]: https://pins-ds.atlassian.net/browse/BOAS-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ