### PR TITLE
Fix/boas 1174 always on

### DIFF
--- a/apps/api/src/server/build-app.js
+++ b/apps/api/src/server/build-app.js
@@ -49,6 +49,14 @@ const buildApp = (
 		res.status(200).send('OK');
 	});
 
+	app.get('/', (req, res, next) => {
+		if (req.headers['user-agent'] === 'AlwaysOn') {
+			res.status(204).end();
+		} else {
+			next();
+		}
+	});
+
 	app.all('*', (req, res, next) => {
 		next(new BackOfficeAppError(`Method is not allowed`, 405));
 	});

--- a/apps/web/src/server/app/app.controller.js
+++ b/apps/web/src/server/app/app.controller.js
@@ -54,6 +54,15 @@ export function handleHealthCheck(_, response) {
 }
 
 /** @type {import('express').RequestHandler} */
+export function handleAlwaysOn(request, response, next) {
+	if (request.headers['user-agent'] === 'AlwaysOn') {
+		response.status(204).end();
+	} else {
+		next();
+	}
+}
+
+/** @type {import('express').RequestHandler} */
 export function viewUnauthenticatedError(_, response) {
 	response.status(200).render('app/401');
 }

--- a/apps/web/src/server/app/app.router.js
+++ b/apps/web/src/server/app/app.router.js
@@ -5,7 +5,12 @@ import applicationsRouter from '../applications/applications.router.js';
 
 import { asyncHandler } from '@pins/express';
 
-import { handleHealthCheck, viewHomepage, viewUnauthenticatedError } from './app.controller.js';
+import {
+	handleHealthCheck,
+	handleAlwaysOn,
+	viewHomepage,
+	viewUnauthenticatedError
+} from './app.controller.js';
 import { handleSignout } from './auth/auth.controller.js';
 import { assertGroupAccess, assertIsAuthenticated } from './auth/auth.guards.js';
 import authRouter from './auth/auth.router.js';
@@ -27,6 +32,7 @@ if (config.authDisabled) {
 router.use(authRouter);
 router.route('/unauthenticated').get(viewUnauthenticatedError);
 router.route('/health').get(handleHealthCheck);
+router.route('/').get(handleAlwaysOn);
 
 // Authenticated routes (all other routes)
 


### PR DESCRIPTION
## Describe your changes

When an Azure web service is set to AlwaysOn, it polls the API root with the user-agent string set to `AlwaysOn`. This change just returns a non-error status code for these specific requests so that our logs aren't flooded with 405 errors.

* fix(api/applications): return 204 for Azure AlwaysOn checks in apps/api
* fix(web/applications): return 204 for AlwaysOn checks in apps/web

Tested by manually sending an 'AlwaysOn' request from Postman, but will need to test in dev to make sure it's working.

## Issue ticket number and link

[BOAS-1174](https://pins-ds.atlassian.net/browse/BOAS-1174)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1174]: https://pins-ds.atlassian.net/browse/BOAS-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ