### PR TITLE
fix(applications/api): remove some of the options from map zoom level list (BOAS-1331)

### DIFF
--- a/apps/api/src/database/migrations/20240112144180_remove_city_town_junction_from_zoomlevels_table/migration.sql
+++ b/apps/api/src/database/migrations/20240112144180_remove_city_town_junction_from_zoomlevels_table/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Delete the zoom levels for town, city and junction
+  Update those application details that referenced the above to a zoom level of district
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+UPDATE [dbo].[ApplicationDetails] SET zoomLevelId = (SELECT [id] FROM [dbo].[ZoomLevel] WHERE name = 'district') WHERE zoomLevelId in (SELECT [id] FROM [dbo].[ZoomLevel] WHERE name = 'town' or name = 'city' or name = 'junction');
+DELETE FROM [dbo].[ZoomLevel] WHERE name = 'town' or name = 'city' or name = 'junction'
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/database/seed/data-static.js
+++ b/apps/api/src/database/seed/data-static.js
@@ -394,24 +394,6 @@ export const zoomLevels = [
 		displayNameCy: 'District'
 	},
 	{
-		name: 'city',
-		displayOrder: 400,
-		displayNameEn: 'City',
-		displayNameCy: 'City'
-	},
-	{
-		name: 'town',
-		displayOrder: 300,
-		displayNameEn: 'Town',
-		displayNameCy: 'Town'
-	},
-	{
-		name: 'junction',
-		displayOrder: 200,
-		displayNameEn: 'Junction',
-		displayNameCy: 'Junction'
-	},
-	{
 		name: 'none',
 		displayOrder: 0,
 		displayNameEn: 'None',


### PR DESCRIPTION
## Describe your changes

- Remove the zoom levels of city, town and junction from the data static definition
- Add a migration to make sure all application detail records with a zoom level of city, town or junction are updated to have a zoom level of district and to remove those zoom levels from the zoom level table

This has been tested manually to make sure the zoom levels of city, town and junction are no longer available.

## BOAS-1331 Remove some of the options from map zoom level list
https://pins-ds.atlassian.net/browse/BOAS-1331

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
