### PR TITLE
Fix/boas 1278 unpublish single

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -6818,138 +6818,134 @@ exports[`applications documentation Document properties page If the user is not 
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/new-version\\"> Upload new version</a>
             </div>
             <nav class=\\"govuk-grid-row govuk-!-margin-top-0\\">
-                <h3 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">Document actions</h3>
-                <form action='../unpublishing-queue' method='post' class=\\"govuk-grid-column-full govuk-!-margin-top-0\\"><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/documents/123/download/11/version//\\">Open</a>
-                    <a                     class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
-                    href=\\"/documents/123/download/11/version//\\">Download</a>
-                        <input type='hidden' value='11' name='selectedFilesIds[]'>
-                        <button class='govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2'
-                        type='submit'>Unpublish</button>
-                </form>
-                <div class=\\"govuk-grid-column-one-third govuk-!-text-align-right\\"></div>
-            </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">12 Ullamco laboris nisi ut</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                <h3 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">Document actions</h3><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/documents/123/download/11/version//\\">Open</a>
+                <a                 class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
+                href=\\"/documents/123/download/11/version//\\">Download</a>
+                    <input type='hidden' value='11' name='selectedFilesIds[]'><a href=\\"./unpublish\\" class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\">Unpublish</a>
+                    <div                     class=\\"govuk-grid-column-one-third govuk-!-text-align-right\\"></div>
+        </nav>
+        <div class=\\"govuk-!-margin-top-7\\">
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">12 Ullamco laboris nisi ut</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Tempor incididunt</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ullamco Aliqua</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ut</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\"></dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Tempor incididunt</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ullamco Aliqua</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ut</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\"></dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Transcript (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/transcript\\"> Change<span class=\\"govuk-visually-hidden\\"> Transcript (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\">07/03/2023</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/published-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Published date</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Published</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Transcript (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/transcript\\"> Change<span class=\\"govuk-visually-hidden\\"> Transcript (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\">07/03/2023</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/published-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Published date</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Published</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
+    </div>
     </div>
 </main>"
 `;
@@ -6982,133 +6978,131 @@ exports[`applications documentation Document properties page If the user is not 
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/new-version\\"> Upload new version</a>
             </div>
             <nav class=\\"govuk-grid-row govuk-!-margin-top-0\\">
-                <h3 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">Document actions</h3>
-                <form action='../unpublishing-queue' method='post' class=\\"govuk-grid-column-full govuk-!-margin-top-0\\"><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/documents/123/download/3/version//preview\\">Open</a>
-                    <a                     class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
-                    href=\\"/documents/123/download/3/version//\\">Download</a><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
-                        href=\\"/applications-service/case/123/project-documentation/21/document/3/delete\\">Delete</a>
-                </form>
-                <div class=\\"govuk-grid-column-one-third govuk-!-text-align-right\\"><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right\\" href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
+                <h3 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">Document actions</h3><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/documents/123/download/3/version//preview\\">Open</a>
+                <a                 class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
+                href=\\"/documents/123/download/3/version//\\">Download</a><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
+                    href=\\"/applications-service/case/123/project-documentation/21/document/3/delete\\">Delete</a>
+                    <div                     class=\\"govuk-grid-column-one-third govuk-!-text-align-right\\"><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right\\" href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
+        </div>
+        </nav>
+        <div class=\\"govuk-!-margin-top-7\\">
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+                                Ut enim ad</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
+                                </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
                 </div>
-            </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
-                                    Ut enim ad</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
+    </div>
     </div>
 </main>"
 `;
@@ -7141,138 +7135,134 @@ exports[`applications documentation Document properties page If the user is not 
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/new-version\\"> Upload new version</a>
             </div>
             <nav class=\\"govuk-grid-row govuk-!-margin-top-0\\">
-                <h3 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">Document actions</h3>
-                <form action='../unpublishing-queue' method='post' class=\\"govuk-grid-column-full govuk-!-margin-top-0\\"><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/documents/123/download/11/version//\\">Open</a>
-                    <a                     class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
-                    href=\\"/documents/123/download/11/version//\\">Download</a>
-                        <input type='hidden' value='11' name='selectedFilesIds[]'>
-                        <button class='govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2'
-                        type='submit'>Unpublish</button>
-                </form>
-                <div class=\\"govuk-grid-column-one-third govuk-!-text-align-right\\"></div>
-            </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">12 Ullamco laboris nisi ut</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                <h3 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">Document actions</h3><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/documents/123/download/11/version//\\">Open</a>
+                <a                 class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
+                href=\\"/documents/123/download/11/version//\\">Download</a>
+                    <input type='hidden' value='11' name='selectedFilesIds[]'><a href=\\"./unpublish\\" class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\">Unpublish</a>
+                    <div                     class=\\"govuk-grid-column-one-third govuk-!-text-align-right\\"></div>
+        </nav>
+        <div class=\\"govuk-!-margin-top-7\\">
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">12 Ullamco laboris nisi ut</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Tempor incididunt</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ullamco Aliqua</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ut</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\"></dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Tempor incididunt</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ullamco Aliqua</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ut</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\"></dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Transcript (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/transcript\\"> Change<span class=\\"govuk-visually-hidden\\"> Transcript (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\">07/03/2023</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/published-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Published date</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Published</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Transcript (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/transcript\\"> Change<span class=\\"govuk-visually-hidden\\"> Transcript (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\">07/03/2023</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/published-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Published date</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Published</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
+    </div>
     </div>
 </main>"
 `;
@@ -7305,133 +7295,131 @@ exports[`applications documentation Document properties page If the user is not 
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/new-version\\"> Upload new version</a>
             </div>
             <nav class=\\"govuk-grid-row govuk-!-margin-top-0\\">
-                <h3 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">Document actions</h3>
-                <form action='../unpublishing-queue' method='post' class=\\"govuk-grid-column-full govuk-!-margin-top-0\\"><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/documents/123/download/3/version//preview\\">Open</a>
-                    <a                     class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
-                    href=\\"/documents/123/download/3/version//\\">Download</a><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
-                        href=\\"/applications-service/case/123/project-documentation/21/document/3/delete\\">Delete</a>
-                </form>
-                <div class=\\"govuk-grid-column-one-third govuk-!-text-align-right\\"><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right\\" href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
+                <h3 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">Document actions</h3><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/documents/123/download/3/version//preview\\">Open</a>
+                <a                 class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
+                href=\\"/documents/123/download/3/version//\\">Download</a><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2\\"
+                    href=\\"/applications-service/case/123/project-documentation/21/document/3/delete\\">Delete</a>
+                    <div                     class=\\"govuk-grid-column-one-third govuk-!-text-align-right\\"><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right\\" href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
+        </div>
+        </nav>
+        <div class=\\"govuk-!-margin-top-7\\">
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+                                Ut enim ad</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
+                                </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
                 </div>
-            </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
-                                    Ut enim ad</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
+    </div>
     </div>
 </main>"
 `;

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -136,7 +136,7 @@ export async function viewApplicationsCaseDocumentationVersionUpload({ params },
 /**
  * View the unpublishing documentation page
  *
- * @type {import('@pins/express').RenderHandler<{}, {}, {selectedFilesIds: Array<string>}, {}, {folderName: string}>}
+ * @type {import('@pins/express').RenderHandler<{}, {}, {selectedFilesIds: Array<string>}, {}, {folderId: string, folderName: string}>}
  */
 export async function viewApplicationsCaseDocumentationUnpublishPage(request, response) {
 	if (request.errors) {
@@ -162,19 +162,36 @@ export async function viewApplicationsCaseDocumentationUnpublishPage(request, re
 		});
 	}
 
-	const pathMatch = request.url.match(/(\d+)\/([a-zA-Z-]+)\/unpublishing-queue$/);
-	const backLink = pathMatch
-		? url('document-category', {
-				caseId: response.locals.caseId,
-				documentationCategory: { id: parseInt(pathMatch[1]), displayNameEn: pathMatch[2] }
-		  })
-		: url('case-view', {
-				caseId: response.locals.caseId
-		  });
-
 	return response.render(`applications/case-documentation/documentation-unpublish`, {
 		documentationFiles,
-		backLink
+		backLink: url('document-category', {
+			caseId: response.locals.caseId,
+			documentationCategory: {
+				id: parseInt(request.params.folderId),
+				displayNameEn: request.params.folderName
+			}
+		})
+	});
+}
+
+/**
+ * View the unpublishing documentation page for a single document
+ *
+ * @type {import('@pins/express').RenderHandler<{}, {}, {}, {}, {folderId: string, folderName: string, documentGuid: string}>}
+ */
+export async function viewApplicationsCaseDocumentationUnpublishSinglePage(request, response) {
+	const caseId = parseInt(response.locals.caseId);
+
+	const file = await getCaseDocumentationFileInfo(caseId, request.params.documentGuid);
+
+	return response.render(`applications/case-documentation/documentation-unpublish`, {
+		documentationFiles: [file],
+		backLink: url('document', {
+			caseId,
+			folderId: parseInt(request.params.folderId),
+			documentGuid: request.params.documentGuid,
+			step: 'properties'
+		})
 	});
 }
 

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.router.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.router.js
@@ -60,6 +60,10 @@ applicationsDocumentationRouter
 	);
 
 applicationsDocumentationRouter
+	.route('/:folderId/document/:documentGuid/unpublish')
+	.get(asyncRoute(controller.viewApplicationsCaseDocumentationUnpublishSinglePage));
+
+applicationsDocumentationRouter
 	.route('/:folderId/:folders/upload')
 	.get(
 		[assertDomainTypeIsNotInspector, locals.registerFolder],

--- a/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
@@ -58,23 +58,21 @@
                 </div>
                 <nav class="govuk-grid-row govuk-!-margin-top-0">
 					<h3 class="govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4">Document actions</h3>
-					<form action='../unpublishing-queue' method='post' class="govuk-grid-column-full govuk-!-margin-top-0">
-						{% set isNotDisabled = documentationFile.publishedStatus !== 'awaiting_upload' and documentationFile.publishedStatus !== 'awaiting_virus_check' and documentationFile.publishedStatus !== 'failed_virus_check' %}
-						{% set isPreviewActive = isNotDisabled and(documentationFile.mime === 'application/pdf' or documentationFile.mime === 'image/jpeg' or documentationFile.mime === 'image/png') %}
+          {% set isNotDisabled = documentationFile.publishedStatus !== 'awaiting_upload' and documentationFile.publishedStatus !== 'awaiting_virus_check' and documentationFile.publishedStatus !== 'failed_virus_check' %}
+          {% set isPreviewActive = isNotDisabled and(documentationFile.mime === 'application/pdf' or documentationFile.mime === 'image/jpeg' or documentationFile.mime === 'image/png') %}
 
-						{% if isNotDisabled %}
-							<a class="govuk-button govuk-button--secondary govuk-!-margin-0" href="{{ 'document-download'|url({caseId: caseId, documentGuid: documentationFile.documentGuid, version: documentationFile.version, isPreviewActive: isPreviewActive}) }}">Open</a>
-							<a class="govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2" href="{{ 'document-download'|url({caseId: caseId, documentGuid: documentationFile.documentGuid, version: documentationFile.version}) }}">Download</a>
-						{% endif %}
+          {% if isNotDisabled %}
+            <a class="govuk-button govuk-button--secondary govuk-!-margin-0" href="{{ 'document-download'|url({caseId: caseId, documentGuid: documentationFile.documentGuid, version: documentationFile.version, isPreviewActive: isPreviewActive}) }}">Open</a>
+            <a class="govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2" href="{{ 'document-download'|url({caseId: caseId, documentGuid: documentationFile.documentGuid, version: documentationFile.version}) }}">Download</a>
+          {% endif %}
 
-						{% if documentationFile.publishedStatus === 'published' %}
-							<input type='hidden' value='{{documentationFile.documentGuid}}' name='selectedFilesIds[]'/>
-							<button class='govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2' type='submit'>Unpublish</button>
-						{% else %}
-              				<a class="govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2" href="{{ 'document'|url({caseId: caseId, folderId: folderId, documentGuid: documentationFile.documentGuid, step: 'delete'}) }}">Delete</a>
-            			{% endif %}
+          {% if documentationFile.publishedStatus === 'published' %}
+            <input type='hidden' value='{{documentationFile.documentGuid}}' name='selectedFilesIds[]'/>
+            <a href="./unpublish" class="govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2">Unpublish</a>
+          {% else %}
+                    <a class="govuk-button govuk-button--secondary govuk-!-margin-0 govuk-!-margin-left-2" href="{{ 'document'|url({caseId: caseId, folderId: folderId, documentGuid: documentationFile.documentGuid, step: 'delete'}) }}">Delete</a>
+                {% endif %}
 
-          			</form>
 					<div class="govuk-grid-column-one-third govuk-!-text-align-right">
 						{% if documentationFile.publishedStatus == 'ready_to_publish' %}
 							<a class="govuk-link govuk-body-m govuk-!-text-align-right" href= "{{'documents-queue'|url({caseId:caseId})}}">View publishing queue</a>


### PR DESCRIPTION
## Describe your changes

The back link doesn't work if we use the same route for linking to the unpublish queue from two different places. This change adds a second controller, but reuses the same template, so we can switch out the URL for the back link.

* fix(web/applications): add controller for unpublishing single document
* test(web/applications): update test snapshots

## Issue ticket number and link

[BOAS-1278](https://pins-ds.atlassian.net/browse/BOAS-1278)

Tested locally

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1278]: https://pins-ds.atlassian.net/browse/BOAS-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ