### PR TITLE
feat(appeals/api): endpoints to manage current and legacy linked appeals

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -567,6 +567,13 @@ interface SetInvalidAppealDecisionRequest {
 	invalidDecisionReason: string;
 }
 
+interface AppealRelationshipRequest {
+	parentRef: string;
+	parentId?: number | null;
+	childRef: string;
+	childId: number | null;
+}
+
 interface UsersToAssign {
 	caseOfficer?: string | null;
 	inspector?: string | null;
@@ -682,5 +689,6 @@ export {
 	UsersToAssign,
 	ValidationOutcomeResponse,
 	SetAppealDecisionRequest,
-	SetInvalidAppealDecisionRequest
+	SetInvalidAppealDecisionRequest,
+	AppealRelationshipRequest
 };

--- a/appeals/api/src/server/endpoints/appeals.routes.js
+++ b/appeals/api/src/server/endpoints/appeals.routes.js
@@ -28,6 +28,7 @@ import { appealsDecisionRoutes } from './appeal-decision/appeal-decision.routes.
 import { invalidAppealDecisionRoutes } from './invalid-appeal-decision/invalid-appeal-decision.routes.js';
 import { changeAppealTypeRoutes } from './change-appeal-type/change-appeal-type.routes.js';
 import { businessDaysRoutes } from './business-days/business-days.routes.js';
+import { linkAppealsRoutes } from './link-appeals/link-appeals.routes.js';
 import checkAzureAdUserIdHeaderExists from '#middleware/check-azure-ad-user-id-header-exists.js';
 
 const router = createRouter();
@@ -62,6 +63,7 @@ router.use(scheduleTypesRoutes);
 router.use(siteVisitRoutes);
 router.use(siteVisitTypesRoutes);
 router.use(changeAppealTypeRoutes);
+router.use(linkAppealsRoutes);
 router.use(appealsRoutes);
 
 export { router as appealsRoutes };

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -199,7 +199,7 @@ const mapAppealStatuses = (rawStatuses) => {
 		...new Set(
 			rawStatuses
 				.flat()
-				.flatMap((/** @type {} */ item) =>
+				.flatMap((/** @type {*} */ item) =>
 					item.appealStatus.map((/** @type {{ status: any; }} */ statusItem) => statusItem.status)
 				)
 		)

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -113,6 +113,8 @@ export const ERROR_INVALID_LPAQ_DATA = 'The integration payload LPA_QUESTIONNAIR
 export const ERROR_INVALID_DOCUMENT_DATA = 'The integration payload DOCUMENT is invalid.';
 export const ERROR_INVALID_APPEAL_STATE = 'The action is invalid on the current appeal state.';
 export const ERROR_CASE_OUTCOME_MUST_BE_ONE_OF = `The case outcome must be one of ${CASE_OUTCOME_ALLOWED}, ${CASE_OUTCOME_DISMISSED}, ${CASE_OUTCOME_SPLIT_DECISION}`;
+export const ERROR_LINKING_APPEALS =
+	'The appeals cannot be linked as the lead or child are already linked to other appeals.';
 
 export const LENGTH_1 = 1;
 export const LENGTH_8 = 8;

--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
@@ -1,0 +1,118 @@
+import { request } from '#tests/../app-test.js';
+import { jest } from '@jest/globals';
+import { azureAdUserId } from '#tests/shared/mocks.js';
+import { householdAppeal, linkedAppeals } from '#tests/appeals/mocks.js';
+import { linkedAppealRequest, linkedAppealLegacyRequest } from '#tests/linked-appeals/mocks.js';
+
+const { databaseConnector } = await import('#utils/database-connector.js');
+
+describe('appeal linked appeals routes', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+	describe('POST', () => {
+		test('returns 400 when the ID in the request is null', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/link-appeal`)
+				.send({
+					...linkedAppealRequest,
+					linkedAppealId: null
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+		});
+
+		test('returns 400 when the ID in the request is not a number', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/link-appeal`)
+				.send({
+					...linkedAppealRequest,
+					linkedAppealId: 'a string'
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+		});
+
+		test('returns 404 when an internal appeal to link is not found', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValueOnce(null);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/link-appeal`)
+				.send({
+					...linkedAppealRequest,
+					linkedAppealId: 100
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(404);
+		});
+
+		test('returns 400 when an external appeal reference is empty', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/link-legacy-appeal`)
+				.send({
+					...linkedAppealLegacyRequest,
+					linkedAppealReference: ''
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+		});
+
+		test('returns 400 when an external appeal reference is null', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+			// @ts-ignore
+			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/link-legacy-appeal`)
+				.send({
+					...linkedAppealLegacyRequest,
+					linkedAppealReference: null
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+		});
+
+		test('returns 400 when an internal appeal is already a parent', async () => {
+			// @ts-ignore
+			databaseConnector.appeal.findUnique.mockResolvedValueOnce(householdAppeal);
+			// @ts-ignore
+			databaseConnector.appealRelationship.findMany.mockResolvedValueOnce(linkedAppeals);
+
+			const response = await request
+				.post(`/appeals/${householdAppeal.id}/link-appeal`)
+				.send({
+					...linkedAppealRequest,
+					isCurrentAppealParent: false
+				})
+				.set('azureAdUserId', azureAdUserId);
+
+			expect(response.status).toEqual(400);
+		});
+	});
+});

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -1,0 +1,94 @@
+import appealRepository from '#repositories/appeal.repository.js';
+import { isAppealLinked } from './link-appeals.service.js';
+import { ERROR_LINKING_APPEALS } from '#endpoints/constants.js';
+
+/** @typedef {import('express').Request} Request */
+/** @typedef {import('express').Response} Response */
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const linkAppeal = async (req, res) => {
+	const { linkedAppealId, isCurrentAppealParent } = req.body;
+	const currentAppeal = req.appeal;
+	const appealToLink = await appealRepository.getAppealById(Number(linkedAppealId));
+
+	if (appealToLink) {
+		if (isAppealLinked(currentAppeal) || isAppealLinked(appealToLink)) {
+			return res.status(400).send({
+				errors: {
+					body: ERROR_LINKING_APPEALS
+				}
+			});
+		}
+
+		const relationship = isCurrentAppealParent
+			? {
+					parentId: currentAppeal.id,
+					parentRef: currentAppeal.reference,
+					childId: appealToLink.id,
+					childRef: appealToLink.reference
+			  }
+			: {
+					parentId: appealToLink.id,
+					parentRef: appealToLink.reference,
+					childId: currentAppeal.id,
+					childRef: currentAppeal.reference
+			  };
+
+		const result = await appealRepository.linkAppeal(relationship);
+		return res.send(result);
+	}
+
+	return res.status(404);
+};
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const linkExternalAppeal = async (req, res) => {
+	const { isCurrentAppealParent, linkedAppealReference } = req.body;
+	const currentAppeal = req.appeal;
+
+	if (isAppealLinked(currentAppeal)) {
+		return res.status(400).send({
+			errors: {
+				body: ERROR_LINKING_APPEALS
+			}
+		});
+	}
+
+	const relationship = isCurrentAppealParent
+		? {
+				parentId: currentAppeal.id,
+				parentRef: currentAppeal.reference,
+				childRef: linkedAppealReference,
+				childId: null
+		  }
+		: {
+				parentId: null,
+				parentRef: linkedAppealReference,
+				childRef: currentAppeal.reference,
+				childId: currentAppeal.id
+		  };
+
+	const result = await appealRepository.linkAppeal(relationship);
+	return res.send(result);
+};
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const unlinkAppeal = async (req, res) => {
+	const { linkedAppealReference } = req.body;
+	const currentAppeal = req.appeal;
+	await appealRepository.unlinkAppeal(currentAppeal.id, linkedAppealReference);
+
+	return res.status(200).send(true);
+};

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.routes.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.routes.js
@@ -1,0 +1,83 @@
+import { Router as createRouter } from 'express';
+import { asyncHandler } from '../../middleware/async-handler.js';
+import checkAppealExistsAndAddToRequest from '#middleware/check-appeal-exists-and-add-to-request.js';
+import {
+	postLinkAppealValidator,
+	postLinkLegacyAppealValidator
+} from './link-appeals.validators.js';
+import { linkExternalAppeal, linkAppeal, unlinkAppeal } from './link-appeals.controller.js';
+
+const router = createRouter();
+
+router.post(
+	'/:appealId/link-appeal',
+	/*
+		#swagger.tags = ['Linked Appeals']
+		#swagger.path = '/appeals/{appealId}/link-appeal'
+		#swagger.description = 'Links an appeal to the current appeal'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Linked Appeal Request',
+			schema: { $ref: '#/definitions/LinkedAppealRequest' },
+			required: true
+		}
+		#swagger.responses[400] = {}
+	 */
+	checkAppealExistsAndAddToRequest,
+	postLinkAppealValidator,
+	asyncHandler(linkAppeal)
+);
+
+router.post(
+	'/:appealId/link-legacy-appeal',
+	/*
+		#swagger.tags = ['Linked Appeals']
+		#swagger.path = '/appeals/{appealId}/link-legacy-appeal'
+		#swagger.description = 'Links a legacy appeal (on Horizon) to the current appeal'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Linked Appeal Request (legacy)',
+			schema: { $ref: '#/definitions/LinkedAppealLegacyRequest' },
+			required: true
+		}
+		#swagger.responses[400] = {}
+	 */
+	checkAppealExistsAndAddToRequest,
+	postLinkLegacyAppealValidator,
+	asyncHandler(linkExternalAppeal)
+);
+
+router.delete(
+	'/:appealId/unlink-appeal',
+	/*
+		#swagger.tags = ['Linked Appeals']
+		#swagger.path = '/appeals/{appealId}/unlink-appeal'
+		#swagger.description = 'Remove a linked appeal from the current appeal'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Unlink Appeal Request',
+			schema: { $ref: '#/definitions/UnlinkAppealRequest' },
+			required: true
+		}
+		#swagger.responses[400] = {}
+	 */
+	checkAppealExistsAndAddToRequest,
+	asyncHandler(unlinkAppeal)
+);
+
+export { router as linkAppealsRoutes };

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -1,0 +1,11 @@
+/** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetByIdResultItem} RepositoryGetByIdResultItem */
+
+/**
+ * Checks if an appeal is linked to other appeals.
+ * @param {RepositoryGetByIdResultItem} appeal The appeal to check for linked appeals.
+ * @returns
+ */
+export const isAppealLinked = (appeal) => {
+	const linkedAppeals = appeal.linkedAppeals || [];
+	return linkedAppeals.length > 0;
+};

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.validators.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.validators.js
@@ -1,0 +1,22 @@
+import { composeMiddleware } from '@pins/express';
+import { validationErrorHandler } from '#middleware/error-handler.js';
+import { ERROR_MUST_BE_NUMBER } from '#endpoints/constants.js';
+import validateStringParameter from '#common/validators/string-parameter.js';
+import { body } from 'express-validator';
+
+const postLinkAppealValidator = composeMiddleware(
+	body('linkedAppealId').isInt().withMessage(ERROR_MUST_BE_NUMBER),
+	validationErrorHandler
+);
+
+const postLinkLegacyAppealValidator = composeMiddleware(
+	validateStringParameter('linkedAppealReference'),
+	validationErrorHandler
+);
+
+const unlinkAppealValidator = composeMiddleware(
+	validateStringParameter('linkedAppealReference'),
+	validationErrorHandler
+);
+
+export { postLinkAppealValidator, postLinkLegacyAppealValidator, unlinkAppealValidator };

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -1,3 +1,22 @@
+export interface LinkedAppealRequest {
+	/** @example 25 */
+	linkedAppealId?: number;
+	/** @example true */
+	isCurrentAppealParent?: boolean;
+}
+
+export interface LinkedAppealLegacyRequest {
+	/** @example "HORIZON/51243165" */
+	linkedAppealReference?: string;
+	/** @example false */
+	isCurrentAppealParent?: boolean;
+}
+
+export interface UnlinkAppealRequest {
+	/** @example "HORIZON/51243165" */
+	linkedAppealReference?: string;
+}
+
 export interface ValidateDate {
 	/** @example "2023-08-17" */
 	inputDate?: string;
@@ -457,6 +476,8 @@ export interface AllAppeals {
 			addressLine1?: string;
 			/** @example "Bristol" */
 			town?: string;
+			/** @example "Bristol" */
+			county?: string;
 			/** @example "BS7 8LQ" */
 			postCode?: string;
 		};
@@ -472,7 +493,7 @@ export interface AllAppeals {
 		appellantCaseStatus?: string;
 		/** @example "Incomplete" */
 		lpaQuestionnaireStatus?: string;
-		/** @example "2023-02-16T00:00:00.000Z" */
+		/** @example "2023-06-18T00:00:00.000Z" */
 		dueDate?: string;
 	}[];
 	/** @example 1 */
@@ -580,8 +601,6 @@ export interface SingleAppealResponse {
 				postCode?: string;
 				/** @example "Woodton" */
 				town?: string;
-				/** @example "Woodton" */
-				county?: string;
 			};
 			/** @example "Fiona" */
 			firstName?: string;

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -2385,11 +2385,170 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/link-appeal": {
+			"post": {
+				"tags": ["Linked Appeals"],
+				"description": "Links an appeal to the current appeal",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"400": {
+						"description": "Bad Request"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Linked Appeal Request",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/LinkedAppealRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/LinkedAppealRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/appeals/{appealId}/link-legacy-appeal": {
+			"post": {
+				"tags": ["Linked Appeals"],
+				"description": "Links a legacy appeal (on Horizon) to the current appeal",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"400": {
+						"description": "Bad Request"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Linked Appeal Request (legacy)",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/LinkedAppealLegacyRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/LinkedAppealLegacyRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/appeals/{appealId}/unlink-appeal": {
+			"delete": {
+				"tags": ["Linked Appeals"],
+				"description": "Remove a linked appeal from the current appeal",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"400": {
+						"description": "Bad Request"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Unlink Appeal Request",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/UnlinkAppealRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/UnlinkAppealRequest"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals": {
 			"get": {
 				"tags": ["Appeals"],
 				"description": "Gets requested appeals, limited to the first 30 appeals if no pagination params are given",
 				"parameters": [
+					{
+						"name": "status",
+						"in": "query",
+						"description": "The appeal status",
+						"example": "lpa_questionnaire_due",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "hasInspector",
+						"in": "query",
+						"description": "The Inspector Filter assigned status",
+						"example": "true",
+						"schema": {
+							"type": "string"
+						}
+					},
 					{
 						"name": "azureAdUserId",
 						"in": "header",
@@ -2425,24 +2584,6 @@
 						"schema": {
 							"type": "string"
 						}
-					},
-					{
-						"name": "status",
-						"in": "query",
-						"description": "The appeal status",
-						"example": "lpa_questionnaire_due",
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "hasInspector",
-						"in": "query",
-						"description": "The Inspector Filter assigned status",
-						"example": "true",
-						"schema": {
-							"type": "string"
-						}
 					}
 				],
 				"responses": {
@@ -2473,6 +2614,15 @@
 				"description": "Gets appeals assigned to the current user",
 				"parameters": [
 					{
+						"name": "status",
+						"in": "query",
+						"description": "The appeal status",
+						"example": "lpa_questionnaire_due",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
 						"name": "azureAdUserId",
 						"in": "header",
 						"required": true,
@@ -2495,15 +2645,6 @@
 						"in": "query",
 						"description": "The pagination page size - required if pageNumber is given",
 						"example": 30,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"name": "status",
-						"in": "query",
-						"description": "The appeal status",
-						"example": "lpa_questionnaire_due",
 						"schema": {
 							"type": "string"
 						}
@@ -2645,6 +2786,50 @@
 	},
 	"components": {
 		"schemas": {
+			"LinkedAppealRequest": {
+				"type": "object",
+				"properties": {
+					"linkedAppealId": {
+						"type": "number",
+						"example": 25
+					},
+					"isCurrentAppealParent": {
+						"type": "boolean",
+						"example": true
+					}
+				},
+				"xml": {
+					"name": "LinkedAppealRequest"
+				}
+			},
+			"LinkedAppealLegacyRequest": {
+				"type": "object",
+				"properties": {
+					"linkedAppealReference": {
+						"type": "string",
+						"example": "HORIZON/51243165"
+					},
+					"isCurrentAppealParent": {
+						"type": "boolean",
+						"example": false
+					}
+				},
+				"xml": {
+					"name": "LinkedAppealLegacyRequest"
+				}
+			},
+			"UnlinkAppealRequest": {
+				"type": "object",
+				"properties": {
+					"linkedAppealReference": {
+						"type": "string",
+						"example": "HORIZON/51243165"
+					}
+				},
+				"xml": {
+					"name": "UnlinkAppealRequest"
+				}
+			},
 			"ValidateDate": {
 				"type": "object",
 				"properties": {
@@ -3648,7 +3833,7 @@
 								},
 								"dueDate": {
 									"type": "string",
-									"example": "2023-02-16T00:00:00.000Z"
+									"example": "2023-06-18T00:00:00.000Z"
 								}
 							}
 						}

--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -16,6 +16,7 @@ import {
 /** @typedef {import('@pins/appeals.api').Schema.DocumentVersion} DocumentVersion */
 /** @typedef {import('@pins/appeals.api').Schema.User} User */
 /** @typedef {import('@pins/appeals.api').Schema.AppealRelationship} AppealRelationship */
+/** @typedef {import('@pins/appeals.api').Appeals.AppealRelationshipRequest } AppealRelationshipRequest */
 /**
  * @typedef {import('#db-client').Prisma.PrismaPromise<T>} PrismaPromise
  * @template T
@@ -432,6 +433,60 @@ const getLinkedAppeals = async (appealReference) => {
 	});
 };
 
+/**
+ *
+ * @param {AppealRelationshipRequest} relation
+ * @returns {Promise<AppealRelationship>}
+ */
+const linkAppeal = async (relation) => {
+	return await databaseConnector.appealRelationship.create({
+		data: relation
+	});
+};
+
+/**
+ *
+ * @param {number} appealId
+ * @param {string} linkedAppealReference
+ * @returns {Promise<void>}
+ */
+const unlinkAppeal = async (appealId, linkedAppealReference) => {
+	await databaseConnector.appealRelationship.deleteMany({
+		where: {
+			AND: [
+				{
+					OR: [
+						{
+							parentId: {
+								equals: appealId
+							}
+						},
+						{
+							childId: {
+								equals: appealId
+							}
+						}
+					]
+				},
+				{
+					OR: [
+						{
+							parentRef: {
+								equals: linkedAppealReference
+							}
+						},
+						{
+							childRef: {
+								equals: linkedAppealReference
+							}
+						}
+					]
+				}
+			]
+		}
+	});
+};
+
 export default {
 	getLinkedAppeals,
 	getAppealById,
@@ -439,5 +494,7 @@ export default {
 	getUserAppeals,
 	updateAppealById,
 	setAppealDecision,
-	setInvalidAppealDecision
+	setInvalidAppealDecision,
+	linkAppeal,
+	unlinkAppeal
 };

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -10,6 +10,11 @@ import {
 	documentVersionAuditEntry,
 	folderWithDocs
 } from '#tests/documents/mocks.js';
+import {
+	linkedAppealRequest,
+	linkedAppealLegacyRequest,
+	unlinkAppealRequest
+} from '#tests/linked-appeals/mocks.js';
 
 export const spec = {
 	info: {
@@ -43,6 +48,15 @@ export const spec = {
 	// by default: empty object (Swagger 2.0)
 	securityDefinitions: {},
 	definitions: {
+		LinkedAppealRequest: {
+			...linkedAppealRequest
+		},
+		LinkedAppealLegacyRequest: {
+			...linkedAppealLegacyRequest
+		},
+		UnlinkAppealRequest: {
+			...unlinkAppealRequest
+		},
 		ValidateDate: {
 			inputDate: '2023-08-17'
 		},

--- a/appeals/api/src/server/tests/linked-appeals/mocks.js
+++ b/appeals/api/src/server/tests/linked-appeals/mocks.js
@@ -1,0 +1,13 @@
+export const linkedAppealRequest = {
+	linkedAppealId: 25,
+	isCurrentAppealParent: true
+};
+
+export const linkedAppealLegacyRequest = {
+	linkedAppealReference: 'HORIZON/51243165',
+	isCurrentAppealParent: false
+};
+
+export const unlinkAppealRequest = {
+	linkedAppealReference: 'HORIZON/51243165'
+};


### PR DESCRIPTION
Adds 3 new endpoints to the API:

- Links an appeal to the current appeal: `/#/Linked%20Appeals/post_appeals__appealId__link_appeal`
- Links a legacy (Horizon) appeal to the current appeal: `/#/Linked%20Appeals/post_appeals__appealId__link_legacy_appeal`
- Remove a linked appeal from the current appeal: `/#/Linked%20Appeals/delete_appeals__appealId__unlink_appeal`

[BOAT-655](https://pins-ds.atlassian.net/browse/BOAT-655)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[BOAT-655]: https://pins-ds.atlassian.net/browse/BOAT-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ