### PR TITLE
fix(web/applications): fix incorrect item range for S51 publishing queue

### DIFF
--- a/apps/web/src/server/views/applications/case-s51/s51-publishing-queue.njk
+++ b/apps/web/src/server/views/applications/case-s51/s51-publishing-queue.njk
@@ -37,8 +37,13 @@
 
 				<p class='govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6'>
                     The queue contains {{ s51Advices.itemCount }} item(s).
-										Showing {{ ((s51Advices.page - 1) * s51Advices.pageDefaultSize) + 1 }}
-										- {{ ((s51Advices.page - 1) * s51Advices.pageDefaultSize) +  s51Advices.items.length }}
+
+                    {% if s51Advices.items.length == 0 %}
+                      Showing 0
+                    {% else %}
+                      Showing {{ ((s51Advices.page - 1) * s51Advices.pageDefaultSize) + 1 }}
+                      - {{ ((s51Advices.page - 1) * s51Advices.pageDefaultSize) +  s51Advices.items.length }}
+                    {% endif %}
 										item(s).
                 </p>
 


### PR DESCRIPTION
## Describe your changes

When the S51 publishing queue is empty, it displays `Showing 1 - 0 items` because we explicitly add 1 to the lower bound of items being shown; when there are no items being shown this resolves to 1.

## Issue ticket number and link

[BOAS-1425](https://pins-ds.atlassian.net/browse/BOAS-1425)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1425]: https://pins-ds.atlassian.net/browse/BOAS-1425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ