### PR TITLE
fix(api/applications): use document GUIDs instead of relation IDs

### DIFF
--- a/apps/api/src/server/applications/s51advice/s51-advice.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.js
@@ -44,5 +44,5 @@ export const buildNsipS51AdvicePayload = (s51Advice) => ({
 	status: s51Advice.publishedStatus,
 	redactionStatus: s51Advice.redactedStatus,
 	// @ts-ignore
-	attachmentIds: s51Advice.S51AdviceDocument.map((doc) => doc.id)
+	attachmentIds: s51Advice.S51AdviceDocument.map((doc) => doc.documentGuid)
 });


### PR DESCRIPTION
## Describe your changes

* fix(api/applications): use document GUIDs instead of relation IDs

Front Office don't have knowledge of our mapping table, so using these IDs will make no sense on their end. We should use the document GUID instead.

## Issue ticket number and link

[BOAS-1267](https://pins-ds.atlassian.net/browse/BOAS-1267)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1267]: https://pins-ds.atlassian.net/browse/BOAS-1267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ