### PR TITLE
fix(api/applications): remove caseId param from representation.getById

### DIFF
--- a/apps/api/src/server/applications/application/representations/representaions.service.js
+++ b/apps/api/src/server/applications/application/representations/representaions.service.js
@@ -13,12 +13,11 @@ export const getCaseRepresentations = async (caseId, pagination, filterAndSort) 
 
 /**
  *
- * @param {number} caseId
  * @param {number} repId
  * @returns {Promise<Prisma.RepresentationSelect>}
  */
-export const getCaseRepresentation = async (caseId, repId) => {
-	return representationsRepository.getById(Number(repId), Number(caseId));
+export const getCaseRepresentation = async (repId) => {
+	return representationsRepository.getById(Number(repId));
 };
 
 /**

--- a/apps/api/src/server/applications/application/representations/representations.controller.js
+++ b/apps/api/src/server/applications/application/representations/representations.controller.js
@@ -19,7 +19,7 @@ import {
  * @type {import("express").RequestHandler<{id: number, repId: number}, ?, ?, any>}
  */
 export const getRepresentation = async ({ params }, response) => {
-	const representation = await getCaseRepresentation(params.id, params.repId);
+	const representation = await getCaseRepresentation(params.repId);
 
 	if (!representation && params.repId) {
 		return response

--- a/apps/api/src/server/repositories/__tests__/representation.repository.test.js
+++ b/apps/api/src/server/repositories/__tests__/representation.repository.test.js
@@ -471,23 +471,6 @@ describe('Representation repository', () => {
 				}
 			});
 		});
-
-		it('finds a representation by id and caseId', async () => {
-			databaseConnector.representation.findUnique.mockResolvedValue(existingRepresentations[0]);
-
-			const representation = await representationRepository.getById(1, 2);
-
-			expect(representation).toEqual(existingRepresentations[0]);
-			expect(databaseConnector.representation.findUnique).toHaveBeenCalledWith({
-				select: expectedSelect,
-				where: {
-					case: {
-						id: 2
-					},
-					id: 1
-				}
-			});
-		});
 	});
 
 	describe('getFirstById', () => {

--- a/apps/api/src/server/repositories/representation.repository.js
+++ b/apps/api/src/server/repositories/representation.repository.js
@@ -61,19 +61,10 @@ export const getByCaseId = async (caseId, { page, pageSize }, { searchTerm, filt
 /**
  *
  * @param {number} id
- * @param {number} [caseId]
  * @returns {Promise<Representation | null>}
  */
-export const getById = async (id, caseId) => {
-	const caseFilter = caseId
-		? {
-				case: {
-					id: caseId
-				}
-		  }
-		: {};
-
-	return await databaseConnector.representation.findUnique({
+export const getById = async (id) =>
+	databaseConnector.representation.findUnique({
 		select: {
 			id: true,
 			reference: true,
@@ -169,11 +160,9 @@ export const getById = async (id, caseId) => {
 			}
 		},
 		where: {
-			id,
-			...caseFilter
+			id
 		}
 	});
-};
 
 /**
  *


### PR DESCRIPTION
## Describe your changes

Fixes issue with `GET /applications/{id}/representations/{repId}` endpoint where passing `caseId` parameter caused an error to be thrown due to Prisma's `findUnique` function only allowing a single parameter to be passed in the `where` section. Passing `{ id: 1, caseId: 2 }` is invalid so I have simplified it to be `{ id: 1 }` - removing `caseId`, as it is not needed anyway.

To replicate:
- Call the  `GET /applications/{id}/representations/{repId}` endpoint
  - for example, on dev: `GET /applications/2133/representations/7707`
- An error is returned: `Argument where of type RepresentationWhereUniqueInput needs exactly one argument, but you provided id and case.\nUnknown arg `case` in where.case for type RepresentationWhereUniqueInput`

Root cause appears to be passing `caseId` and `id` to `prisma.representation.findUnique`. 

This PR removes `caseId` as it is not used anywhere and not needed when using `findUnique`. Used to work OK with `findMany` but now redundant since https://github.com/Planning-Inspectorate/back-office/pull/1864

## Issue ticket number and link

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
