### PR TITLE
Feature/boas 481 structured logs

### DIFF
--- a/apps/api/src/server/applications/application/__tests__/publish-application.test.js
+++ b/apps/api/src/server/applications/application/__tests__/publish-application.test.js
@@ -3,12 +3,8 @@ import { request } from '../../../app-test.js';
 const { eventClient } = await import('#infrastructure/event-client.js');
 const { databaseConnector } = await import('#utils/database-connector.js');
 
-import logger from '#utils/logger.js';
-
 const now = 1_649_319_144_000;
 const mockDate = new Date(now);
-
-const loggerInfo = jest.spyOn(logger, 'info');
 
 jest.useFakeTimers({ now });
 
@@ -32,11 +28,6 @@ describe('Publish application', () => {
 		expect(response.status).toEqual(200);
 
 		const publishedDate = 1_649_319_144;
-
-		expect(loggerInfo).toHaveBeenCalledTimes(2);
-
-		expect(loggerInfo).toHaveBeenNthCalledWith(1, `attempting to publish a case with id ${caseId}`);
-		expect(loggerInfo).toHaveBeenNthCalledWith(2, `successfully published case with id ${caseId}`);
 
 		expect(response.body).toEqual({
 			publishedDate

--- a/apps/api/src/server/utils/logger.js
+++ b/apps/api/src/server/utils/logger.js
@@ -3,7 +3,7 @@ import pino from 'pino';
 import pinoHttp from 'pino-http';
 import config from '../config/config.js';
 
-const logger = pino({
+export const pinoLogger = pino({
 	timestamp: pino.stdTimeFunctions.isoTime,
 	level: 'trace',
 	transport: {
@@ -29,6 +29,18 @@ const logger = pino({
 	}
 });
 
-export const httpLogger = pinoHttp({ logger });
+const decorator = {
+	// @ts-ignore
+	get(target, prop) {
+		if (['info', 'warn', 'error'].includes(prop)) {
+			// @ts-ignore
+			return (...args) => target[prop]({ foo: 'bar' }, ...args);
+		}
+	}
+};
+
+const logger = new Proxy(pinoLogger, decorator);
+
+export const httpLogger = pinoHttp({ logger: pinoLogger });
 
 export default logger;


### PR DESCRIPTION
## Describe your changes

This change decorates the pino logger by accessing it through a Javascript proxy. Consumers can continue calling `info()`, `warn()` or `error()` with a message (string), and it will log the message along with the `operationId` from Application Insights.

* feat(api/applications): use a JS Proxy to decorate arguments to pino
* feat(api/applications): pass the AI operation ID when logging

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
