### PR TITLE
chore(applications): stop returning 405 for unregistered routes (BOAS-1009)

### DIFF
--- a/apps/api-testing/tests/inspector/inspector.test.js
+++ b/apps/api-testing/tests/inspector/inspector.test.js
@@ -23,9 +23,9 @@ describe(`GET - ${endpoint}`, () => {
 			validateSchema(schema, body);
 		});
 
-		it('should return a 405 status code and an error message indicating that the requested method is not allowed', async () => {
+		it('should return a 404 status code and an error message indicating that the requested method is not found', async () => {
 			const { body, statusCode } = await request.post();
-			expect(statusCode).to.equal(405);
+			expect(statusCode).to.equal(404);
 		});
 	});
 });

--- a/apps/api-testing/tests/region/region.test.js
+++ b/apps/api-testing/tests/region/region.test.js
@@ -23,9 +23,9 @@ describe(`GET - ${endpoint}`, () => {
 			validateSchema(schema, body);
 		});
 
-		it('should return a 405 status code and an error message indicating that the requested method is not allowed', async () => {
+		it('should return a 404 status code and an error message indicating that the requested method is not found', async () => {
 			const { statusCode } = await request.post();
-			expect(statusCode).to.equal(405);
+			expect(statusCode).to.equal(404);
 		});
 	});
 });

--- a/apps/api-testing/tests/sector/sector.test.js
+++ b/apps/api-testing/tests/sector/sector.test.js
@@ -23,9 +23,9 @@ describe(`GET - ${endpoint}`, () => {
 			validateSchema(schema, body);
 		});
 
-		it('should return a 405 status code and an error message indicating that the requested method is not allowed', async () => {
+		it('should return a 404 status code and an error message indicating that the requested method is not found', async () => {
 			const { statusCode } = await request.post();
-			expect(statusCode).to.equal(405);
+			expect(statusCode).to.equal(404);
 		});
 	});
 });

--- a/apps/api-testing/tests/zoom-level/zoom-level.test.js
+++ b/apps/api-testing/tests/zoom-level/zoom-level.test.js
@@ -23,9 +23,9 @@ describe(`GET - ${endpoint}`, () => {
 			validateSchema(schema, body);
 		});
 
-		it('should return a 405 status code and an error message indicating that the requested method is not allowed', async () => {
+		it('should return a 404 status code and an error message indicating that the requested method is not found', async () => {
 			const { statusCode } = await request.post();
-			expect(statusCode).to.equal(405);
+			expect(statusCode).to.equal(404);
 		});
 	});
 });

--- a/apps/api/src/server/build-app.js
+++ b/apps/api/src/server/build-app.js
@@ -64,7 +64,7 @@ const buildApp = (
 	app.use('/migration', migrationRoutes);
 
 	app.all('*', (req, res, next) => {
-		next(new BackOfficeAppError(`Method is not allowed`, 405));
+		next(new BackOfficeAppError(`Not found`, 404));
 	});
 
 	app.use(stateMachineErrorHandler);


### PR DESCRIPTION
## Describe your changes

- Replaced the catch-all 405 error with a catch-all 404 error
- Updated application-service tests to expect a 404 instead of a 405 when the route does not exist

The missing routes were tested using postman.
I have been unable to run the application-service tests locally, but I expect them to work as expected when they do run.

## BOAS-1009 Stop returning 405 for unregistered routes
https://pins-ds.atlassian.net/browse/BOAS-1009

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
