### PR TITLE
fix(appeals/api): logic to add linked appeals

### DIFF
--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.service.js
@@ -1,11 +1,36 @@
 /** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetByIdResultItem} RepositoryGetByIdResultItem */
 
 /**
- * Checks if an appeal is linked to other appeals.
+ * Checks if an appeal is linked to other appeals as a parent.
  * @param {RepositoryGetByIdResultItem} appeal The appeal to check for linked appeals.
- * @returns
+ * @returns {boolean}
  */
-export const isAppealLinked = (appeal) => {
+const isAppealLead = (appeal) => {
 	const linkedAppeals = appeal.linkedAppeals || [];
-	return linkedAppeals.length > 0;
+	const linkedAppealsAsLead = linkedAppeals.filter((link) => link.parentRef === appeal.reference);
+	return linkedAppealsAsLead.length > 0;
+};
+
+/**
+ * Checks if an appeal is linked to other appeals as a child.
+ * @param {RepositoryGetByIdResultItem} appeal The appeal to check for linked appeals.
+ * @returns {boolean}
+ */
+const isAppealChild = (appeal) => {
+	const linkedAppeals = appeal.linkedAppeals || [];
+	const linkedAppealsAsChild = linkedAppeals.filter((link) => link.childRef === appeal.reference);
+	return linkedAppealsAsChild.length > 0;
+};
+
+/**
+ * Checks if an appeal can be linked, with a specific relationship type (parent/child).
+ * @param {RepositoryGetByIdResultItem} appeal The appeal to check for linked appeals.
+ * @param {'lead'|'child'} relationship The relationship to check for.
+ * @returns {boolean}
+ */
+export const canLinkAppeals = (appeal, relationship) => {
+	const isLead = isAppealLead(appeal);
+	const isChild = isAppealChild(appeal);
+
+	return relationship === 'lead' ? !isChild : !isChild && !isLead;
 };


### PR DESCRIPTION
Fixes the logic for assigning additional linked appeals:
- Can only add child appeals to an existing parent appeal (as long as the child is not already linked)
- Cannot add any lead or child relationship to an existing child appeal

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
