### PR TITLE
fix(web/applications): add fileRowId to file instead of copying object

### DIFF
--- a/apps/web/src/client/components/file-uploader/_server-actions.js
+++ b/apps/web/src/client/components/file-uploader/_server-actions.js
@@ -142,18 +142,22 @@ const serverActions = (uploadForm) => {
 						{
 							message: result.errors,
 							name: file.name,
-							fileRowId: `file_row_${file.lastModified}_${file.size}`
+							fileRowId: file.fileRowId ?? ''
 						}
 					]
 				};
 			}
 
+			/** @type {File} */
 			const newFile = new File([result.html], file.name, {
 				type: 'text/html'
 			});
 
+			// @ts-ignore
+			newFile.fileRowId = file.fileRowId;
+
 			return {
-				file: { ...newFile, fileRowId: file.fileRowId },
+				file: newFile,
 				errors: []
 			};
 		} catch (/** @type {*} */ error) {
@@ -164,7 +168,7 @@ const serverActions = (uploadForm) => {
 					{
 						message: error.message,
 						name: file.name,
-						fileRowId: `file_row_${file.lastModified}_${file.size}`
+						fileRowId: file.fileRowId ?? ''
 					}
 				]
 			};


### PR DESCRIPTION
It is not possible to use the spread operator on File objects because they inherit properties from Blob. Inherited properties are ignored by the spread operator.

## Describe your changes

* fix(web/applications): add fileRowId to file instead of copying object
It is not possible to use the spread operator on File objects because
they inherit properties from Blob. Inherited properties are ignored by
the spread operator.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
