### PR TITLE
fix(api/applications): fix logic error when counting documents

### DIFF
--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -272,8 +272,8 @@ export const getDocumentsCountInFolder = (folderId, getAllDocuments = false) => 
 	/** @type {{folderId: number, isDeleted?:boolean}} */
 	const where = { folderId };
 
-	if (getAllDocuments) {
-		where.isDeleted = true;
+	if (!getAllDocuments) {
+		where.isDeleted = false;
 	}
 
 	return databaseConnector.document.count({


### PR DESCRIPTION
## Describe your changes

* fix(api/applications): fix logic error when counting documents

The `getAllDocuments` argument should only affect the `where` clause
when it is `false`.

$$
getAllDocuments = true \implies isDeleted = true\ ||\ isDeleted = false
$$
   
$$
getAllDocuments = false \implies isDeleted = false
$$


## Issue ticket number and link

[BOAS-1267](https://pins-ds.atlassian.net/browse/BOAS-1267)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1267]: https://pins-ds.atlassian.net/browse/BOAS-1267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ