### PR TITLE
fix(api/applications): unable to publish s51 advice 2 (boas-1394)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -493,11 +493,17 @@ export const publishDocuments = async (documentGuids, username) => {
 
 	await Promise.all(activityLogs);
 
-	const publishedDocuments = await publishDocumentVersions(publishableDocumentVersionIds);
-	logger.info(`Published ${publishedDocuments.length} documents`);
+	// only publish docs if there are any that are verified as publishable
+	/** @type {string[]} */
+	let successfulPublishedDocGuids = [];
+	if (publishableDocumentVersionIds.length > 0) {
+		const publishedDocuments = await publishDocumentVersions(publishableDocumentVersionIds);
+		logger.info(`Published ${publishedDocuments.length} documents`);
+		successfulPublishedDocGuids = publishedDocuments.map((d) => d.documentGuid);
+	}
 
 	return {
-		successful: publishedDocuments.map((d) => d.documentGuid),
+		successful: successfulPublishedDocGuids,
 		failed: invalid
 	};
 };


### PR DESCRIPTION
## Describe your changes

the previous PR fixed S51 advice publishing for advice without documents attached, but Advice with docs fails to publish.  This fixes this by only publishing docs that have been verified as ready for publishing (eg required properties are complete)

## BOAS-1394 Unable to Publish S51 Advice
https://pins-ds.atlassian.net/browse/BOAS-1394

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
