### PR TITLE
fix(applications/web): remove test option from representation invalid (BOAS-1391)

### DIFF
--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/__tests__/representation-status-notes.test.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/__tests__/representation-status-notes.test.js
@@ -65,7 +65,6 @@ describe('Change representation status page', () => {
 			expect(element.innerHTML).toContain('Merged');
 			expect(element.innerHTML).toContain('Not relevant');
 			expect(element.innerHTML).toContain('Resubmitted');
-			expect(element.innerHTML).toContain('TEST');
 		});
 	});
 

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
@@ -60,11 +60,6 @@ const getPageContentByStatus = (newStatus) => {
 			value: 'Resubmitted',
 			text: 'Resubmitted',
 			checked: false
-		},
-		{
-			value: 'Test',
-			text: 'TEST',
-			checked: false
 		}
 	];
 


### PR DESCRIPTION
## Describe your changes

- Remove test option from representation invalid
- Fix unit tests

This has been tested manually to make sure the 'TEST' option is no longer displayed

## BOAS-1391 'TEST' option displayed when invalidating a relevant representative
https://pins-ds.atlassian.net/browse/BOAS-1391

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
