### PR TITLE
fix(applications/web): fix timetable item success page (BOAS-1327)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/examTimetable.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/examTimetable.spec.js
@@ -33,7 +33,7 @@ const itemOptions = [
 const texts = {
 	examTimetableLinkText: 'Examination timetable',
 	createTimetableButtonText: 'Create new timetable item',
-	successMessageText: 'Timetable successfully created'
+	successMessageText: 'Timetable item successfully created'
 };
 
 describe('Examination Timetable Errors', () => {

--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -1265,7 +1265,7 @@ exports[`Delete examination timetable POST /case/123/examination-timetable/item/
     <div class=\\"govuk-grid-row\\">
         <div class=\\"govuk-grid-column-two-thirds govuk-!-margin-top-0\\">
             <div class=\\"govuk-panel govuk-panel--confirmation\\">
-                <h1 class=\\"govuk-panel__title\\"> Timetable successfully deleted</h1>
+                <h1 class=\\"govuk-panel__title\\"> Timetable item successfully deleted</h1>
                 <div class=\\"govuk-panel__body\\">Title CASE/04
                     <br>The case reference number
                     <br><strong>CASE/04</strong>
@@ -1898,7 +1898,7 @@ exports[`Publish examination timetable success page POST /case/123/examination-t
     <div class=\\"govuk-grid-row\\">
         <div class=\\"govuk-grid-column-two-thirds govuk-!-margin-top-0\\">
             <div class=\\"govuk-panel govuk-panel--confirmation\\">
-                <h1 class=\\"govuk-panel__title\\"> Timetable successfully published</h1>
+                <h1 class=\\"govuk-panel__title\\"> Timetable item successfully published</h1>
                 <div class=\\"govuk-panel__body\\">Title CASE/04
                     <br>The case reference number
                     <br><strong>CASE/04</strong>
@@ -2043,7 +2043,7 @@ exports[`Unpublish examination timetable success page POST /case/123/examination
     <div class=\\"govuk-grid-row\\">
         <div class=\\"govuk-grid-column-two-thirds govuk-!-margin-top-0\\">
             <div class=\\"govuk-panel govuk-panel--confirmation\\">
-                <h1 class=\\"govuk-panel__title\\"> Timetable successfully unpublished</h1>
+                <h1 class=\\"govuk-panel__title\\"> Timetable item successfully unpublished</h1>
                 <div class=\\"govuk-panel__body\\">Title CASE/04
                     <br>The case reference number
                     <br><strong>CASE/04</strong>

--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/applications-timetable.test.js
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/applications-timetable.test.js
@@ -435,7 +435,7 @@ describe('Delete examination timetable', () => {
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Timetable successfully deleted');
+			expect(element.innerHTML).toContain('Timetable item successfully deleted');
 		});
 	});
 });
@@ -461,7 +461,7 @@ describe('Publish examination timetable success page', () => {
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Timetable successfully published');
+			expect(element.innerHTML).toContain('Timetable item successfully published');
 		});
 	});
 });
@@ -487,7 +487,7 @@ describe('Unpublish examination timetable success page', () => {
 			const element = parseHtml(response.text);
 
 			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Timetable successfully unpublished');
+			expect(element.innerHTML).toContain('Timetable item successfully unpublished');
 		});
 	});
 });

--- a/apps/web/src/server/views/applications/case-timetable/timetable-success-banner.njk
+++ b/apps/web/src/server/views/applications/case-timetable/timetable-success-banner.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% set serviceName = ["Timetable successfully ", action]|join  %}
+{% set serviceName = ["Timetable item successfully ", action]|join  %}
 
 {% block pageTitle %}
 	{{ serviceName }} – {{ pageTitle | default('GOV.UK') }}


### PR DESCRIPTION
## Describe your changes

Corrected text in timetable item success banner

- Updated the timetable success banner to replace 'Timetable successfully' with 'Timetable item successfully'
- Updated the web unit tests to match
- Updated the e2e test to match

This has also been tested manually

## BOAS-1327 Wording on success screen when creating, editing or deleting a timetable item is incorrect
https://pins-ds.atlassian.net/browse/BOAS-1327

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
