### PR TITLE
Fix/boas 1422 s51 advice documents not publishing

### DIFF
--- a/apps/api/src/database/migrations/20240110164180_s51_folder_default_stage/migration.sql
+++ b/apps/api/src/database/migrations/20240110164180_s51_folder_default_stage/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Update the S51 Advice folders to have default stage '0' set
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+UPDATE [dbo].[Folder] SET stage = '0' WHERE [displayNameEn] = 'S51 advice';
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -37,8 +37,6 @@ import { verifyAllDocumentsHaveRequiredPropertiesForPublishing } from './documen
  * @typedef {import('@pins/applications.api').Api.PaginatedDocumentDetails} PaginatedDocumentDetails
  */
 
-const DOCUMENT_CASE_STAGE_S51_ADVICE = '0';
-
 /**
  * Remove extension from document name
  *
@@ -147,11 +145,6 @@ const attemptInsertDocuments = async (caseId, documents, isS51) => {
 
 			// Get the cases stage to be applied to the document based on the folder
 			let stage = await getCaseStageMapping(documentToDB.folderId);
-
-			// special case for S51 Advice Documents
-			if (isS51) {
-				stage = DOCUMENT_CASE_STAGE_S51_ADVICE;
-			}
 
 			logger.info(`Upserting metadata for document with guid: ${document.guid}`);
 

--- a/apps/api/src/server/applications/constants.js
+++ b/apps/api/src/server/applications/constants.js
@@ -19,6 +19,7 @@ const DOCUMENT_CASE_STAGE_RECOMMENDATION = 'Recommendation';
 const DOCUMENT_CASE_STAGE_DECISION = 'Decision';
 const DOCUMENT_CASE_STAGE_POST_DECISION = 'Post-decision';
 const DOCUMENT_CASE_STAGE_CORRESPONDENCE = 'Correspondence';
+const DOCUMENT_CASE_STAGE_S51_ADVICE = '0'; // special value required by Front Office
 
 // Define top level document case stage mappings, so we can change in one single place if needed
 export const folderDocumentCaseStageMappings = {
@@ -27,7 +28,7 @@ export const folderDocumentCaseStageMappings = {
 	LEGAL_ADVICE: null,
 	TRANSBOUNDARY: DOCUMENT_CASE_STAGE_PRE_APPLICATION,
 	LAND_RIGHTS: null,
-	S51_ADVICE: null,
+	S51_ADVICE: DOCUMENT_CASE_STAGE_S51_ADVICE,
 	PRE_APPLICATION: DOCUMENT_CASE_STAGE_PRE_APPLICATION,
 	ACCEPTANCE: DOCUMENT_CASE_STAGE_ACCEPTANCE,
 	DEVELOPERS_APPLICATION: DOCUMENT_CASE_STAGE_DEVELOPERS_APPLICATION,

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -138,6 +138,8 @@ export const getDocuments = async ({ params }, response) => {
 };
 
 /**
+ * Add an S51 Advice document to an S51 Advice
+ *
  * @type {import('express').RequestHandler}
  * @throws {Error}
  * @returns {Promise<void>}
@@ -443,6 +445,7 @@ export const verifyS51TitleIsUnique = async ({ params }, response) => {
 };
 
 /**
+ * Publishes an array of S51 Advice selected from the Ready to Publish queue, and any attached documents
  *
  * @type {import('express').RequestHandler<{ id: string }, ?, {selectAll?: boolean, ids: string[]}>}
  * */

--- a/apps/api/src/server/applications/s51advice/s51-advice.service.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.service.js
@@ -164,7 +164,7 @@ export const publishS51 = async (id) => {
 			(/** @type {S51AdviceDocument} */ advice) => advice.documentGuid
 		);
 
-		await publishDocuments(docsToPublish, 'System');
+		await publishDocuments(docsToPublish, 'System', true);
 	}
 
 	return publishedAdvice;

--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -167,6 +167,48 @@ export const getPublishableDocuments = (documentIds) => {
 };
 
 /**
+ * From a given list of document ids, retrieve the ones which are publishable.
+ * similar to the fn getPublishableDocuments but without checking for required fields.
+ * This is used for S51 Advice documents
+ *
+ * @param {string[]} documentIds
+ * @returns {Promise<{guid: string, latestVersionId: number, latestDocumentVersion: {mime: string}}[]>}
+ */
+export const getPublishableDocumentsWithoutRequiredPropertiesCheck = (documentIds) => {
+	// @ts-ignore - if there is a latestDocumentVersion, there will be a latestVerionid
+	return databaseConnector.document.findMany({
+		where: {
+			guid: {
+				in: documentIds
+			},
+			latestDocumentVersion: {
+				NOT: {
+					OR: [
+						// TODO: Move name from Document.name to DocumentVersion.fileName
+						{
+							fileName: ''
+						},
+						{
+							fileName: null
+						}
+					]
+				}
+			},
+			isDeleted: false
+		},
+		select: {
+			guid: true,
+			latestVersionId: true,
+			latestDocumentVersion: {
+				select: {
+					mime: true
+				}
+			}
+		}
+	});
+};
+
+/**
  *
  * @param {string} documentId
  * @param {import('@pins/applications.api').Schema.DocumentUpdateInput} documentDetails


### PR DESCRIPTION
## Describe your changes

Fix S51 Advice document publishing
- modified doc publishing code to skip the “normal” doc required field checks, for S51 Advice documents
- Also set stage = '0' for S51 Advice documents when they are uploaded - as per original requirements. Takes value from S51 Advice folder stage default value.
- update folder template to set stage '0' for the S51 advice folder
- db update to correctly set default stage for all existing S51 advice folders - **note: this requires DB Migrate**

## BOAS-1422 S51 Advice documents not publishing
https://pins-ds.atlassian.net/browse/BOAS-1422

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
