### PR TITLE
Feature/boas 469 add api key for internal auth

### DIFF
--- a/appeals/api/src/server/utils/cache-data.js
+++ b/appeals/api/src/server/utils/cache-data.js
@@ -6,7 +6,7 @@ export const setCache = (
 	/** @type {NodeCache.Key} */ key,
 	/** @type {Record<string,any>[]} */ value
 ) => {
-	nodeCache.set(key, value, 3_600_000);
+	nodeCache.set(key, value, 3600);
 };
 
 export const getCache = (/** @type {NodeCache.Key} */ key) => {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
     "@pins/applications": "^0.0.0",
     "@pins/event-client": "^0.0.0",
     "@pins/express": "^0.0.0",
+		"@pins/key-vault-secrets-client": "^0.0.0",
     "@pins/platform": "^0.0.0",
     "@prisma/client": "^4.16.1",
     "@prisma/instrumentation": "^5.6.0",

--- a/apps/api/src/server/build-app.js
+++ b/apps/api/src/server/build-app.js
@@ -9,6 +9,8 @@ import versionRoutes from './middleware/version-routes.js';
 import BackOfficeAppError from './utils/app-error.js';
 import { databaseConnector } from './utils/database-connector.js';
 import { migrationRoutes } from './migration/migration.routes.js';
+import { authoriseRequest } from './middleware/authorise-request.js';
+import { asyncHandler } from '@pins/express';
 
 // The purpose of this is to allow the jest environment to create an instance of the app without loading Swagger
 // We have to use a HOF (i.e. we can't just conditionally register swagger UI) because Jest doesn't care about our conditionals and loads all of the modules based on the top-level imports
@@ -21,6 +23,8 @@ const buildApp = (
 	if (addSwaggerUi) {
 		addSwaggerUi(app);
 	}
+
+	app.use(asyncHandler(authoriseRequest));
 
 	app.use('/migration', bodyParser.json({ limit: '30mb' }));
 	app.use(bodyParser.json());

--- a/apps/api/src/server/config/config.js
+++ b/apps/api/src/server/config/config.js
@@ -34,7 +34,8 @@ const { value, error } = schema.validate({
 			? false
 			: environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
 	},
-	serviceBusEnabled: environment.SERVICE_BUS_ENABLED && environment.SERVICE_BUS_ENABLED === 'true'
+	serviceBusEnabled: environment.SERVICE_BUS_ENABLED && environment.SERVICE_BUS_ENABLED === 'true',
+	azureKeyVaultEnabled: environment.KEY_VAULT_ENABLED && environment.KEY_VAULT_ENABLED === 'true'
 });
 
 if (error) {

--- a/apps/api/src/server/config/schema.js
+++ b/apps/api/src/server/config/schema.js
@@ -28,6 +28,7 @@ export default joi
 		}),
 		cwd: joi.string(),
 		featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean()),
-		serviceBusEnabled: joi.boolean().optional()
+		serviceBusEnabled: joi.boolean().optional(),
+		azureKeyVaultEnabled: joi.boolean().optional()
 	})
 	.options({ presence: 'required' }); // required by default

--- a/apps/api/src/server/middleware/authorise-request.js
+++ b/apps/api/src/server/middleware/authorise-request.js
@@ -1,4 +1,4 @@
-import BackOfficeAppError from '#utils/app-error.js';
+// import BackOfficeAppError from '#utils/app-error.js';
 import { getCache, setCache } from '#utils/cache-data.js';
 import { fetchApiKey } from '#utils/fetch-api-key.js';
 import logger from '#utils/logger.js';
@@ -11,14 +11,18 @@ export const authoriseRequest = async (request, _response, next) => {
 	const incomingRequestApiKey = request.headers['x-api-key'];
 
 	if (!callingClient) {
-		throw new BackOfficeAppError("No 'x-service-name' header found on request", 400);
+		console.log("API_KEY_TESTING: No 'x-service-name' header found on request");
+		return next();
+		// throw new BackOfficeAppError("No 'x-service-name' header found on request", 400);
 	}
 	if (!incomingRequestApiKey) {
-		throw new BackOfficeAppError(`No API key present on request from ${callingClient}`, 403);
+		console.log(`API_KEY_TESTING: No API key present on request from ${callingClient}`);
+		return next();
+		// throw new BackOfficeAppError(`No API key present on request from ${callingClient}`, 403);
 	}
 
 	logger.info(`Request received from ${callingClient}`);
-	const callingClientApiKeyName = callingClient + '-api-key';
+	const callingClientApiKeyName = 'backoffice-applications-api-key-' + callingClient;
 	if (!getCache(callingClientApiKeyName)) {
 		const callingClientApiKey = await fetchApiKey(callingClientApiKeyName);
 		const lessThanHourTtl = 3540;
@@ -29,9 +33,13 @@ export const authoriseRequest = async (request, _response, next) => {
 		logger.info(`Request from ${callingClient} authenticated`);
 		next();
 	} else {
-		throw new BackOfficeAppError(
-			`Could not authenticate request from ${callingClient} - invalid API key`
+		console.log(
+			`API_KEY_TESTING: Could not authenticate request from ${callingClient} - invalid API key`
 		);
+		return next();
+		// throw new BackOfficeAppError(
+		// 	`Could not authenticate request from ${callingClient} - invalid API key`
+		// );
 	}
 };
 
@@ -52,7 +60,9 @@ const isRequestApiKeyValid = (incomingRequestApiKey, cachedApiKeyAddress) => {
 	}
 	if (incomingRequestApiKey === oldestApiKey.key && !isOldestKeyStillValid(oldestApiKey)) {
 		// Set up alerting for Application Insights
-		throw new BackOfficeAppError('Expired API key used');
+		console.log(`API_KEY_TESTING: Expired API key used`);
+		return false;
+		// throw new BackOfficeAppError('Expired API key used');
 	}
 	return false;
 };

--- a/apps/api/src/server/middleware/authorise-request.js
+++ b/apps/api/src/server/middleware/authorise-request.js
@@ -1,0 +1,68 @@
+import BackOfficeAppError from '#utils/app-error.js';
+import { getCache, setCache } from '#utils/cache-data.js';
+import { fetchApiKey } from '#utils/fetch-api-key.js';
+import logger from '#utils/logger.js';
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+export const authoriseRequest = async (request, _response, next) => {
+	const callingClient = request.headers['x-service-name'];
+	const incomingRequestApiKey = request.headers['x-api-key'];
+
+	if (!callingClient) {
+		throw new BackOfficeAppError("No 'x-service-name' header found on request", 400);
+	}
+	if (!incomingRequestApiKey) {
+		throw new BackOfficeAppError(`No API key present on request from ${callingClient}`, 403);
+	}
+
+	logger.info(`Request received from ${callingClient}`);
+	const callingClientApiKeyName = callingClient + '-api-key';
+	if (!getCache(callingClientApiKeyName)) {
+		const callingClientApiKey = await fetchApiKey(callingClientApiKeyName);
+		const lessThanHourTtl = 3540;
+		setCache(callingClientApiKeyName, callingClientApiKey, lessThanHourTtl);
+	}
+
+	if (isRequestApiKeyValid(incomingRequestApiKey, callingClientApiKeyName)) {
+		logger.info(`Request from ${callingClient} authenticated`);
+		next();
+	} else {
+		throw new BackOfficeAppError(
+			`Could not authenticate request from ${callingClient} - invalid API key`
+		);
+	}
+};
+
+/**
+ * @param {string} incomingRequestApiKey
+ * @param {string} cachedApiKeyAddress
+ */
+const isRequestApiKeyValid = (incomingRequestApiKey, cachedApiKeyAddress) => {
+	const apiKeyPair = getCache(cachedApiKeyAddress);
+	const newestApiKey = apiKeyPair.find((key) => key.status === 'newest');
+	const oldestApiKey = apiKeyPair.find((key) => key.status === 'oldest');
+
+	if (incomingRequestApiKey === newestApiKey.key) {
+		return true;
+	}
+	if (incomingRequestApiKey === oldestApiKey.key && isOldestKeyStillValid(oldestApiKey)) {
+		return true;
+	}
+	if (incomingRequestApiKey === oldestApiKey.key && !isOldestKeyStillValid(oldestApiKey)) {
+		// Set up alerting for Application Insights
+		throw new BackOfficeAppError('Expired API key used');
+	}
+	return false;
+};
+
+/**
+ * @param {Object} oldestApiKey
+ */
+const isOldestKeyStillValid = (oldestApiKey) => {
+	const currentTime = new Date();
+	const expiryTime = new Date(oldestApiKey.expiry);
+
+	return currentTime < expiryTime;
+};

--- a/apps/api/src/server/utils/cache-data.js
+++ b/apps/api/src/server/utils/cache-data.js
@@ -4,9 +4,10 @@ export const nodeCache = new NodeCache();
 
 export const setCache = (
 	/** @type {NodeCache.Key} */ key,
-	/** @type {Record<string,any>[]} */ value
+	/** @type {Record<string,any>[]} */ value,
+	/** @type {number} */ ttl = 3600
 ) => {
-	nodeCache.set(key, value, 3_600_000);
+	nodeCache.set(key, value, ttl);
 };
 
 export const getCache = (/** @type {NodeCache.Key} */ key) => {

--- a/apps/api/src/server/utils/fetch-api-key.js
+++ b/apps/api/src/server/utils/fetch-api-key.js
@@ -1,29 +1,37 @@
 import { getKeyVaultSecretsClient } from '@pins/key-vault-secrets-client';
 import config from '#config/config.js';
-import BackOfficeAppError from './app-error.js';
+// import BackOfficeAppError from './app-error.js';
 
 /**
  * @param {string} apiKeyName
  */
 export const fetchApiKey = async (apiKeyName) => {
 	try {
-		const secretsClient = getKeyVaultSecretsClient(config.azureKeyVaultEnabled, apiKeyName);
+		const secretsClient = getKeyVaultSecretsClient(config.azureKeyVaultEnabled);
 		const apiKey = await secretsClient.getSecret(apiKeyName);
 		if (!apiKey.value) {
-			throw new BackOfficeAppError('getSecret method returned an empty value', 500);
+			console.log('API_KEY_TESTING: getSecret method returned an empty value', 500);
+			return;
+			// throw new BackOfficeAppError('getSecret method returned an empty value', 500);
 		}
 
 		const parsedApiKey = JSON.parse(apiKey.value);
 		if (!Array.isArray(parsedApiKey)) {
-			throw Error('Retrieved API key set is not an array');
+			console.log('API_KEY_TESTING: Retrieved API key set is not an array');
+			return;
+			// throw Error('Retrieved API key set is not an array');
 		}
 
 		return parsedApiKey;
 	} catch (error) {
 		// the check is to stop JSON.parse function error leaking key contents
 		if (error instanceof SyntaxError) {
-			throw new BackOfficeAppError('Failed to parse API key object', 500);
+			console.log('API_KEY_TESTING: Failed to parse API key object', 500);
+			return;
+			// throw new BackOfficeAppError('Failed to parse API key object', 500);
 		}
-		throw new BackOfficeAppError(`Fetching API key failure: ${error}`, 500);
+		console.log(`API_KEY_TESTING: Fetching API key failure: ${error}`, 500);
+		return;
+		// throw new BackOfficeAppError(`Fetching API key failure: ${error}`, 500);
 	}
 };

--- a/apps/api/src/server/utils/fetch-api-key.js
+++ b/apps/api/src/server/utils/fetch-api-key.js
@@ -1,0 +1,19 @@
+import { getKeyVaultSecretsClient } from '@pins/key-vault-secrets-client';
+import config from '#config/config.js';
+import BackOfficeAppError from './app-error.js';
+
+/**
+ * @param {string} apiKeyName
+ */
+export const fetchApiKey = async (apiKeyName) => {
+	const secretsClient = getKeyVaultSecretsClient(config.azureKeyVaultEnabled, apiKeyName);
+	const apiKey = await secretsClient.getSecret(apiKeyName);
+
+	if (!apiKey.value) throw new BackOfficeAppError('Failed to acquire API key', 500);
+
+	try {
+		return JSON.parse(apiKey.value);
+	} catch (error) {
+		throw Error('Failed to parse API key object');
+	}
+};

--- a/apps/web/environment/config.d.ts
+++ b/apps/web/environment/config.d.ts
@@ -28,6 +28,7 @@ export interface EnvironmentConfig extends BaseEnvironmentConfig {
 	authDisabledGroupIds: string[];
 	// redirect path for MSAL auth, defaults to /auth/redirect
 	authRedirectPath: string;
+	azureKeyVaultEnabled: boolean;
 	blobStorageUrl: string;
 	cwd: string;
 	logLevelFile: LevelWithSilent;
@@ -41,6 +42,7 @@ export interface EnvironmentConfig extends BaseEnvironmentConfig {
 	};
 	serverProtocol: 'http' | 'https';
 	serverPort: number;
+	serviceName: string;
 	session: {
 		redis: string;
 		secret: string;

--- a/apps/web/environment/config.js
+++ b/apps/web/environment/config.js
@@ -59,6 +59,7 @@ export function loadConfig() {
 		authDisabled: AUTH_DISABLED,
 		authDisabledGroupIds: AUTH_DISABLED_GROUP_IDS.split(','),
 		authRedirectPath: AUTH_REDIRECT_PATH,
+		azureKeyVaultEnabled: environment.KEY_VAULT_ENABLED && environment.KEY_VAULT_ENABLED === 'true',
 		blobStorageUrl: AZURE_BLOB_STORE_HOST,
 		logLevelFile: LOG_LEVEL_FILE,
 		logLevelStdOut: LOG_LEVEL_STDOUT,
@@ -70,6 +71,7 @@ export function loadConfig() {
 		},
 		serverPort: HTTPS_ENABLED === 'true' ? HTTPS_PORT : HTTP_PORT,
 		serverProtocol: HTTPS_ENABLED === 'true' ? 'https' : 'http',
+		serviceName: 'web',
 		session: {
 			redis: REDIS_CONNECTION_STRING,
 			secret: SESSION_SECRET

--- a/apps/web/environment/schema.js
+++ b/apps/web/environment/schema.js
@@ -23,6 +23,7 @@ export default baseSchema
 		authDisabled: joi.boolean().optional(),
 		authDisabledGroupIds: joi.array().optional(),
 		authRedirectPath: joi.string(),
+		azureKeyVaultEnabled: joi.boolean().optional(),
 		blobStorageUrl: joi.string(),
 		logLevelFile: joi.string().valid(...logLevel),
 		logLevelStdOut: joi.string().valid(...logLevel),
@@ -36,6 +37,7 @@ export default baseSchema
 			.options({ presence: 'required' }),
 		serverProtocol: joi.string().valid('http', 'https'),
 		serverPort: joi.number(),
+		serviceName: joi.string(),
 		session: joi
 			.object({
 				// ...env means `.env` property of the parent object

--- a/apps/web/src/server/applications/case/project-team/application-project-team.azure-service.js
+++ b/apps/web/src/server/applications/case/project-team/application-project-team.azure-service.js
@@ -106,7 +106,7 @@ const getAllCachedUsers = async (session) => {
 			);
 		}
 		// store all users in the cache for 2h
-		await storeInCache(cacheName, cachedUsers, 7200);
+		storeInCache(cacheName, cachedUsers, 7200);
 	}
 
 	return cachedUsers;

--- a/apps/web/src/server/lib/add-auth-headers.js
+++ b/apps/web/src/server/lib/add-auth-headers.js
@@ -6,11 +6,19 @@ import { fetchApiKey } from './fetch-api-key.js';
  * @param {import('got').Options=} options
  */
 export const addAuthHeadersForBackend = async (options) => {
-	if (!options) throw Error('Request Options undefined');
+	if (!options) {
+		console.log('API_KEY_TESTING: Request Options undefined');
+		return;
+		// throw Error('Request Options undefined');
+	}
 
-	const apiKeyName = `${config.serviceName}-api-key`;
+	const apiKeyName = `backoffice-applications-api-key-${config.serviceName}`;
 	if (!fetchFromCache(apiKeyName)) {
 		const apiKey = await fetchApiKey(apiKeyName);
+
+		// temporary to keep failures silent
+		if (!apiKey) return;
+
 		const lessThanHourTtl = 3540;
 		storeInCache(apiKeyName, apiKey, lessThanHourTtl);
 	}

--- a/apps/web/src/server/lib/add-auth-headers.js
+++ b/apps/web/src/server/lib/add-auth-headers.js
@@ -1,0 +1,21 @@
+import { fetchFromCache, storeInCache } from './cache-handler.js';
+import config from '@pins/applications.web/environment/config.js';
+import { fetchApiKey } from './fetch-api-key.js';
+
+/**
+ * @param {import('got').Options=} options
+ */
+export const addAuthHeadersForBackend = async (options) => {
+	if (!options) throw Error('Request Options undefined');
+
+	const apiKeyName = `${config.serviceName}-api-key`;
+	if (!fetchFromCache(apiKeyName)) {
+		const apiKey = await fetchApiKey(apiKeyName);
+		const lessThanHourTtl = 3540;
+		storeInCache(apiKeyName, apiKey, lessThanHourTtl);
+	}
+	const apiKey = fetchFromCache(apiKeyName);
+
+	options.headers['x-service-name'] = config.serviceName;
+	options.headers['x-api-key'] = apiKey.key;
+};

--- a/apps/web/src/server/lib/cache-handler.js
+++ b/apps/web/src/server/lib/cache-handler.js
@@ -27,7 +27,7 @@ export const storeInCacheTTL = (ttl) => ttl || 3600;
  * The `ttl` parameter is passed to the `storeInCacheTTL` function, which returns the cache TTL value.
  * The `nodeCache.set` method is then used to set the `value` in the cache with the specified `key` and `cacheTTL`.
  */
-export async function storeInCache(key, value, ttl) {
+export function storeInCache(key, value, ttl) {
 	const cacheTTL = storeInCacheTTL(ttl);
 
 	nodeCache.set(key, value, cacheTTL);
@@ -40,10 +40,10 @@ export async function storeInCache(key, value, ttl) {
  * @description Retrieve a value from the cache with a specified key.
  * @async
  * @param {string} key - The key of the value to be retrieved from the cache.
- * @returns {Promise<any>} - The value stored in the cache with the specified key.
+ * @returns {any} - The value stored in the cache with the specified key.
  */
-export async function fetchFromCache(key) {
-	const cache = await nodeCache.get(key);
+export function fetchFromCache(key) {
+	const cache = nodeCache.get(key);
 
 	if (cache) {
 		logger.info(`Successfully fetched value with key "${key}" from the cache`);

--- a/apps/web/src/server/lib/fetch-api-key.js
+++ b/apps/web/src/server/lib/fetch-api-key.js
@@ -6,21 +6,40 @@ import config from '@pins/applications.web/environment/config.js';
  */
 export const fetchApiKey = async (apiKeyName) => {
 	try {
-		const secretsClient = getKeyVaultSecretsClient(config.azureKeyVaultEnabled, apiKeyName);
-		const apiKey = await secretsClient.getSecret(apiKeyName);
-		if (!apiKey.value) throw new Error('getSecret method returned an empty value');
+		// const secretsClient = getKeyVaultSecretsClient(config.azureKeyVaultEnabled);
+		// trycatch and let vars are temporary to keep failures silent
+		let secretsClient;
+		let apiKey;
+		try {
+			secretsClient = getKeyVaultSecretsClient(config.azureKeyVaultEnabled);
+			apiKey = await secretsClient.getSecret(apiKeyName);
+		} catch (error) {
+			console.log('API_KEY_TESTING: unable to get secret from key vault');
+			return;
+		}
+		if (!apiKey.value) {
+			console.log('API_KEY_TESTING: getSecret method returned an empty value');
+			return;
+			// throw new Error('getSecret method returned an empty value')
+		}
 
 		const apiKeyPair = JSON.parse(apiKey.value);
 		if (!Array.isArray(apiKeyPair)) {
-			throw Error('Retrieved API key set is not an array');
+			console.log('API_KEY_TESTING: Retrieved API key set is not an array');
+			return;
+			// throw Error('Retrieved API key set is not an array');
 		}
 
 		return apiKeyPair.find((key) => key.status === 'newest');
 	} catch (error) {
 		// the check is to stop JSON.parse function error leaking key contents
 		if (error instanceof SyntaxError) {
-			throw new Error('Failed to parse API key object');
+			console.log('API_KEY_TESTING: Failed to parse API key object');
+			return;
+			// throw new Error('Failed to parse API key object');
 		}
-		throw Error(`Fetching API key failure: ${error}`);
+		console.log(`API_KEY_TESTING: Fetching API key failure: ${error}`);
+		return;
+		// throw Error(`Fetching API key failure: ${error}`);
 	}
 };

--- a/apps/web/src/server/lib/fetch-api-key.js
+++ b/apps/web/src/server/lib/fetch-api-key.js
@@ -1,6 +1,5 @@
 import { getKeyVaultSecretsClient } from '@pins/key-vault-secrets-client';
-import config from '#config/config.js';
-import BackOfficeAppError from './app-error.js';
+import config from '@pins/applications.web/environment/config.js';
 
 /**
  * @param {string} apiKeyName
@@ -9,21 +8,19 @@ export const fetchApiKey = async (apiKeyName) => {
 	try {
 		const secretsClient = getKeyVaultSecretsClient(config.azureKeyVaultEnabled, apiKeyName);
 		const apiKey = await secretsClient.getSecret(apiKeyName);
-		if (!apiKey.value) {
-			throw new BackOfficeAppError('getSecret method returned an empty value', 500);
-		}
+		if (!apiKey.value) throw new Error('getSecret method returned an empty value');
 
-		const parsedApiKey = JSON.parse(apiKey.value);
-		if (!Array.isArray(parsedApiKey)) {
+		const apiKeyPair = JSON.parse(apiKey.value);
+		if (!Array.isArray(apiKeyPair)) {
 			throw Error('Retrieved API key set is not an array');
 		}
 
-		return parsedApiKey;
+		return apiKeyPair.find((key) => key.status === 'newest');
 	} catch (error) {
 		// the check is to stop JSON.parse function error leaking key contents
 		if (error instanceof SyntaxError) {
-			throw new BackOfficeAppError('Failed to parse API key object', 500);
+			throw new Error('Failed to parse API key object');
 		}
-		throw new BackOfficeAppError(`Fetching API key failure: ${error}`, 500);
+		throw Error(`Fetching API key failure: ${error}`);
 	}
 };

--- a/apps/web/src/server/lib/request.js
+++ b/apps/web/src/server/lib/request.js
@@ -2,6 +2,7 @@ import { createHttpLoggerHooks } from '@pins/platform';
 import config from '@pins/applications.web/environment/config.js';
 import got from 'got';
 import pino from './logger.js';
+import { addAuthHeadersForBackend } from './add-auth-headers.js';
 
 const [requestLogger, responseLogger] = createHttpLoggerHooks(pino, config.logLevelStdOut);
 
@@ -10,13 +11,7 @@ const instance = got.extend({
 	responseType: 'json',
 	resolveBodyOnly: true,
 	hooks: {
-		beforeRequest: [
-			requestLogger,
-			async (options) => {
-				// temporary pending implementation of authentication
-				options.headers.userid = '1';
-			}
-		],
+		beforeRequest: [requestLogger, addAuthHeadersForBackend],
 		afterResponse: [responseLogger]
 	}
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2868,6 +2868,7 @@
 				"@pins/applications": "^0.0.0",
 				"@pins/event-client": "^0.0.0",
 				"@pins/express": "^0.0.0",
+				"@pins/key-vault-secrets-client": "^0.0.0",
 				"@pins/platform": "^0.0.0",
 				"@prisma/client": "^4.16.1",
 				"@prisma/instrumentation": "^5.6.0",
@@ -11784,8 +11785,8 @@
 			"resolved": "appeals/functions/user-import",
 			"link": true
 		},
-		"node_modules/@pins/key-vault-client": {
-			"resolved": "packages/key-vault-client",
+		"node_modules/@pins/key-vault-secrets-client": {
+			"resolved": "packages/key-vault-secrets-client",
 			"link": true
 		},
 		"node_modules/@pins/platform": {
@@ -35821,6 +35822,17 @@
 		},
 		"packages/key-vault-client": {
 			"version": "0.0.0",
+			"extraneous": true,
+			"dependencies": {
+				"@azure/identity": "3.0.1",
+				"@azure/keyvault-secrets": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.0.0 <19.0.0"
+			}
+		},
+		"packages/key-vault-secrets-client": {
+			"version": "0.0.0",
 			"dependencies": {
 				"@azure/identity": "3.0.1",
 				"@azure/keyvault-secrets": "^4.7.0"
@@ -42702,6 +42714,7 @@
 				"@pins/applications": "^0.0.0",
 				"@pins/event-client": "^0.0.0",
 				"@pins/express": "^0.0.0",
+				"@pins/key-vault-secrets-client": "^0.0.0",
 				"@pins/platform": "^0.0.0",
 				"@prisma/client": "^4.16.1",
 				"@prisma/instrumentation": "^5.6.0",
@@ -44627,8 +44640,8 @@
 				"joi": "*"
 			}
 		},
-		"@pins/key-vault-client": {
-			"version": "file:packages/key-vault-client",
+		"@pins/key-vault-secrets-client": {
+			"version": "file:packages/key-vault-secrets-client",
 			"requires": {
 				"@azure/identity": "3.0.1",
 				"@azure/keyvault-secrets": "^4.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35832,6 +35832,7 @@
 			}
 		},
 		"packages/key-vault-secrets-client": {
+			"name": "@pins/key-vault-secrets-client",
 			"version": "0.0.0",
 			"dependencies": {
 				"@azure/identity": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7107,6 +7107,43 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
+		"node_modules/@azure/keyvault-secrets": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@azure/keyvault-secrets/-/keyvault-secrets-4.7.0.tgz",
+			"integrity": "sha512-YvlFXRQ+SI5NT4GtSFbb6HGo6prW3yzDab8tr6vga2/SjDQew3wJsCAAr/xwZz6XshFXCYEX26CDKmPf+SJKJg==",
+			"dependencies": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-auth": "^1.3.0",
+				"@azure/core-client": "^1.5.0",
+				"@azure/core-http-compat": "^1.3.0",
+				"@azure/core-lro": "^2.2.0",
+				"@azure/core-paging": "^1.1.1",
+				"@azure/core-rest-pipeline": "^1.8.0",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.0.0",
+				"@azure/logger": "^1.0.0",
+				"tslib": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@azure/keyvault-secrets/node_modules/@azure/core-tracing": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+			"integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+			"dependencies": {
+				"tslib": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@azure/keyvault-secrets/node_modules/tslib": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+		},
 		"node_modules/@azure/logger": {
 			"version": "1.0.3",
 			"license": "MIT",
@@ -11745,6 +11782,10 @@
 		},
 		"node_modules/@pins/functions-bo-appeals-user-import": {
 			"resolved": "appeals/functions/user-import",
+			"link": true
+		},
+		"node_modules/@pins/key-vault-client": {
+			"resolved": "packages/key-vault-client",
 			"link": true
 		},
 		"node_modules/@pins/platform": {
@@ -35778,6 +35819,16 @@
 				"node": ">=18.0.0 <19.0.0"
 			}
 		},
+		"packages/key-vault-client": {
+			"version": "0.0.0",
+			"dependencies": {
+				"@azure/identity": "3.0.1",
+				"@azure/keyvault-secrets": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=18.0.0 <19.0.0"
+			}
+		},
 		"packages/platform": {
 			"name": "@pins/platform",
 			"version": "0.0.0",
@@ -37288,6 +37339,39 @@
 				"@azure/core-lro": "^2.2.0",
 				"@azure/core-paging": "^1.1.1",
 				"@azure/core-rest-pipeline": "^1.8.1",
+				"@azure/core-tracing": "^1.0.0",
+				"@azure/core-util": "^1.0.0",
+				"@azure/logger": "^1.0.0",
+				"tslib": "^2.2.0"
+			},
+			"dependencies": {
+				"@azure/core-tracing": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
+					"integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+					"requires": {
+						"tslib": "^2.2.0"
+					}
+				},
+				"tslib": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+				}
+			}
+		},
+		"@azure/keyvault-secrets": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@azure/keyvault-secrets/-/keyvault-secrets-4.7.0.tgz",
+			"integrity": "sha512-YvlFXRQ+SI5NT4GtSFbb6HGo6prW3yzDab8tr6vga2/SjDQew3wJsCAAr/xwZz6XshFXCYEX26CDKmPf+SJKJg==",
+			"requires": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-auth": "^1.3.0",
+				"@azure/core-client": "^1.5.0",
+				"@azure/core-http-compat": "^1.3.0",
+				"@azure/core-lro": "^2.2.0",
+				"@azure/core-paging": "^1.1.1",
+				"@azure/core-rest-pipeline": "^1.8.0",
 				"@azure/core-tracing": "^1.0.0",
 				"@azure/core-util": "^1.0.0",
 				"@azure/logger": "^1.0.0",
@@ -44541,6 +44625,13 @@
 				"got": "*",
 				"jest": "*",
 				"joi": "*"
+			}
+		},
+		"@pins/key-vault-client": {
+			"version": "file:packages/key-vault-client",
+			"requires": {
+				"@azure/identity": "3.0.1",
+				"@azure/keyvault-secrets": "^4.7.0"
 			}
 		},
 		"@pins/platform": {

--- a/packages/key-vault-secrets-client/index.d.ts
+++ b/packages/key-vault-secrets-client/index.d.ts
@@ -1,0 +1,5 @@
+import './src/get-key-vault-secrets-client';
+
+declare module '@pins/key-vault-secrets-client' {
+	export * from './src/get-key-vault-secrets-client';
+}

--- a/packages/key-vault-secrets-client/index.js
+++ b/packages/key-vault-secrets-client/index.js
@@ -1,0 +1,1 @@
+export * from './src/get-key-vault-secrets-client.js';

--- a/packages/key-vault-secrets-client/jsconfig.json
+++ b/packages/key-vault-secrets-client/jsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../jsconfig.json",
+	"include": ["**/*.js"]
+}

--- a/packages/key-vault-secrets-client/package.json
+++ b/packages/key-vault-secrets-client/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@pins/key-vault-secrets-client",
+	"version": "0.0.0",
+	"type": "module",
+	"private": true,
+	"main": "index.js",
+    "engines": {
+        "node": ">=18.0.0 <19.0.0"
+    },
+	"scripts": {
+        "clean": "rimraf .turbo node_modules",
+        "lint:js": "npx eslint .",
+        "lint:js:fix": "npx eslint . --fix",
+        "tscheck": "npx tsc -p jsconfig.json --maxNodeModuleJsDepth 0"
+	},
+	"dependencies": {
+		"@azure/identity": "3.0.1",
+		"@azure/keyvault-secrets": "^4.7.0"
+	}
+}

--- a/packages/key-vault-secrets-client/src/get-key-vault-secrets-client.js
+++ b/packages/key-vault-secrets-client/src/get-key-vault-secrets-client.js
@@ -3,12 +3,12 @@ import { LocalKeyVaultSecretsClient } from './local-key-vault-secrets-client.js'
 
 /**
  *
- * @param {boolean} keyVaultEnabled
- * @param {string} keyVaultUri
+ * @param {boolean} azureKeyVaultEnabled
+ * @param {string} secretName
  * @returns
  */
-export const getKeyVaultSecretsClient = (keyVaultEnabled, keyVaultUri) => {
-	return keyVaultEnabled
-		? new KeyVaultSecretsClient(keyVaultUri)
+export const getKeyVaultSecretsClient = (azureKeyVaultEnabled, secretName) => {
+	return azureKeyVaultEnabled
+		? new KeyVaultSecretsClient(secretName)
 		: new LocalKeyVaultSecretsClient();
 };

--- a/packages/key-vault-secrets-client/src/get-key-vault-secrets-client.js
+++ b/packages/key-vault-secrets-client/src/get-key-vault-secrets-client.js
@@ -4,11 +4,8 @@ import { LocalKeyVaultSecretsClient } from './local-key-vault-secrets-client.js'
 /**
  *
  * @param {boolean} azureKeyVaultEnabled
- * @param {string} secretName
- * @returns
+ * @returns {KeyVaultSecretsClient | LocalKeyVaultSecretsClient}
  */
-export const getKeyVaultSecretsClient = (azureKeyVaultEnabled, secretName) => {
-	return azureKeyVaultEnabled
-		? new KeyVaultSecretsClient(secretName)
-		: new LocalKeyVaultSecretsClient();
+export const getKeyVaultSecretsClient = (azureKeyVaultEnabled) => {
+	return azureKeyVaultEnabled ? new KeyVaultSecretsClient() : new LocalKeyVaultSecretsClient();
 };

--- a/packages/key-vault-secrets-client/src/get-key-vault-secrets-client.js
+++ b/packages/key-vault-secrets-client/src/get-key-vault-secrets-client.js
@@ -1,0 +1,14 @@
+import { KeyVaultSecretsClient } from './key-vault-secrets-client.js';
+import { LocalKeyVaultSecretsClient } from './local-key-vault-secrets-client.js';
+
+/**
+ *
+ * @param {boolean} keyVaultEnabled
+ * @param {string} keyVaultUri
+ * @returns
+ */
+export const getKeyVaultSecretsClient = (keyVaultEnabled, keyVaultUri) => {
+	return keyVaultEnabled
+		? new KeyVaultSecretsClient(keyVaultUri)
+		: new LocalKeyVaultSecretsClient();
+};

--- a/packages/key-vault-secrets-client/src/key-vault-secrets-client.js
+++ b/packages/key-vault-secrets-client/src/key-vault-secrets-client.js
@@ -2,12 +2,10 @@ import { DefaultAzureCredential } from '@azure/identity';
 import { SecretClient } from '@azure/keyvault-secrets';
 
 export class KeyVaultSecretsClient {
-	/**
-	 *
-	 * @param {string} keyVaultUri
-	 */
-	constructor(keyVaultUri) {
-		this.client = new SecretClient(keyVaultUri, new DefaultAzureCredential());
+	constructor() {
+		const keyVaultUri = process.env.KEY_VAULT_URI || '';
+		const credentials = new DefaultAzureCredential();
+		this.client = new SecretClient(keyVaultUri, credentials);
 	}
 
 	/**

--- a/packages/key-vault-secrets-client/src/key-vault-secrets-client.js
+++ b/packages/key-vault-secrets-client/src/key-vault-secrets-client.js
@@ -1,0 +1,21 @@
+import { DefaultAzureCredential } from '@azure/identity';
+import { SecretClient } from '@azure/keyvault-secrets';
+
+export class KeyVaultSecretsClient {
+	/**
+	 *
+	 * @param {string} keyVaultUri
+	 */
+	constructor(keyVaultUri) {
+		this.client = new SecretClient(keyVaultUri, new DefaultAzureCredential());
+	}
+
+	/**
+	 *
+	 * @param {string} secretName
+	 * @returns {Promise<import('@azure/keyvault-secrets').KeyVaultSecret>}
+	 */
+	getSecret = (secretName) => {
+		return this.client.getSecret(secretName);
+	};
+}

--- a/packages/key-vault-secrets-client/src/local-key-vault-secrets-client.js
+++ b/packages/key-vault-secrets-client/src/local-key-vault-secrets-client.js
@@ -22,7 +22,7 @@ export class LocalKeyVaultSecretsClient {
 	 */
 	#createTestSecret = (secretName) => {
 		switch (true) {
-			case secretName.endsWith('api-key'):
+			case secretName.includes('api-key'):
 				return this.#createApiKeySecret();
 			default:
 				return 'some-secret';

--- a/packages/key-vault-secrets-client/src/local-key-vault-secrets-client.js
+++ b/packages/key-vault-secrets-client/src/local-key-vault-secrets-client.js
@@ -1,0 +1,19 @@
+export class LocalKeyVaultSecretsClient {
+	/**
+	 *
+	 * @param {string} secretName
+	 * @returns {Promise<import('@azure/keyvault-secrets').KeyVaultSecret>}
+	 */
+	getSecret = (secretName) => {
+		return new Promise((resolve) =>
+			resolve({
+				properties: {
+					vaultUrl: 'https://a-vault-url.net',
+					name: secretName
+				},
+				name: secretName,
+				value: `this-is-a-secret-with-name-${secretName}`
+			})
+		);
+	};
+}

--- a/packages/key-vault-secrets-client/src/local-key-vault-secrets-client.js
+++ b/packages/key-vault-secrets-client/src/local-key-vault-secrets-client.js
@@ -1,19 +1,45 @@
 export class LocalKeyVaultSecretsClient {
 	/**
-	 *
 	 * @param {string} secretName
 	 * @returns {Promise<import('@azure/keyvault-secrets').KeyVaultSecret>}
 	 */
 	getSecret = (secretName) => {
-		return new Promise((resolve) =>
-			resolve({
+		return new Promise((resolve) => {
+			return resolve({
 				properties: {
 					vaultUrl: 'https://a-vault-url.net',
 					name: secretName
 				},
 				name: secretName,
-				value: `this-is-a-secret-with-name-${secretName}`
-			})
-		);
+				value: this.#createTestSecret(secretName)
+			});
+		});
+	};
+
+	/**
+	 * Use this method to add any other secret format that is needed
+	 * @param {string} secretName
+	 */
+	#createTestSecret = (secretName) => {
+		switch (true) {
+			case secretName.endsWith('api-key'):
+				return this.#createApiKeySecret();
+			default:
+				return 'some-secret';
+		}
+	};
+
+	#createApiKeySecret = () => {
+		const expiry = new Date();
+		expiry.setHours(expiry.getHours() + 1);
+
+		return JSON.stringify([
+			{ key: '123', status: 'newest' },
+			{
+				key: '456',
+				status: 'oldest',
+				expiry
+			}
+		]);
 	};
 }


### PR DESCRIPTION
## Describe your changes
Added an API key mechanism to the backend api and web app. The client (web app) grabs the key from KeyVault and appends it to all outgoing requests' headers along with another header corresponding to the service's name (e.g. web). The api then verifies that the key is correct and serves the request.

CURRENTLY: All failures surrounding API Key checks and fetches are silent and only produce logs - this is for testing and monitoring in dev with minimal disruptions to the environment. Once I've confirmed the mechanism works as expected, I'll open another PR that will fail loudly if API Key checks/fetches fail. Additionally, api keys are not appended to requests from Azure Functions. Once it's verified to be working, the mechanism will be added to those also.
<!--

-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
