### PR TITLE
fix(applications/web): fix s51 advice property edit pages styling (BOAS-1208)

### DIFF
--- a/apps/web/src/server/views/applications/case-s51/properties/edit/s51-edit-advice-detail.njk
+++ b/apps/web/src/server/views/applications/case-s51/properties/edit/s51-edit-advice-detail.njk
@@ -13,7 +13,7 @@
     name: "adviceDetails",
     id: "adviceDetails",
     formGroup: {
-      classes: 'govuk-grid-column-two-thirds govuk-!-margin-top-4 govuk-!-margin-bottom-0'
+      classes: 'govuk-!-width-two-thirds govuk-!-margin-top-4 govuk-!-margin-bottom-0'
     },
     hint: {
         text: "Add the details of the advice given. You will be able to add attachments later."

--- a/apps/web/src/server/views/applications/case-s51/properties/edit/s51-edit-enquiry-details.njk
+++ b/apps/web/src/server/views/applications/case-s51/properties/edit/s51-edit-enquiry-details.njk
@@ -13,7 +13,7 @@
     name: "enquiryDetails",
     id: "enquiryDetails",
     formGroup: {
-      classes: 'govuk-grid-column-two-thirds govuk-!-margin-top-4 govuk-!-margin-bottom-0'
+      classes: 'govuk-!-width-two-thirds govuk-!-margin-top-4 govuk-!-margin-bottom-0'
     },
     hint: {
         text: "Add the details of the enquiry. You will be able to add attachments later."

--- a/apps/web/src/server/views/applications/layouts/s51-edit.layout.njk
+++ b/apps/web/src/server/views/applications/layouts/s51-edit.layout.njk
@@ -13,7 +13,7 @@
 
 {% block pageContent %}
   {% block formHeading %}{% endblock %}
-  <form method="post" action="" novalidate="novalidate" class="govuk-grid-row govuk-!-margin-top-2">
+  <form method="post" action="" novalidate="novalidate" class="pins-s51-edit-form govuk-!-margin-top-2">
     {% block formContent %}{% endblock %}
     {{ govukButton({ text: 'Save and return' }) }}
   </form>

--- a/apps/web/src/styles/7-components/s51-edit-form.scss
+++ b/apps/web/src/styles/7-components/s51-edit-form.scss
@@ -1,0 +1,6 @@
+.pins-s51-edit-form {
+	// target dateInput component to compensate for the margin-left 15px in that component
+	.govuk-grid-column-full {
+		margin-left: -15px;
+	}
+}

--- a/apps/web/src/styles/main.scss
+++ b/apps/web/src/styles/main.scss
@@ -57,6 +57,7 @@
 @use "7-components/sort-table";
 @use "7-components/status-tag";
 @use "7-components/results-per-page";
+@use "7-components/s51-edit-form";
 @use "7-components/filter-box";
 @use "7-components/html-content-editor";
 @use "7-components/project-update";


### PR DESCRIPTION
## Describe your changes

- Fix s51-layout css classes so all controls including the buttons line up correctly
- Fix the classes in both the "Edit advice details" and "Edit enquiry details" so the button is under the text area as expected
- Checked the web unit tests for any regression

All s51 advice property edit pages have been tested manually

## BOAS-1208 'Save and return' button not in the correct place when editing enquiry or advice details on S51 advice
https://pins-ds.atlassian.net/browse/BOAS-1208

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
