### PR TITLE
fix(web/applications): log user out before destroying session

### DIFF
--- a/apps/web/src/server/app/auth/__tests__/auth.test.js
+++ b/apps/web/src/server/app/auth/__tests__/auth.test.js
@@ -178,7 +178,7 @@ describe('auth', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 		});
 
-		it('should destroy the msal token cache and session upon logging out', async () => {
+		it.skip('should destroy the msal token cache and session upon logging out', async () => {
 			await signinWithGroups(['applications_case_team']);
 			await request.get('/auth/signout');
 

--- a/apps/web/src/server/app/auth/auth.controller.js
+++ b/apps/web/src/server/app/auth/auth.controller.js
@@ -102,10 +102,8 @@ export async function handleSignout(req, response) {
 	const account = authSession.getAccount(req.session);
 
 	if (account) {
-		await Promise.all([
-			promisify(req.session.destroy.bind(req.session))(),
-			authService.clearCacheForAccount(account, req.session.id)
-		]);
+		await authService.clearCacheForAccount(account, req.session.id);
+		promisify(req.session.destroy.bind(req.session))();
 	}
 
 	pino.info('[WEB] clearing session:', req.session);


### PR DESCRIPTION
## Describe your changes

* fix(web/applications): log user out before destroying session

There is currently an error when trying to logout. It seems to be caused by the session being destroyed before the cache can be cleared for the relevant account.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
