### PR TITLE
fix(api/applications): include the owner when creating document versions

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -142,6 +142,7 @@ const attemptInsertDocuments = async (caseId, documents) => {
 				originalFilename: documentToDB.documentName,
 				mime: documentToDB.documentType,
 				size: documentToDB.documentSize,
+				owner: documentToDB.username,
 				stage: stage,
 				version: 1,
 				...(config.virusScanningDisabled && {
@@ -357,6 +358,7 @@ export const obtainURLForDocumentVersion = async (documentToUpload, caseId, docu
 	currentDocumentVersion[0].fileName = fileName;
 	currentDocumentVersion[0].mime = documentToSendToDatabase.documentType;
 	currentDocumentVersion[0].size = documentToSendToDatabase.documentSize;
+	currentDocumentVersion[0].owner = documentToUpload.username;
 
 	await documentVersionRepository.upsert(currentDocumentVersion[0]);
 
@@ -775,7 +777,7 @@ export const unpublishDocuments = async (guids) => {
 				status: 'unpublished'
 			})
 		)
-  );
+	);
 
 	await eventClient.sendEvents(
 		NSIP_DOCUMENT,


### PR DESCRIPTION
## Describe your changes

Include the `owner` when creating document versions. We don't currently do this, so after unpublishing, it says it was the `System` that acted rather than the user.

I can't test this locally as it is a step that happens post-crash when you upload a file. Will need to test in dev.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
