### PR TITLE
fix(api/applications): skip initialising app insights locally

### DIFF
--- a/apps/api/src/server/app.js
+++ b/apps/api/src/server/app.js
@@ -6,15 +6,21 @@ import logger from '#utils/logger.js';
 import { buildApp } from './build-app.js';
 import config from './config/config.js';
 
-try {
-	appInsights
-		.setup(config.APPLICATIONINSIGHTS_CONNECTION_STRING)
-		.setAutoDependencyCorrelation(true)
-		.setAutoCollectConsole(true)
-		.setSendLiveMetrics(true)
-		.start();
-} catch (err) {
-	logger.warn({ err }, 'Application insights failed to start: ');
+if (config.APPLICATIONINSIGHTS_CONNECTION_STRING) {
+	try {
+		appInsights
+			.setup(config.APPLICATIONINSIGHTS_CONNECTION_STRING)
+			.setAutoDependencyCorrelation(true)
+			.setAutoCollectConsole(true)
+			.setSendLiveMetrics(true)
+			.start();
+	} catch (err) {
+		logger.warn({ err }, 'Application insights failed to start: ');
+	}
+} else {
+	logger.warn(
+		'Skipped initialising Application Insights because `APPLICATIONINSIGHTS_CONNECTION_STRING` is undefined. If running locally, this is expected.'
+	);
 }
 
 const app = buildApp((expressApp) => {

--- a/apps/api/src/server/config/schema.js
+++ b/apps/api/src/server/config/schema.js
@@ -4,7 +4,7 @@ export default joi
 	.object({
 		NODE_ENV: joi.string().valid('development', 'production', 'test'),
 		PORT: joi.number(),
-		APPLICATIONINSIGHTS_CONNECTION_STRING: joi.string(),
+		APPLICATIONINSIGHTS_CONNECTION_STRING: joi.string().optional(),
 		SWAGGER_JSON_DIR: joi.string(),
 		DATABASE_URL: joi.string(),
 		blobStorageUrl: joi.string().when('NODE_ENV', { not: 'production', then: joi.optional() }),


### PR DESCRIPTION
## Describe your changes

fix(api/applications): skip initialising app insights locally

Tested locally.

## Issue ticket number and link

[BOAS-481](https://pins-ds.atlassian.net/browse/BOAS-481)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-481]: https://pins-ds.atlassian.net/browse/BOAS-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ