### PR TITLE
fix(api): fix for publishing of reps where status being sent as valid

### DIFF
--- a/apps/api/src/server/applications/application/representations/publish/__tests__/publish-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/publish/__tests__/publish-representation.test.js
@@ -160,7 +160,7 @@ const expectedNsipRepresentationPayload = [
 		representationType: null,
 		representativeId: undefined,
 		representedId: '10105',
-		status: 'VALID',
+		status: 'PUBLISHED',
 		registerFor: 'ORGANISATION',
 		representationFrom: 'ORGANISATION'
 	},

--- a/apps/api/src/server/applications/application/representations/publish/publish.service.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.service.js
@@ -4,7 +4,7 @@ import logger from '#utils/logger.js';
 import { NSIP_REPRESENTATION, SERVICE_USER } from '#infrastructure/topics.js';
 import { EventType } from '@pins/event-client';
 import {
-	buildNsipRepresentationPayload,
+	buildNsipRepresentationPayloadForPublish,
 	buildRepresentationServiceUserPayload
 } from '../representations.service.js';
 import { setRepresentationsAsPublished } from '#repositories/representation.repository.js';
@@ -22,7 +22,9 @@ export const publishCaseRepresentations = async (caseId, representationIds, acti
 	);
 
 	if (representations.length > 0) {
-		const nsipRepresentationsPayload = representations.map(buildNsipRepresentationPayload);
+		const nsipRepresentationsPayload = representations.map(
+			buildNsipRepresentationPayloadForPublish
+		);
 		const serviceUsersPayload = representations.flatMap(buildRepresentationServiceUserPayload);
 
 		try {

--- a/apps/api/src/server/applications/application/representations/representations.service.js
+++ b/apps/api/src/server/applications/application/representations/representations.service.js
@@ -122,6 +122,20 @@ export const buildNsipRepresentationPayload = (representation) => {
 };
 
 /**
+ * Build Representation message event payload which optimistically sets the message status to published before being
+ * updated in the database.  This avoids multiple reads of representation data in the controller.
+ * The message is idempotent so in case of failure to update in DB users would re-publish for eventual consistency.
+ *
+ * @param {Representation} representation
+ * @returns {{representationType: *, attachments: *, representationId: *, originalRepresentation: *, examinationLibraryRef: string, referenceId: *, caseRef: *, dateReceived: *, caseId: *, representedType: *, represented: ({}|{firstName: *, lastName: *, under18: *, organisationName: *, emailAddress: *, telephone: *, id: *, contactMethod: *}), representative: ({}|{firstName: *, lastName: *, under18: *, organisationName: *, emailAddress: *, telephone: *, id: *, contactMethod: *}), status: *}|{caseRef: *, representationType: *, attachments: *, representationId: *, redacted, redactedRepresentation, dateReceived: *, caseId: *, originalRepresentation: *, examinationLibraryRef: string, referenceId: *, status: *}|{redactedBy, redactedNotes, caseRef: *, representationType: *, attachments: *, representationId: *, dateReceived: *, caseId: *, originalRepresentation: *, examinationLibraryRef: string, referenceId: *, status: *}}
+ */
+export const buildNsipRepresentationPayloadForPublish = (representation) => {
+	let publishRepresentationPayload = buildNsipRepresentationPayload(representation);
+	publishRepresentationPayload.status = 'PUBLISHED';
+	return publishRepresentationPayload;
+};
+
+/**
  * Build Rel Rep Service User event message payload
  *
  * @param {Prisma.RepresentationSelect} representation


### PR DESCRIPTION
## Describe your changes

Change to the send of publish relevant reps so that the status is sent as 'PUBLISHED' rather than 'VALID'.  
We only want to do this specifically on the publish of reps rather than patch of status/redaction or other messages sent on create and update for ODW.
A wrapper has been created specifically for the publish service so that the status is updated on the message payload.
This does mean that the message is sent with Published status set optimistically before the DB has updated, however the message is idempotent and in the rare case of DB update failure a republish will sync BO with FO.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/ASB-2246

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
