### PR TITLE
fix(appeals): async validator needs to return a rejected promise

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/__snapshots__/appellant-case.test.js.snap
@@ -2013,11 +2013,6 @@ exports[`appellant-case GET /appellant-case/check-your-answers should render the
                     <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/incomplete"> Change</a>
                     </dd>
                 </div>
-                <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Updated due date</dt>
-                    <dd class="govuk-summary-list__value">1 December 3000</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/appeals-service/appeal-details/1/appellant-case/incomplete/date"> Change</a>
-                    </dd>
-                </div>
             </dl>
             <div class="govuk-inset-text">Confirming this review will inform the appellant and LPA of the outcome</div>
             <form             method="post" novalidate="novalidate">

--- a/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/appellant-case/__tests__/appellant-case.test.js
@@ -924,7 +924,7 @@ describe('appellant-case', () => {
 					'due-date-year': '3000'
 				});
 
-			expect(response.statusCode).toBe(302);
+			expect(response.statusCode).toBe(200);
 		});
 	});
 
@@ -1018,7 +1018,7 @@ describe('appellant-case', () => {
 					'due-date-year': '3000'
 				});
 
-			expect(updateDateResponse.statusCode).toBe(302);
+			expect(updateDateResponse.statusCode).toBe(200);
 
 			const response = await request.get(
 				`${baseUrl}/1${appellantCasePagePath}${checkYourAnswersPagePath}`

--- a/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/lpa-questionnaire/__tests__/lpa-questionnaire.test.js
@@ -572,7 +572,7 @@ describe('LPA Questionnaire review', () => {
 				'due-date-year': '3000'
 			});
 
-			expect(response.statusCode).toBe(302);
+			expect(response.statusCode).toBe(200);
 		});
 	});
 

--- a/appeals/web/src/server/lib/validators/date-input.validator.js
+++ b/appeals/web/src/server/lib/validators/date-input.validator.js
@@ -198,6 +198,9 @@ export const createDateInputDateBusinessDayValidator = async (
 					.split('T')[0];
 
 				const result = await dateIsABusinessDay(req.apiClient, dateToValidate);
+				if (result === false) {
+					return Promise.reject();
+				}
 				return result;
 			})
 			.withMessage(


### PR DESCRIPTION
Fixes async validator for calculating business days.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
