### PR TITLE
feat(web): file upload back modal

### DIFF
--- a/appeals/web/src/client/components/file-uploader/_client-actions.js
+++ b/appeals/web/src/client/components/file-uploader/_client-actions.js
@@ -187,6 +187,7 @@ const clientActions = (uploadForm) => {
 			// eslint-disable-next-line no-throw-literal
 			throw { message: 'FILE_SPECIFIC_ERRORS', details: errors };
 		} else {
+			disableLeavePageWarning();
 			window.location.href = uploadForm.dataset.nextPageUrl || '';
 		}
 	};
@@ -199,6 +200,8 @@ const clientActions = (uploadForm) => {
 
 		const { getUploadInfoFromInternalDB, uploadFiles, getVersionUploadInfoFromInternalDB } =
 			serverActions(uploadForm);
+
+		enableLeavePageWarning();
 
 		try {
 			const fileList = await onSubmitValidation();
@@ -230,6 +233,18 @@ const clientActions = (uploadForm) => {
 		uploadInput.addEventListener('change', onFileSelect, false);
 
 		submitButton.addEventListener('click', onSubmit);
+	};
+
+	const leavePageWarningEventHandler = (/** @type {{ preventDefault: () => any; }} */ event) => {
+		event.preventDefault();
+	};
+
+	const enableLeavePageWarning = () => {
+		window.addEventListener('beforeunload', leavePageWarningEventHandler);
+	};
+
+	const disableLeavePageWarning = () => {
+		window.removeEventListener('beforeunload', leavePageWarningEventHandler);
 	};
 
 	return { onFileSelect, onSubmitValidation, registerEvents };


### PR DESCRIPTION
## Describe your changes

add beforeunload listener to display native browser confirmation dialog when user attempts to navigate away from file upload page while upload is still in progress

## Issue ticket number and link

BOAT-831

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
