### PR TITLE
Fix/boas 1329 exam timetable name must be unique

### DIFF
--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
@@ -79,6 +79,7 @@ export const getExaminationTimetableItem = async (_request, response) => {
  * @returns {Promise<void>}
  */
 export const createExaminationTimetableItem = async ({ body }, response) => {
+	console.log('create body: ', body);
 	let examinationTimetable = await examinationTimetableRepository.getByCaseId(body.caseId);
 	if (!examinationTimetable) {
 		// @ts-ignore
@@ -228,6 +229,7 @@ export const deleteExaminationTimetableItem = async ({ params }, response) => {
  * @returns {Promise<void>}
  */
 export const updateExaminationTimetableItem = async ({ params, body }, response) => {
+	console.log('update request body: ', body);
 	const { id } = params;
 
 	const timetableBeforeUpdate = await examinationTimetableItemsRepository.getById(+id);

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
@@ -79,7 +79,6 @@ export const getExaminationTimetableItem = async (_request, response) => {
  * @returns {Promise<void>}
  */
 export const createExaminationTimetableItem = async ({ body }, response) => {
-	console.log('create body: ', body);
 	let examinationTimetable = await examinationTimetableRepository.getByCaseId(body.caseId);
 	if (!examinationTimetable) {
 		// @ts-ignore
@@ -229,9 +228,7 @@ export const deleteExaminationTimetableItem = async ({ params }, response) => {
  * @returns {Promise<void>}
  */
 export const updateExaminationTimetableItem = async ({ params, body }, response) => {
-	console.log('update request body: ', body);
 	const { id } = params;
-
 	const timetableBeforeUpdate = await examinationTimetableItemsRepository.getById(+id);
 
 	if (!timetableBeforeUpdate) {

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.routes.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.routes.js
@@ -32,7 +32,7 @@ router.get(
         }
         #swagger.responses[200] = {
             description: 'List of examination timetable items',
-            schema: { $ref: '#/definitions/ExaminationTimetableItems' }
+            schema: { $ref: '#/definitions/ExaminationTimetableWithItems' }
         }
     */
 	asyncHandler(getExaminationTimetableItems)
@@ -52,7 +52,7 @@ router.get(
         }
         #swagger.responses[200] = {
             description: 'Examination timetable item',
-            schema: { $ref: '#/definitions/ExaminationTimetableItemResponseBody' }
+            schema: { $ref: '#/definitions/ExaminationTimetableItemWithExamTimetable' }
         }
     */
 	asyncHandler(getExaminationTimetableItem)
@@ -66,13 +66,17 @@ router.post(
         #swagger.description = 'Create an examination timetable item for the case'
         #swagger.parameters['body'] = {
             in: 'body',
-            description: 'document pagination parameters',
-            schema: { $ref: '#/definitions/ExaminationTimetableItemRequestBody' },
+            description: 'New examination timetable item',
+            schema: { $ref: '#/definitions/ExaminationTimetableItemCreateRequestBody' },
             required: true
         }
         #swagger.responses[200] = {
             description: 'Created examination timetable item',
-            schema: { $ref: '#/definitions/ExaminationTimetableItemResponseBody' }
+            schema: { $ref: '#/definitions/ExaminationTimetableItemSaveResponse' }
+        }
+		#swagger.responses[400] = {
+            description: 'Bad Request',
+            schema: { $ref: '#/definitions/ExaminationTimetableItemSaveBadRequest' }
         }
     */
 	validateCreateExaminationTimetableItem,
@@ -145,7 +149,7 @@ router.patch(
 	'/:id',
 	/*
         #swagger.tags = ['Applications']
-        #swagger.path = '/applications/examination-timetable-items/{id}/update'
+        #swagger.path = '/applications/examination-timetable-items/{id}'
         #swagger.description = 'Updates an examination timetable item'
         #swagger.parameters['id'] = {
             in: 'path',
@@ -156,12 +160,12 @@ router.patch(
 		#swagger.parameters['body'] = {
             in: 'body',
             description: 'Examination timetable item update details',
-            schema: { $ref: '#/definitions/ExaminationTimetableItemRequestBody' },
+            schema: { $ref: '#/definitions/ExaminationTimetableItemUpdateRequestBody' },
 			required: true
         }
         #swagger.responses[200] = {
             description: 'Examination timetable item',
-            schema: { $ref: '#/definitions/ExaminationTimetableItemResponseBody' }
+            schema: { $ref: '#/definitions/ExaminationTimetableItemSaveResponse' }
         }
 		#swagger.responses[400] = {
             description: 'Example of an error response',

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.validators.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.validators.js
@@ -1,12 +1,13 @@
 import { composeMiddleware } from '@pins/express';
 import { body } from 'express-validator';
 import { param } from 'express-validator';
-import * as examinationTimetableTypesRepository from '../../repositories/examination-timetable-types.repository.js';
-import * as examinationTimetableItemsRepository from '../../repositories/examination-timetable-items.repository.js';
+import * as examinationTimetableTypesRepository from '#repositories/examination-timetable-types.repository.js';
+import * as examinationTimetableItemsRepository from '#repositories/examination-timetable-items.repository.js';
 import { validateExistingApplication } from '../application/application.validators.js';
-import { validationErrorHandler } from '../../middleware/error-handler.js';
+import { validationErrorHandler } from '#middleware/error-handler.js';
 
 /**
+ * Validate that an exam timetable item type exists
  *
  * @param {number} value
  * @throws {Error}
@@ -21,6 +22,7 @@ const validateExistingExaminationTimetableType = async (value) => {
 };
 
 /**
+ * Validate that an exam timetable item record exists
  *
  * @param {number} value
  * @throws {Error}

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.validators.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.validators.js
@@ -51,7 +51,14 @@ export const validateCreateExaminationTimetableItem = composeMiddleware(
 		.toInt()
 		.custom(validateExistingExaminationTimetableType)
 		.withMessage('Must be valid examination type'),
-	body('name').notEmpty().withMessage('Name not be empty'),
+	body('name')
+		.notEmpty()
+		.withMessage('Name not be empty')
+		.not()
+		.toUpperCase()
+		.trim()
+		.equals('OTHER')
+		.withMessage('Name cannot be Other, please enter another name'),
 	body('description').optional({ nullable: true }),
 	body('date').toDate(),
 	body('startDate').toDate().optional({ nullable: true }),
@@ -73,7 +80,13 @@ export const validateUpdateExaminationTimetableItem = composeMiddleware(
 		.custom(validateExistingExaminationTimetableType)
 		.withMessage('Must be valid examination type')
 		.optional({ nullable: true }),
-	body('name').optional({ nullable: true }),
+	body('name')
+		.not()
+		.toUpperCase()
+		.trim()
+		.equals('OTHER')
+		.withMessage('Name cannot be Other, please enter another name')
+		.optional({ nullable: true }),
 	body('description').optional({ nullable: true }),
 	body('date').toDate().optional({ nullable: true }),
 	body('startDate').toDate().optional({ nullable: true }),

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.validators.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.validators.js
@@ -35,6 +35,19 @@ const validateExistingExaminationTimetableItem = async (value) => {
 	}
 };
 
+/**
+ * Validate that an exam timetable item name is not 'Other'
+ *
+ * @param {string} value
+ * @throws {Error}
+ * @returns {Promise<void>}
+ */
+const validateExaminationTimetableItemNameNotOther = async (value) => {
+	if (value.toLowerCase() === 'other') {
+		throw new Error('Cannot use exam item name Other');
+	}
+};
+
 export const validateExistingExaminationTimetableItemId = composeMiddleware(
 	param('id')
 		.isInt()
@@ -52,12 +65,10 @@ export const validateCreateExaminationTimetableItem = composeMiddleware(
 		.custom(validateExistingExaminationTimetableType)
 		.withMessage('Must be valid examination type'),
 	body('name')
+		.trim()
 		.notEmpty()
 		.withMessage('Name not be empty')
-		.not()
-		.toUpperCase()
-		.trim()
-		.equals('OTHER')
+		.custom(validateExaminationTimetableItemNameNotOther)
 		.withMessage('Name cannot be Other, please enter another name'),
 	body('description').optional({ nullable: true }),
 	body('date').toDate(),
@@ -81,10 +92,8 @@ export const validateUpdateExaminationTimetableItem = composeMiddleware(
 		.withMessage('Must be valid examination type')
 		.optional({ nullable: true }),
 	body('name')
-		.not()
-		.toUpperCase()
 		.trim()
-		.equals('OTHER')
+		.custom(validateExaminationTimetableItemNameNotOther)
 		.withMessage('Name cannot be Other, please enter another name')
 		.optional({ nullable: true }),
 	body('description').optional({ nullable: true }),

--- a/apps/api/src/server/repositories/examination-timetable-items.repository.js
+++ b/apps/api/src/server/repositories/examination-timetable-items.repository.js
@@ -32,6 +32,38 @@ export const getByExaminationTimetableId = (examinationTimetableId) => {
 };
 
 /**
+ * returns all exam timetable item records for this exam timetable, where the item name matches.
+ * ignoreSelfId ignores that record id, used when updating.  For creating a new record, this should be null
+ *
+ * @param {number} examinationTimetableId
+ * @param {string} examinationTimetableName
+ * @param {number |null} ignoreSelfId
+ * @returns {Promise<import('@pins/applications.api').Schema.ExaminationTimetableItem[] | null>}
+ */
+export const getByExaminationTimetableName = (
+	examinationTimetableId,
+	examinationTimetableName,
+	ignoreSelfId
+) => {
+	let whereClause = {
+		name: examinationTimetableName,
+		examinationTimetableId: examinationTimetableId
+	};
+	if (ignoreSelfId) {
+		// @ts-ignore
+		whereClause.NOT = { id: ignoreSelfId };
+	}
+
+	return databaseConnector.examinationTimetableItem.findMany({
+		include: { ExaminationTimetableType: true },
+		where: whereClause,
+		orderBy: {
+			date: 'asc'
+		}
+	});
+};
+
+/**
  *
  * @param {import('@pins/applications.api').Schema.ExaminationTimetableItem} examinationTimetableItem
  * @returns {Promise<import('@pins/applications.api').Schema.ExaminationTimetableItem>}

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -2942,7 +2942,7 @@
 					"200": {
 						"description": "List of examination timetable items",
 						"schema": {
-							"$ref": "#/definitions/ExaminationTimetableItems"
+							"$ref": "#/definitions/ExaminationTimetableWithItems"
 						}
 					}
 				}
@@ -2965,7 +2965,7 @@
 					"200": {
 						"description": "Examination timetable item",
 						"schema": {
-							"$ref": "#/definitions/ExaminationTimetableItemResponseBody"
+							"$ref": "#/definitions/ExaminationTimetableItemWithExamTimetable"
 						}
 					}
 				}
@@ -2992,6 +2992,56 @@
 						"description": "Examination timetable item successfully deleted"
 					}
 				}
+			},
+			"patch": {
+				"tags": ["Applications"],
+				"description": "Updates an examination timetable item",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Examination timetable item ID"
+					},
+					{
+						"name": "body",
+						"in": "body",
+						"description": "Examination timetable item update details",
+						"schema": {
+							"$ref": "#/definitions/ExaminationTimetableItemUpdateRequestBody"
+						},
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Examination timetable item",
+						"schema": {
+							"$ref": "#/definitions/ExaminationTimetableItemSaveResponse"
+						}
+					},
+					"400": {
+						"description": "Example of an error response",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"errors": {
+									"type": "object",
+									"properties": {
+										"id": {
+											"type": "string",
+											"example": "Must be an existing examination timetable item"
+										}
+									}
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
 			}
 		},
 		"/applications/examination-timetable-items": {
@@ -3002,9 +3052,9 @@
 					{
 						"name": "body",
 						"in": "body",
-						"description": "document pagination parameters",
+						"description": "New examination timetable item",
 						"schema": {
-							"$ref": "#/definitions/ExaminationTimetableItemRequestBody"
+							"$ref": "#/definitions/ExaminationTimetableItemCreateRequestBody"
 						},
 						"required": true
 					}
@@ -3013,7 +3063,13 @@
 					"200": {
 						"description": "Created examination timetable item",
 						"schema": {
-							"$ref": "#/definitions/ExaminationTimetableItemResponseBody"
+							"$ref": "#/definitions/ExaminationTimetableItemSaveResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/ExaminationTimetableItemSaveBadRequest"
 						}
 					}
 				}
@@ -3073,58 +3129,6 @@
 								"success": {
 									"type": "boolean",
 									"example": true
-								}
-							},
-							"xml": {
-								"name": "main"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/applications/examination-timetable-items/{id}/update": {
-			"patch": {
-				"tags": ["Applications"],
-				"description": "Updates an examination timetable item",
-				"parameters": [
-					{
-						"name": "id",
-						"in": "path",
-						"required": true,
-						"type": "integer",
-						"description": "Examination timetable item ID"
-					},
-					{
-						"name": "body",
-						"in": "body",
-						"description": "Examination timetable item update details",
-						"schema": {
-							"$ref": "#/definitions/ExaminationTimetableItemRequestBody"
-						},
-						"required": true
-					}
-				],
-				"responses": {
-					"200": {
-						"description": "Examination timetable item",
-						"schema": {
-							"$ref": "#/definitions/ExaminationTimetableItemResponseBody"
-						}
-					},
-					"400": {
-						"description": "Example of an error response",
-						"schema": {
-							"type": "object",
-							"properties": {
-								"errors": {
-									"type": "object",
-									"properties": {
-										"id": {
-											"type": "string",
-											"example": "Must be an existing examination timetable item"
-										}
-									}
 								}
 							},
 							"xml": {
@@ -4493,188 +4497,6 @@
 						"type": "string",
 						"example": "Region Name Cy"
 					}
-				}
-			}
-		},
-		"ExaminationTimetableTypes": {
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"id": {
-						"type": "number",
-						"example": 1
-					},
-					"templateType": {
-						"type": "string",
-						"example": "starttime-mandatory"
-					},
-					"name": {
-						"type": "string",
-						"example": "Accompanied Site Inspection"
-					},
-					"displayNameEn": {
-						"type": "string",
-						"example": "Accompanied site inspection"
-					},
-					"displayNameCy": {
-						"type": "string",
-						"example": "Accompanied site inspection Cy"
-					}
-				}
-			}
-		},
-		"ExaminationTimetableItems": {
-			"type": "array",
-			"items": {
-				"type": "object",
-				"properties": {
-					"id": {
-						"type": "number",
-						"example": 1
-					},
-					"caseId": {
-						"type": "number",
-						"example": 1
-					},
-					"examinationTypeId": {
-						"type": "number",
-						"example": 1
-					},
-					"name": {
-						"type": "string",
-						"example": "Examination Timetable Item"
-					},
-					"description": {
-						"type": "string",
-						"example": "{\"preText\":\"Examination Timetable Item Description\\r\\n\",\"bulletPoints\":[\" Line item 1\\r\\n\",\" Line item 2\"]}"
-					},
-					"date": {
-						"type": "string",
-						"example": "2023-02-27T10:00:00Z"
-					},
-					"startDate": {
-						"type": "string",
-						"example": "2023-02-27T10:00:00Z"
-					},
-					"published": {
-						"type": "boolean",
-						"example": false
-					},
-					"folderId": {
-						"type": "number",
-						"example": 134
-					},
-					"startTime": {
-						"type": "string",
-						"example": "10:20"
-					},
-					"endTime": {
-						"type": "string",
-						"example": "12:20"
-					},
-					"submissions": {
-						"type": "boolean",
-						"example": true
-					}
-				}
-			}
-		},
-		"ExaminationTimetableItemRequestBody": {
-			"type": "object",
-			"properties": {
-				"caseId": {
-					"type": "number",
-					"example": 1
-				},
-				"examinationTypeId": {
-					"type": "number",
-					"example": 1
-				},
-				"name": {
-					"type": "string",
-					"example": "Examination Timetable Item"
-				},
-				"description": {
-					"type": "string",
-					"example": "{\"preText\":\"Examination Timetable Item Description\\r\\n\",\"bulletPoints\":[\" Line item 1\\r\\n\",\" Line item 2\"]}"
-				},
-				"date": {
-					"type": "string",
-					"example": "2023-02-27T10:00:00Z"
-				},
-				"published": {
-					"type": "boolean",
-					"example": false
-				},
-				"folderId": {
-					"type": "number",
-					"example": 134
-				},
-				"startDate": {
-					"type": "string",
-					"example": "2023-02-27T10:00:00Z"
-				},
-				"startTime": {
-					"type": "string",
-					"example": "10:20"
-				},
-				"endTime": {
-					"type": "string",
-					"example": "12:20"
-				}
-			}
-		},
-		"ExaminationTimetableItemResponseBody": {
-			"type": "object",
-			"properties": {
-				"id": {
-					"type": "number",
-					"example": 1
-				},
-				"caseId": {
-					"type": "number",
-					"example": 1
-				},
-				"examinationTypeId": {
-					"type": "number",
-					"example": 1
-				},
-				"name": {
-					"type": "string",
-					"example": "Examination Timetable Item"
-				},
-				"description": {
-					"type": "string",
-					"example": "{\"preText\":\"Examination Timetable Item Description\\r\\n\",\"bulletPoints\":[\" Line item 1\\r\\n\",\" Line item 2\"]}"
-				},
-				"date": {
-					"type": "string",
-					"example": "2023-02-27T10:00:00Z"
-				},
-				"published": {
-					"type": "boolean",
-					"example": false
-				},
-				"folderId": {
-					"type": "number",
-					"example": 134
-				},
-				"startDate": {
-					"type": "string",
-					"example": "2023-02-27T10:00:00Z"
-				},
-				"startTime": {
-					"type": "string",
-					"example": "10:20"
-				},
-				"endTime": {
-					"type": "string",
-					"example": "12:20"
-				},
-				"submissions": {
-					"type": "boolean",
-					"example": true
 				}
 			}
 		},
@@ -6508,6 +6330,449 @@
 					"properties": {
 						"message": {
 							"type": "string"
+						}
+					}
+				}
+			}
+		},
+		"ExaminationTimetableType": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"description": "Examination timetable type id",
+					"example": 1
+				},
+				"templateType": {
+					"type": "string",
+					"description": "Examination timetable type template type",
+					"example": "starttime-mandatory"
+				},
+				"name": {
+					"type": "string",
+					"description": "Examination timetable type name",
+					"example": "Accompanied Site Inspection"
+				},
+				"displayNameEn": {
+					"type": "string",
+					"description": "Examination timetable type display name",
+					"example": "Accompanied site inspection"
+				},
+				"displayNameCy": {
+					"type": "string",
+					"description": "Examination timetable type display name in Welsh",
+					"example": "Accompanied site inspection Cy"
+				}
+			}
+		},
+		"ExaminationTimetableTypes": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/ExaminationTimetableType"
+			}
+		},
+		"ExaminationTimetable": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"description": "Examination timetable id",
+					"example": 1
+				},
+				"caseId": {
+					"type": "integer",
+					"description": "Case Id",
+					"example": 1
+				},
+				"published": {
+					"type": "boolean",
+					"description": "Is the examination timetable published?",
+					"example": true
+				},
+				"publishedAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date Examination timetable was published",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"createdAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date created",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"updateAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date last updated",
+					"example": "2023-02-01T00:00:00.000Z"
+				}
+			}
+		},
+		"ExaminationTimetableWithItems": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"description": "Examination timetable id",
+					"example": 1
+				},
+				"caseId": {
+					"type": "integer",
+					"description": "Case Id",
+					"example": 1
+				},
+				"published": {
+					"type": "boolean",
+					"description": "Is the examination timetable published?",
+					"example": true
+				},
+				"publishedAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date Examination timetable was published",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"createdAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date created",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"updateAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date last updated",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"items": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/ExaminationTimetableItem"
+					}
+				}
+			}
+		},
+		"ExaminationTimetableItem": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"description": "Examination timetable item id",
+					"example": 1
+				},
+				"examinationTimetableId": {
+					"type": "integer",
+					"description": "Examination timetable parent id",
+					"example": 1
+				},
+				"examinationTypeId": {
+					"type": "integer",
+					"description": "Examination timetable type id",
+					"example": 1
+				},
+				"name": {
+					"type": "string",
+					"description": "Examination timetable item name",
+					"example": "Deadline 1"
+				},
+				"description": {
+					"type": "string",
+					"description": "Examination timetable item name including line items",
+					"example": "{\"preText\":\"Deadline 1 line items\\r\\n\",\"bulletPoints\":[\" Line item 1\\r\\n\",\" Line item 2\"]}"
+				},
+				"date": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item date / end date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startDate": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item start date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startTime": {
+					"type": "string",
+					"description": "Examination timetable start time",
+					"example": "10:20"
+				},
+				"endTime": {
+					"type": "string",
+					"description": "Examination timetable end time",
+					"example": "23:59"
+				},
+				"folderId": {
+					"type": "integer",
+					"description": "Examination timetable item corresponding folder id",
+					"example": 123
+				},
+				"createdAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date created",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"ExaminationTimetableType": {
+					"$ref": "#/definitions/ExaminationTimetableType"
+				},
+				"submissions": {
+					"type": "boolean",
+					"description": "Matching folder contains submissions",
+					"example": true
+				}
+			}
+		},
+		"ExaminationTimetableItemWithExamTimetable": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"description": "Examination timetable item id",
+					"example": 1
+				},
+				"examinationTimetableId": {
+					"type": "integer",
+					"description": "Examination timetable parent id",
+					"example": 1
+				},
+				"examinationTypeId": {
+					"type": "integer",
+					"description": "Examination timetable type id",
+					"example": 1
+				},
+				"name": {
+					"type": "string",
+					"description": "Examination timetable item name",
+					"example": "Deadline 1"
+				},
+				"description": {
+					"type": "string",
+					"description": "Examination timetable item name including line items",
+					"example": "{\"preText\":\"Deadline 1 line items\\r\\n\",\"bulletPoints\":[\" Line item 1\\r\\n\",\" Line item 2\"]}"
+				},
+				"date": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item date / end date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startDate": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item start date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startTime": {
+					"type": "string",
+					"description": "Examination timetable start time",
+					"example": "10:20"
+				},
+				"endTime": {
+					"type": "string",
+					"description": "Examination timetable end time",
+					"example": "23:59"
+				},
+				"folderId": {
+					"type": "integer",
+					"description": "Examination timetable item corresponding folder id",
+					"example": 123
+				},
+				"createdAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date created",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"ExaminationTimetableType": {
+					"$ref": "#/definitions/ExaminationTimetableType"
+				},
+				"ExaminationTimetable": {
+					"$ref": "#/definitions/ExaminationTimetable"
+				},
+				"submissions": {
+					"type": "boolean",
+					"description": "Matching folder contains submissions",
+					"example": true
+				}
+			}
+		},
+		"ExaminationTimetableItemCreateRequestBody": {
+			"type": "object",
+			"properties": {
+				"caseId": {
+					"type": "integer",
+					"description": "Case id",
+					"example": 1
+				},
+				"examinationTypeId": {
+					"type": "integer",
+					"description": "Examination timetable type id",
+					"example": 1
+				},
+				"name": {
+					"type": "string",
+					"description": "Examination timetable item name",
+					"example": "Deadline 1"
+				},
+				"description": {
+					"type": "string",
+					"description": "Examination timetable item name including line items",
+					"example": "{\"preText\":\"Deadline 1 line items\\r\\n\",\"bulletPoints\":[\" Line item 1\\r\\n\",\" Line item 2\"]}"
+				},
+				"date": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item date / end date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startDate": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item start date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startTime": {
+					"type": "string",
+					"description": "Examination timetable start time",
+					"example": "10:20"
+				},
+				"endTime": {
+					"type": "string",
+					"description": "Examination timetable end time",
+					"example": "23:59"
+				}
+			}
+		},
+		"ExaminationTimetableItemUpdateRequestBody": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"description": "Examination timetable item id",
+					"example": 1
+				},
+				"caseId": {
+					"type": "integer",
+					"description": "Case id",
+					"example": 1
+				},
+				"examinationTypeId": {
+					"type": "integer",
+					"description": "Examination timetable type id",
+					"example": 1
+				},
+				"name": {
+					"type": "string",
+					"description": "Examination timetable item name",
+					"example": "Deadline 1"
+				},
+				"description": {
+					"type": "string",
+					"description": "Examination timetable item name including line items",
+					"example": "{\"preText\":\"Deadline 1 line items\\r\\n\",\"bulletPoints\":[\" Line item 1\\r\\n\",\" Line item 2\"]}"
+				},
+				"date": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item date / end date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startDate": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item start date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startTime": {
+					"type": "string",
+					"description": "Examination timetable start time",
+					"example": "10:20"
+				},
+				"endTime": {
+					"type": "string",
+					"description": "Examination timetable end time",
+					"example": "23:59"
+				}
+			}
+		},
+		"ExaminationTimetableItemSaveResponse": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"description": "Examination timetable item id",
+					"example": 1
+				},
+				"examinationTimetableId": {
+					"type": "integer",
+					"description": "Examination timetable parent id",
+					"example": 1
+				},
+				"examinationTypeId": {
+					"type": "integer",
+					"description": "Examination timetable type id",
+					"example": 1
+				},
+				"name": {
+					"type": "string",
+					"description": "Examination timetable item name",
+					"example": "Deadline 1"
+				},
+				"description": {
+					"type": "string",
+					"description": "Examination timetable item name including line items",
+					"example": "{\"preText\":\"Deadline 1 line items\\r\\n\",\"bulletPoints\":[\" Line item 1\\r\\n\",\" Line item 2\"]}"
+				},
+				"date": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item date / end date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startDate": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Examination timetable item start date",
+					"example": "2023-02-01T00:00:00.000Z"
+				},
+				"startTime": {
+					"type": "string",
+					"description": "Examination timetable start time",
+					"example": "10:20"
+				},
+				"endTime": {
+					"type": "string",
+					"description": "Examination timetable end time",
+					"example": "23:59"
+				},
+				"folderId": {
+					"type": "integer",
+					"description": "Examination timetable item corresponding folder id",
+					"example": 123
+				},
+				"createdAt": {
+					"type": "string",
+					"string": "date-time",
+					"description": "Date created",
+					"example": "2023-02-01T00:00:00.000Z"
+				}
+			}
+		},
+		"ExaminationTimetableItemSaveBadRequest": {
+			"type": "object",
+			"properties": {
+				"errors": {
+					"type": "object",
+					"properties": {
+						"caseId": {
+							"type": "string",
+							"example": "Must be valid case id"
+						},
+						"examinationTypeId": {
+							"type": "string",
+							"example": "Must be valid examination type"
 						}
 					}
 				}

--- a/apps/api/src/server/swagger-types.ts
+++ b/apps/api/src/server/swagger-types.ts
@@ -168,96 +168,6 @@ export type MapZoomLevelForApplications = {
 	displayNameCy?: string;
 }[];
 
-export type ExaminationTimetableTypes = {
-	/** @example 1 */
-	id?: number;
-	/** @example "starttime-mandatory" */
-	templateType?: string;
-	/** @example "Accompanied Site Inspection" */
-	name?: string;
-	/** @example "Accompanied site inspection" */
-	displayNameEn?: string;
-	/** @example "Accompanied site inspection Cy" */
-	displayNameCy?: string;
-}[];
-
-export type ExaminationTimetableItems = {
-	/** @example 1 */
-	id?: number;
-	/** @example 1 */
-	caseId?: number;
-	/** @example 1 */
-	examinationTypeId?: number;
-	/** @example "Examination Timetable Item" */
-	name?: string;
-	/** @example "{"preText":"Examination Timetable Item Description\r\n","bulletPoints":[" Line item 1\r\n"," Line item 2"]}" */
-	description?: string;
-	/** @example "2023-02-27T10:00:00Z" */
-	date?: string;
-	/** @example "2023-02-27T10:00:00Z" */
-	startDate?: string;
-	/** @example false */
-	published?: boolean;
-	/** @example 134 */
-	folderId?: number;
-	/** @example "10:20" */
-	startTime?: string;
-	/** @example "12:20" */
-	endTime?: string;
-	/** @example true */
-	submissions?: boolean;
-}[];
-
-export interface ExaminationTimetableItemRequestBody {
-	/** @example 1 */
-	caseId?: number;
-	/** @example 1 */
-	examinationTypeId?: number;
-	/** @example "Examination Timetable Item" */
-	name?: string;
-	/** @example "{"preText":"Examination Timetable Item Description\r\n","bulletPoints":[" Line item 1\r\n"," Line item 2"]}" */
-	description?: string;
-	/** @example "2023-02-27T10:00:00Z" */
-	date?: string;
-	/** @example false */
-	published?: boolean;
-	/** @example 134 */
-	folderId?: number;
-	/** @example "2023-02-27T10:00:00Z" */
-	startDate?: string;
-	/** @example "10:20" */
-	startTime?: string;
-	/** @example "12:20" */
-	endTime?: string;
-}
-
-export interface ExaminationTimetableItemResponseBody {
-	/** @example 1 */
-	id?: number;
-	/** @example 1 */
-	caseId?: number;
-	/** @example 1 */
-	examinationTypeId?: number;
-	/** @example "Examination Timetable Item" */
-	name?: string;
-	/** @example "{"preText":"Examination Timetable Item Description\r\n","bulletPoints":[" Line item 1\r\n"," Line item 2"]}" */
-	description?: string;
-	/** @example "2023-02-27T10:00:00Z" */
-	date?: string;
-	/** @example false */
-	published?: boolean;
-	/** @example 134 */
-	folderId?: number;
-	/** @example "2023-02-27T10:00:00Z" */
-	startDate?: string;
-	/** @example "10:20" */
-	startTime?: string;
-	/** @example "12:20" */
-	endTime?: string;
-	/** @example true */
-	submissions?: boolean;
-}
-
 export interface DocumentDetails {
 	/** @example "123" */
 	documentId?: string;
@@ -1524,6 +1434,390 @@ export interface DocumentHTMLResponse {
 export interface DocumentBadHTMLResponse {
 	errors?: {
 		message?: string;
+	};
+}
+
+export interface ExaminationTimetableType {
+	/**
+	 * Examination timetable type id
+	 * @example 1
+	 */
+	id?: number;
+	/**
+	 * Examination timetable type template type
+	 * @example "starttime-mandatory"
+	 */
+	templateType?: string;
+	/**
+	 * Examination timetable type name
+	 * @example "Accompanied Site Inspection"
+	 */
+	name?: string;
+	/**
+	 * Examination timetable type display name
+	 * @example "Accompanied site inspection"
+	 */
+	displayNameEn?: string;
+	/**
+	 * Examination timetable type display name in Welsh
+	 * @example "Accompanied site inspection Cy"
+	 */
+	displayNameCy?: string;
+}
+
+export type ExaminationTimetableTypes = ExaminationTimetableType[];
+
+export interface ExaminationTimetable {
+	/**
+	 * Examination timetable id
+	 * @example 1
+	 */
+	id?: number;
+	/**
+	 * Case Id
+	 * @example 1
+	 */
+	caseId?: number;
+	/**
+	 * Is the examination timetable published?
+	 * @example true
+	 */
+	published?: boolean;
+	/**
+	 * Date Examination timetable was published
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	publishedAt?: string;
+	/**
+	 * Date created
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	createdAt?: string;
+	/**
+	 * Date last updated
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	updateAt?: string;
+}
+
+export interface ExaminationTimetableWithItems {
+	/**
+	 * Examination timetable id
+	 * @example 1
+	 */
+	id?: number;
+	/**
+	 * Case Id
+	 * @example 1
+	 */
+	caseId?: number;
+	/**
+	 * Is the examination timetable published?
+	 * @example true
+	 */
+	published?: boolean;
+	/**
+	 * Date Examination timetable was published
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	publishedAt?: string;
+	/**
+	 * Date created
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	createdAt?: string;
+	/**
+	 * Date last updated
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	updateAt?: string;
+	items?: ExaminationTimetableItem[];
+}
+
+export interface ExaminationTimetableItem {
+	/**
+	 * Examination timetable item id
+	 * @example 1
+	 */
+	id?: number;
+	/**
+	 * Examination timetable parent id
+	 * @example 1
+	 */
+	examinationTimetableId?: number;
+	/**
+	 * Examination timetable type id
+	 * @example 1
+	 */
+	examinationTypeId?: number;
+	/**
+	 * Examination timetable item name
+	 * @example "Deadline 1"
+	 */
+	name?: string;
+	/**
+	 * Examination timetable item name including line items
+	 * @example "{"preText":"Deadline 1 line items\r\n","bulletPoints":[" Line item 1\r\n"," Line item 2"]}"
+	 */
+	description?: string;
+	/**
+	 * Examination timetable item date / end date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	date?: string;
+	/**
+	 * Examination timetable item start date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	startDate?: string;
+	/**
+	 * Examination timetable start time
+	 * @example "10:20"
+	 */
+	startTime?: string;
+	/**
+	 * Examination timetable end time
+	 * @example "23:59"
+	 */
+	endTime?: string;
+	/**
+	 * Examination timetable item corresponding folder id
+	 * @example 123
+	 */
+	folderId?: number;
+	/**
+	 * Date created
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	createdAt?: string;
+	ExaminationTimetableType?: ExaminationTimetableType;
+	/**
+	 * Matching folder contains submissions
+	 * @example true
+	 */
+	submissions?: boolean;
+}
+
+export interface ExaminationTimetableItemWithExamTimetable {
+	/**
+	 * Examination timetable item id
+	 * @example 1
+	 */
+	id?: number;
+	/**
+	 * Examination timetable parent id
+	 * @example 1
+	 */
+	examinationTimetableId?: number;
+	/**
+	 * Examination timetable type id
+	 * @example 1
+	 */
+	examinationTypeId?: number;
+	/**
+	 * Examination timetable item name
+	 * @example "Deadline 1"
+	 */
+	name?: string;
+	/**
+	 * Examination timetable item name including line items
+	 * @example "{"preText":"Deadline 1 line items\r\n","bulletPoints":[" Line item 1\r\n"," Line item 2"]}"
+	 */
+	description?: string;
+	/**
+	 * Examination timetable item date / end date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	date?: string;
+	/**
+	 * Examination timetable item start date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	startDate?: string;
+	/**
+	 * Examination timetable start time
+	 * @example "10:20"
+	 */
+	startTime?: string;
+	/**
+	 * Examination timetable end time
+	 * @example "23:59"
+	 */
+	endTime?: string;
+	/**
+	 * Examination timetable item corresponding folder id
+	 * @example 123
+	 */
+	folderId?: number;
+	/**
+	 * Date created
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	createdAt?: string;
+	ExaminationTimetableType?: ExaminationTimetableType;
+	ExaminationTimetable?: ExaminationTimetable;
+	/**
+	 * Matching folder contains submissions
+	 * @example true
+	 */
+	submissions?: boolean;
+}
+
+export interface ExaminationTimetableItemCreateRequestBody {
+	/**
+	 * Case id
+	 * @example 1
+	 */
+	caseId?: number;
+	/**
+	 * Examination timetable type id
+	 * @example 1
+	 */
+	examinationTypeId?: number;
+	/**
+	 * Examination timetable item name
+	 * @example "Deadline 1"
+	 */
+	name?: string;
+	/**
+	 * Examination timetable item name including line items
+	 * @example "{"preText":"Deadline 1 line items\r\n","bulletPoints":[" Line item 1\r\n"," Line item 2"]}"
+	 */
+	description?: string;
+	/**
+	 * Examination timetable item date / end date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	date?: string;
+	/**
+	 * Examination timetable item start date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	startDate?: string;
+	/**
+	 * Examination timetable start time
+	 * @example "10:20"
+	 */
+	startTime?: string;
+	/**
+	 * Examination timetable end time
+	 * @example "23:59"
+	 */
+	endTime?: string;
+}
+
+export interface ExaminationTimetableItemUpdateRequestBody {
+	/**
+	 * Examination timetable item id
+	 * @example 1
+	 */
+	id?: number;
+	/**
+	 * Case id
+	 * @example 1
+	 */
+	caseId?: number;
+	/**
+	 * Examination timetable type id
+	 * @example 1
+	 */
+	examinationTypeId?: number;
+	/**
+	 * Examination timetable item name
+	 * @example "Deadline 1"
+	 */
+	name?: string;
+	/**
+	 * Examination timetable item name including line items
+	 * @example "{"preText":"Deadline 1 line items\r\n","bulletPoints":[" Line item 1\r\n"," Line item 2"]}"
+	 */
+	description?: string;
+	/**
+	 * Examination timetable item date / end date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	date?: string;
+	/**
+	 * Examination timetable item start date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	startDate?: string;
+	/**
+	 * Examination timetable start time
+	 * @example "10:20"
+	 */
+	startTime?: string;
+	/**
+	 * Examination timetable end time
+	 * @example "23:59"
+	 */
+	endTime?: string;
+}
+
+export interface ExaminationTimetableItemSaveResponse {
+	/**
+	 * Examination timetable item id
+	 * @example 1
+	 */
+	id?: number;
+	/**
+	 * Examination timetable parent id
+	 * @example 1
+	 */
+	examinationTimetableId?: number;
+	/**
+	 * Examination timetable type id
+	 * @example 1
+	 */
+	examinationTypeId?: number;
+	/**
+	 * Examination timetable item name
+	 * @example "Deadline 1"
+	 */
+	name?: string;
+	/**
+	 * Examination timetable item name including line items
+	 * @example "{"preText":"Deadline 1 line items\r\n","bulletPoints":[" Line item 1\r\n"," Line item 2"]}"
+	 */
+	description?: string;
+	/**
+	 * Examination timetable item date / end date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	date?: string;
+	/**
+	 * Examination timetable item start date
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	startDate?: string;
+	/**
+	 * Examination timetable start time
+	 * @example "10:20"
+	 */
+	startTime?: string;
+	/**
+	 * Examination timetable end time
+	 * @example "23:59"
+	 */
+	endTime?: string;
+	/**
+	 * Examination timetable item corresponding folder id
+	 * @example 123
+	 */
+	folderId?: number;
+	/**
+	 * Date created
+	 * @example "2023-02-01T00:00:00.000Z"
+	 */
+	createdAt?: string;
+}
+
+export interface ExaminationTimetableItemSaveBadRequest {
+	errors?: {
+		/** @example "Must be valid case id" */
+		caseId?: string;
+		/** @example "Must be valid examination type" */
+		examinationTypeId?: string;
 	};
 }
 

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -171,60 +171,6 @@ export const spec = {
 				displayNameCy: 'Region Name Cy'
 			}
 		],
-		ExaminationTimetableTypes: [
-			{
-				id: 1,
-				templateType: 'starttime-mandatory',
-				name: 'Accompanied Site Inspection',
-				displayNameEn: 'Accompanied site inspection',
-				displayNameCy: 'Accompanied site inspection Cy'
-			}
-		],
-		ExaminationTimetableItems: [
-			{
-				id: 1,
-				caseId: 1,
-				examinationTypeId: 1,
-				name: 'Examination Timetable Item',
-				description:
-					'{"preText":"Examination Timetable Item Description\\r\\n","bulletPoints":[" Line item 1\\r\\n"," Line item 2"]}',
-				date: '2023-02-27T10:00:00Z',
-				startDate: '2023-02-27T10:00:00Z',
-				published: false,
-				folderId: 134,
-				startTime: '10:20',
-				endTime: '12:20',
-				submissions: true
-			}
-		],
-		ExaminationTimetableItemRequestBody: {
-			caseId: 1,
-			examinationTypeId: 1,
-			name: 'Examination Timetable Item',
-			description:
-				'{"preText":"Examination Timetable Item Description\\r\\n","bulletPoints":[" Line item 1\\r\\n"," Line item 2"]}',
-			date: '2023-02-27T10:00:00Z',
-			published: false,
-			folderId: 134,
-			startDate: '2023-02-27T10:00:00Z',
-			startTime: '10:20',
-			endTime: '12:20'
-		},
-		ExaminationTimetableItemResponseBody: {
-			id: 1,
-			caseId: 1,
-			examinationTypeId: 1,
-			name: 'Examination Timetable Item',
-			description:
-				'{"preText":"Examination Timetable Item Description\\r\\n","bulletPoints":[" Line item 1\\r\\n"," Line item 2"]}',
-			date: '2023-02-27T10:00:00Z',
-			published: false,
-			folderId: 134,
-			startDate: '2023-02-27T10:00:00Z',
-			startTime: '10:20',
-			endTime: '12:20',
-			submissions: true
-		},
 		DocumentDetails: {
 			documentId: '123',
 			version: 1,
@@ -1416,6 +1362,386 @@ export const spec = {
 						message: {
 							type: 'string'
 						}
+					}
+				}
+			}
+		},
+		ExaminationTimetableType: {
+			type: 'object',
+			properties: {
+				id: { type: 'integer', description: 'Examination timetable type id', example: 1 },
+				templateType: {
+					type: 'string',
+					description: 'Examination timetable type template type',
+					example: 'starttime-mandatory'
+				},
+				name: {
+					type: 'string',
+					description: 'Examination timetable type name',
+					example: 'Accompanied Site Inspection'
+				},
+				displayNameEn: {
+					type: 'string',
+					description: 'Examination timetable type display name',
+					example: 'Accompanied site inspection'
+				},
+				displayNameCy: {
+					type: 'string',
+					description: 'Examination timetable type display name in Welsh',
+					example: 'Accompanied site inspection Cy'
+				}
+			}
+		},
+		ExaminationTimetableTypes: {
+			type: 'array',
+			items: { $ref: '#/definitions/ExaminationTimetableType' }
+		},
+		ExaminationTimetable: {
+			type: 'object',
+			properties: {
+				id: { type: 'integer', description: 'Examination timetable id', example: 1 },
+				caseId: { type: 'integer', description: 'Case Id', example: 1 },
+				published: {
+					type: 'boolean',
+					description: 'Is the examination timetable published?',
+					example: true
+				},
+				publishedAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date Examination timetable was published',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				createdAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date created',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				updateAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date last updated',
+					example: '2023-02-01T00:00:00.000Z'
+				}
+			}
+		},
+		ExaminationTimetableWithItems: {
+			type: 'object',
+			properties: {
+				id: { type: 'integer', description: 'Examination timetable id', example: 1 },
+				caseId: { type: 'integer', description: 'Case Id', example: 1 },
+				published: {
+					type: 'boolean',
+					description: 'Is the examination timetable published?',
+					example: true
+				},
+				publishedAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date Examination timetable was published',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				createdAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date created',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				updateAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date last updated',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				items: {
+					type: 'array',
+					items: { $ref: '#/definitions/ExaminationTimetableItem' }
+				}
+			}
+		},
+		ExaminationTimetableItem: {
+			type: 'object',
+			properties: {
+				id: { type: 'integer', description: 'Examination timetable item id', example: 1 },
+				examinationTimetableId: {
+					type: 'integer',
+					description: 'Examination timetable parent id',
+					example: 1
+				},
+				examinationTypeId: {
+					type: 'integer',
+					description: 'Examination timetable type id',
+					example: 1
+				},
+				name: {
+					type: 'string',
+					description: 'Examination timetable item name',
+					example: 'Deadline 1'
+				},
+				description: {
+					type: 'string',
+					description: 'Examination timetable item name including line items',
+					example:
+						'{"preText":"Deadline 1 line items\\r\\n","bulletPoints":[" Line item 1\\r\\n"," Line item 2"]}'
+				},
+				date: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item date / end date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startDate: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item start date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startTime: {
+					type: 'string',
+					description: 'Examination timetable start time',
+					example: '10:20'
+				},
+				endTime: {
+					type: 'string',
+					description: 'Examination timetable end time',
+					example: '23:59'
+				},
+				folderId: {
+					type: 'integer',
+					description: 'Examination timetable item corresponding folder id',
+					example: 123
+				},
+				createdAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date created',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				ExaminationTimetableType: { $ref: '#/definitions/ExaminationTimetableType' },
+				submissions: {
+					type: 'boolean',
+					description: 'Matching folder contains submissions',
+					example: true
+				}
+			}
+		},
+		ExaminationTimetableItemWithExamTimetable: {
+			type: 'object',
+			properties: {
+				id: { type: 'integer', description: 'Examination timetable item id', example: 1 },
+				examinationTimetableId: {
+					type: 'integer',
+					description: 'Examination timetable parent id',
+					example: 1
+				},
+				examinationTypeId: {
+					type: 'integer',
+					description: 'Examination timetable type id',
+					example: 1
+				},
+				name: {
+					type: 'string',
+					description: 'Examination timetable item name',
+					example: 'Deadline 1'
+				},
+				description: {
+					type: 'string',
+					description: 'Examination timetable item name including line items',
+					example:
+						'{"preText":"Deadline 1 line items\\r\\n","bulletPoints":[" Line item 1\\r\\n"," Line item 2"]}'
+				},
+				date: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item date / end date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startDate: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item start date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startTime: {
+					type: 'string',
+					description: 'Examination timetable start time',
+					example: '10:20'
+				},
+				endTime: {
+					type: 'string',
+					description: 'Examination timetable end time',
+					example: '23:59'
+				},
+				folderId: {
+					type: 'integer',
+					description: 'Examination timetable item corresponding folder id',
+					example: 123
+				},
+				createdAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date created',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				ExaminationTimetableType: { $ref: '#/definitions/ExaminationTimetableType' },
+				ExaminationTimetable: { $ref: '#/definitions/ExaminationTimetable' },
+				submissions: {
+					type: 'boolean',
+					description: 'Matching folder contains submissions',
+					example: true
+				}
+			}
+		},
+		ExaminationTimetableItemCreateRequestBody: {
+			type: 'object',
+			properties: {
+				caseId: { type: 'integer', description: 'Case id', example: 1 },
+				examinationTypeId: {
+					type: 'integer',
+					description: 'Examination timetable type id',
+					example: 1
+				},
+				name: {
+					type: 'string',
+					description: 'Examination timetable item name',
+					example: 'Deadline 1'
+				},
+				description: {
+					type: 'string',
+					description: 'Examination timetable item name including line items',
+					example:
+						'{"preText":"Deadline 1 line items\\r\\n","bulletPoints":[" Line item 1\\r\\n"," Line item 2"]}'
+				},
+				date: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item date / end date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startDate: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item start date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startTime: {
+					type: 'string',
+					description: 'Examination timetable start time',
+					example: '10:20'
+				},
+				endTime: { type: 'string', description: 'Examination timetable end time', example: '23:59' }
+			}
+		},
+		ExaminationTimetableItemUpdateRequestBody: {
+			type: 'object',
+			properties: {
+				id: { type: 'integer', description: 'Examination timetable item id', example: 1 },
+				caseId: { type: 'integer', description: 'Case id', example: 1 },
+				examinationTypeId: {
+					type: 'integer',
+					description: 'Examination timetable type id',
+					example: 1
+				},
+				name: {
+					type: 'string',
+					description: 'Examination timetable item name',
+					example: 'Deadline 1'
+				},
+				description: {
+					type: 'string',
+					description: 'Examination timetable item name including line items',
+					example:
+						'{"preText":"Deadline 1 line items\\r\\n","bulletPoints":[" Line item 1\\r\\n"," Line item 2"]}'
+				},
+				date: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item date / end date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startDate: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item start date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startTime: {
+					type: 'string',
+					description: 'Examination timetable start time',
+					example: '10:20'
+				},
+				endTime: { type: 'string', description: 'Examination timetable end time', example: '23:59' }
+			}
+		},
+		ExaminationTimetableItemSaveResponse: {
+			type: 'object',
+			properties: {
+				id: { type: 'integer', description: 'Examination timetable item id', example: 1 },
+				examinationTimetableId: {
+					type: 'integer',
+					description: 'Examination timetable parent id',
+					example: 1
+				},
+				examinationTypeId: {
+					type: 'integer',
+					description: 'Examination timetable type id',
+					example: 1
+				},
+				name: {
+					type: 'string',
+					description: 'Examination timetable item name',
+					example: 'Deadline 1'
+				},
+				description: {
+					type: 'string',
+					description: 'Examination timetable item name including line items',
+					example:
+						'{"preText":"Deadline 1 line items\\r\\n","bulletPoints":[" Line item 1\\r\\n"," Line item 2"]}'
+				},
+				date: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item date / end date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startDate: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Examination timetable item start date',
+					example: '2023-02-01T00:00:00.000Z'
+				},
+				startTime: {
+					type: 'string',
+					description: 'Examination timetable start time',
+					example: '10:20'
+				},
+				endTime: {
+					type: 'string',
+					description: 'Examination timetable end time',
+					example: '23:59'
+				},
+				folderId: {
+					type: 'integer',
+					description: 'Examination timetable item corresponding folder id',
+					example: 123
+				},
+				createdAt: {
+					type: 'string',
+					string: 'date-time',
+					description: 'Date created',
+					example: '2023-02-01T00:00:00.000Z'
+				}
+			}
+		},
+		ExaminationTimetableItemSaveBadRequest: {
+			type: 'object',
+			properties: {
+				errors: {
+					type: 'object',
+					properties: {
+						caseId: { type: 'string', example: 'Must be valid case id' },
+						examinationTypeId: { type: 'string', example: 'Must be valid examination type' }
 					}
 				}
 			}

--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
@@ -9,7 +9,8 @@ import {
 	getCaseTimetableItemById,
 	deleteCaseTimetableItem,
 	updateCaseTimetableItem,
-	getCaseTimetableItemTypeByName
+	getCaseTimetableItemTypeByName,
+	getCaseTimetableItemTypeById
 } from './applications-timetable.service.js';
 import pino from '../../../lib/logger.js';
 
@@ -381,6 +382,11 @@ export async function postApplicationsCaseTimetableSave({ body }, response) {
 	}
 
 	if (errors) {
+		// need to repopulate the item type info into body
+		const selectedItemType = await getCaseTimetableItemTypeById(Number(body.timetableTypeId));
+		body.itemTypeName = selectedItemType.name;
+		body.templateType = selectedItemType.templateType;
+
 		const rows = getCheckYourAnswersRows(body);
 		return response.render(`applications/case-timetable/timetable-check-your-answers.njk`, {
 			isEditing: !!payload.id,

--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
@@ -113,7 +113,7 @@ export async function viewApplicationsCaseTimetablesPreview(_, response) {
 }
 
 /**
- * View the preview page of the examination timetables for a single case
+ * View the unpublish preview page of the examination timetables for a single case
  *
  * @type {import('@pins/express').RenderHandler<{timetableItems: Array<Record<string, any>>, backLink: string, stage: string}>}
  */
@@ -224,6 +224,7 @@ export async function deleteApplicationsCaseTimetable(request, response) {
 
 	response.redirect('../../deleted/success');
 }
+
 /**
  * Set the type for a new examination timetable (1st step)
  *
@@ -386,8 +387,12 @@ export async function postApplicationsCaseTimetableSave({ body }, response) {
 		const selectedItemType = await getCaseTimetableItemTypeById(Number(body.timetableTypeId));
 		body.itemTypeName = selectedItemType.name;
 		body.templateType = selectedItemType.templateType;
+		// need to copy timetableTypeId into templateId, as that is the value that the check-your-answers page expects,
+		// otherwise the type value is lost
+		body.templateId = body.timetableTypeId;
 
 		const rows = getCheckYourAnswersRows(body);
+
 		return response.render(`applications/case-timetable/timetable-check-your-answers.njk`, {
 			isEditing: !!payload.id,
 			rows,

--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.service.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.service.js
@@ -31,10 +31,16 @@ export const createCaseTimetableItem = async (payload) => {
 		});
 		response = { updatedTimetable };
 	} catch (/** @type {*} */ error) {
-		pino.error(`[API] ${error?.response?.body?.errors?.message || 'Unknown error'}`);
+		let errorMsg = 'There was an issue and your item could not be saved, try again';
+		if (error?.response?.body?.errors?.unique) {
+			// unique name test failed
+			errorMsg = error.response.body.errors.unique;
+		}
+
+		pino.error(`[API] ${JSON.stringify(error?.response?.body?.errors) || 'Unknown error'}`);
 
 		response = new Promise((resolve) => {
-			resolve({ errors: { msg: 'An error occurred, please try again later' } });
+			resolve({ errors: { msg: errorMsg } });
 		});
 	}
 
@@ -55,10 +61,16 @@ export const updateCaseTimetableItem = async (payload) => {
 		});
 		response = { updatedTimetable };
 	} catch (/** @type {*} */ error) {
-		pino.error(`[API] ${error?.response?.body?.errors?.message || 'Unknown error'}`);
+		let errorMsg = 'There was an issue and your item could not be saved, try again';
+		if (error?.response?.body?.errors?.unique) {
+			// unique name test failed
+			errorMsg = error.response.body.errors.unique;
+		}
+
+		pino.error(`[API] ${JSON.stringify(error?.response?.body?.errors) || 'Unknown error'}`);
 
 		response = new Promise((resolve) => {
-			resolve({ errors: { msg: 'An error occurred, please try again later' } });
+			resolve({ errors: { msg: errorMsg } });
 		});
 	}
 
@@ -94,6 +106,26 @@ export const getCaseTimetableItemTypeByName = async (selectedItemTypeName) => {
 
 	const selectedItemType =
 		timetableItemTypes.find((itemType) => itemType.name === selectedItemTypeName) ||
+		timetableItemTypes[0];
+
+	return {
+		name: selectedItemType.name || '',
+		templateType: selectedItemType.templateType,
+		id: selectedItemType.id
+	};
+};
+
+/**
+ * Return Timetable Item Type by its id
+ *
+ * @param {number} selectedItemTypeId
+ * @returns {Promise<{name: string, templateType: string, id: number}>}
+ */
+export const getCaseTimetableItemTypeById = async (selectedItemTypeId) => {
+	const timetableItemTypes = await getCaseTimetableItemTypes();
+
+	const selectedItemType =
+		timetableItemTypes.find((itemType) => itemType.id === selectedItemTypeId) ||
 		timetableItemTypes[0];
 
 	return {

--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.service.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.service.js
@@ -35,6 +35,9 @@ export const createCaseTimetableItem = async (payload) => {
 		if (error?.response?.body?.errors?.unique) {
 			// unique name test failed
 			errorMsg = error.response.body.errors.unique;
+		} else if (error?.response?.body?.errors?.name) {
+			// Name 'Other' name test failed
+			errorMsg = error.response.body.errors.name;
 		}
 
 		pino.error(`[API] ${JSON.stringify(error?.response?.body?.errors) || 'Unknown error'}`);
@@ -65,6 +68,9 @@ export const updateCaseTimetableItem = async (payload) => {
 		if (error?.response?.body?.errors?.unique) {
 			// unique name test failed
 			errorMsg = error.response.body.errors.unique;
+		} else if (error?.response?.body?.errors?.name) {
+			// Name 'Other' name test failed
+			errorMsg = error.response.body.errors.name;
 		}
 
 		pino.error(`[API] ${JSON.stringify(error?.response?.body?.errors) || 'Unknown error'}`);


### PR DESCRIPTION
## Describe your changes

- Fix issue with Examination Timetable items, that incorrectly allowed duplicate item names to be created
- Also fixed issue that allowed the item name 'Other' to be created / changed.  'Other' should not be allowed 
- fixed issue in the UI that did not display error messages correctly if there are errors from the API
- also fixed existing swagger route documentation errors for exam timetables, including payload definitions

## BOAS-1329 - Fix Able to create and save timetable items with the same item name and with 'Other' as the item name
https://pins-ds.atlassian.net/browse/BOAS-1329

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
