### PR TITLE
fix(appeals/web): add time display to site visit in appeals details

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -168,7 +168,12 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit</dt>
-                            <dd class="govuk-summary-list__value">9 October 2023</dd>
+                            <dd class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                    <li>9 October 2023</li>
+                                    <li>9:38am - 10:44am</li>
+                                </ul>
+                            </dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/schedule-visit"> Change</a>
                             </dd>
                         </div>
@@ -391,7 +396,12 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit</dt>
-                            <dd class="govuk-summary-list__value">9 October 2023</dd>
+                            <dd class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                    <li>9 October 2023</li>
+                                    <li>9:38am - 10:44am</li>
+                                </ul>
+                            </dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/3/site-visit/schedule-visit"> Change</a>
                             </dd>
                         </div>
@@ -616,7 +626,12 @@ exports[`appeal-details GET /:appealId should render the received appeal details
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit</dt>
-                            <dd class="govuk-summary-list__value">9 October 2023</dd>
+                            <dd class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                    <li>9 October 2023</li>
+                                    <li>9:38am - 10:44am</li>
+                                </ul>
+                            </dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/2/site-visit/schedule-visit"> Change</a>
                             </dd>
                         </div>

--- a/appeals/web/src/server/appeals/appeal-details/assign-user/__tests__/__snapshots__/assign-user.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/assign-user/__tests__/__snapshots__/assign-user.test.js.snap
@@ -822,7 +822,12 @@ exports[`assign-user POST /assign-user/case-officer/1/confirm should send a patc
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit</dt>
-                            <dd class="govuk-summary-list__value">9 October 2023</dd>
+                            <dd class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                    <li>9 October 2023</li>
+                                    <li>9:38am - 10:44am</li>
+                                </ul>
+                            </dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/schedule-visit"> Change</a>
                             </dd>
                         </div>
@@ -1290,7 +1295,12 @@ exports[`assign-user POST /assign-user/inspector/1/confirm should send a patch r
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit</dt>
-                            <dd class="govuk-summary-list__value">9 October 2023</dd>
+                            <dd class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                    <li>9 October 2023</li>
+                                    <li>9:38am - 10:44am</li>
+                                </ul>
+                            </dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/schedule-visit"> Change</a>
                             </dd>
                         </div>
@@ -1619,7 +1629,12 @@ exports[`assign-user POST /unassign-user/case-officer/1/confirm should send a pa
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit</dt>
-                            <dd class="govuk-summary-list__value">9 October 2023</dd>
+                            <dd class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                    <li>9 October 2023</li>
+                                    <li>9:38am - 10:44am</li>
+                                </ul>
+                            </dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/schedule-visit"> Change</a>
                             </dd>
                         </div>
@@ -1948,7 +1963,12 @@ exports[`assign-user POST /unassign-user/inspector/1/confirm should send a patch
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit</dt>
-                            <dd class="govuk-summary-list__value">9 October 2023</dd>
+                            <dd class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                    <li>9 October 2023</li>
+                                    <li>9:38am - 10:44am</li>
+                                </ul>
+                            </dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/schedule-visit"> Change</a>
                             </dd>
                         </div>

--- a/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/site-visit/__tests__/__snapshots__/site-visit.test.js.snap
@@ -2149,7 +2149,12 @@ exports[`site-visit POST /site-visit/set-visit-type should render the case detai
                             </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site visit</dt>
-                            <dd class="govuk-summary-list__value">9 October 2023</dd>
+                            <dd class="govuk-summary-list__value">
+                                <ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0">
+                                    <li>9 October 2023</li>
+                                    <li>9:38am - 10:44am</li>
+                                </ul>
+                            </dd>
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/site-visit/schedule-visit"> Change</a>
                             </dd>
                         </div>

--- a/appeals/web/src/server/lib/__tests__/libraries.test.js
+++ b/appeals/web/src/server/lib/__tests__/libraries.test.js
@@ -24,7 +24,11 @@ import {
 	mapReasonsToReasonsList,
 	getNotValidReasonsTextFromRequestBody
 } from '../mappers/validation-outcome-reasons.mapper.js';
-import { timeIsBeforeTime } from '#lib/times.js';
+import {
+	timeIsBeforeTime,
+	convert24hTo12hTimeStringFormat,
+	is24HourTimeValid
+} from '#lib/times.js';
 import { appellantCaseInvalidReasons, baseSession } from '#testing/app/fixtures/referencedata.js';
 import { stringContainsDigitsOnly } from '#lib/string-utilities.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
@@ -399,6 +403,67 @@ describe('Libraries', () => {
 				const gmtDate = displayDate(date);
 
 				expect(gmtDate).toEqual('29 October 2023');
+			});
+		});
+		describe('convert24hTo12hTimeFormat', () => {
+			it('should take a valid 24h timestring and convert it to a 12h timestring', () => {
+				const validTimes = [
+					{
+						input: '00:00',
+						expectedOutput: '12am'
+					},
+					{
+						input: '00:01',
+						expectedOutput: '12:01am'
+					},
+					{
+						input: '06:12',
+						expectedOutput: '6:12am'
+					},
+					{
+						input: '6:12',
+						expectedOutput: '6:12am'
+					},
+					{
+						input: '6:2',
+						expectedOutput: '6:02am'
+					},
+					{
+						input: '12:00',
+						expectedOutput: '12pm'
+					},
+					{
+						input: '16:30',
+						expectedOutput: '4:30pm'
+					}
+				];
+				for (const set of validTimes) {
+					expect(convert24hTo12hTimeStringFormat(set.input)).toBe(set.expectedOutput);
+				}
+			});
+			it('should return an undefined value if the input is undefined or null', () => {
+				expect(convert24hTo12hTimeStringFormat(undefined)).toBe(undefined);
+				expect(convert24hTo12hTimeStringFormat(null)).toBe(undefined);
+			});
+			it('should return undefined for invalid 24h time', () => {
+				expect(convert24hTo12hTimeStringFormat('25:00')).toBe(undefined);
+				expect(convert24hTo12hTimeStringFormat('21:00:00')).toBe(undefined);
+				expect(convert24hTo12hTimeStringFormat('12:60')).toBe(undefined);
+				expect(convert24hTo12hTimeStringFormat('1200')).toBe(undefined);
+			});
+		});
+		describe('is24HoursTimeValid', () => {
+			it('should return true for valid times', () => {
+				const validTimes = ['00:00', '06:12', '6:12', '12:00', '16:30'];
+				for (const set of validTimes) {
+					expect(is24HourTimeValid(set)).toBe(true);
+				}
+			});
+			it('should return false for invalid times', () => {
+				const validTimes = ['0000', '26:12', '24:00', '13:60', '16:30:00'];
+				for (const set of validTimes) {
+					expect(is24HourTimeValid(set)).toBe(false);
+				}
 			});
 		});
 	});

--- a/appeals/web/src/server/lib/mappers/appeal.mapper.js
+++ b/appeals/web/src/server/lib/mappers/appeal.mapper.js
@@ -5,7 +5,12 @@ import * as displayPageFormatter from '#lib/display-page-formatter.js';
 import usersService from '../../appeals/appeal-users/users-service.js';
 import config from '#environment/config.js';
 import { surnameFirstToFullName } from '#lib/person-name-formatter.js';
-import { conditionalFormatter, mapAddressInput } from './global-mapper-formatter.js';
+import {
+	conditionalFormatter,
+	dateAndTimeFormatter,
+	mapAddressInput
+} from './global-mapper-formatter.js';
+import { convert24hTo12hTimeStringFormat } from '#lib/times.js';
 
 // TODO: Limit the input types to constants
 /**
@@ -994,7 +999,12 @@ export async function initialiseAndMapAppealData(data, currentRoute, session) {
 					text: 'Site visit'
 				},
 				value: {
-					html: dateToDisplayDate(data.appeal.siteVisit?.visitDate) || 'Visit date not yet set'
+					html:
+						dateAndTimeFormatter(
+							dateToDisplayDate(data.appeal.siteVisit?.visitDate),
+							convert24hTo12hTimeStringFormat(data.appeal.siteVisit?.visitStartTime),
+							convert24hTo12hTimeStringFormat(data.appeal.siteVisit?.visitEndTime)
+						) || 'Visit date not yet set'
 				},
 				actions: {
 					items: [

--- a/appeals/web/src/server/lib/mappers/global-mapper-formatter.js
+++ b/appeals/web/src/server/lib/mappers/global-mapper-formatter.js
@@ -96,3 +96,14 @@ export function conditionalFormatter(id, name, hint, details, type = 'textarea')
 	  </div>`
 	};
 }
+
+/**
+ * @param {string} date
+ * @param {string} [startTime]
+ * @param {string} [endTime]
+ */
+export function dateAndTimeFormatter(date, startTime, endTime) {
+	const to = endTime ? ` - ${endTime}` : '';
+	const fromToListItem = startTime ? `<li>${startTime}${to}</li>` : '';
+	return `<ul class="govuk-list govuk-!-margin-top-0 govuk-!-padding-left-0"><li>${date}</li>${fromToListItem}</ul>`;
+}

--- a/appeals/web/src/server/lib/times.js
+++ b/appeals/web/src/server/lib/times.js
@@ -1,3 +1,5 @@
+import logger from './logger.js';
+
 /**
  *
  * @param {number} timeHour
@@ -8,4 +10,46 @@
  */
 export function timeIsBeforeTime(timeHour, timeMinute, beforeTimeHour, beforeTimeMinute) {
 	return timeHour * 60 + timeMinute < beforeTimeHour * 60 + beforeTimeMinute;
+}
+
+/**
+ * @param {string | null | undefined} time24
+ * @returns {string | undefined}
+ */
+export function convert24hTo12hTimeStringFormat(time24) {
+	if (time24 && is24HourTimeValid(time24)) {
+		const [hours, minutes] = time24.split(':');
+		const hoursInt = parseInt(hours, 10);
+		const period = hoursInt >= 12 ? 'pm' : 'am';
+		const hours12 = hoursInt % 12 || 12;
+		const minutesInt = parseInt(minutes, 10);
+		const formattedMinutes = minutesInt < 10 ? `0${minutesInt}` : `${minutesInt}`;
+		const minutesIsZero = minutes === '00';
+		return minutesIsZero ? `${hours12}${period}` : `${hours12}:${formattedMinutes}${period}`;
+	}
+	logger.warn(
+		`Issue converting ${time24} from 24h to 12h: Time is either null, undefined, or invalid`
+	);
+	return undefined;
+}
+
+/**
+ * @param {string} timeString
+ */
+export function is24HourTimeValid(timeString) {
+	//Check the format hh:mm
+	const timeRegex = /^(0?[0-9]|1[0-9]|2[0-3]?):(0?[0-9]|[1-5][0-9])$/;
+	if (!timeRegex.test(timeString)) {
+		return false;
+	}
+
+	// Validate the ranges
+	const [hours, minutes] = timeString.split(':');
+	const hoursInt = parseInt(hours, 10);
+	const minutesInt = parseInt(minutes, 10);
+	if (hoursInt < 0 || hoursInt > 23 || minutesInt < 0 || minutesInt > 59) {
+		return false;
+	}
+
+	return true;
 }


### PR DESCRIPTION
## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->
Add the start and end times of site visits as described in the prototype.

## Issue ticket number and link
[BOAT-540](https://pins-ds.atlassian.net/browse/BOAT-540)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAT-540]: https://pins-ds.atlassian.net/browse/BOAT-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ