### PR TITLE
feat(appeals/api): Add virusScanStatus to appellantcase and lpaq calls

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -391,6 +391,7 @@ interface DocumentInfo {
 	createdAt?: string;
 	folderId?: number;
 	caseId?: number;
+	virusCheckStatus?: any;
 	latestDocumentVersion?: LatestDocumentVersionInfo;
 }
 

--- a/appeals/api/src/server/endpoints/documents/documents.formatter.js
+++ b/appeals/api/src/server/endpoints/documents/documents.formatter.js
@@ -17,6 +17,7 @@ const formatFolder = (folder) => ({
 				published: document?.latestDocumentVersion?.published,
 				dateReceived: document?.latestDocumentVersion?.dateReceived,
 				redactionStatus: document?.latestDocumentVersion?.redactionStatusId,
+				virusCheckStatus: document?.latestDocumentVersion?.virusCheckStatus,
 				size: document?.latestDocumentVersion?.size,
 				mime: document?.latestDocumentVersion?.mime,
 				draft: document?.latestDocumentVersion?.draft

--- a/appeals/api/src/server/endpoints/documents/documents.mapper.js
+++ b/appeals/api/src/server/endpoints/documents/documents.mapper.js
@@ -129,7 +129,8 @@ const mapFoldersLayoutForAppealFolder = (folders, path) => {
 							id: d.guid,
 							name: d.name,
 							folderId: d.folderId,
-							caseId: folder.caseId
+							caseId: folder.caseId,
+							virusCheckStatus: d.latestDocumentVersion?.virusCheckStatus
 						};
 					}) || []
 		};

--- a/appeals/api/src/server/repositories/folder.repository.js
+++ b/appeals/api/src/server/repositories/folder.repository.js
@@ -49,6 +49,12 @@ export const getByCaseIdPath = (caseId, path) => {
 			caseId,
 			path: { startsWith: path }
 		},
-		include: { documents: true }
+		include: {
+			documents: {
+				include: {
+					latestDocumentVersion: true
+				}
+			}
+		}
 	});
 };


### PR DESCRIPTION
add virusCheckStatus to folderInfo on API to allow LPAQ and AppellantCase to see

## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
