### PR TITLE
fix(web/applications): fix back link on document unpublish queue page

### DIFF
--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -154,8 +154,19 @@ export async function viewApplicationsCaseDocumentationUnpublishPage(request, re
 		true
 	);
 
+	const pathMatch = request.url.match(/(\d+)\/([a-zA-Z-]+)\/unpublishing-queue$/);
+	const backLink = pathMatch
+		? url('document-category', {
+				caseId: response.locals.caseId,
+				documentationCategory: { id: parseInt(pathMatch[1]), displayNameEn: pathMatch[2] }
+		  })
+		: url('case-view', {
+				caseId: response.locals.caseId
+		  });
+
 	return response.render(`applications/case-documentation/documentation-unpublish`, {
-		documentationFiles
+		documentationFiles,
+		backLink
 	});
 }
 

--- a/apps/web/src/server/views/applications/case-documentation/documentation-unpublish.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-unpublish.njk
@@ -8,7 +8,7 @@
 <aside>
   {{ govukBackLink({
     text: "Back",
-		href: 'document'|url({caseId: caseId, folderId: folderId, documentGuid: documentationFile.documentGuid, step: "properties"})
+    href: backLink
   }) }}
 </aside>
 {% endblock %}


### PR DESCRIPTION
## Describe your changes

The back link is currently not working on the unpublish queue page.

Tested locally.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
