### PR TITLE
fix(applications/api): unable to publish a document for s51 advice (BOAS-1449)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.js
+++ b/apps/api/src/server/applications/application/documents/document.js
@@ -16,19 +16,25 @@ export const buildNsipDocumentPayload = (version) => {
 		throw new Error(`Missing document for version ${version.documentGuid}`);
 	}
 
-	if (
-		!(
-			version.fileName &&
-			version.originalFilename &&
-			version.size &&
-			version.privateBlobContainer &&
-			version.privateBlobPath &&
-			version.publishedBlobPath &&
-			version.publishedBlobContainer &&
-			version.dateCreated
-		)
-	) {
-		throw new Error(`Missing required properties for version ${version.documentGuid}`);
+	const requiredProperties = [
+		'fileName',
+		'originalFilename',
+		'size',
+		'privateBlobContainer',
+		'privateBlobPath',
+		'dateCreated'
+	];
+
+	const missingProperties = requiredProperties.filter(
+		(property) => !Object.hasOwn(version, property)
+	);
+
+	if (missingProperties.length) {
+		throw new Error(
+			`Missing required properties (${missingProperties.join(', ')}) for version ${
+				version.documentGuid
+			}`
+		);
 	}
 
 	return {
@@ -39,8 +45,10 @@ export const buildNsipDocumentPayload = (version) => {
 		originalFilename: version.originalFilename,
 		size: version.size,
 		documentURI: buildBlobUri(version.privateBlobContainer, version.privateBlobPath),
-		publishedDocumentURI: buildBlobUri(version.publishedBlobContainer, version.publishedBlobPath),
-		dateCreated: version.dateCreated?.toISOString() ?? null, // TODO: Should this come from the version?
+		publishedDocumentURI: version.publishedBlobPath
+			? buildBlobUri(version.publishedBlobContainer, version.publishedBlobPath)
+			: undefined,
+		dateCreated: version.dateCreated?.toISOString() ?? null,
 		...(version.lastModified ? { lastModified: version.lastModified.toISOString() } : {}),
 		...(version.datePublished ? { datePublished: version.datePublished.toISOString() } : {}),
 		...(version.horizonDataID ? { horizonFolderId: version.horizonDataID } : {}),


### PR DESCRIPTION
## Describe your changes

- Amend the validation of required properties to ignore publishedBlobPath and publishedBlobContainer if they are not present
- Report on which required properties are missing in the error message if thrown
- Don't attempt to populate the publishedDocumentURI if publishedBlobPath is missing

This has been tested manually to make sure that documents can be published for an S51 Advice,  This should also solve the issue [BOAS-1437](https://pins-ds.atlassian.net/browse/BOAS-1437) as this was a bug that affected publishing all documents.

## BOAS-1449 Unable to publish the document with Caseoffice admin and Inspector user due to There is a problem error
https://pins-ds.atlassian.net/browse/BOAS-1449

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1437]: https://pins-ds.atlassian.net/browse/BOAS-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ