### PR TITLE
feat(appeals): av scan result and api

### DIFF
--- a/appeals/api/src/database/migrations/20231130170615_document_version_refactor/migration.sql
+++ b/appeals/api/src/database/migrations/20231130170615_document_version_refactor/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `examinationRefNo` on the `DocumentVersion` table. All the data in the column will be lost.
+  - You are about to drop the column `filter1` on the `DocumentVersion` table. All the data in the column will be lost.
+  - You are about to drop the column `filter2` on the `DocumentVersion` table. All the data in the column will be lost.
+  - You are about to drop the column `publishedStatus` on the `DocumentVersion` table. All the data in the column will be lost.
+  - You are about to drop the column `publishedStatusPrev` on the `DocumentVersion` table. All the data in the column will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropIndex
+DROP INDEX [filter1] ON [dbo].[DocumentVersion];
+ALTER TABLE [dbo].[DocumentVersion] DROP CONSTRAINT [DocumentVersion_publishedStatus_df]
+
+-- AlterTable
+ALTER TABLE [dbo].[DocumentVersion] DROP COLUMN [examinationRefNo],
+[filter1],
+[filter2],
+[publishedStatus],
+[publishedStatusPrev];
+ALTER TABLE [dbo].[DocumentVersion] ADD CONSTRAINT [DocumentVersion_virusCheckStatus_df] DEFAULT 'not_checked' FOR [virusCheckStatus];
+ALTER TABLE [dbo].[DocumentVersion] ADD [draft] BIT NOT NULL CONSTRAINT [DocumentVersion_draft_df] DEFAULT 1;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -430,6 +430,7 @@ model DocumentVersion {
   lastModified           DateTime?
   documentType           String?
   published              Boolean                  @default(false)
+  draft                  Boolean                  @default(true)
   sourceSystem           String                   @default("back-office-appeals")
   origin                 String?
   originalFilename       String?
@@ -443,29 +444,23 @@ model DocumentVersion {
   horizonDataID          String?
   fileMD5                String?
   path                   String?
-  virusCheckStatus       String?
+  virusCheckStatus       String?                  @default("not_checked")
   size                   Int?
   stage                  String?
-  filter1                String?
   blobStorageContainer   String?
   blobStoragePath        String?
   dateCreated            DateTime?                @default(now())
   datePublished          DateTime?
+  dateReceived           DateTime?
   isDeleted              Boolean                  @default(false)
-  examinationRefNo       String?
-  filter2                String?
-  publishedStatus        String?                  @default("awaiting_upload")
-  publishedStatusPrev    String?
   redactionStatusId      Int?
   redacted               Boolean                  @default(false)
   documentURI            String?
-  dateReceived           DateTime?
   parentDocument         Document?                @relation("VersionHistory", fields: [documentGuid], references: [guid])
   latestVersionDocument  Document?                @relation("LatestVersion")
   redactionStatus        DocumentRedactionStatus? @relation(fields: [redactionStatusId], references: [id])
 
   @@id([documentGuid, version])
-  @@index([filter1], map: "filter1")
   @@index([documentGuid], map: "documentGuid")
 }
 

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -352,6 +352,7 @@ interface FolderInfo {
 
 interface LatestDocumentVersionInfo {
 	published: boolean | null | undefined;
+	draft: boolean;
 	dateReceived: Date | null | undefined;
 	redactionStatusId: number | null | undefined;
 	documentGuid?: string | null | undefined;
@@ -374,16 +375,11 @@ interface LatestDocumentVersionInfo {
 	virusCheckStatus?: any;
 	size?: number | null | undefined;
 	stage?: string | null | undefined;
-	filter1?: any;
 	blobStorageContainer?: string | null | undefined;
 	blobStoragePath?: string | null | undefined;
 	dateCreated?: string | null | undefined;
 	datePublished?: any;
 	isDeleted?: boolean | null | undefined;
-	examinationRefNo?: any;
-	filter2?: any;
-	publishedStatus?: string | null | undefined;
-	publishedStatusPrev?: any;
 	redactionStatus?: number | null | undefined;
 	redacted?: boolean | null | undefined;
 	documentURI?: string | null | undefined;
@@ -586,6 +582,14 @@ type UpdateDocumentsRequest = {
 	receivedDate: string;
 	redactionStatus: number;
 	latestVersion: number;
+	published: boolean;
+	draft: boolean;
+}[];
+
+type UpdateDocumentsAvCheckRequest = {
+	id: string;
+	virusCheckStatus: string;
+	version: number;
 }[];
 
 type ListedBuildingDetailsResponse = Pick<ListedBuildingDetails, 'listEntry'>[];
@@ -638,7 +642,7 @@ export {
 	UpdateAppellantCaseValidationOutcomeParams,
 	UpdateAppellantRequest,
 	UpdateDocumentsRequest,
-	UpdateDocumentRequest,
+	UpdateDocumentsAvCheckRequest,
 	UpdateLPAQuestionaireValidationOutcomeParams,
 	UpdateLPAQuestionnaireRequest,
 	UpdateTimetableRequest,

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -55,6 +55,8 @@ export const ERROR_APPEAL_ALLOCATION_SPECIALISMS = 'invalid allocation specialis
 export const ERROR_CANNOT_BE_EMPTY_STRING = 'cannot be an empty string';
 export const ERROR_DOCUMENT_REDACTION_STATUSES_MUST_BE_ONE_OF =
 	'document redaction statuses must be one of {replacement0}';
+export const ERROR_DOCUMENT_AV_RESULT_STATUSES_MUST_BE_ONE_OF =
+	'document AV check statuses must be one of {replacement0}';
 export const ERROR_FAILED_TO_ADD_DOCUMENTS = 'failed to add documents';
 export const ERROR_DOCUMENT_NAME_ALREADY_EXISTS = 'a document with the same name already exists';
 export const ERROR_FAILED_TO_GET_DATA = 'failed to get data';

--- a/appeals/api/src/server/endpoints/documents/documents.formatter.js
+++ b/appeals/api/src/server/endpoints/documents/documents.formatter.js
@@ -8,6 +8,7 @@
  */
 const formatFolder = (folder) => ({
 	caseId: folder.caseId,
+	// @ts-ignore
 	documents:
 		folder.documents?.map((/** @type {Document} */ document) => ({
 			id: document.guid,
@@ -17,7 +18,8 @@ const formatFolder = (folder) => ({
 				dateReceived: document?.latestDocumentVersion?.dateReceived,
 				redactionStatus: document?.latestDocumentVersion?.redactionStatusId,
 				size: document?.latestDocumentVersion?.size,
-				mime: document?.latestDocumentVersion?.mime
+				mime: document?.latestDocumentVersion?.mime,
+				draft: document?.latestDocumentVersion?.draft
 			}
 		})) || null,
 	id: folder.id,

--- a/appeals/api/src/server/endpoints/documents/documents.routes.js
+++ b/appeals/api/src/server/endpoints/documents/documents.routes.js
@@ -8,7 +8,8 @@ import {
 	getDocumentIdValidator,
 	getDocumentValidator,
 	getDocumentsValidator,
-	patchDocumentsValidator
+	patchDocumentsValidator,
+	patchDocumentsAvCheckValidator
 } from './documents.validators.js';
 import * as controller from './documents.controller.js';
 
@@ -176,6 +177,34 @@ router.patch(
 	patchDocumentsValidator,
 	checkAppealExistsAndAddToRequest,
 	asyncHandler(controller.updateDocuments)
+);
+
+router.patch(
+	'/documents/avcheck',
+	/*
+		#swagger.tags = ['Documents']
+		#swagger.path = '/appeals/documents/avcheck'
+		#swagger.description = Updates multiple documents, following an AV check
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Documents to update for AV report',
+			schema: { $ref: '#/definitions/UpdateDocumentsAvCheckRequest' },
+			required: true
+		}
+		#swagger.responses[200] = {
+			description: 'Documents to update',
+			schema: { $ref: '#/definitions/UpdateDocumentsAvCheckResponse' }
+		}
+		#swagger.responses[400] = {}
+		#swagger.responses[404] = {}
+	 */
+	patchDocumentsAvCheckValidator,
+	asyncHandler(controller.updateDocumentsAvCheckStatus)
 );
 
 router.delete(

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -1573,6 +1573,28 @@ export interface UpdateDocumentsResponse {
 	}[];
 }
 
+export interface UpdateDocumentsAvCheckRequest {
+	documents?: {
+		/** @example "987e66e0-1db4-404b-8213-8082919159e9" */
+		id?: string;
+		/** @example 1 */
+		version?: number;
+		/** @example "checked" */
+		virusCheckStatus?: string;
+	}[];
+}
+
+export interface UpdateDocumentsAvCheckResponse {
+	documents?: {
+		/** @example "987e66e0-1db4-404b-8213-8082919159e9" */
+		id?: string;
+		/** @example 1 */
+		version?: number;
+		/** @example "checked" */
+		virusCheckStatus?: string;
+	}[];
+}
+
 export type GetAuditTrailsResponse = {
 	/** @example "f7ea429b-65d8-4c44-8fc2-7f1a34069855" */
 	azureAdUserId?: string;

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -1479,6 +1479,63 @@
 				}
 			}
 		},
+		"/appeals/documents/avcheck": {
+			"patch": {
+				"tags": ["Documents"],
+				"description": "Updates multiple documents, following an AV check",
+				"parameters": [
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Documents to update",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateDocumentsAvCheckResponse"
+								}
+							},
+							"application/xml": {
+								"schema": {
+									"$ref": "#/components/schemas/UpdateDocumentsAvCheckResponse"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request"
+					},
+					"404": {
+						"description": "Not Found"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Documents to update for AV report",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateDocumentsAvCheckRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/UpdateDocumentsAvCheckRequest"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/documents/{documentId}/{version}": {
 			"delete": {
 				"tags": ["Documents"],
@@ -5937,6 +5994,62 @@
 				},
 				"xml": {
 					"name": "UpdateDocumentsResponse"
+				}
+			},
+			"UpdateDocumentsAvCheckRequest": {
+				"type": "object",
+				"properties": {
+					"documents": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "string",
+									"example": "987e66e0-1db4-404b-8213-8082919159e9"
+								},
+								"version": {
+									"type": "number",
+									"example": 1
+								},
+								"virusCheckStatus": {
+									"type": "string",
+									"example": "checked"
+								}
+							}
+						}
+					}
+				},
+				"xml": {
+					"name": "UpdateDocumentsAvCheckRequest"
+				}
+			},
+			"UpdateDocumentsAvCheckResponse": {
+				"type": "object",
+				"properties": {
+					"documents": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "string",
+									"example": "987e66e0-1db4-404b-8213-8082919159e9"
+								},
+								"version": {
+									"type": "number",
+									"example": 1
+								},
+								"virusCheckStatus": {
+									"type": "string",
+									"example": "checked"
+								}
+							}
+						}
+					}
+				},
+				"xml": {
+					"name": "UpdateDocumentsAvCheckResponse"
 				}
 			},
 			"GetAuditTrailsResponse": {

--- a/appeals/api/src/server/repositories/document.repository.js
+++ b/appeals/api/src/server/repositories/document.repository.js
@@ -7,6 +7,7 @@ import { databaseConnector } from '#utils/database-connector.js';
 /** @typedef {import('@pins/appeals.api').Schema.Document} Document */
 /** @typedef {import('@pins/appeals.api').Schema.DocumentVersions} DocumentVersions */
 /** @typedef {import('@pins/appeals.api').Appeals.UpdateDocumentsRequest} UpdateDocumentsRequest */
+/** @typedef {import('@pins/appeals.api').Appeals.UpdateDocumentsAvCheckRequest} UpdateDocumentsAvCheckRequest */
 
 /**
  * @param {string} guid
@@ -86,10 +87,29 @@ export const updateDocuments = (data) =>
 							id: document.redactionStatus
 						}
 					},
-					published: true
+					published: document.published,
+					draft: false
 				},
 				where: {
 					documentGuid_version: { documentGuid: document.id, version: document.latestVersion }
+				}
+			})
+		)
+	);
+
+/**
+ * @param {UpdateDocumentsAvCheckRequest} data
+ * @returns
+ */
+export const updateDocumentAvStatus = (data) =>
+	Promise.all(
+		data.map((document) =>
+			databaseConnector.documentVersion.update({
+				data: {
+					virusCheckStatus: document.virusCheckStatus
+				},
+				where: {
+					documentGuid_version: { documentGuid: document.id, version: document.version }
 				}
 			})
 		)

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -662,6 +662,24 @@ export const spec = {
 				}
 			]
 		},
+		UpdateDocumentsAvCheckRequest: {
+			documents: [
+				{
+					id: '987e66e0-1db4-404b-8213-8082919159e9',
+					version: 1,
+					virusCheckStatus: 'checked'
+				}
+			]
+		},
+		UpdateDocumentsAvCheckResponse: {
+			documents: [
+				{
+					id: '987e66e0-1db4-404b-8213-8082919159e9',
+					version: 1,
+					virusCheckStatus: 'checked'
+				}
+			]
+		},
 		GetAuditTrailsResponse: [
 			{
 				azureAdUserId: 'f7ea429b-65d8-4c44-8fc2-7f1a34069855',

--- a/appeals/functions/document-processing/document-copy/function.json
+++ b/appeals/functions/document-processing/document-copy/function.json
@@ -4,8 +4,8 @@
 			"name": "registerSubscription",
 			"type": "serviceBusTrigger",
 			"direction": "in",
-			"topicName": "appeal-fo-appellant-submission",
-			"subscriptionName": "fo-appellant-submission-subscription",
+			"topicName": "appeal-document-copy",
+			"subscriptionName": "appeal-document-copy-subscription",
 			"connection": "ServiceBusConnection"
 		}
 	]

--- a/appeals/functions/document-processing/malware-detection/back-office-api-client.js
+++ b/appeals/functions/document-processing/malware-detection/back-office-api-client.js
@@ -1,0 +1,35 @@
+import got from 'got';
+import config from './config.js';
+/**
+ * @param {*} info
+ * @param {*} status
+ * @returns {Promise<{id: string | null}>}
+ */
+async function patch(info, status) {
+	try {
+		const version = info.version.replace('v', '');
+		const payload = {
+			documents: [
+				{
+					id: info.id,
+					version,
+					virusCheckStatus: status
+				}
+			]
+		};
+
+		const result = await got
+			.post(`https://${config.API_HOST}/appeals/documents/avcheck`, {
+				json: payload
+			})
+			.json();
+
+		return result;
+	} catch (err) {
+		throw new Error(`post document submission failed with error: ${err}`);
+	}
+}
+
+export default {
+	patch
+};

--- a/appeals/functions/document-processing/malware-detection/index.js
+++ b/appeals/functions/document-processing/malware-detection/index.js
@@ -1,3 +1,5 @@
+import api from './back-office-api-client.js';
+
 /**
  *
  * @param {import('@azure/functions').Context} context
@@ -5,4 +7,54 @@
  */
 export default async function (context, msg) {
 	context.log('Document malware scan', msg);
+	if (!msg?.data) {
+		throw new Error('received no input');
+	}
+
+	const info = getInfoFromBlobURI(msg.data.blobUri);
+	if (!info) {
+		context.log.warn(
+			`stopped: not possible to extract info from blob with URI ${msg.data.blobUri}`
+		);
+		return;
+	}
+
+	await api.patch(info, statusFromScanResult(msg.data.scanResultType));
 }
+
+/**
+ * @param {string} scanResult
+ * @returns {string}
+ * @throws {Error}
+ * */
+const statusFromScanResult = (scanResult) => {
+	switch (scanResult) {
+		case 'Malicious':
+			return 'failed_virus_check';
+		case 'No threats found':
+			return 'checked';
+		default:
+			throw new Error(`could not map scan result '${scanResult}' to a document status`);
+	}
+};
+
+/**
+ * @param {string} uri
+ * @returns {{ id: string, reference: string, version: string} | null}
+ * */
+const getInfoFromBlobURI = (uri) => {
+	const match = uri.match(/^.+\/appeal-bo-documents\/appeal\/(.+?)\/(.+?)\/(.+?)\//);
+	const reference = match?.[1] ?? null;
+	const id = match?.[2] ?? null;
+	const version = match?.[3] ?? null;
+
+	if (reference && id && version) {
+		return {
+			reference,
+			id,
+			version
+		};
+	}
+
+	return null;
+};

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -135,8 +135,8 @@ const mapDocumentFileTypeAndSize = (document) => {
  * @returns {PageContent}
  */
 export function addDocumentDetailsPage(backLinkUrl, folder, bodyItems) {
-	const unpublishedDocuments = folder.documents.filter(
-		(document) => document.latestDocumentVersion?.published === false
+	const incompleteDocuments = folder.documents.filter(
+		(document) => document.latestDocumentVersion?.draft === true
 	);
 
 	/** @type {PageContent} */
@@ -146,11 +146,11 @@ export function addDocumentDetailsPage(backLinkUrl, folder, bodyItems) {
 		backLinkUrl: backLinkUrl?.replace('{{folderId}}', folder.id),
 		preHeading: 'Add document details',
 		heading: `${folderPathToFolderNameText(folder.path)} documents`,
-		pageComponentGroups: unpublishedDocuments.map((document, index) => ({
+		pageComponentGroups: incompleteDocuments.map((document, index) => ({
 			wrapperHtml: {
 				opening: `<div class="govuk-form-group"><h2 class="govuk-heading-m">${document.name}</h2>`,
 				closing:
-					index < unpublishedDocuments.length - 1
+					index < incompleteDocuments.length - 1
 						? '<hr class="govuk-!-margin-top-7"></div>'
 						: '</div>'
 			},
@@ -780,7 +780,7 @@ export const mapDocumentsForDisplay = (
  */
 export function changeDocumentDetailsPage(backLinkUrl, folder, bodyItems) {
 	const latestDocuments = folder.documents.filter(
-		(document) => document.latestDocumentVersion?.published === true
+		(document) => document.latestDocumentVersion?.draft === false
 	);
 
 	/** @type {PageContent} */

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -946,7 +946,7 @@ export const documentFolderInfo = {
 			id: '15d19184-155b-4b6c-bba6-2bd2a61ca9a3',
 			name: 'test-pdf.pdf',
 			latestDocumentVersion: {
-				published: true,
+				draft: false,
 				dateReceived: '2023-02-01T01:00:00.000Z',
 				redactionStatus: 1,
 				size: 129363,
@@ -957,7 +957,7 @@ export const documentFolderInfo = {
 			id: '47d8f073-c837-4f07-9161-c1a5626eba56',
 			name: 'sample-20s.mp4',
 			latestDocumentVersion: {
-				published: true,
+				draft: false,
 				dateReceived: '2024-03-02T01:00:00.000Z',
 				redactionStatus: 2,
 				size: 11815175,
@@ -968,7 +968,7 @@ export const documentFolderInfo = {
 			id: '97260151-4334-407f-a76a-0b5666cbcfa6',
 			name: 'ph0.jpeg',
 			latestDocumentVersion: {
-				published: false,
+				draft: true,
 				dateReceived: '2025-04-03T01:00:00.000Z',
 				redactionStatus: 3,
 				size: 58861,
@@ -979,7 +979,7 @@ export const documentFolderInfo = {
 			id: '97260151-4334-407f-a76a-0b5666cbcfa7',
 			name: 'ph1.jpeg',
 			latestDocumentVersion: {
-				published: false,
+				draft: true,
 				dateReceived: '2025-04-03T01:00:00.000Z',
 				redactionStatus: 2,
 				size: 58987,


### PR DESCRIPTION
Implementation of AV scanning and document metadata updates:
- Azure function reporting AV scan status through EventGrid
- API endpoint to update the `virusCheckStatus` field in document versions
- Introduced a `draft` flag on the document version, to replace the current use of the `published` flag
- Refactored the DocumentVersion SQL table to remove unused fields

[BOAT-710](https://pins-ds.atlassian.net/browse/BOAT-710)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ x I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[BOAT-710]: https://pins-ds.atlassian.net/browse/BOAT-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ