### PR TITLE
feat(api/applications): set training documents to published immediately

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -544,10 +544,7 @@ export const publishDocumentVersions = async (documentVersionIds) => {
 
 	const currentlyPublished = await getCurrentlyPublished(documentGuids);
 
-	const publishedDocuments = await documentVersionRepository.updateAll(documentVersionIds, {
-		publishedStatus: 'publishing',
-		publishedStatusPrev: 'ready_to_publish'
-	});
+	const publishedDocuments = await documentVersionRepository.publishMany(documentVersionIds);
 
 	const unpublishedDocuments = await documentVersionRepository.updateAll(
 		currentlyPublished.map((version) => ({
@@ -872,15 +869,11 @@ export const unpublishDocuments = async (guids) => {
 
 	const allVersions = versions.flatMap((docVersions) => docVersions?.filter(Boolean) ?? []);
 
-	const unpublishedDocuments = await documentVersionRepository.updateAll(
+	const unpublishedDocuments = await documentVersionRepository.unpublishMany(
 		allVersions.map((version) => ({
 			documentGuid: version.documentGuid,
 			version: version.version
-		})),
-		{
-			publishedStatus: 'unpublishing',
-			publishedStatusPrev: 'published'
-		}
+		}))
 	);
 
 	await Promise.all(

--- a/apps/api/src/server/repositories/document-metadata.repository.js
+++ b/apps/api/src/server/repositories/document-metadata.repository.js
@@ -249,3 +249,103 @@ export const updateAll = async (documentVersionIds, documentDetails) => {
 
 	return results;
 };
+
+/**
+ * Set publishedStatus of training cases to 'published', and non-training cases to 'publishing'.
+ *
+ * @param {{documentGuid: string, version: number}[]} documentVersionIds
+ * @returns {Promise<DocumentVersionWithDocument[]>}
+ */
+export const publishMany = async (documentVersionIds) => {
+	const results = [];
+
+	for (const documentGuid_version of documentVersionIds) {
+		const current = await databaseConnector.documentVersion.findUnique({
+			where: { documentGuid_version },
+			include: {
+				Document: {
+					include: {
+						case: {
+							include: {
+								ApplicationDetails: {
+									include: {
+										subSector: {
+											include: {
+												sector: true
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		});
+
+		const isTraining =
+			current?.Document?.case?.ApplicationDetails?.subSector?.sector.name === 'training';
+
+		const result = await databaseConnector.documentVersion.update({
+			where: { documentGuid_version },
+			data: {
+				publishedStatus: isTraining ? 'published' : 'publishing',
+				publishedStatusPrev: current?.publishedStatus
+			}
+		});
+
+		results.push(result);
+	}
+
+	return results;
+};
+
+/**
+ * Set publishedStatus of training cases to 'unpublished', and non-training cases to 'unpublishing'.
+ *
+ * @param {{documentGuid: string, version: number}[]} documentVersionIds
+ * @returns {Promise<DocumentVersionWithDocument[]>}
+ */
+export const unpublishMany = async (documentVersionIds) => {
+	const results = [];
+
+	for (const documentGuid_version of documentVersionIds) {
+		const current = await databaseConnector.documentVersion.findUnique({
+			where: { documentGuid_version },
+			include: {
+				Document: {
+					include: {
+						case: {
+							include: {
+								ApplicationDetails: {
+									include: {
+										subSector: {
+											include: {
+												sector: true
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		});
+
+		const isTraining =
+			current?.Document?.case?.ApplicationDetails?.subSector?.sector.name === 'training';
+
+		const result = await databaseConnector.documentVersion.update({
+			where: { documentGuid_version },
+			data: {
+				publishedStatus: isTraining ? 'unpublished' : 'unpublishing',
+				publishedStatusPrev: current?.publishedStatus
+			}
+		});
+
+		results.push(result);
+	}
+
+	return results;
+};


### PR DESCRIPTION
## Describe your changes

On publish/unpublish, set training cases to published/unpublished (respectively) immediately rather than waiting for the Azure function to run.

Tested locally.

## Issue ticket number and link

[BOAS-1466](https://pins-ds.atlassian.net/browse/BOAS-1466)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1466]: https://pins-ds.atlassian.net/browse/BOAS-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ