### PR TITLE
fix(api/applications): subscription service user migration

### DIFF
--- a/apps/api/src/server/migration/migrators/utils.js
+++ b/apps/api/src/server/migration/migrators/utils.js
@@ -35,6 +35,30 @@ const getCaseIdFromRef = async (reference) => {
 };
 
 /**
+ * @param {string }email
+ * @returns {Promise<number>} serviceUserId
+ */
+export const getOrCreateServiceUserId = async ({ emailAddress: email }) => {
+	const existingServiceUser = await databaseConnector.serviceUser.findFirst({
+		where: { email },
+		select: { id: true }
+	});
+
+	if (existingServiceUser) return existingServiceUser.id;
+
+	const newServiceUser = await databaseConnector.serviceUser.create({
+		data: {
+			email
+		},
+		select: {
+			id: true
+		}
+	});
+
+	return newServiceUser.id;
+};
+
+/**
  * @param {NSIPProjectMinimalCaseData} projectUpdate
  *
  * @returns {Promise<number>} caseId


### PR DESCRIPTION
## Describe your changes

Fixes issue with `/migration/nsip-subscription` endpoint where is was attempting to write to the `emailAddress` field in the `Subscription` table, which no longer exists. Updated the implementation to fetch or create the ServiceUser associated with the email, and link the `Subscription` and `ServiceUser` via `serviceUserId`

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAS-1423

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
