### PR TITLE
chore(api/applications): change to Node slim from Alpine

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,6 @@
-FROM node:18-alpine
-RUN apk add --no-cache libc6-compat openssl openssl-dev
+FROM node:18-slim
+RUN apt-get update
+RUN apt-get install -y openssl
 
 WORKDIR /src/app
 COPY package*.json ./


### PR DESCRIPTION
## Describe your changes

Change from **node:18-alpine -> node:18-slim**. This seems to fix an error during build caused by the new Prisma version.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
