### PR TITLE
fix(applications/api): allow mailto links in project updates

### DIFF
--- a/apps/api/src/server/applications/application/project-updates/__tests__/project-updates.test.js
+++ b/apps/api/src/server/applications/application/project-updates/__tests__/project-updates.test.js
@@ -502,6 +502,39 @@ describe('project-updates', () => {
 							'<strong>Something Important</strong> My new update <ul><li>list item 1</li><li>list item 1</li></ul><a href="https://my-important-link.com">More info</a>'
 					}
 				}
+			},
+			{
+				name: 'should allow a valid request with a mailto: link',
+				body: {
+					emailSubscribers: true,
+					status: 'draft',
+					htmlContent:
+						'<strong>Something Important</strong> My new update <ul><li>list item 1</li><li>list item 1</li></ul><a href="mailto:me@example.com">email us</a>'
+				},
+				existingCase: {
+					reference: 'abc-123'
+				},
+				created: {
+					id: 5,
+					caseId: 1,
+					dateCreated: new Date('2023-07-04T10:00:00.000Z'),
+					sentToSubscribers: false,
+					type: 'general'
+				},
+				want: {
+					status: 200,
+					body: {
+						id: 5,
+						caseId: 1,
+						dateCreated: '2023-07-04T10:00:00.000Z',
+						emailSubscribers: true,
+						sentToSubscribers: false,
+						status: 'draft',
+						type: 'general',
+						htmlContent:
+							'<strong>Something Important</strong> My new update <ul><li>list item 1</li><li>list item 1</li></ul><a href="mailto:me@example.com">email us</a>'
+					}
+				}
 			}
 		];
 

--- a/apps/api/src/server/applications/application/project-updates/project-updates.validators.js
+++ b/apps/api/src/server/applications/application/project-updates/project-updates.validators.js
@@ -100,7 +100,7 @@ export function contentIsSafe(content) {
 		allowedAttributes: {
 			a: ['href']
 		},
-		allowedSchemes: ['https']
+		allowedSchemes: ['https', 'mailto']
 	});
 	// if the sanitized content differs, then it's not considered safe
 	return sanitized === content;

--- a/apps/api/src/server/migration/migrators/nsip-project-update-migrator.js
+++ b/apps/api/src/server/migration/migrators/nsip-project-update-migrator.js
@@ -154,6 +154,6 @@ const prepareAndSanitizeHtml = (html) => {
 		allowedAttributes: {
 			a: ['href']
 		},
-		allowedSchemes: ['https']
+		allowedSchemes: ['https', 'mailto']
 	});
 };


### PR DESCRIPTION
## Describe your changes

As per title, allowing `mailto:` links in project updates, which are used quite often.

## Issue ticket number and link

[BOAS-1307](https://pins-ds.atlassian.net/browse/BOAS-1307)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1307]: https://pins-ds.atlassian.net/browse/BOAS-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ