### PR TITLE
fix(api/applications): publish representation service user ids as str…

### DIFF
--- a/apps/api/src/server/applications/application/representations/publish/__tests__/publish-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/publish/__tests__/publish-representation.test.js
@@ -159,7 +159,7 @@ const expectedNsipRepresentationPayload = [
 		representationId: 6409,
 		representationType: null,
 		representativeId: undefined,
-		representedId: 10105,
+		representedId: '10105',
 		status: 'VALID',
 		registerFor: 'ORGANISATION',
 		representationFrom: 'ORGANISATION'
@@ -175,8 +175,8 @@ const expectedNsipRepresentationPayload = [
 		referenceId: 'BC0110001-1533',
 		representationId: 6579,
 		representationType: null,
-		representativeId: 10382,
-		representedId: 10381,
+		representativeId: '10382',
+		representedId: '10381',
 		status: 'PUBLISHED',
 		registerFor: undefined,
 		representationFrom: 'AGENT'

--- a/apps/api/src/server/applications/application/representations/publish/representation.js
+++ b/apps/api/src/server/applications/application/representations/publish/representation.js
@@ -16,8 +16,8 @@ export const buildNsipRepresentationPayload = (representation) => {
 		redacted,
 		originalRepresentation: representation.originalRepresentation,
 		representationType: representation.type,
-		representedId: representation.represented?.id,
-		representativeId: representation.representative?.id,
+		representedId: representation.represented?.id.toString(),
+		representativeId: representation.representative?.id.toString(),
 		representationFrom: representation.representative?.id
 			? 'AGENT'
 			: representation.representedType,


### PR DESCRIPTION
## Describe your changes

ASB-2136

When publishing `nsip-representation` message, ensure `representedId` and `representativeId` are strings (as per [schema](https://github.com/Planning-Inspectorate/back-office/blob/main/apps/api/src/message-schemas/events/nsip-representation.schema.json#L59))

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
