### PR TITLE
Feature/boas 1184 pretty print

### DIFF
--- a/apps/api/src/server/utils/logger.js
+++ b/apps/api/src/server/utils/logger.js
@@ -15,7 +15,7 @@ const decorator = {
 	get(target, prop) {
 		if (['info', 'warn', 'error', 'debug'].includes(prop)) {
 			const context = AppInsights.getCorrelationContext();
-			const operationId = context?.operation.id;
+			const operationId = context?.operation.id ?? null;
 
 			/** @type {(m: string) => void} */
 			return (...args) => {

--- a/apps/api/src/server/utils/logger.js
+++ b/apps/api/src/server/utils/logger.js
@@ -1,33 +1,10 @@
 import AppInsights from 'applicationinsights';
-import path from 'node:path';
 import pino from 'pino';
 import pinoHttp from 'pino-http';
-import config from '../config/config.js';
 
 export const pinoLogger = pino({
 	timestamp: pino.stdTimeFunctions.isoTime,
-	level: 'trace',
-	transport: {
-		targets: [
-			{
-				target: 'pino/file',
-				level: config.log.levelFile,
-				options: {
-					destination: path.join(config.cwd, './server.log')
-				}
-			},
-			{
-				target: 'pino-pretty',
-				level: config.log.levelStdOut,
-				options: {
-					destination: 1,
-					ignore: 'pid,hostname',
-					colorize: true,
-					translateTime: 'HH:MM:ss.l'
-				}
-			}
-		]
-	}
+	level: 'trace'
 });
 
 const decorator = {


### PR DESCRIPTION
## Describe your changes

* chore(api/applications): remove pretty print transport for pino
Also removed the pino/file transport as strangely the service fails to
startup if the pino/file transport is used alone (not in conjuction with
pino-pretty).
* chore(api/applications): pass null to pino if there is no operationId
This will make it easier to see if the code for grabbing the operationId
is working.

## Issue ticket number and link

[BOAS-1184](https://pins-ds.atlassian.net/browse/BOAS-1184)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1184]: https://pins-ds.atlassian.net/browse/BOAS-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ