### PR TITLE
fix(web/applications): use a relative path for unpublish formaction

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -133,7 +133,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             <p class=\\"govuk-heading-s\\">Document actions</p>
                             <button type=\\"button\\" class=\\"govuk-link pins-files-list__button-link\\"
                             id=\\"bulkDownload\\">Download selected</button>
-                            <button type=\\"submit\\" formaction='unpublishing-queue'
+                            <button type=\\"submit\\" formaction=\\"./unpublishing-queue\\"
                             class=\\"govuk-link pins-files-list__button-link\\">Unpublish selected</button>
                         </div>
                     </div>
@@ -950,7 +950,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             <p class=\\"govuk-heading-s\\">Document actions</p>
                             <button type=\\"button\\" class=\\"govuk-link pins-files-list__button-link\\"
                             id=\\"bulkDownload\\">Download selected</button>
-                            <button type=\\"submit\\" formaction='unpublishing-queue'
+                            <button type=\\"submit\\" formaction=\\"./unpublishing-queue\\"
                             class=\\"govuk-link pins-files-list__button-link\\">Unpublish selected</button>
                         </div>
                     </div>
@@ -2235,7 +2235,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             <p class=\\"govuk-heading-s\\">Document actions</p>
                             <button type=\\"button\\" class=\\"govuk-link pins-files-list__button-link\\"
                             id=\\"bulkDownload\\">Download selected</button>
-                            <button type=\\"submit\\" formaction='unpublishing-queue'
+                            <button type=\\"submit\\" formaction=\\"./unpublishing-queue\\"
                             class=\\"govuk-link pins-files-list__button-link\\">Unpublish selected</button>
                         </div>
                     </div>
@@ -3143,7 +3143,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             <p class=\\"govuk-heading-s\\">Document actions</p>
                             <button type=\\"button\\" class=\\"govuk-link pins-files-list__button-link\\"
                             id=\\"bulkDownload\\">Download selected</button>
-                            <button type=\\"submit\\" formaction='unpublishing-queue'
+                            <button type=\\"submit\\" formaction=\\"./unpublishing-queue\\"
                             class=\\"govuk-link pins-files-list__button-link\\">Unpublish selected</button>
                         </div>
                     </div>
@@ -4375,7 +4375,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             <p class=\\"govuk-heading-s\\">Document actions</p>
                             <button type=\\"button\\" class=\\"govuk-link pins-files-list__button-link\\"
                             id=\\"bulkDownload\\">Download selected</button>
-                            <button type=\\"submit\\" formaction='unpublishing-queue'
+                            <button type=\\"submit\\" formaction=\\"./unpublishing-queue\\"
                             class=\\"govuk-link pins-files-list__button-link\\">Unpublish selected</button>
                         </div>
                     </div>
@@ -5605,7 +5605,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             <p class=\\"govuk-heading-s\\">Document actions</p>
                             <button type=\\"button\\" class=\\"govuk-link pins-files-list__button-link\\"
                             id=\\"bulkDownload\\">Download selected</button>
-                            <button type=\\"submit\\" formaction='unpublishing-queue'
+                            <button type=\\"submit\\" formaction=\\"./unpublishing-queue\\"
                             class=\\"govuk-link pins-files-list__button-link\\">Unpublish selected</button>
                         </div>
                     </div>

--- a/apps/web/src/server/views/applications/components/folder/folder-actions.component.njk
+++ b/apps/web/src/server/views/applications/components/folder/folder-actions.component.njk
@@ -68,7 +68,7 @@
 					<button type="button" class="govuk-link pins-files-list__button-link"
 												id="bulkDownload">Download selected
 										</button>
-					<button type="submit" formaction='unpublishing-queue' class="govuk-link pins-files-list__button-link">
+					<button type="submit" formaction="./unpublishing-queue" class="govuk-link pins-files-list__button-link">
 						Unpublish selected</button>
 				</div>
 			</div>


### PR DESCRIPTION
## Describe your changes

Use a relative path for the unpublish `formaction`.

There is currently a bug in dev where the wrong error message shows up after clicking the 'Unpublish selected' button. I suspect it's an issue with the path but I'll need to test in dev.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
