### PR TITLE
feat(applications/web): Increase height of description field for Examination Timetable (BOAS-1349)

### DIFF
--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -96,7 +96,7 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\"></textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\"></textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -265,7 +265,7 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\"></textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\"></textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -452,7 +452,7 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\"></textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\"></textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -548,7 +548,7 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\"></textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\"></textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -692,7 +692,7 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\"></textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\"></textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -828,7 +828,7 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\"></textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\"></textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -989,7 +989,7 @@ exports[`Create examination timetable page should display errors if start date a
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\"></textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\"></textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -1148,7 +1148,7 @@ exports[`Create examination timetable page should display errors if start time a
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\"></textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\"></textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -1402,7 +1402,7 @@ exports[`Edit examination timetable GET /case/123/examination-timetable/item/1/e
                     <div id=\\"description-hint\\"
                     class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
                     <textarea class=\\"govuk-textarea\\"
-                    id=\\"description\\" name=\\"description\\" rows=\\"5\\" aria-describedby=\\"description-hint\\">test*ponintone*pointtwo</textarea>
+                    id=\\"description\\" name=\\"description\\" rows=\\"20\\" aria-describedby=\\"description-hint\\">test*ponintone*pointtwo</textarea>
                 </div>
                 <div class='govuk-grid-column-full'>
                     <button class=\\"govuk-button govuk-!-margin-top-6\\" data-module=\\"govuk-button\\">Continue</button>
@@ -1575,8 +1575,8 @@ exports[`POST /case/123/examination-timetable/item/check-your-answers should sho
                 <input class=\\"govuk-input\\" value='1' id=\\"timetableId\\" name=\\"timetableId\\"
                 type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='Lorem' id=\\"name\\" name=\\"name\\" type=\\"hidden\\">
-                <input class=\\"govuk-input\\" value='Some text with 
- * one point 
+                <input class=\\"govuk-input\\" value='Some text with
+ * one point
 * another point ' id=\\"description\\" name=\\"description\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='01' id=\\"date.day\\" name=\\"date.day\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='02' id=\\"date.month\\" name=\\"date.month\\"
@@ -1639,8 +1639,8 @@ exports[`POST /case/123/examination-timetable/item/check-your-answers should sho
                 <input class=\\"govuk-input\\" value='1' id=\\"timetableId\\" name=\\"timetableId\\"
                 type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='Lorem' id=\\"name\\" name=\\"name\\" type=\\"hidden\\">
-                <input class=\\"govuk-input\\" value='Some text with 
- * one point 
+                <input class=\\"govuk-input\\" value='Some text with
+ * one point
 * another point ' id=\\"description\\" name=\\"description\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='01' id=\\"date.day\\" name=\\"date.day\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='02' id=\\"date.month\\" name=\\"date.month\\"
@@ -1689,8 +1689,8 @@ exports[`POST /case/123/examination-timetable/item/check-your-answers should sho
                 <input class=\\"govuk-input\\" value='' id=\\"timetableId\\" name=\\"timetableId\\"
                 type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='Lorem' id=\\"name\\" name=\\"name\\" type=\\"hidden\\">
-                <input class=\\"govuk-input\\" value='Some text with 
- * one point 
+                <input class=\\"govuk-input\\" value='Some text with
+ * one point
 * another point ' id=\\"description\\" name=\\"description\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='01' id=\\"date.day\\" name=\\"date.day\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='02' id=\\"date.month\\" name=\\"date.month\\"
@@ -1753,8 +1753,8 @@ exports[`POST /case/123/examination-timetable/item/check-your-answers should sho
                 <input class=\\"govuk-input\\" value='' id=\\"timetableId\\" name=\\"timetableId\\"
                 type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='Lorem' id=\\"name\\" name=\\"name\\" type=\\"hidden\\">
-                <input class=\\"govuk-input\\" value='Some text with 
- * one point 
+                <input class=\\"govuk-input\\" value='Some text with
+ * one point
 * another point ' id=\\"description\\" name=\\"description\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='01' id=\\"date.day\\" name=\\"date.day\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='02' id=\\"date.month\\" name=\\"date.month\\"

--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -1575,8 +1575,8 @@ exports[`POST /case/123/examination-timetable/item/check-your-answers should sho
                 <input class=\\"govuk-input\\" value='1' id=\\"timetableId\\" name=\\"timetableId\\"
                 type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='Lorem' id=\\"name\\" name=\\"name\\" type=\\"hidden\\">
-                <input class=\\"govuk-input\\" value='Some text with
- * one point
+                <input class=\\"govuk-input\\" value='Some text with 
+ * one point 
 * another point ' id=\\"description\\" name=\\"description\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='01' id=\\"date.day\\" name=\\"date.day\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='02' id=\\"date.month\\" name=\\"date.month\\"
@@ -1639,8 +1639,8 @@ exports[`POST /case/123/examination-timetable/item/check-your-answers should sho
                 <input class=\\"govuk-input\\" value='1' id=\\"timetableId\\" name=\\"timetableId\\"
                 type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='Lorem' id=\\"name\\" name=\\"name\\" type=\\"hidden\\">
-                <input class=\\"govuk-input\\" value='Some text with
- * one point
+                <input class=\\"govuk-input\\" value='Some text with 
+ * one point 
 * another point ' id=\\"description\\" name=\\"description\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='01' id=\\"date.day\\" name=\\"date.day\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='02' id=\\"date.month\\" name=\\"date.month\\"
@@ -1689,8 +1689,8 @@ exports[`POST /case/123/examination-timetable/item/check-your-answers should sho
                 <input class=\\"govuk-input\\" value='' id=\\"timetableId\\" name=\\"timetableId\\"
                 type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='Lorem' id=\\"name\\" name=\\"name\\" type=\\"hidden\\">
-                <input class=\\"govuk-input\\" value='Some text with
- * one point
+                <input class=\\"govuk-input\\" value='Some text with 
+ * one point 
 * another point ' id=\\"description\\" name=\\"description\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='01' id=\\"date.day\\" name=\\"date.day\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='02' id=\\"date.month\\" name=\\"date.month\\"
@@ -1753,8 +1753,8 @@ exports[`POST /case/123/examination-timetable/item/check-your-answers should sho
                 <input class=\\"govuk-input\\" value='' id=\\"timetableId\\" name=\\"timetableId\\"
                 type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='Lorem' id=\\"name\\" name=\\"name\\" type=\\"hidden\\">
-                <input class=\\"govuk-input\\" value='Some text with
- * one point
+                <input class=\\"govuk-input\\" value='Some text with 
+ * one point 
 * another point ' id=\\"description\\" name=\\"description\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='01' id=\\"date.day\\" name=\\"date.day\\" type=\\"hidden\\">
                 <input class=\\"govuk-input\\" value='02' id=\\"date.month\\" name=\\"date.month\\"

--- a/apps/web/src/server/views/applications/case-timetable/timetable-details-form.njk
+++ b/apps/web/src/server/views/applications/case-timetable/timetable-details-form.njk
@@ -156,6 +156,7 @@
 							formGroup: {
 								classes: 'govuk-grid-column-full govuk-!-margin-top-4'
 							},
+						    rows: "20",
   							label: {
     							text: "Timetable item description (optional)",
 								classes: 'font-weight--700 govuk-!-margin-bottom-4'


### PR DESCRIPTION
## Describe your changes

- Increased the height of the description field from 5 rows to 20 rows
- Updated the affected web unit tests

This has been tested manually to make sure the description field height has increased.

## BOAS-1349 Increase height of description field for Examination Timetable
https://pins-ds.atlassian.net/browse/BOAS-1349

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
