### PR TITLE
fix(appeals/api): new appeals default to assign_case_officer

### DIFF
--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -4,6 +4,7 @@ import { databaseConnector } from '#utils/database-connector.js';
 import { mapDefaultCaseFolders } from '#endpoints/documents/documents.mapper.js';
 import { mapBlobPath } from '#endpoints/documents/documents.mapper.js';
 import { getDefaultRedactionStatus } from './document-metadata.repository.js';
+import { STATE_TARGET_ASSIGN_CASE_OFFICER } from '#endpoints/constants.js';
 
 import config from '#config/config.js';
 
@@ -27,7 +28,12 @@ export const createAppeal = async (data, documents) => {
 			where: { id: appeal.id },
 			data: {
 				reference,
-				appealStatus: { create: {} }
+				appealStatus: {
+					create: {
+						status: STATE_TARGET_ASSIGN_CASE_OFFICER,
+						createdAt: new Date().toISOString()
+					}
+				}
 			}
 		});
 


### PR DESCRIPTION
When creating a new appeal as a result of an integration with the FO, the status should be 'assign_case_officer'

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
