### PR TITLE
fix(api/applications): allow clearing document transcript ref (boas-1316)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -489,7 +489,10 @@ export const storeDocumentVersion = async (request, response) => {
 		throw new BackOfficeAppError(`Document not found: guid ${guid}`, 404);
 	}
 
-	if (transcriptReference) {
+	if (transcriptReference === '') {
+		// user requested to explicitly clear the transcription field value
+		documentVersion.transcriptGuid = null;
+	} else if (transcriptReference) {
 		const transcriptDocument = await documentRepository.getByReferenceRelatedToCaseId(
 			transcriptReference,
 			Number(caseId)
@@ -498,7 +501,6 @@ export const storeDocumentVersion = async (request, response) => {
 		if (!transcriptDocument) {
 			const transcriptErrorMsg = `Transcript document not found: reference ${transcriptReference}`;
 			response.status(404).send({ errors: { transcript: transcriptErrorMsg } });
-
 			throw new BackOfficeAppError(transcriptErrorMsg, 404);
 		}
 

--- a/apps/api/src/server/applications/application/documents/document.validators.js
+++ b/apps/api/src/server/applications/application/documents/document.validators.js
@@ -110,7 +110,7 @@ export const validateDocumentVersionMetadataBody = (documentVersionEventBody) =>
 		filter1: joi.string().optional(),
 		filter2: joi.string().optional(),
 		examinationRefNo: joi.string().optional(),
-		transcript: joi.string().optional()
+		transcript: joi.string().allow('').optional()
 	});
 
 	// Validate the document version event body using the schema


### PR DESCRIPTION
## Describe your changes

Allow Document Transcription Reference to be cleared by a user.  
API modified to allow blank value, and to set the DB field transcriptGuid to null.
- The other 2 scenarios on the bug ticket (MP3 and MP4 issues) appear to be solved already

## BOAS-1316 Allow Clearing of Document Transcript Ref
https://pins-ds.atlassian.net/browse/BOAS-1316

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
