### PR TITLE
chore(applications): remove usage of querystring (BOAS-1113)

### DIFF
--- a/apps/functions/applications-background-jobs/notify-subscribers/src/back-office-api-client.js
+++ b/apps/functions/applications-background-jobs/notify-subscribers/src/back-office-api-client.js
@@ -1,5 +1,4 @@
 import { HTTPError } from 'got';
-import querystring from 'querystring';
 import { gotInstance } from '../../common/backend-api-request.js';
 
 /**
@@ -78,7 +77,8 @@ export class BackOfficeApiClient {
 		if (endAfter) {
 			queryInput.endAfter = endAfter.toISOString();
 		}
-		const query = querystring.stringify(queryInput);
+		const queryParams = new URLSearchParams(queryInput);
+		const query = queryParams.toString();
 		return gotInstance.get(`${this.baseUrl}/applications/subscriptions/list/?${query}`).json();
 	}
 

--- a/apps/web/src/server/applications/case/representations/__tests__/applications-representaions.test.js
+++ b/apps/web/src/server/applications/case/representations/__tests__/applications-representaions.test.js
@@ -29,7 +29,14 @@ const nocks = () => {
 	nock('http://test/').get('/applications/1').reply(200, mockCaseReference);
 	nock('http://test/')
 		.get(`/applications/1/representations`)
-		.query({ searchTerm: 'mock-search-term', sortBy: '', page: 1, pageSize: 25, under18: false })
+		.query({
+			searchTerm: 'mock-search-term',
+			sortBy: '',
+			page: 1,
+			pageSize: 25,
+			status: '',
+			under18: false
+		})
 		.reply(200, {
 			page: 1,
 			pageSize: 25,
@@ -40,7 +47,7 @@ const nocks = () => {
 		.persist();
 	nock('http://test/')
 		.get(`/applications/1/representations`)
-		.query({ searchTerm: '', sortBy: '', page: 1, pageSize: 25, under18: false })
+		.query({ searchTerm: '', sortBy: '', status: '', page: 1, pageSize: 25, under18: false })
 		.reply(200, representationsFixture)
 		.persist();
 	nock('http://test/')

--- a/apps/web/src/server/applications/common/components/__tests__/build-query-string.unit.test.js
+++ b/apps/web/src/server/applications/common/components/__tests__/build-query-string.unit.test.js
@@ -1,0 +1,24 @@
+import { buildQueryString } from '../build-query-string.js';
+
+describe('#buildQueryString', () => {
+	test('should return a query string with no undefined values', () => {
+		const query = {
+			param1: 'value1',
+			param2: undefined,
+			param3: 'value3'
+		};
+		const expectedQueryString = 'param1=value1&param2=&param3=value3';
+		expect(buildQueryString(query)).toEqual(expectedQueryString);
+	});
+
+	test('should stringify arrays as expected', () => {
+		const query = {
+			param1: 'value1',
+			param2: ['value2-1', 'value2-2', 'value2-3'],
+			param3: 'value3'
+		};
+		const expectedQueryString =
+			'param1=value1&param2=value2-1&param2=value2-2&param2=value2-3&param3=value3';
+		expect(buildQueryString(query)).toEqual(expectedQueryString);
+	});
+});

--- a/apps/web/src/server/applications/common/components/build-query-string.js
+++ b/apps/web/src/server/applications/common/components/build-query-string.js
@@ -1,8 +1,12 @@
-import querystring from 'node:querystring';
-
 /**
  *
  * @param {any} query
  * @returns {string}
  */
-export const buildQueryString = (query) => querystring.stringify(query);
+export const buildQueryString = (query) => {
+	const params = new URLSearchParams(query);
+
+	return Array.from(params.entries())
+		.map(([prop, val]) => `${prop}=${val === 'undefined' ? '' : val.split(',').join(`&${prop}=`)}`)
+		.join('&');
+};


### PR DESCRIPTION
## Describe your changes

- Replaced usages of querystring with URLSearchParams accounting for the differences
- Created a unit test to ensure undefined values are treated as they were before
- Created a unit test to ensure array values are treated as they were before

The Relevant representations page has been tested manually to make the filters work correctly as they did previously

## BOAS-1113 Remove usage of 'querystring' API
https://pins-ds.atlassian.net/browse/BOAS-1113

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
