### PR TITLE
feat(applications/web): updates to delete document and success pages (BOAS-1237)

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -6706,7 +6706,7 @@ exports[`applications documentation Document properties delete page GET /case/12
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row\\">
         <form action='' method='post' class=\\"govuk-grid-column-full govuk-!-margin-top-0\\">
-            <h1 class=\\"govuk-heading-l\\">Delete selected document</h1>
+            <h1 class=\\"govuk-heading-l\\">Delete document</h1>
             <input type=\\"hidden\\" value=\\"\\" name=\\"status\\">
             <table class=\\"govuk-table\\">
                 <thead class=\\"govuk-table__head\\">
@@ -6725,6 +6725,10 @@ exports[`applications documentation Document properties delete page GET /case/12
             <p class=\\"govuk-body govuk-!-margin-top-7 govuk-!-margin-bottom-7\\">You are deleting the document from:<span class=\\"font-weight--700\\"> Project documentation > </span>
                 <span                 class=\\"font-weight--700\\">Project management ></span><span class=\\"font-weight--700\\"> Sub folder level 2 </span>
             </p>
+            <div class=\\"govuk-warning-text\\"><span class=\\"govuk-warning-text__icon\\" aria-hidden=\\"true\\">!</span>
+                <strong                 class=\\"govuk-warning-text__text\\"><span class=\\"govuk-warning-text__assistive\\">Warning</span> This will delete
+                    all versions of this document.</strong>
+            </div>
             <button class=\\"govuk-button govuk-button--warning\\" data-module=\\"govuk-button\\">Delete</button>
         </form>
     </div>
@@ -6739,7 +6743,7 @@ exports[`applications documentation Document properties delete page GET /case/12
     </div>
     <div class=\\"govuk-grid-row\\">
         <form action='' method='post' class=\\"govuk-grid-column-full govuk-!-margin-top-0\\">
-            <h1 class=\\"govuk-heading-l\\">Delete selected document</h1>
+            <h1 class=\\"govuk-heading-l\\">Delete document</h1>
             <input type=\\"hidden\\" value=\\"\\" name=\\"status\\">
             <table class=\\"govuk-table\\">
                 <thead class=\\"govuk-table__head\\">
@@ -6758,6 +6762,10 @@ exports[`applications documentation Document properties delete page GET /case/12
             <p class=\\"govuk-body govuk-!-margin-top-7 govuk-!-margin-bottom-7\\">You are deleting the document from:<span class=\\"font-weight--700\\"> Project documentation > </span>
                 <span                 class=\\"font-weight--700\\">Project management ></span><span class=\\"font-weight--700\\"> Sub folder level 2 </span>
             </p>
+            <div class=\\"govuk-warning-text\\"><span class=\\"govuk-warning-text__icon\\" aria-hidden=\\"true\\">!</span>
+                <strong                 class=\\"govuk-warning-text__text\\"><span class=\\"govuk-warning-text__assistive\\">Warning</span> This will delete
+                    all versions of this document.</strong>
+            </div>
             <button class=\\"govuk-button govuk-button--warning\\" data-module=\\"govuk-button\\">Delete</button>
         </form>
     </div>
@@ -6770,6 +6778,10 @@ exports[`applications documentation Document properties delete page POST /case/1
         <div class=\\"govuk-grid-column-two-thirds govuk-!-margin-top-0\\">
             <div class=\\"govuk-panel govuk-panel--confirmation\\">
                 <h1 class=\\"govuk-panel__title\\"> Document successfully deleted</h1>
+                <div class=\\"govuk-panel__body\\">
+                    <p class=\\"govuk-!-font-size-19\\">Case: Title CASE/04
+                        <br>Reference: CASE/04</p>
+                </div>
             </div>
             <div class=\\"govuk-body\\">Return to folder:<a href=\\"/applications-service/case/123/project-documentation/21/sub-folder-level-2/\\"
                 class=\\"govuk-link\\"><span> Project documentation  > </span><span> Project management  > </span><span  class=\\"font-weight--700\\" > Sub folder level 2 </span></a>

--- a/apps/web/src/server/applications/case/documentation/__tests__/applications-documentation.test.js
+++ b/apps/web/src/server/applications/case/documentation/__tests__/applications-documentation.test.js
@@ -317,7 +317,7 @@ describe('applications documentation', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('Delete selected document');
+				expect(element.innerHTML).toContain('Delete document');
 			});
 
 			it('should display warning if status is "ready_to_publish"', async () => {

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -251,6 +251,7 @@ export async function updateApplicationsCaseDocumentationDelete(
 ) {
 	const { documentGuid } = params;
 	const { caseId } = response.locals;
+	const { title: caseName, reference: caseReference } = response.locals.case;
 	const documentationFile = await getCaseDocumentationFileInfo(caseId, documentGuid);
 
 	const { errors } = validationErrors
@@ -265,7 +266,8 @@ export async function updateApplicationsCaseDocumentationDelete(
 	}
 
 	response.render(`applications/case-documentation/documentation-success-banner`, {
-		serviceName: 'Document successfully deleted'
+		serviceName: 'Document successfully deleted',
+		successMessage: `<p class="govuk-!-font-size-19">Case: ${caseName}<br>Reference: ${caseReference}</p>`
 	});
 }
 

--- a/apps/web/src/server/views/applications/case-documentation/documentation-delete.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-delete.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-{% set serviceName = "Delete selected document" %}
+{% set serviceName = "Delete document" %}
 {% block pageTitle %}
     {{ serviceName }} – {{ pageTitle | default('GOV.UK') }}
 {% endblock %}
@@ -75,6 +75,10 @@
                     </span>
                 {% endfor %}
             </p>
+			{{ govukWarningText({
+				text: "This will delete all versions of this document.",
+				iconFallbackText: "Warning"
+			}) }}
             {{ govukButton({ text: "Delete",  classes: "govuk-button--warning" }) }}
         </form>
     </div>


### PR DESCRIPTION
## Describe your changes

The steps 1, 2, 4, and 5 of the ticket have been implemented in this PR as follows:
- Amended the title in the documentation delete page to ‘Delete document’.
- Added the warning ‘This will delete all versions of this document.’
- Added the case name to the successful delete page.
- Added the case reference to the successful delete page.

Note that step 3 has not been implemented as a long filename already wraps to the next line but only if there are spaces in the filename.  I don't think it's possible to wrap the filename when there are no spaces in the name as I've tried several possible solutions that have all failed.

The changes have been tested manually to make sure the user journey works as expected for the deletion of a document for steps 1, 2, 4 and 5 in the ticket.

## BOAS-1237 Updates to 'Delete document' and 'Success' pages
https://pins-ds.atlassian.net/browse/BOAS-1237

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes