### PR TITLE
feat(applications/web): remove return to folder text (BOAS-1327)

### DIFF
--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -1271,9 +1271,7 @@ exports[`Delete examination timetable POST /case/123/examination-timetable/item/
                     <br><strong>CASE/04</strong>
                 </div>
             </div>
-            <div class=\\"govuk-body\\">
-                <p class=\\"govuk-body\\">Return to folder:</p><a href=\\"/applications-service/case/123/examination-timetable/\\"
-                class=\\"govuk-link\\"> Go back to examination timetable</a>
+            <div class=\\"govuk-body\\"><a href=\\"/applications-service/case/123/examination-timetable/\\" class=\\"govuk-link\\"> Go back to examination timetable</a>
             </div>
         </div>
     </div>
@@ -2053,7 +2051,7 @@ exports[`Unpublish examination timetable success page POST /case/123/examination
             </div>
             <div class=\\"govuk-body\\">
                 <p class=\\"govuk-body\\">The examination timetable will be unpublished from the NI website within
-                    the hour</p><a href=\\"/applications-service/case/123/examination-timetable/\\"
+                    the hour z</p><a href=\\"/applications-service/case/123/examination-timetable/\\"
                 class=\\"govuk-link\\"> Go back to examination timetable</a>
             </div>
         </div>

--- a/apps/web/src/server/views/applications/case-timetable/timetable-success-banner.njk
+++ b/apps/web/src/server/views/applications/case-timetable/timetable-success-banner.njk
@@ -20,15 +20,15 @@
 			}) }}
 
 			<div class="govuk-body">
-				<p class="govuk-body">
-					{% if action === 'published' %}
+				{% if action === 'published' %}
+					<p class="govuk-body">
 						The examination timetable will show on the NI website within the hour
-					{% elseif action === 'unpublished' %}
+					</p>
+				{% elseif action === 'unpublished' %}
+					<p class="govuk-body">
 						The examination timetable will be unpublished from the NI website within the hour
-					{% else %}
-						Return to folder:
-					{% endif %}
-				</p>
+					z</p>
+				{% endif %}
 				<a href="{{'timetable'|url({caseId: caseId})}}" class="govuk-link">
 					Go back to examination timetable
 				</a>


### PR DESCRIPTION
## Describe your changes

- Remove return to folder text from timetable success banner
- Fix unit tests

This has been tested manually

## BOAS-1327 Wording on success screen when creating, editing or deleting a timetable item is incorrect
https://pins-ds.atlassian.net/browse/BOAS-1327

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
