### PR TITLE
Fix/boas 1293 auto unpublishing document versions

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -555,8 +555,8 @@ export const getReadyToPublishDocuments = async ({ params: { id }, body }, respo
 };
 
 /**
- * Publishes an array of documents
- * on any errors, none are published
+ * Publishes an array of documents. If there are any errors, none are published.
+ * It publishes the latest version of each document, and auto unpublishes any older published version
  *
  * @type {import('express').RequestHandler}
  */

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -619,9 +619,9 @@ export const markAsPublished = async (
  * @type {import('express').RequestHandler}
  */
 export const markAsUnpublished = async ({ params }, response) => {
-	const { guid } = params;
+	const { guid, version } = params;
 
-	const updateResponse = await markDocumentVersionAsUnpublished({ guid });
+	const updateResponse = await markDocumentVersionAsUnpublished({ guid, version: Number(version) });
 
 	response.send(updateResponse);
 };

--- a/apps/api/src/server/applications/application/documents/document.routes.js
+++ b/apps/api/src/server/applications/application/documents/document.routes.js
@@ -211,8 +211,8 @@ router.post(
 	'/:id/documents/:guid/version/:version/mark-as-published',
 	/*
         #swagger.tags = ['Applications']
-        #swagger.path = '/applications/{id}/documents/{guid}/mark-as-published'
-        #swagger.description = 'Marks as published'
+        #swagger.path = '/applications/{id}/documents/{guid}/version/{version}/mark-as-published'
+        #swagger.description = 'Completes publishing to mark as document as Published'
         #swagger.parameters['id'] = {
             in: 'path',
 			description: 'Application ID',
@@ -231,17 +231,21 @@ router.post(
 			required: true,
 			type: 'integer'
         }
-        #swagger.parameters['body'] = {
+		#swagger.parameters['body'] = {
             in: 'body',
             description: 'Mark as Published Request',
-            schema: { $ref: '#/definitions/markAsPublishedRequestBody' },
+            schema: { $ref: '#/definitions/DocumentMarkAsPublishedRequestBody' },
 			required: true
         }
         #swagger.responses[200] = {
             description: 'Updated document response',
-            schema: { guid: '0084b156-006b-48b1-a47f-e7176414db29' }
+            schema: { $ref: '#definitions/DocumentPropertiesWithVersionWithCase' }
         }
 		#swagger.responses[400] = {
+            description: 'Example of a missing body error response',
+            schema: { $ref: '#/definitions/DocumentMarkAsPublishedBadRequest' }
+        }
+		#swagger.responses[404] = {
             description: 'Example of an error response',
             schema: { errors: { id: "Must be an existing application" } }
         }
@@ -255,8 +259,8 @@ router.post(
 	'/:id/documents/:guid/version/:version/mark-as-unpublished',
 	/*
         #swagger.tags = ['Applications']
-        #swagger.path = '/applications/{id}/documents/{guid}/mark-as-unpublished'
-        #swagger.description = 'Marks as unpublished'
+        #swagger.path = '/applications/{id}/documents/{guid}/version/{version}/mark-as-unpublished'
+        #swagger.description = 'Completes unpublishing to mark as document as Unpublished'
         #swagger.parameters['id'] = {
             in: 'path',
 			description: 'Application ID',
@@ -275,17 +279,11 @@ router.post(
 			required: true,
 			type: 'integer'
         }
-        #swagger.parameters['body'] = {
-            in: 'body',
-            description: 'Mark as unpublished Request',
-            schema: { $ref: '#/definitions/markAsPublishedRequestBody' },
-			required: true
-        }
         #swagger.responses[200] = {
             description: 'Updated document response',
-            schema: { guid: '0084b156-006b-48b1-a47f-e7176414db29' }
+            schema: { $ref: '#definitions/DocumentPropertiesWithVersionWithCase' }
         }
-		#swagger.responses[400] = {
+		#swagger.responses[404] = {
             description: 'Example of an error response',
             schema: { errors: { id: "Must be an existing application" } }
         }

--- a/apps/api/src/server/applications/constants.js
+++ b/apps/api/src/server/applications/constants.js
@@ -1,2 +1,4 @@
 export const DEFAULT_PAGE_NUMBER = 1;
 export const DEFAULT_PAGE_SIZE = 25;
+
+export const SYSTEM_USER_NAME = 'System';

--- a/apps/api/src/server/repositories/document-metadata.repository.js
+++ b/apps/api/src/server/repositories/document-metadata.repository.js
@@ -229,8 +229,6 @@ export const update = (documentGuid, { version = 1, ...documentDetails }) => {
  * @returns {Promise<DocumentVersionWithDocument[]>}
  */
 export const updateAll = async (documentVersionIds, documentDetails) => {
-	console.log('upd unpub versionids:', documentVersionIds);
-	console.log('upd unpub details:', documentDetails);
 	const results = [];
 
 	for (const { documentGuid, version } of documentVersionIds) {

--- a/apps/api/src/server/repositories/document-metadata.repository.js
+++ b/apps/api/src/server/repositories/document-metadata.repository.js
@@ -171,7 +171,7 @@ export const getAll = () => {
 };
 
 /**
- * Get all published version of a document
+ * Get 'all' published versions of a document (there should only be one)
  *
  * @param {string} documentGuid
  * @returns {import('@prisma/client').PrismaPromise<import('@pins/applications.api').Schema.DocumentVersion[] |null>}
@@ -229,6 +229,8 @@ export const update = (documentGuid, { version = 1, ...documentDetails }) => {
  * @returns {Promise<DocumentVersionWithDocument[]>}
  */
 export const updateAll = async (documentVersionIds, documentDetails) => {
+	console.log('upd unpub versionids:', documentVersionIds);
+	console.log('upd unpub details:', documentDetails);
 	const results = [];
 
 	for (const { documentGuid, version } of documentVersionIds) {

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -1559,10 +1559,10 @@
 				}
 			}
 		},
-		"/applications/{id}/documents/{guid}/mark-as-published": {
+		"/applications/{id}/documents/{guid}/version/{version}/mark-as-published": {
 			"post": {
 				"tags": ["Applications"],
-				"description": "Marks as published",
+				"description": "Completes publishing to mark as document as Published",
 				"parameters": [
 					{
 						"name": "id",
@@ -1581,16 +1581,16 @@
 					{
 						"name": "version",
 						"in": "path",
-						"description": "Version",
 						"required": true,
-						"type": "integer"
+						"type": "integer",
+						"description": "Version"
 					},
 					{
 						"name": "body",
 						"in": "body",
 						"description": "Mark as Published Request",
 						"schema": {
-							"$ref": "#/definitions/markAsPublishedRequestBody"
+							"$ref": "#/definitions/DocumentMarkAsPublishedRequestBody"
 						},
 						"required": true
 					}
@@ -1599,19 +1599,16 @@
 					"200": {
 						"description": "Updated document response",
 						"schema": {
-							"type": "object",
-							"properties": {
-								"guid": {
-									"type": "string",
-									"example": "0084b156-006b-48b1-a47f-e7176414db29"
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
+							"$ref": "#/definitions/DocumentPropertiesWithVersionWithCase"
 						}
 					},
 					"400": {
+						"description": "Example of a missing body error response",
+						"schema": {
+							"$ref": "#/definitions/DocumentMarkAsPublishedBadRequest"
+						}
+					},
+					"404": {
 						"description": "Example of an error response",
 						"schema": {
 							"type": "object",
@@ -1634,10 +1631,10 @@
 				}
 			}
 		},
-		"/applications/{id}/documents/{guid}/mark-as-unpublished": {
+		"/applications/{id}/documents/{guid}/version/{version}/mark-as-unpublished": {
 			"post": {
 				"tags": ["Applications"],
-				"description": "Marks as unpublished",
+				"description": "Completes unpublishing to mark as document as Unpublished",
 				"parameters": [
 					{
 						"name": "id",
@@ -1656,37 +1653,19 @@
 					{
 						"name": "version",
 						"in": "path",
-						"description": "Version",
 						"required": true,
-						"type": "integer"
-					},
-					{
-						"name": "body",
-						"in": "body",
-						"description": "Mark as unpublished Request",
-						"schema": {
-							"$ref": "#/definitions/markAsPublishedRequestBody"
-						},
-						"required": true
+						"type": "integer",
+						"description": "Version"
 					}
 				],
 				"responses": {
 					"200": {
 						"description": "Updated document response",
 						"schema": {
-							"type": "object",
-							"properties": {
-								"guid": {
-									"type": "string",
-									"example": "0084b156-006b-48b1-a47f-e7176414db29"
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
+							"$ref": "#/definitions/DocumentPropertiesWithVersionWithCase"
 						}
 					},
-					"400": {
+					"404": {
 						"description": "Example of an error response",
 						"schema": {
 							"type": "object",
@@ -5008,7 +4987,7 @@
 						"type": {
 							"type": "string",
 							"enum": ["general", "applicationSubmitted", "applicationDecided", "registrationOpen"],
-							"description": "the type of update - which determines which subscribers will recieve the notification emails"
+							"description": "the type of update - which determines which subscribers will receive the notification emails"
 						}
 					}
 				}
@@ -5517,6 +5496,265 @@
 				}
 			}
 		},
+		"DocumentPropertiesWithVersionWithCase": {
+			"type": "object",
+			"properties": {
+				"documentGuid": {
+					"type": "string",
+					"description": "Document guid",
+					"example": "ab12cd34-5678-90ef-ghij-klmnopqrstuv"
+				},
+				"version": {
+					"type": "integer",
+					"description": "Document version",
+					"example": 1
+				},
+				"lastModified": {
+					"type": "integer",
+					"description": "Last modified Unix timestamp",
+					"example": 1696418643
+				},
+				"documentType": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"published": {
+					"type": "boolean",
+					"description": "",
+					"example": false
+				},
+				"sourceSystem": {
+					"type": "string",
+					"description": "Source system of the document",
+					"example": "back-office"
+				},
+				"origin": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"originalFilename": {
+					"type": "string",
+					"description": "The original filename",
+					"example": "Small1.pdf"
+				},
+				"fileName": {
+					"type": "string",
+					"description": "File Title",
+					"example": "Small Doc 1"
+				},
+				"representative": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"description": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"owner": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"author": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"securityClassification": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"mime": {
+					"type": "string",
+					"description": "Document mime type",
+					"example": "application/pdf"
+				},
+				"horizonDataID": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"fileMD5": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"virusCheckStatus": {
+					"type": "string",
+					"description": "",
+					"example": null
+				},
+				"size": {
+					"type": "integer",
+					"description": "File size in bytes",
+					"example": 1024
+				},
+				"stage": {
+					"type": "integer",
+					"description": "",
+					"example": 3
+				},
+				"filter1": {
+					"type": "string",
+					"description": "",
+					"example": "some filter"
+				},
+				"privateBlobContainer": {
+					"type": "string",
+					"description": "Back Office blob storage container",
+					"example": "document-service-uploads"
+				},
+				"privateBlobPath": {
+					"type": "string",
+					"description": "Back Office blob storage path",
+					"example": "https://intranet.planninginspectorate.gov.uk/wp-content/uploads/2023/10/Lightbulb-L-and-D.gif"
+				},
+				"publishedBlobContainer": {
+					"type": "string",
+					"description": "Published blob storage container",
+					"example": "published-documents"
+				},
+				"publishedBlobPath": {
+					"type": "string",
+					"description": "Published blob storage path",
+					"example": "published/bc0110001-filename.pdf"
+				},
+				"dateCreated": {
+					"type": "string",
+					"description": "Date document was created",
+					"example": "2022-12-21T12:42:40.885Z"
+				},
+				"datePublished": {
+					"type": "string",
+					"description": "Date document was published",
+					"example": "2022-12-21T12:42:40.885Z"
+				},
+				"isDeleted": {
+					"type": "boolean",
+					"description": "Is the document marked as deleted",
+					"example": false
+				},
+				"examinationRefNo": {
+					"type": "string",
+					"description": "Examination Timetable reference number",
+					"example": null
+				},
+				"filter2": {
+					"type": "string",
+					"description": "",
+					"example": "some filter"
+				},
+				"publishedStatus": {
+					"type": "string",
+					"enum": ["not_checked", "checked", "ready_to_publish", "published", "not_published"],
+					"description": "Published status",
+					"example": "ready_to_publish"
+				},
+				"publishedStatusPrev": {
+					"type": "string",
+					"enum": ["not_checked", "checked", "ready_to_publish", "published", "not_published"],
+					"description": "The previous status",
+					"example": "not_checked"
+				},
+				"Document": {
+					"type": "object",
+					"properties": {
+						"guid": {
+							"type": "string",
+							"description": "Document guid",
+							"example": "ab12cd34-5678-90ef-ghij-klmnopqrstuv"
+						},
+						"documentRef": {
+							"type": "string",
+							"description": "Document Reference",
+							"example": "BC011001-000001"
+						},
+						"folderId": {
+							"type": "integer",
+							"description": "Folder Id",
+							"example": 2
+						},
+						"createdAt": {
+							"type": "string",
+							"description": "Date document was created",
+							"example": "2022-12-21T12:42:40.885Z"
+						},
+						"isDeleted": {
+							"type": "boolean",
+							"description": "Is the document marked as deleted",
+							"example": false
+						},
+						"latestVersionId": {
+							"type": "integer",
+							"description": "Document latest version id",
+							"example": 2
+						},
+						"caseId": {
+							"type": "integer",
+							"description": "Application case id",
+							"example": 1
+						},
+						"fromFrontOffice": {
+							"type": "boolean",
+							"description": "Document from front office",
+							"example": false
+						}
+					}
+				},
+				"case": {
+					"type": "object",
+					"properties": {
+						"id": {
+							"type": "number",
+							"description": "Application id",
+							"example": 1
+						},
+						"reference": {
+							"type": "string",
+							"description": "Application unique reference",
+							"example": "BC0110001"
+						},
+						"modifiedAt": {
+							"type": "string",
+							"format": "date-time",
+							"description": "The date this case was last modified",
+							"example": "2022-12-21T12:42:40.885Z"
+						},
+						"createdAt": {
+							"type": "string",
+							"format": "date-time",
+							"description": "The date this case was created",
+							"example": "2022-12-21T12:42:40.885Z"
+						},
+						"description": {
+							"type": "string",
+							"description": "Application description",
+							"example": "A description of the application"
+						},
+						"title": {
+							"type": "string",
+							"description": "Application title",
+							"example": "NSIP Application Title"
+						},
+						"hasUnpublishedChanges": {
+							"type": "boolean",
+							"description": "Does case have unpublished changes",
+							"example": true
+						},
+						"applicantId": {
+							"type": "number",
+							"description": "Applicant Id",
+							"example": "1000000"
+						}
+					}
+				}
+			}
+		},
 		"DocumentPropertiesWithAuditHistory": {
 			"type": "object",
 			"properties": {
@@ -5638,12 +5876,12 @@
 				"publishedBlobContainer": {
 					"type": "string",
 					"description": "Published blob storage container",
-					"example": null
+					"example": "published-documents"
 				},
 				"publishedBlobPath": {
 					"type": "string",
 					"description": "Published blob storage path",
-					"example": null
+					"example": "published/bc0110001-filename.pdf"
 				},
 				"dateCreated": {
 					"type": "integer",
@@ -6058,6 +6296,48 @@
 					"type": "array",
 					"items": {
 						"type": "string"
+					}
+				}
+			}
+		},
+		"DocumentMarkAsPublishedRequestBody": {
+			"type": "object",
+			"properties": {
+				"publishedBlobPath": {
+					"type": "string",
+					"description": "The published blob path",
+					"example": "published/en010120-filename.pdf"
+				},
+				"publishedBlobContainer": {
+					"type": "string",
+					"description": "The published blob container",
+					"example": "published-documents"
+				},
+				"publishedDate": {
+					"type": "string",
+					"description": "The published date",
+					"example": "2023-11-14T00:00:00Z"
+				}
+			}
+		},
+		"DocumentMarkAsPublishedBadRequest": {
+			"type": "object",
+			"properties": {
+				"errors": {
+					"type": "object",
+					"properties": {
+						"publishedBlobPath": {
+							"type": "string",
+							"example": "Must provide a published blob path"
+						},
+						"publishedBlobContainer": {
+							"type": "string",
+							"example": "Must provide a published blob container"
+						},
+						"publishedDate": {
+							"type": "string",
+							"example": "Must provide a published date"
+						}
 					}
 				}
 			}

--- a/apps/api/src/server/swagger-types.ts
+++ b/apps/api/src/server/swagger-types.ts
@@ -554,7 +554,7 @@ export type ApplicationProjectUpdate = ApplicationProjectUpdateCreateRequest & {
 	 * @example "2022-12-21T12:42:40.885Z"
 	 */
 	datePublished?: string;
-	/** the type of update - which determines which subscribers will recieve the notification emails */
+	/** the type of update - which determines which subscribers will receive the notification emails */
 	type?: 'general' | 'applicationSubmitted' | 'applicationDecided' | 'registrationOpen';
 };
 
@@ -904,6 +904,218 @@ export interface DocumentProperties {
 	fromFrontOffice?: boolean;
 }
 
+export interface DocumentPropertiesWithVersionWithCase {
+	/**
+	 * Document guid
+	 * @example "ab12cd34-5678-90ef-ghij-klmnopqrstuv"
+	 */
+	documentGuid?: string;
+	/**
+	 * Document version
+	 * @example 1
+	 */
+	version?: number;
+	/**
+	 * Last modified Unix timestamp
+	 * @example 1696418643
+	 */
+	lastModified?: number;
+	/** @example null */
+	documentType?: string;
+	/** @example false */
+	published?: boolean;
+	/**
+	 * Source system of the document
+	 * @example "back-office"
+	 */
+	sourceSystem?: string;
+	/** @example null */
+	origin?: string;
+	/**
+	 * The original filename
+	 * @example "Small1.pdf"
+	 */
+	originalFilename?: string;
+	/**
+	 * File Title
+	 * @example "Small Doc 1"
+	 */
+	fileName?: string;
+	/** @example null */
+	representative?: string;
+	/** @example null */
+	description?: string;
+	/** @example null */
+	owner?: string;
+	/** @example null */
+	author?: string;
+	/** @example null */
+	securityClassification?: string;
+	/**
+	 * Document mime type
+	 * @example "application/pdf"
+	 */
+	mime?: string;
+	/** @example null */
+	horizonDataID?: string;
+	/** @example null */
+	fileMD5?: string;
+	/** @example null */
+	virusCheckStatus?: string;
+	/**
+	 * File size in bytes
+	 * @example 1024
+	 */
+	size?: number;
+	/** @example 3 */
+	stage?: number;
+	/** @example "some filter" */
+	filter1?: string;
+	/**
+	 * Back Office blob storage container
+	 * @example "document-service-uploads"
+	 */
+	privateBlobContainer?: string;
+	/**
+	 * Back Office blob storage path
+	 * @example "https://intranet.planninginspectorate.gov.uk/wp-content/uploads/2023/10/Lightbulb-L-and-D.gif"
+	 */
+	privateBlobPath?: string;
+	/**
+	 * Published blob storage container
+	 * @example "published-documents"
+	 */
+	publishedBlobContainer?: string;
+	/**
+	 * Published blob storage path
+	 * @example "published/bc0110001-filename.pdf"
+	 */
+	publishedBlobPath?: string;
+	/**
+	 * Date document was created
+	 * @example "2022-12-21T12:42:40.885Z"
+	 */
+	dateCreated?: string;
+	/**
+	 * Date document was published
+	 * @example "2022-12-21T12:42:40.885Z"
+	 */
+	datePublished?: string;
+	/**
+	 * Is the document marked as deleted
+	 * @example false
+	 */
+	isDeleted?: boolean;
+	/**
+	 * Examination Timetable reference number
+	 * @example null
+	 */
+	examinationRefNo?: string;
+	/** @example "some filter" */
+	filter2?: string;
+	/**
+	 * Published status
+	 * @example "ready_to_publish"
+	 */
+	publishedStatus?: 'not_checked' | 'checked' | 'ready_to_publish' | 'published' | 'not_published';
+	/**
+	 * The previous status
+	 * @example "not_checked"
+	 */
+	publishedStatusPrev?:
+		| 'not_checked'
+		| 'checked'
+		| 'ready_to_publish'
+		| 'published'
+		| 'not_published';
+	Document?: {
+		/**
+		 * Document guid
+		 * @example "ab12cd34-5678-90ef-ghij-klmnopqrstuv"
+		 */
+		guid?: string;
+		/**
+		 * Document Reference
+		 * @example "BC011001-000001"
+		 */
+		documentRef?: string;
+		/**
+		 * Folder Id
+		 * @example 2
+		 */
+		folderId?: number;
+		/**
+		 * Date document was created
+		 * @example "2022-12-21T12:42:40.885Z"
+		 */
+		createdAt?: string;
+		/**
+		 * Is the document marked as deleted
+		 * @example false
+		 */
+		isDeleted?: boolean;
+		/**
+		 * Document latest version id
+		 * @example 2
+		 */
+		latestVersionId?: number;
+		/**
+		 * Application case id
+		 * @example 1
+		 */
+		caseId?: number;
+		/**
+		 * Document from front office
+		 * @example false
+		 */
+		fromFrontOffice?: boolean;
+	};
+	case?: {
+		/**
+		 * Application id
+		 * @example 1
+		 */
+		id?: number;
+		/**
+		 * Application unique reference
+		 * @example "BC0110001"
+		 */
+		reference?: string;
+		/**
+		 * The date this case was last modified
+		 * @format date-time
+		 * @example "2022-12-21T12:42:40.885Z"
+		 */
+		modifiedAt?: string;
+		/**
+		 * The date this case was created
+		 * @format date-time
+		 * @example "2022-12-21T12:42:40.885Z"
+		 */
+		createdAt?: string;
+		/**
+		 * Application description
+		 * @example "A description of the application"
+		 */
+		description?: string;
+		/**
+		 * Application title
+		 * @example "NSIP Application Title"
+		 */
+		title?: string;
+		/**
+		 * Does case have unpublished changes
+		 * @example true
+		 */
+		hasUnpublishedChanges?: boolean;
+		/**
+		 * Applicant Id
+		 * @example "1000000"
+		 */
+		applicantId?: number;
+	};
+}
+
 export interface DocumentPropertiesWithAuditHistory {
 	/**
 	 * Username
@@ -983,12 +1195,12 @@ export interface DocumentPropertiesWithAuditHistory {
 	privateBlobPath?: string;
 	/**
 	 * Published blob storage container
-	 * @example null
+	 * @example "published-documents"
 	 */
 	publishedBlobContainer?: string;
 	/**
 	 * Published blob storage path
-	 * @example null
+	 * @example "published/bc0110001-filename.pdf"
 	 */
 	publishedBlobPath?: string;
 	/**
@@ -1273,6 +1485,35 @@ export interface DocumentsUnpublishResponseBody {
 		msg?: msg;
 	}[];
 	successful?: string[];
+}
+
+export interface DocumentMarkAsPublishedRequestBody {
+	/**
+	 * The published blob path
+	 * @example "published/en010120-filename.pdf"
+	 */
+	publishedBlobPath?: string;
+	/**
+	 * The published blob container
+	 * @example "published-documents"
+	 */
+	publishedBlobContainer?: string;
+	/**
+	 * The published date
+	 * @example "2023-11-14T00:00:00Z"
+	 */
+	publishedDate?: string;
+}
+
+export interface DocumentMarkAsPublishedBadRequest {
+	errors?: {
+		/** @example "Must provide a published blob path" */
+		publishedBlobPath?: string;
+		/** @example "Must provide a published blob container" */
+		publishedBlobContainer?: string;
+		/** @example "Must provide a published date" */
+		publishedDate?: string;
+	};
 }
 
 export interface PaginationRequestBody {

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -455,7 +455,7 @@ export const spec = {
 							type: 'string',
 							enum: ['general', 'applicationSubmitted', 'applicationDecided', 'registrationOpen'],
 							description:
-								'the type of update - which determines which subscribers will recieve the notification emails'
+								'the type of update - which determines which subscribers will receive the notification emails'
 						}
 					}
 				}
@@ -819,6 +819,178 @@ export const spec = {
 				}
 			}
 		},
+		DocumentPropertiesWithVersionWithCase: {
+			type: 'object',
+			properties: {
+				documentGuid: {
+					type: 'string',
+					description: 'Document guid',
+					example: 'ab12cd34-5678-90ef-ghij-klmnopqrstuv'
+				},
+				version: { type: 'integer', description: 'Document version', example: 1 },
+				lastModified: {
+					type: 'integer',
+					description: 'Last modified Unix timestamp',
+					example: 1696418643
+				},
+				documentType: { type: 'string', description: '', example: null },
+				published: { type: 'boolean', description: '', example: false },
+				sourceSystem: {
+					type: 'string',
+					description: 'Source system of the document',
+					example: 'back-office'
+				},
+				origin: { type: 'string', description: '', example: null },
+				originalFilename: {
+					type: 'string',
+					description: 'The original filename',
+					example: 'Small1.pdf'
+				},
+				fileName: { type: 'string', description: 'File Title', example: 'Small Doc 1' },
+				representative: { type: 'string', description: '', example: null },
+				description: { type: 'string', description: '', example: null },
+				owner: { type: 'string', description: '', example: null },
+				author: { type: 'string', description: '', example: null },
+				securityClassification: { type: 'string', description: '', example: null },
+				mime: { type: 'string', description: 'Document mime type', example: 'application/pdf' },
+				horizonDataID: { type: 'string', description: '', example: null },
+				fileMD5: { type: 'string', description: '', example: null },
+				virusCheckStatus: { type: 'string', description: '', example: null },
+				size: { type: 'integer', description: 'File size in bytes', example: 1024 },
+				stage: { type: 'integer', description: '', example: 3 },
+				filter1: { type: 'string', description: '', example: 'some filter' },
+				privateBlobContainer: {
+					type: 'string',
+					description: 'Back Office blob storage container',
+					example: 'document-service-uploads'
+				},
+				privateBlobPath: {
+					type: 'string',
+					description: 'Back Office blob storage path',
+					example:
+						'https://intranet.planninginspectorate.gov.uk/wp-content/uploads/2023/10/Lightbulb-L-and-D.gif'
+				},
+				publishedBlobContainer: {
+					type: 'string',
+					description: 'Published blob storage container',
+					example: 'published-documents'
+				},
+				publishedBlobPath: {
+					type: 'string',
+					description: 'Published blob storage path',
+					example: 'published/bc0110001-filename.pdf'
+				},
+				dateCreated: {
+					type: 'string',
+					description: 'Date document was created',
+					example: '2022-12-21T12:42:40.885Z'
+				},
+				datePublished: {
+					type: 'string',
+					description: 'Date document was published',
+					example: '2022-12-21T12:42:40.885Z'
+				},
+				isDeleted: {
+					type: 'boolean',
+					description: 'Is the document marked as deleted',
+					example: false
+				},
+				examinationRefNo: {
+					type: 'string',
+					description: 'Examination Timetable reference number',
+					example: null
+				},
+				filter2: { type: 'string', description: '', example: 'some filter' },
+				publishedStatus: {
+					type: 'string',
+					enum: ['not_checked', 'checked', 'ready_to_publish', 'published', 'not_published'],
+					description: 'Published status',
+					example: 'ready_to_publish'
+				},
+				publishedStatusPrev: {
+					type: 'string',
+					enum: ['not_checked', 'checked', 'ready_to_publish', 'published', 'not_published'],
+					description: 'The previous status',
+					example: 'not_checked'
+				},
+				Document: {
+					type: 'object',
+					properties: {
+						guid: {
+							type: 'string',
+							description: 'Document guid',
+							example: 'ab12cd34-5678-90ef-ghij-klmnopqrstuv'
+						},
+						documentRef: {
+							type: 'string',
+							description: 'Document Reference',
+							example: 'BC011001-000001'
+						},
+						folderId: { type: 'integer', description: 'Folder Id', example: 2 },
+						createdAt: {
+							type: 'string',
+							description: 'Date document was created',
+							example: '2022-12-21T12:42:40.885Z'
+						},
+						isDeleted: {
+							type: 'boolean',
+							description: 'Is the document marked as deleted',
+							example: false
+						},
+						latestVersionId: {
+							type: 'integer',
+							description: 'Document latest version id',
+							example: 2
+						},
+						caseId: { type: 'integer', description: 'Application case id', example: 1 },
+						fromFrontOffice: {
+							type: 'boolean',
+							description: 'Document from front office',
+							example: false
+						}
+					}
+				},
+				case: {
+					type: 'object',
+					properties: {
+						id: { type: 'number', description: 'Application id', example: 1 },
+						reference: {
+							type: 'string',
+							description: 'Application unique reference',
+							example: 'BC0110001'
+						},
+						modifiedAt: {
+							type: 'string',
+							format: 'date-time',
+							description: 'The date this case was last modified',
+							example: '2022-12-21T12:42:40.885Z'
+						},
+						createdAt: {
+							type: 'string',
+							format: 'date-time',
+							description: 'The date this case was created',
+							example: '2022-12-21T12:42:40.885Z'
+						},
+						description: {
+							type: 'string',
+							description: 'Application description',
+							example: 'A description of the application'
+						},
+						title: {
+							type: 'string',
+							description: 'Application title',
+							example: 'NSIP Application Title'
+						},
+						hasUnpublishedChanges: {
+							type: 'boolean',
+							description: 'Does case have unpublished changes',
+							example: true
+						},
+						applicantId: { type: 'number', description: 'Applicant Id', example: '1000000' }
+					}
+				}
+			}
+		},
 		DocumentPropertiesWithAuditHistory: {
 			type: 'object',
 			properties: {
@@ -873,12 +1045,12 @@ export const spec = {
 				publishedBlobContainer: {
 					type: 'string',
 					description: 'Published blob storage container',
-					example: null
+					example: 'published-documents'
 				},
 				publishedBlobPath: {
 					type: 'string',
 					description: 'Published blob storage path',
-					example: null
+					example: 'published/bc0110001-filename.pdf'
 				},
 				dateCreated: {
 					type: 'integer',
@@ -1181,6 +1353,48 @@ export const spec = {
 				successful: {
 					type: 'array',
 					items: { type: 'string' }
+				}
+			}
+		},
+		DocumentMarkAsPublishedRequestBody: {
+			type: 'object',
+			properties: {
+				publishedBlobPath: {
+					type: 'string',
+					description: 'The published blob path',
+					example: 'published/en010120-filename.pdf'
+				},
+				publishedBlobContainer: {
+					type: 'string',
+					description: 'The published blob container',
+					example: 'published-documents'
+				},
+				publishedDate: {
+					type: 'string',
+					description: 'The published date',
+					example: '2023-11-14T00:00:00Z'
+				}
+			}
+		},
+		DocumentMarkAsPublishedBadRequest: {
+			type: 'object',
+			properties: {
+				errors: {
+					type: 'object',
+					properties: {
+						publishedBlobPath: {
+							type: 'string',
+							example: 'Must provide a published blob path'
+						},
+						publishedBlobContainer: {
+							type: 'string',
+							example: 'Must provide a published blob container'
+						},
+						publishedDate: {
+							type: 'string',
+							example: 'Must provide a published date'
+						}
+					}
 				}
 			}
 		},


### PR DESCRIPTION
## Describe your changes

- (general) corrected swagger definitions and payloads to match actual, for documents for apis: mark-as-published and mark-as-unpublished

- Scenario 7 fix: updated the documentActivityLog to ensure that when publishing a new version of a document, the auto-unpublishing of any previous published version is stamped with the user  “System” as the actioner.

## BOAS-1293 Fix auto unpublishing document versions (scenario 7 only)
https://pins-ds.atlassian.net/browse/BOAS-1293

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
