### PR TITLE
fix(api/applications): unable to publish s51 advice no docs (boas-1394)

### DIFF
--- a/apps/api/src/server/applications/s51advice/s51-advice.service.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.service.js
@@ -136,6 +136,8 @@ export const extractDuplicates = async (adviceId, fileNames) => {
 };
 
 /**
+ * Publish S51 advice and any associated documents
+ *
  * @param {number} id
  * @returns {Promise<S51Advice>}
  * @throws {Error}
@@ -156,17 +158,20 @@ export const publishS51 = async (id) => {
 		datePublished: new Date()
 	});
 
-	const docsToPublish = advice.S51AdviceDocument.map(
-		(/** @type {S51AdviceDocument} */ advice) => advice.documentGuid
-	);
+	// if there are associated S51 Advice documents, publish them too
+	if (advice.S51AdviceDocument.length > 0) {
+		const docsToPublish = advice.S51AdviceDocument.map(
+			(/** @type {S51AdviceDocument} */ advice) => advice.documentGuid
+		);
 
-	publishDocuments(docsToPublish, 'System');
+		await publishDocuments(docsToPublish, 'System');
+	}
 
 	return publishedAdvice;
 };
 
 /**
- * Publish a set of S51 items given their IDs
+ * Publish a set of S51 items given their IDs, and any associated documents
  *
  * @param {number[]} ids
  * @returns {Promise<{ fulfilled: S51Advice[], errors: string[] }>}


### PR DESCRIPTION
## Describe your changes

S51 Advice publishing fails on the service bus event broadcast for documents, when there are no attached documents. Fix to only attempt doc publishing for S51 advice if there are attached documents
- also ensured the publishedDocs call uses await, as it is async

## BOAS-1394 Unable to Publish S51 advice (no documents)
https://pins-ds.atlassian.net/browse/BOAS-1394

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
