### PR TITLE
fix(web/applications): correct unpublish documents form endpoint

### DIFF
--- a/apps/web/src/server/views/applications/case-documentation/documentation-unpublish.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-unpublish.njk
@@ -57,7 +57,7 @@
 							{% endfor %}
 						</tbody>
 					</table>
-					<form action='' method='post'>
+					<form action='./unpublish' method='post'>
 						{% for documentationFile in documentationFiles %}
 							<input name="documentGuids[]" type="hidden" value="{{documentationFile.documentGuid}}">
 						{% endfor %}


### PR DESCRIPTION
## Describe your changes

Form for unpublishing multiple documents was pointing to the wrong endpoint, and therefore being blocked by a validator which shouldn't have been running at that stage.

## Issue ticket number and link

[BOAS-1380](https://pins-ds.atlassian.net/browse/BOAS-1380)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1380]: https://pins-ds.atlassian.net/browse/BOAS-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ