### PR TITLE
fix(applications/api): format exam timetable item description items (BOAS-1461)

### DIFF
--- a/apps/api/src/server/applications/examination-timetable-items/__tests__/examination-timetable-items.test.js
+++ b/apps/api/src/server/applications/examination-timetable-items/__tests__/examination-timetable-items.test.js
@@ -10,7 +10,7 @@ const examinationTimetableItem = {
 	id: 1,
 	examinationTypeId: 1,
 	name: 'Examination Timetable Item',
-	description: 'Examination Timetable Item Description',
+	description: '{"preText":"pretext", "bulletPoints":["pointone", "pointtwo"]}',
 	date: '2023-02-27T10:00:00Z',
 	folderId: 1234,
 	startDate: '2023-02-27T10:00:00Z',
@@ -260,6 +260,9 @@ describe('Test examination timetable items API', () => {
 		const resp = await request.get('/applications/examination-timetable-items/case/1');
 		expect(resp.status).toEqual(200);
 		expect(resp.body.items[0].submissions).toBe(false);
+		expect(resp.body.items[0].description).toBe(
+			`{"preText":"pretext\\r\\n","bulletPoints":[" pointone\\r\\n"," pointtwo"]}`
+		);
 		expect(databaseConnector.examinationTimetable.findUnique).toHaveBeenCalledWith({
 			where: { caseId: 1 }
 		});
@@ -288,6 +291,9 @@ describe('Test examination timetable items API', () => {
 		const resp = await request.get('/applications/examination-timetable-items/1');
 		expect(resp.status).toEqual(200);
 		expect(resp.body.submissions).toBe(true);
+		expect(resp.body.description).toBe(
+			`{"preText":"pretext\\r\\n","bulletPoints":[" pointone\\r\\n"," pointtwo"]}`
+		);
 		expect(databaseConnector.examinationTimetableItem.findUnique).toHaveBeenCalledWith({
 			include: { ExaminationTimetable: true, ExaminationTimetableType: true },
 			where: { id: 1 }

--- a/apps/api/src/server/utils/mapping/__tests__/map-examination-timetable-item-description.test.js
+++ b/apps/api/src/server/utils/mapping/__tests__/map-examination-timetable-item-description.test.js
@@ -1,0 +1,24 @@
+import {
+	mapExaminationTimetableItemDescriptionToSave,
+	mapExaminationTimetableItemDescriptionToView
+} from '#utils/mapping/map-examination-timetable-item-description.js';
+
+describe('mapExaminationTimetableItemDescriptionToSave', () => {
+	it('removes trailing line breaks as expected', () => {
+		const originalDescription = `{"preText":"List items\\r\\n","bulletPoints":[" item 1\\r\\n"," item 2\\r\\n"," item 3"]}`;
+		const expectedDescription = `{"preText":"List items","bulletPoints":["item 1","item 2","item 3"]}`;
+		expect(mapExaminationTimetableItemDescriptionToSave(originalDescription)).toBe(
+			expectedDescription
+		);
+	});
+});
+
+describe('mapExaminationTimetableItemDescriptionToView', () => {
+	it('adds trailing line breaks as expected', () => {
+		const originalDescription = `{"preText":"List items","bulletPoints":["item 1","item 2","item 3"]}`;
+		const expectedDescription = `{"preText":"List items\\r\\n","bulletPoints":[" item 1\\r\\n"," item 2\\r\\n"," item 3"]}`;
+		expect(mapExaminationTimetableItemDescriptionToView(originalDescription)).toBe(
+			expectedDescription
+		);
+	});
+});

--- a/apps/api/src/server/utils/mapping/map-examination-timetable-item-description.js
+++ b/apps/api/src/server/utils/mapping/map-examination-timetable-item-description.js
@@ -1,0 +1,38 @@
+/**
+ * Remove trailing line breaks from the preText and each bulletPoint
+ * within the examinationTimetableItemDescription
+ *
+ * @param {string} examinationTimetableItemDescription
+ * @returns {string} formatedExaminationTimetableItemDescription
+ */
+export const mapExaminationTimetableItemDescriptionToSave = (
+	examinationTimetableItemDescription
+) => {
+	const { preText = '', bulletPoints = [] } = JSON.parse(examinationTimetableItemDescription);
+	const formattedDescription = {
+		preText: preText.trim(),
+		bulletPoints: bulletPoints.map((bulletPoint) => bulletPoint.trim())
+	};
+	return JSON.stringify(formattedDescription);
+};
+
+/**
+ * Add trailing line breaks from the preText and each bulletPoint
+ * within the examinationTimetableItemDescription
+ *
+ * @param {string} examinationTimetableItemDescription
+ * @returns {string} formatedExaminationTimetableItemDescription
+ */
+export const mapExaminationTimetableItemDescriptionToView = (
+	examinationTimetableItemDescription
+) => {
+	const { preText = '', bulletPoints = [] } = JSON.parse(examinationTimetableItemDescription);
+	const formattedDescription = {
+		preText: preText.trim() + `\r\n`,
+		bulletPoints: bulletPoints.map(
+			(bulletPoint, index) =>
+				' ' + bulletPoint.trim() + (index < bulletPoints.length - 1 ? `\r\n` : '')
+		)
+	};
+	return JSON.stringify(formattedDescription);
+};


### PR DESCRIPTION
## Describe your changes

After splitting the Exam Timetable Item Description, remove new lines from items before saving to the database.

- Make sure the new lines are removed from items before saving to the database
- Make sure new lines are added to items after retrieving from the database

This has been tested manually

## BOAS-1461 Exam Timetable Item Description items
https://pins-ds.atlassian.net/browse/BOAS-1461

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
