### PR TITLE
fix(functions): split config into separate functions

### DIFF
--- a/apps/functions/applications-migration/common/back-office-api-client.js
+++ b/apps/functions/applications-migration/common/back-office-api-client.js
@@ -1,7 +1,7 @@
 import got from 'got';
-import { loadConfig } from './config.js';
+import { loadApiConfig } from './config.js';
 
-const config = loadConfig();
+const config = loadApiConfig();
 
 /**
  * Handle an HTTP trigger/request to run the migration

--- a/apps/functions/applications-migration/common/synapse-db.js
+++ b/apps/functions/applications-migration/common/synapse-db.js
@@ -1,9 +1,9 @@
 import { DefaultAzureCredential } from '@azure/identity';
 import { Sequelize } from 'sequelize';
 import * as tedious from 'tedious';
-import { loadConfig } from './config.js';
+import { loadSynapseConfig } from './config.js';
 
-const config = loadConfig();
+const config = loadSynapseConfig();
 
 const credential = new DefaultAzureCredential();
 

--- a/apps/functions/applications-migration/project-updates-migration/src/project-updates-migration.js
+++ b/apps/functions/applications-migration/project-updates-migration/src/project-updates-migration.js
@@ -1,11 +1,11 @@
 import { chunk as chunkArray } from 'lodash-es';
 import { QueryTypes, Sequelize } from 'sequelize';
-import { loadConfig } from '../../common/config.js';
+import { loadWordpressConfig } from '../../common/config.js';
 import { makePostRequest } from '../../common/back-office-api-client.js';
 
 const MAX_BODY_ITEMS_LENGTH = 100;
 
-const config = loadConfig();
+const config = loadWordpressConfig();
 const { username, password, database, host, port, dialect } = config.wordpressDatabase;
 
 const sequelize = new Sequelize(database, username, password, {


### PR DESCRIPTION
## Describe your changes

Split up function `config` / `loadConfig` into separate parts: api, synpase and wordpress. Allows for each function to only import the config it needs. 

Fixes an issue where the `project-updates` migration function fails in production due to the Synapse host environment variable not being defined. That function now only imports the config it needs (wordpress)

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAS-1423

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
