### PR TITLE
fix(applications/web): fix highlighting in project documentation link menu (BOAS-1465)

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -21921,9 +21921,11 @@ exports[`applications documentation GET /case/123/project-documentation should r
                         <button class=\\"govuk-button pins-dashboard-form--btn\\" data-module=\\"govuk-button\\">Search</button>
                     </form>
                 </div>
-            </div><a class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/1/project-management/\\"> Project management</a>
-            <a             class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/11/correspondence/\\">Correspondence</a><a class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/2/legal-advice/\\"> Legal advice</a>
-                <a                 class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/3/transboundary/\\">Transboundary</a><a class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/4/land-rights/\\"> Land rights</a>
+            </div>
+            <div class=\\"pins-link-menu\\"><a class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/1/project-management/\\"> Project management</a>
+                <a                 class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/11/correspondence/\\">Correspondence</a><a class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/2/legal-advice/\\"> Legal advice</a>
+                    <a                     class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/3/transboundary/\\">Transboundary</a><a class=\\"govuk-link govuk-heading-s\\" href=\\"/applications-service/case/123/project-documentation/4/land-rights/\\"> Land rights</a>
+            </div>
         </div>
     </div>
 </main>"

--- a/apps/web/src/server/views/applications/case/project-documentation.njk
+++ b/apps/web/src/server/views/applications/case/project-documentation.njk
@@ -27,10 +27,12 @@
 		</div>
 	</div>
 
-	{% for documentationCategory in documentationCategories %}
-		<a class="govuk-link govuk-heading-s" href="{{ 'document-category'|url({caseId: caseId, documentationCategory: documentationCategory}) }}">
-			{{ documentationCategory.displayNameEn }}
-		</a>
-	{% endfor %}
+	<div class="pins-link-menu">
+		{% for documentationCategory in documentationCategories %}
+			<a class="govuk-link govuk-heading-s" href="{{ 'document-category'|url({caseId: caseId, documentationCategory: documentationCategory}) }}">
+				{{ documentationCategory.displayNameEn }}
+			</a>
+		{% endfor %}
+	</div>
 
 {% endblock %}

--- a/apps/web/src/styles/7-components/link-menu.scss
+++ b/apps/web/src/styles/7-components/link-menu.scss
@@ -1,0 +1,5 @@
+.pins-link-menu {
+	a {
+		width: max-content;
+	}
+}

--- a/apps/web/src/styles/main.scss
+++ b/apps/web/src/styles/main.scss
@@ -42,6 +42,7 @@
 @use "7-components/InfoBox/InfoBox" as InfoBox;
 @use "7-components/DashboardBox/DashboardBox" as DashboardBox;
 @use "7-components/list-menu";
+@use "7-components/link-menu";
 @use "7-components/app-header";
 @use "7-components/file-upload";
 @use "7-components/files-list";


### PR DESCRIPTION
## Describe your changes

- Create a new scss component for the class pins-link-menu
- Add a div for the links with the pins-link-menu class
- Fix the web unit tests

This has been tested manually

## BOAS-1465 On Project documentation page - When hovered over the links, highlighting should be restricted to the text of the link. Currently highlighting is displayed across the entire line.
https://pins-ds.atlassian.net/browse/BOAS-1465

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
