### PR TITLE
fix(api/applications): fix error publishing timetable (boas-1322)

### DIFF
--- a/apps/api/src/database/schema.d.ts
+++ b/apps/api/src/database/schema.d.ts
@@ -118,11 +118,6 @@ export interface DocumentMetadata extends schema.DocumentMetadata {}
 
 export interface ExaminationTimetableType extends schema.ExaminationTimetableType {}
 
-export interface ExaminationTimetableWithItems extends schema.ExaminationTimetable {
-	ExaminationTimetableItem: ExaminationTimetableItem[];
-	case: Case;
-}
-
 export interface S51Advice extends schema.S51Advice {}
 
 export interface S51AdviceDocument extends schema.S51AdviceDocument {}

--- a/apps/api/src/message-schemas/events/nsip-exam-timetable.d.ts
+++ b/apps/api/src/message-schemas/events/nsip-exam-timetable.d.ts
@@ -26,5 +26,5 @@ export interface NSIPExamTimetableItem {
 
 export interface NSIPExamTimetable {
 	caseReference: string;
-	events: NSIPExamTimetableItem;
+	events: NSIPExamTimetableItem[];
 }

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.routes.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.routes.js
@@ -1,5 +1,5 @@
 import { Router as createRouter } from 'express';
-import { asyncHandler } from '../../middleware/async-handler.js';
+import { asyncHandler } from '#middleware/async-handler.js';
 import {
 	createExaminationTimetableItem,
 	getExaminationTimetableItem,
@@ -91,9 +91,9 @@ router.patch(
 			required: true,
 			type: 'integer'
         }
-        #swagger.parameters['body'] = {}
         #swagger.responses[200] = {
             description: 'Examination timetable items published',
+			schema: { success: true } }
         }
     */
 	validateApplicationId,
@@ -112,9 +112,9 @@ router.patch(
 			required: true,
 			type: 'integer'
         }
-        #swagger.parameters['body'] = {}
         #swagger.responses[200] = {
             description: 'Examination timetable items unpublished',
+			schema: { success: true } }
         }
     */
 	validateApplicationId,

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.service.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.service.js
@@ -1,16 +1,17 @@
 import { eventClient } from '#infrastructure/event-client.js';
 import { NSIP_EXAM_TIMETABLE } from '#infrastructure/topics.js';
-import * as examinationTimetableRepository from '../../repositories/examination-timetable.repository.js';
-import * as examinationTimetableTypesRepository from '../../repositories/examination-timetable-types.repository.js';
-import * as documentRepository from '../../repositories/document.repository.js';
-import * as folderRepository from '../../repositories/folder.repository.js';
-import logger from '../../utils/logger.js';
+import * as examinationTimetableRepository from '#repositories/examination-timetable.repository.js';
+import * as examinationTimetableTypesRepository from '#repositories/examination-timetable-types.repository.js';
+import * as documentRepository from '#repositories/document.repository.js';
+import * as folderRepository from '#repositories/folder.repository.js';
+import logger from '#utils/logger.js';
 import { EventType } from '@pins/event-client';
 
 /**
  * @typedef {import('../../../message-schemas/events/nsip-exam-timetable.js').NSIPExamTimetableItem} NSIPExamTimetableItem
  * @typedef {import('../../../message-schemas/events/nsip-exam-timetable.js').NSIPExamTimetable} NSIPExamTimetable
  * @typedef {import('@pins/applications.api').Schema.Folder} Folder
+ * @typedef {import('@prisma/client').Prisma.ExaminationTimetableItemGetPayload<{include: {ExaminationTimetableType: true} }>} ExaminationTimetableItemWithType
  */
 
 /**
@@ -67,7 +68,7 @@ async function buildExamTimetableItemsPayload(examinationTimetableId) {
 /**
  * Returns a single examination timetable item to add to the full payload.
  *
- * @param {import('@prisma/client').ExaminationTimetableItem} examinationTimetableItem
+ * @param {ExaminationTimetableItemWithType} examinationTimetableItem
  * @returns {NSIPExamTimetableItem}
  */
 function buildSingleExaminationTimetableItemPayload(examinationTimetableItem) {

--- a/apps/api/src/server/repositories/examination-timetable.repository.js
+++ b/apps/api/src/server/repositories/examination-timetable.repository.js
@@ -8,7 +8,7 @@ import { databaseConnector } from '#utils/database-connector.js';
  * Returns a whole Examination Timetable inc case, with associated Examination Timetable Item records inc Exam Type records
  *
  * @param {number} id
- * @returns {import('@prisma/client').PrismaPromise<ExaminationTimetableWithCaseAndItemsAndType>}
+ * @returns {import('@prisma/client').PrismaPromise<ExaminationTimetableWithCaseAndItemsAndType |null>}
  * */
 export const getWithItems = (id) => {
 	return databaseConnector.examinationTimetable.findUnique({

--- a/apps/api/src/server/repositories/examination-timetable.repository.js
+++ b/apps/api/src/server/repositories/examination-timetable.repository.js
@@ -1,14 +1,24 @@
-import { databaseConnector } from '../utils/database-connector.js';
+import { databaseConnector } from '#utils/database-connector.js';
 
 /**
+ * @typedef {import('@prisma/client').Prisma.ExaminationTimetableGetPayload<{include: {ExaminationTimetableItem: {include: {ExaminationTimetableType: true}}, case: true } }>} ExaminationTimetableWithCaseAndItemsAndType
+ */
+
+/**
+ * Returns a whole Examination Timetable inc case, with associated Examination Timetable Item records inc Exam Type records
+ *
  * @param {number} id
- * @returns {import('apps/api/src/database/schema.js').ExaminationTimetableWithItems}
+ * @returns {import('@prisma/client').PrismaPromise<ExaminationTimetableWithCaseAndItemsAndType>}
  * */
 export const getWithItems = (id) => {
 	return databaseConnector.examinationTimetable.findUnique({
 		where: { id },
 		include: {
-			ExaminationTimetableItem: true,
+			ExaminationTimetableItem: {
+				include: {
+					ExaminationTimetableType: true
+				}
+			},
 			case: true
 		}
 	});

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -3019,16 +3019,23 @@
 						"required": true,
 						"type": "integer",
 						"description": "Application ID"
-					},
-					{
-						"name": "body",
-						"in": "query",
-						"type": "string"
 					}
 				],
 				"responses": {
 					"200": {
-						"description": "Examination timetable items published"
+						"description": "Examination timetable items published",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"success": {
+									"type": "boolean",
+									"example": true
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
 					}
 				}
 			}
@@ -3044,16 +3051,23 @@
 						"required": true,
 						"type": "integer",
 						"description": "Application ID"
-					},
-					{
-						"name": "body",
-						"in": "query",
-						"type": "string"
 					}
 				],
 				"responses": {
 					"200": {
-						"description": "Examination timetable items unpublished"
+						"description": "Examination timetable items unpublished",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"success": {
+									"type": "boolean",
+									"example": true
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Describe your changes

- Fix for Error publishing exam timetable on a case.  The original code used to include the Exam Type record with the Exam Items, as the type.name is needed in the map fn for publishing, but this is missing in the latest fn.  Amended to include this.
- also fixed some type errors / mismatches, and swagger api definitions

## BOAS-1322 Error Publishing Exam Timetable
https://pins-ds.atlassian.net/browse/BOAS-1322

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
