### PR TITLE
Fix/boas 1261 s51 advice publish exclude deleted attachments

### DIFF
--- a/apps/api/src/server/applications/s51advice/__tests__/s51-advice.test.js
+++ b/apps/api/src/server/applications/s51advice/__tests__/s51-advice.test.js
@@ -84,7 +84,9 @@ const s51AdvicesOnCase1 = [
 		redactedStatus: 'not_redacted',
 		isDeleted: false,
 		createdAt: '2023-01-01T00:00:00.000Z',
-		updatedAt: '2023-01-01T00:00:00.000Z'
+		updatedAt: '2023-01-01T00:00:00.000Z',
+		attachments: [],
+		totalAttachments: 0
 	}
 ];
 
@@ -262,7 +264,9 @@ describe('Test S51 advice API', () => {
 					redactedStatus: 'not_redacted',
 					dateCreated: 1672531200,
 					dateUpdated: 1672531200,
-					datePublished: null
+					attachments: [],
+					datePublished: null,
+					totalAttachments: 0
 				}
 			]
 		});

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -36,6 +36,7 @@ import logger from '#utils/logger.js';
 /**
  * @typedef {import('@pins/applications.api').Schema.Folder} Folder
  * @typedef {import('@pins/applications.api').Api.DocumentToSaveExtended} DocumentToSaveExtended
+ * @typedef {import('@pins/applications.api').Api.S51AdviceDocumentDetails} S51AdviceDocumentDetails
  */
 
 /**
@@ -78,7 +79,7 @@ export const getS51Advice = async (_request, response) => {
 	const attachments = await s51AdviceDocumentRepository.getForAdvice(Number(adviceId));
 
 	/**
-	 * @type {import("@pins/applications").S51AdviceDetails[] | { documentName: any; documentType: string; documentSize: string; dateAdded: number; status: string; documentGuid: string, version: number }[]}
+	 * @type {import("@pins/applications").S51AdviceDetails[] | S51AdviceDocumentDetails[]}
 	 */
 	const attachmentsWithVersion = [];
 	if (attachments?.length > 0) {

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -376,6 +376,11 @@ export const getReadyToPublishAdvices = async ({ params: { id }, body }, respons
 	const skipValue = getSkipValue(pageNumber, pageSize);
 	const caseId = Number(id);
 
+	//get the case Reference name - needed for the formatted advice ReferenceNumbers
+	const caseDetails = await getCaseDetails(+id, {});
+	// @ts-ignore
+	const caseRef = caseDetails.reference;
+
 	const paginatedAdviceToPublish = await s51AdviceRepository.getReadyToPublishAdvices({
 		skipValue,
 		pageSize,
@@ -386,7 +391,7 @@ export const getReadyToPublishAdvices = async ({ params: { id }, body }, respons
 
 	// @ts-ignore
 	const items = paginatedAdviceToPublish.map((advice) =>
-		mapS51Advice(caseId, advice, advice.S51AdviceDocument, true)
+		mapS51Advice(caseRef, advice, advice.S51AdviceDocument, true)
 	);
 
 	response.send({

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -366,7 +366,7 @@ export const updateManyS51Advices = async ({ body }, response) => {
 };
 
 /**
- * Gets paginated array of S51 advices
+ * Gets paginated array of 'Ready to Publish' S51 advices
  *
  * @type {import('express').RequestHandler<{ folderId: number, id: number }, ?, {pageNumber?: number, pageSize?: number}, any>}
  */
@@ -386,7 +386,7 @@ export const getReadyToPublishAdvices = async ({ params: { id }, body }, respons
 
 	// @ts-ignore
 	const items = paginatedAdviceToPublish.map((advice) =>
-		mapS51Advice(caseId, advice, advice.S51AdviceDocument)
+		mapS51Advice(caseId, advice, advice.S51AdviceDocument, true)
 	);
 
 	response.send({

--- a/apps/api/src/server/repositories/s51-advice.repository.js
+++ b/apps/api/src/server/repositories/s51-advice.repository.js
@@ -1,7 +1,7 @@
 import { databaseConnector } from '#utils/database-connector.js';
 
 /**
- * @typedef {import('@prisma/client').Prisma.S51AdviceGetPayload<{include: {S51AdviceDocument: {include: {Document: true }} }}>} S51AdviceWithS51AdviceDocumentWithDocument
+ * @typedef {import('@prisma/client').Prisma.S51AdviceGetPayload<{include: {S51AdviceDocument: {include: {Document: {include: {latestDocumentVersion: true}}}} }}>} S51AdviceWithS51AdviceDocumentsWithLatestVersion
  */
 
 /**
@@ -175,8 +175,8 @@ export const getPublishedAdvicesByIds = (s51AdviceIds) => {
  * Filter S51 advice table to retrieve documents by 'ready-to-publish' status, ignoring deleted advice,
  * and not including any deleted attachments
  *
- * @param {{skipValue: number, pageSize: number, caseId: number, documentVersion?: number}} params
- * @returns {S51AdviceWithS51AdviceDocumentWithDocument[]}
+ * @param {{skipValue: number, pageSize: number, caseId: number}} params
+ * @returns {import('@prisma/client').PrismaPromise<S51AdviceWithS51AdviceDocumentsWithLatestVersion[]>}
  */
 export const getReadyToPublishAdvices = ({ skipValue, pageSize, caseId }) => {
 	// in order to ensure only non-deleted attachments are included, have to use a select instead of an include, to be able to add a where clause
@@ -216,7 +216,24 @@ export const getReadyToPublishAdvices = ({ skipValue, pageSize, caseId }) => {
 			createdAt: true,
 			updatedAt: true,
 			S51AdviceDocument: {
-				select: { Document: true },
+				select: {
+					Document: {
+						select: {
+							latestDocumentVersion: {
+								select: {
+									fileName: true,
+									mime: true,
+									size: true,
+									dateCreated: true,
+									lastModified: true,
+									publishedStatus: true,
+									documentGuid: true,
+									version: true
+								}
+							}
+						}
+					}
+				},
 				where: {
 					Document: { isDeleted: false }
 				}

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -6851,7 +6851,7 @@
 				},
 				"dateAdded": {
 					"type": "number",
-					"description": "Date document was added",
+					"description": "Date document was added in Unix timestamp format",
 					"example": 1694179427
 				},
 				"status": {
@@ -7113,7 +7113,7 @@
 				},
 				"enquiryDate": {
 					"type": "number",
-					"description": "Date of enquiry",
+					"description": "Date of enquiry in Unix timestamp format",
 					"example": 1646822400
 				},
 				"enquiryDetails": {
@@ -7128,7 +7128,7 @@
 				},
 				"adviceDate": {
 					"type": "number",
-					"description": "Date advice given",
+					"description": "Date advice given in Unix timestamp format",
 					"example": 1646822400
 				},
 				"adviceDetails": {
@@ -7136,26 +7136,26 @@
 					"description": "Details of the advive given",
 					"example": "details of the advice provided"
 				},
-				"redactedStatus": {
-					"type": "string",
-					"enum": ["not_redacted", "redacted"],
-					"description": "Redacted status",
-					"example": "not_redacted"
-				},
 				"publishedStatus": {
 					"type": "string",
 					"enum": ["not_checked", "checked", "ready_to_publish", "published", "not_published"],
 					"description": "Published status",
 					"example": "published"
 				},
+				"redactedStatus": {
+					"type": "string",
+					"enum": ["not_redacted", "redacted"],
+					"description": "Redacted status",
+					"example": "not_redacted"
+				},
 				"dateCreated": {
 					"type": "number",
-					"description": "Date advice record was created",
+					"description": "Date advice record was created in Unix timestamp format",
 					"example": 1646822400
 				},
 				"dateUpdated": {
 					"type": "number",
-					"description": "Date advice record was last updated",
+					"description": "Date advice record was last updated in Unix timestamp format",
 					"example": 1646822400
 				},
 				"attachments": {
@@ -7163,6 +7163,11 @@
 					"items": {
 						"$ref": "#/definitions/S51AdviceDocumentDetails"
 					}
+				},
+				"datePublished": {
+					"type": "number",
+					"description": "Date advice record was published in Unix timestamp format",
+					"example": 1646822400
 				},
 				"totalAttachments": {
 					"type": "number",

--- a/apps/api/src/server/swagger-types.ts
+++ b/apps/api/src/server/swagger-types.ts
@@ -1909,7 +1909,7 @@ export interface S51AdviceDocumentDetails {
 	 */
 	documentSize?: number;
 	/**
-	 * Date document was added
+	 * Date document was added in Unix timestamp format
 	 * @example 1694179427
 	 */
 	dateAdded?: number;
@@ -2153,7 +2153,7 @@ export interface S51AdviceDetailsWithDocumentDetails {
 	 */
 	enquiryMethod?: 'phone' | 'email' | 'meeting' | 'post';
 	/**
-	 * Date of enquiry
+	 * Date of enquiry in Unix timestamp format
 	 * @example 1646822400
 	 */
 	enquiryDate?: number;
@@ -2168,7 +2168,7 @@ export interface S51AdviceDetailsWithDocumentDetails {
 	 */
 	adviser?: string;
 	/**
-	 * Date advice given
+	 * Date advice given in Unix timestamp format
 	 * @example 1646822400
 	 */
 	adviceDate?: number;
@@ -2178,26 +2178,31 @@ export interface S51AdviceDetailsWithDocumentDetails {
 	 */
 	adviceDetails?: string;
 	/**
-	 * Redacted status
-	 * @example "not_redacted"
-	 */
-	redactedStatus?: 'not_redacted' | 'redacted';
-	/**
 	 * Published status
 	 * @example "published"
 	 */
 	publishedStatus?: 'not_checked' | 'checked' | 'ready_to_publish' | 'published' | 'not_published';
 	/**
-	 * Date advice record was created
+	 * Redacted status
+	 * @example "not_redacted"
+	 */
+	redactedStatus?: 'not_redacted' | 'redacted';
+	/**
+	 * Date advice record was created in Unix timestamp format
 	 * @example 1646822400
 	 */
 	dateCreated?: number;
 	/**
-	 * Date advice record was last updated
+	 * Date advice record was last updated in Unix timestamp format
 	 * @example 1646822400
 	 */
 	dateUpdated?: number;
 	attachments?: S51AdviceDocumentDetails[];
+	/**
+	 * Date advice record was published in Unix timestamp format
+	 * @example 1646822400
+	 */
+	datePublished?: number;
 	/**
 	 * Total S51 Documents attached to this advice
 	 * @example 1

--- a/apps/api/src/server/swagger.js
+++ b/apps/api/src/server/swagger.js
@@ -1820,7 +1820,7 @@ export const spec = {
 				},
 				dateAdded: {
 					type: 'number',
-					description: 'Date document was added',
+					description: 'Date document was added in Unix timestamp format',
 					example: 1694179427
 				},
 				status: {
@@ -2032,7 +2032,11 @@ export const spec = {
 					description: 'Enquiry method',
 					example: 'email'
 				},
-				enquiryDate: { type: 'number', description: 'Date of enquiry', example: 1_646_822_400 },
+				enquiryDate: {
+					type: 'number',
+					description: 'Date of enquiry in Unix timestamp format',
+					example: 1_646_822_400
+				},
 				enquiryDetails: {
 					type: 'string',
 					description: 'Details of the enquiry',
@@ -2043,17 +2047,15 @@ export const spec = {
 					description: 'Name of who gave the advice',
 					example: 'John Caseworker-Smith'
 				},
-				adviceDate: { type: 'number', description: 'Date advice given', example: 1_646_822_400 },
+				adviceDate: {
+					type: 'number',
+					description: 'Date advice given in Unix timestamp format',
+					example: 1_646_822_400
+				},
 				adviceDetails: {
 					type: 'string',
 					description: 'Details of the advive given',
 					example: 'details of the advice provided'
-				},
-				redactedStatus: {
-					type: 'string',
-					enum: ['not_redacted', 'redacted'],
-					description: 'Redacted status',
-					example: 'not_redacted'
 				},
 				publishedStatus: {
 					type: 'string',
@@ -2061,19 +2063,30 @@ export const spec = {
 					description: 'Published status',
 					example: 'published'
 				},
+				redactedStatus: {
+					type: 'string',
+					enum: ['not_redacted', 'redacted'],
+					description: 'Redacted status',
+					example: 'not_redacted'
+				},
 				dateCreated: {
 					type: 'number',
-					description: 'Date advice record was created',
+					description: 'Date advice record was created in Unix timestamp format',
 					example: 1_646_822_400
 				},
 				dateUpdated: {
 					type: 'number',
-					description: 'Date advice record was last updated',
+					description: 'Date advice record was last updated in Unix timestamp format',
 					example: 1_646_822_400
 				},
 				attachments: {
 					type: 'array',
 					items: { $ref: '#/definitions/S51AdviceDocumentDetails' }
+				},
+				datePublished: {
+					type: 'number',
+					description: 'Date advice record was published in Unix timestamp format',
+					example: 1_646_822_400
 				},
 				totalAttachments: {
 					type: 'number',


### PR DESCRIPTION
## Describe your changes

- The S51 Advice Ready to Publish page was showing incorrect attachment numbers, after attachments had been deleted, as the DB call did not exclude deleted attachments.  Fixed.
- also fixed existing incorrect S51 payloads and types
- also fixed existing error, the Ready to Publish fn was not correctly building the 'referenceCode' property to include the case reference, eg should be EN0110001 - Advice - 00001. Fixed for consistency.

## BOAS-1261 S51 Advice Ready to Publish number of attachments not displaying correctly
https://pins-ds.atlassian.net/browse/BOAS-1261

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
