### PR TITLE
fix(applications/web): fix document case stage copy (BOAS-1439)

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -6845,10 +6845,10 @@ exports[`applications documentation Document properties page page should render 
                             <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
                             </dd>
                         </div>
-                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Documentation case stage</dt>
-                            <dd                             class=\\"govuk-summary-list__value\\">withdrawn</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
                         </div>
                         <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
                             <dd class=\\"govuk-summary-list__value\\">Ut</dd>
@@ -7007,10 +7007,10 @@ exports[`applications documentation Document properties page should not show pub
                             <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
                             </dd>
                         </div>
-                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Documentation case stage</dt>
-                            <dd                             class=\\"govuk-summary-list__value\\">pre-examination</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
                         </div>
                         <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
                             <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
@@ -7162,10 +7162,10 @@ exports[`applications documentation Document properties page should not show pub
                             <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
                             </dd>
                         </div>
-                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Documentation case stage</dt>
-                            <dd                             class=\\"govuk-summary-list__value\\">withdrawn</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
                         </div>
                         <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
                             <dd class=\\"govuk-summary-list__value\\">Ut</dd>
@@ -7324,10 +7324,10 @@ exports[`applications documentation Document properties page should show publish
                             <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
                             </dd>
                         </div>
-                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Documentation case stage</dt>
-                            <dd                             class=\\"govuk-summary-list__value\\">pre-examination</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
                         </div>
                         <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
                             <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>

--- a/apps/web/src/server/views/applications/case-documentation/properties/tab-details.component.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/tab-details.component.njk
@@ -27,7 +27,7 @@
 						{label: 'Description', value: documentationFile.description, link: 'description'},
 						{label: 'From', value: documentationFile.author, link: 'author'},
 						{label: 'Agent (optional)', value: documentationFile.representative, link: 'agent'},
-						{label: 'Documentation case stage', value: documentationFile.stage},
+						{label: 'Document case stage', value: documentationFile.stage},
 						{label: 'Webfilter', value: documentationFile.filter1, link: 'webfilter'},
 						{label: 'Document type (optional)', value: documentationFile.documentType, link: 'type'},
 						transcriptRow,


### PR DESCRIPTION
## Describe your changes

- Rename incorrectly named 'Documentation case stage' to 'Document case stage' within the 'Document properties' tab
- Amend unit test to work with the change

This has been tested manually to make sure that 'Document case stage' is displayed within the 'Document properties' tab.

## BOAS-1439 Rename 'Case stage' to 'Document case stage' within the 'Document properties' tab (BOAS-1371)
https://pins-ds.atlassian.net/browse/BOAS-1439

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
