### PR TITLE
fix(appeals): av scan regex and block downloads

### DIFF
--- a/appeals/api/src/server/endpoints/documents/documents.controller.js
+++ b/appeals/api/src/server/endpoints/documents/documents.controller.js
@@ -232,8 +232,8 @@ const updateDocumentsAvCheckStatus = async (req, res) => {
 			if (!latestDocument) {
 				return res.status(404).send({ errors: { body: ERROR_NOT_FOUND } });
 			}
-			const versionList = latestDocument.documentVersions?.map((v) => v.version) || [1];
-			if (versionList.indexOf(document.version) < 0) {
+			const versionList = latestDocument.documentVersion?.map((v) => v.version);
+			if (!versionList || versionList.indexOf(document.version) < 0) {
 				return res.status(404).send({ errors: { body: ERROR_NOT_FOUND } });
 			}
 		}

--- a/appeals/api/src/server/repositories/document.repository.js
+++ b/appeals/api/src/server/repositories/document.repository.js
@@ -24,7 +24,7 @@ export const getDocumentById = (guid) => {
 
 /**
  * @param {string} guid
- * @returns {PrismaPromise<DocumentVersions|null>}
+ * @returns {PrismaPromise<Document|null>}
  */
 export const getDocumentWithAllVersionsById = (guid) => {
 	return databaseConnector.document.findUnique({

--- a/appeals/functions/document-processing/malware-detection/index.js
+++ b/appeals/functions/document-processing/malware-detection/index.js
@@ -43,7 +43,7 @@ const statusFromScanResult = (scanResult) => {
  * @returns {{ id: string, reference: string, version: string} | null}
  * */
 const getInfoFromBlobURI = (uri) => {
-	const match = uri.match(/^.+\/appeal-bo-documents\/appeal\/(.+?)\/(.+?)\/(.+?)\//);
+	const match = uri.match(/^.+\/bo-appeals-documents\/appeal\/(.+?)\/(.+?)\/(.+?)\//);
 	const reference = match?.[1] ?? null;
 	const id = match?.[2] ?? null;
 	const version = match?.[3] ?? null;

--- a/appeals/web/src/server/app/components/file-downloader.component.js
+++ b/appeals/web/src/server/app/components/file-downloader.component.js
@@ -28,9 +28,15 @@ export const getDocumentDownload = async ({ apiClient, params, session }, respon
 		return response.status(404);
 	}
 
-	const { blobStorageContainer, blobStoragePath } = fileInfo.latestDocumentVersion;
+	const { blobStorageContainer, blobStoragePath, virusCheckStatus } =
+		fileInfo.latestDocumentVersion;
 	if (!blobStorageContainer || !blobStoragePath) {
 		throw new Error('Blob storage container or Blob storage path not found');
+	}
+
+	const validScanResult = 'checked';
+	if (virusCheckStatus !== validScanResult) {
+		throw new Error('Document cannot be downloaded, incorrect AV scan result');
 	}
 
 	let blobStorageClient = undefined;


### PR DESCRIPTION
Fix the regex to get document guid and version from documentURI
Throws an error when trying to download a file not scanned successfully
## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
