### PR TITLE
fix(applications/web): fix S51 advice copy (BOAS-1258)

### DIFF
--- a/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
+++ b/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
@@ -94,7 +94,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
             <h1 class=\\"govuk-heading-xl govuk-!-margin-top-4\\"><span class=\\"govuk-caption-xl\\">S51 advice properties</span> Minim veniam quis nostrud</h1>
             <ul class=\\"govuk-list\\">
                 <li class=\\"govuk-!-margin-top-4\\"><strong>Case reference:</strong> CASE/04</li>
-                <li class=\\"govuk-!-margin-top-4\\"><strong>Document reference number:</strong> BC0110001-Advice-00001</li>
+                <li class=\\"govuk-!-margin-top-4\\"><strong>Advice reference:</strong> BC0110001-Advice-00001</li>
             </ul>
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/upload\\"> Upload files</a>
             </div>
@@ -529,7 +529,7 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
             <h1 class=\\"govuk-heading-xl govuk-!-margin-top-4\\"><span class=\\"govuk-caption-xl\\">S51 advice properties</span> Minim veniam quis nostrud</h1>
             <ul class=\\"govuk-list\\">
                 <li class=\\"govuk-!-margin-top-4\\"><strong>Case reference:</strong> CASE/04</li>
-                <li class=\\"govuk-!-margin-top-4\\"><strong>Document reference number:</strong> BC0110001-Advice-00001</li>
+                <li class=\\"govuk-!-margin-top-4\\"><strong>Advice reference:</strong> BC0110001-Advice-00001</li>
             </ul>
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/upload\\"> Upload files</a>
             </div>
@@ -1553,7 +1553,7 @@ exports[`S51 Advice S51 folder page GET /case/123/project-documentation/21/s51-a
             <div class=\\"govuk-width-container\\">
                 <div class=\\"govuk-grid-row govuk-!-margin-top-0\\">
                     <div class=\\"govuk-grid-column-two-thirds govuk-!-margin-top-0\\">
-                        <h3 class=\\"govuk-heading-m\\">Documents</h3>
+                        <h3 class=\\"govuk-heading-m\\">S51 advice</h3>
                         <p class=\\"govuk-body\\">This folder contains item(s) of S51 advice.</p>
                     </div>
                 </div>

--- a/apps/web/src/server/views/applications/case-s51/properties/s51-properties.njk
+++ b/apps/web/src/server/views/applications/case-s51/properties/s51-properties.njk
@@ -45,7 +45,7 @@
 						<strong>Case reference:</strong>
 						{{ case.reference }}</li>
 					<li class="govuk-!-margin-top-4">
-						<strong>Document reference number:</strong>
+						<strong>Advice reference:</strong>
 						{{ s51Advice.referenceCode }}</li>
 
 				</ul>

--- a/apps/web/src/server/views/applications/components/folder/folder-status.component.njk
+++ b/apps/web/src/server/views/applications/components/folder/folder-status.component.njk
@@ -40,7 +40,7 @@
 	<div class="govuk-width-container">
 		<div class="govuk-grid-row govuk-!-margin-top-0">
 			<div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
-				<h3 class="govuk-heading-m">Documents</h3>
+				<h3 class="govuk-heading-m">{% if isS51folder %}S51 advice{% else %}Documents{% endif %}</h3>
 				<p class="govuk-body">
 					{{ contentNumberText }}
 				</p>


### PR DESCRIPTION
## Describe your changes

- Changed the S51 advice copy as described in the linked ticket
- Updated the affected web unit tests

This has been tested manually to make sure the S51 Advice copy is now as expected.

## BOAS-1258 S51 'Advice reference' field and folder sub heading are labelled incorrectly
https://pins-ds.atlassian.net/browse/BOAS-1258

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
