### PR TITLE
fix(functions/document-publish): add @pins/platform dependency to package.json

### DIFF
--- a/apps/functions/document-publish/package.json
+++ b/apps/functions/document-publish/package.json
@@ -15,6 +15,7 @@
         "@azure/functions": "^1.2.2",
         "azure-functions-core-tools": "3",
         "@pins/blob-storage-client": "^0.0.0",
+        "@pins/platform": "^0.0.0",
         "dotenv": "16.0.3",
         "got": "^12.5.2",
         "joi": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4970,6 +4970,7 @@
 			"dependencies": {
 				"@azure/functions": "^1.2.2",
 				"@pins/blob-storage-client": "^0.0.0",
+				"@pins/platform": "^0.0.0",
 				"azure-functions-core-tools": "3",
 				"dotenv": "16.0.3",
 				"got": "^12.5.2",
@@ -44719,6 +44720,7 @@
 			"requires": {
 				"@azure/functions": "^1.2.2",
 				"@pins/blob-storage-client": "^0.0.0",
+				"@pins/platform": "^0.0.0",
 				"azure-functions-core-tools": "3",
 				"cross-env": "^7.0.3",
 				"dotenv": "16.0.3",


### PR DESCRIPTION
…

## Describe your changes

The publish function was erroring:

```
'Cannot find package '@pins/platform' imported from /home/site/wwwroot/publish-document/config.js' 
```

This was broken inadvertently when the function build was changed. Before it copied all packages, now it just copies the actual dependencies. Since platform wasn't in package.json, it broke.

## Issue ticket number and link

[BOAS-1419](https://pins-ds.atlassian.net/browse/BOAS-1419)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1419]: https://pins-ds.atlassian.net/browse/BOAS-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ