### PR TITLE
fix(applications/web): prevent extra newline added when going back to edit (BOAS-1308)

### DIFF
--- a/apps/web/src/client/components/html-content-editor/__tests__/html-content-editor.test.js
+++ b/apps/web/src/client/components/html-content-editor/__tests__/html-content-editor.test.js
@@ -2,13 +2,15 @@
  * @jest-environment jsdom
  */
 import initHtmlContentEditor from '../html-content-editor.js';
+const initialText = `<p>Paragraph no break line</p><p>Paragraph one break line</p><br /><p>Paragraph two break lines</p><br /><br />`;
+const editorText = initialText.replaceAll(`<br />`, `<p><br></p>`);
 
 const DOM = `
 <div class="govuk-form-group">
     <label class="govuk-label govuk-!-font-weight-bold">
         Content
     </label>
-    <input type="hidden" name="content">
+    <input type="hidden" name="content" value="${editorText}">
     <div class="html-content-editor"></div>
 	<div class="govuk-hint govuk-!-margin-top-4">You have entered <span class="character-count">0</span> characters.</div>
     <noscript>
@@ -39,6 +41,22 @@ describe('html-content-editor', () => {
 		expect(buttons.item(2)?.classList.contains('bullet-list')).toEqual(true);
 	});
 
+	it('should remain the same when nothing is changed after a focus and blur', () => {
+		// first textbox is markdown preview (hidden/not-used)
+		const textBox = document.getElementsByClassName('toastui-editor-contents')[1];
+		const input = document.getElementsByName('content')[0];
+		if (!(textBox instanceof HTMLDivElement)) {
+			throw new Error('div expected');
+		}
+		if (!(input instanceof HTMLInputElement)) {
+			throw new Error('input expected');
+		}
+
+		textBox.focus();
+		textBox.blur();
+		expect(decodeURI(input.value)).toEqual(editorText);
+	});
+
 	it('should populate input value when content changes', async () => {
 		// first textbox is markdown preview (hidden/not-used)
 		const textBox = document.getElementsByClassName('toastui-editor-contents')[1];
@@ -58,6 +76,7 @@ describe('html-content-editor', () => {
 		// check the hidden input has the correct value - used for form submission
 		expect(input.value).toEqual(encodeURI(exampleText));
 	});
+
 	it('should count characters', async () => {
 		// first textbox is markdown preview (hidden/not-used)
 		const textBox = document.getElementsByClassName('toastui-editor-contents')[1];

--- a/apps/web/src/server/applications/case/project-updates/project-updates.view-model.js
+++ b/apps/web/src/server/applications/case/project-updates/project-updates.view-model.js
@@ -86,6 +86,8 @@ export function createContentFormView({
 					characterCountWarningMessage:
 						'You have exceeded the recommended length for a project update. Consider reviewing the content to make it shorter and easier to understand',
 					value: values.backOfficeProjectUpdateContent,
+					// The editorValue contains the content converted to the format expected by the toastUI editor
+					editorValue: values.backOfficeProjectUpdateContent?.replaceAll(`<br />`, `<p><br></p>`),
 					errorMessage: errors?.backOfficeProjectUpdateContent
 				},
 				{

--- a/apps/web/src/server/views/applications/components/html-content-editor.njk
+++ b/apps/web/src/server/views/applications/components/html-content-editor.njk
@@ -5,7 +5,7 @@
 
 {#
     Show an html-content-editor (using toastui)
-    
+
     Used in conjuction with some client-side JS
     See: src/client/components/html-content-editor
     If no JS is enabled, fallsback to the govukTextarea component
@@ -23,8 +23,8 @@
         {% if params.errorMessage %}
             {{ govukErrorMessage({text: errorMessage}) }}
         {% endif %}
-        <input type="hidden" name="{{ params.name }}" value="{{ params.value }}">
-        <div class="html-content-editor" id="{{ params.name }}">{{ params.value }}</div>
+        <input type="hidden" name="{{ params.name }}" value="{{ params.editorValue }}">
+        <div class="html-content-editor" id="{{ params.name }}"></div>
         {% if params.characterCount %}
             <div class="govuk-hint govuk-!-margin-top-4">You have entered <span class="character-count">0</span> characters.</div>
         {% endif %}


### PR DESCRIPTION
## Describe your changes

The content passed into the toastUI editor must match the format it expects to handle line breaks correctly.

- Make sure the html editor is initialised with the content converted to the format expected by the toastUI editor
- Added a unit test to make sure extra lines are not added when nothing is changed

This has been tested manually

## BOAS-1308 Extra newline added when going back to edit
https://pins-ds.atlassian.net/browse/BOAS-1308

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
