### PR TITLE
fix(api/applications): use npm script instead of npx directly in Docker

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -13,7 +13,7 @@ ENV SWAGGER_JSON_DIR=./src/server/swagger-output.json
 ENV DATABASE_URL=$DATABASE_URL
 
 WORKDIR /src/app/apps/api
-RUN npx prisma generate
+RUN npm run prisma-generate
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Describe your changes

Use npm script instead of npx directly in Dockerfile.

The dev build is failing when running `npx prisma generate`. I suspect it might be because of a version mismatch--using the script in package.json should prevent this.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
