### PR TITLE
fix(applications/web): application documents folder needs developers application (BOAS-1443)

### DIFF
--- a/apps/api/src/server/repositories/folder.repository.js
+++ b/apps/api/src/server/repositories/folder.repository.js
@@ -538,7 +538,7 @@ const defaultCaseFolders = [
 				{
 					displayNameEn: 'Application documents',
 					displayOrder: 400,
-					stage: folderDocumentCaseStageMappings.ACCEPTANCE,
+					stage: folderDocumentCaseStageMappings.DEVELOPERS_APPLICATION,
 					childFolders: {
 						create: [
 							{


### PR DESCRIPTION
## Describe your changes

- Set `Developer's Application` as the document case stage for documents uploaded to the folder `Application documents`

This has been tested manually to make sure that for any new case,  `Developer's Application` is the value displayed in the Document properties for any uploaded documents in the `Application documents` folder.

## BOAS-1443 Add 'Developer's Application' as a document case stage in 'Document properties' (BOAS-1389)
https://pins-ds.atlassian.net/browse/BOAS-1443

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
