### PR TITLE
fix(api): fix integration of reps representation reference and status

### DIFF
--- a/apps/api/src/server/applications/application/representations/representation.mapper.js
+++ b/apps/api/src/server/applications/application/representations/representation.mapper.js
@@ -23,7 +23,7 @@ export const mapCreateOrUpdateRepRequestToRepository = (
 
 	if (method === 'POST') {
 		defaultRepresentationDetails = {
-			reference: '',
+			reference: representation.reference || '',
 			caseId,
 			status: representation.status || 'DRAFT',
 			originalRepresentation: representation.originalRepresentation || '',

--- a/apps/api/src/server/repositories/__tests__/representation.repository.test.js
+++ b/apps/api/src/server/repositories/__tests__/representation.repository.test.js
@@ -595,5 +595,76 @@ describe('Representation repository', () => {
 				}
 			});
 		});
+
+		it('Create a representation with reference id', async () => {
+			// GIVEN
+			const mappedData = {
+				representationDetails: {
+					status: 'DRAFT',
+					caseId: 1,
+					reference: 'FRONT_OFFICE_REFERENCE_ID'
+				},
+				represented: {
+					firstName: 'Joe',
+					lastName: 'Bloggs',
+					under18: false,
+					type: 'PERSON',
+					received: '2023-05-11T09:57:06.139Z'
+				},
+				representedAddress: {
+					addressLine1: 'Test Address Line 1'
+				}
+			};
+
+			const createdRepresentationWithReference = {
+				...createdRepresentation,
+				reference: 'FRONT_OFFICE_REFERENCE_ID'
+			};
+
+			databaseConnector.representation.create.mockResolvedValue(createdRepresentationWithReference);
+
+			// WHEN
+			const representation = await representationRepository.createApplicationRepresentation(
+				mappedData
+			);
+
+			// THEN
+			expect(representation).toEqual({
+				caseId: 1,
+				id: 1,
+				originalRepresentation: '',
+				received: '2023-05-11T09:57:06.139Z',
+				redacted: false,
+				redactedRepresentation: null,
+				reference: 'FRONT_OFFICE_REFERENCE_ID',
+				status: 'DRAFT',
+				userId: null
+			});
+
+			expect(databaseConnector.representation.create).toHaveBeenCalledWith({
+				data: {
+					status: 'DRAFT',
+					//
+					case: {
+						connect: {
+							id: 1
+						}
+					},
+					reference: 'FRONT_OFFICE_REFERENCE_ID',
+					represented: {
+						create: {
+							firstName: 'Joe',
+							lastName: 'Bloggs',
+							under18: false,
+							type: 'PERSON',
+							received: '2023-05-11T09:57:06.139Z',
+							address: { create: { addressLine1: 'Test Address Line 1' } }
+						}
+					}
+				}
+			});
+
+			expect(databaseConnector.representation.update).toHaveBeenCalledTimes(0);
+		});
 	});
 });

--- a/apps/api/src/server/repositories/representation.repository.js
+++ b/apps/api/src/server/repositories/representation.repository.js
@@ -262,13 +262,16 @@ export const createApplicationRepresentation = async ({
 		data: representation
 	});
 
-	// Using the DB Id to generate a short reference id, references will also be created in FO so prefix id with 'B'
-	return databaseConnector.representation.update({
-		where: { id: createResponse.id },
-		data: {
-			reference: generateRepresentationReference(createResponse.id)
-		}
-	});
+	if (representation.reference) return createResponse;
+	else {
+		// Using the DB Id to generate a short reference id, references will also be created in FO so prefix id with 'B'
+		return databaseConnector.representation.update({
+			where: { id: createResponse.id },
+			data: {
+				reference: generateRepresentationReference(createResponse.id)
+			}
+		});
+	}
 };
 
 export const updateApplicationRepresentation = async (

--- a/apps/functions/applications-command-handlers/register-representation-command/__tests__/register-representation-command.test.js
+++ b/apps/functions/applications-command-handlers/register-representation-command/__tests__/register-representation-command.test.js
@@ -66,6 +66,7 @@ describe('register-representation-command', () => {
 		expect(api.getCaseID).toHaveBeenCalledWith('BC0110002');
 		expect(api.postRepresentation).toHaveBeenCalledWith(1, {
 			reference: 'BC0110002-091222133021123',
+			status: 'AWAITING_REVIEW',
 			type: 'Members of the Public/Businesses',
 			originalRepresentation: 'this is the representation',
 			represented: message.represented,

--- a/apps/functions/applications-command-handlers/register-representation-command/index.js
+++ b/apps/functions/applications-command-handlers/register-representation-command/index.js
@@ -45,6 +45,7 @@ export default async function (context, msg) {
 
 	const representation = {
 		reference: msg.referenceId,
+		status: 'AWAITING_REVIEW',
 		type: msg.representationType,
 		originalRepresentation: msg.originalRepresentation,
 		represented: mapContactDetails(msg.represented),

--- a/packages/applications/types/representation.d.ts
+++ b/packages/applications/types/representation.d.ts
@@ -16,6 +16,7 @@ export interface Contact {
 }
 
 export interface CreateUpdateRepresentation {
+	reference?: string;
 	status?: string;
 	redacted?: boolean;
 	received?: Date;


### PR DESCRIPTION


## Describe your changes

Bug fix for relevant reps command messages:
1) Fix reference Id issue where if API is invoked then POST creates a BO reference ignoring the Front Office reference.
2) Fix status issue so that reps arriving from Front Office a put into AWAITING_REVEW status rather than defaulting to DRAFT.

Unit tested and tested locally via API.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/ASB-2229

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
