### PR TITLE
feat(appeals/api): clearing up old fields for BOAT-676

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -189,8 +189,6 @@ interface NeighbouringSiteContactsResponse {
 }
 
 interface SingleAppealDetailsResponse {
-	agentName?: string | null;
-	appellantName?: string;
 	allocationDetails: AppealAllocation | null;
 	appealId: number;
 	appealReference: string;

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -485,13 +485,11 @@ describe('appeals routes', () => {
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
-					agentName: `${householdAppeal.agent.firstName} ${householdAppeal.agent.lastName}`,
 					agent: {
 						firstName: householdAppeal.agent.firstName,
 						lastName: householdAppeal.agent.lastName,
 						email: householdAppeal.agent.email
 					},
-					appellantName: `${householdAppeal.appellant.firstName} ${householdAppeal.appellant.lastName}`,
 					appellant: {
 						firstName: householdAppeal.appellant.firstName,
 						lastName: householdAppeal.appellant.lastName,
@@ -593,13 +591,11 @@ describe('appeals routes', () => {
 
 				expect(response.status).toEqual(200);
 				expect(response.body).toEqual({
-					agentName: `${fullPlanningAppeal.agent.firstName} ${fullPlanningAppeal.agent.lastName}`,
 					agent: {
 						firstName: fullPlanningAppeal.agent.firstName,
 						lastName: fullPlanningAppeal.agent.lastName,
 						email: fullPlanningAppeal.agent.email
 					},
-					appellantName: `${fullPlanningAppeal.appellant.firstName} ${fullPlanningAppeal.appellant.lastName}`,
 					appellant: {
 						firstName: fullPlanningAppeal.appellant.firstName,
 						lastName: fullPlanningAppeal.appellant.lastName,

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -97,8 +97,6 @@ const formatMyAppeals = (appeal, linkedAppeals) => ({
 const formatAppeal = (appeal, folders) => {
 	if (appeal) {
 		return {
-			agentName: `${appeal.agent?.firstName} ${appeal.agent?.lastName}`,
-			appellantName: `${appeal.appellant?.firstName} ${appeal.appellant?.lastName}`,
 			...(appeal.agent && {
 				agent: {
 					firstName: appeal.agent?.firstName,
@@ -135,7 +133,7 @@ const formatAppeal = (appeal, folders) => {
 				  }
 				: null,
 			appealType: appeal.appealType?.type,
-			appellantCaseId: appeal.appellantCase?.id,
+			appellantCaseId: appeal.appellantCase?.id || 0,
 			caseOfficer: appeal.caseOfficer?.azureAdUserId || null,
 			decision: {
 				folderId: folders[0].id,

--- a/appeals/web/testing/app/fixtures/referencedata.js
+++ b/appeals/web/testing/app/fixtures/referencedata.js
@@ -54,7 +54,6 @@ export const appealsNationalList = {
  * @type {import('../../../src/server/appeals/appeal-details/appeal-details.types.d').WebAppeal}
  */
 export const appealData = {
-	agentName: 'Ryan Marshall',
 	allocationDetails: {
 		level: 'A',
 		band: 3,


### PR DESCRIPTION
Additional API changes to remove old appellant fields.

BOAT-676

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
