### PR TITLE
fix(api): send representation messages as list to fix update bug

### DIFF
--- a/apps/api/src/server/applications/application/representations/__tests__/create-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/create-representation.test.js
@@ -179,7 +179,7 @@ describe('Create Representation', () => {
 		expect(eventClient.sendEvents).toHaveBeenNthCalledWith(
 			1,
 			NSIP_REPRESENTATION,
-			rep1CreateMsgPayload,
+			[rep1CreateMsgPayload],
 			EventType.Create
 		);
 		expect(eventClient.sendEvents).toHaveBeenNthCalledWith(2, SERVICE_USER, [], EventType.Create, {
@@ -283,7 +283,7 @@ describe('Create Representation', () => {
 		expect(eventClient.sendEvents).toHaveBeenNthCalledWith(
 			3,
 			NSIP_REPRESENTATION,
-			rep1CreateMsgPayloadWithUsers,
+			[rep1CreateMsgPayloadWithUsers],
 			EventType.Create
 		);
 		expect(eventClient.sendEvents).toHaveBeenNthCalledWith(

--- a/apps/api/src/server/applications/application/representations/__tests__/patch-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/patch-representation.test.js
@@ -104,24 +104,26 @@ const existingRepresentations = [
 	}
 ];
 
-const rep1UpdatePayload = {
-	attachmentIds: [],
-	caseId: 200,
-	caseRef: 'BC0110001',
-	dateReceived: '2023-03-14T14:28:25.704Z',
-	examinationLibraryRef: '',
-	originalRepresentation: 'the original representation',
-	redactedRepresentation: 'redacted version',
-	redacted: true,
-	referenceId: 'BC0110001-2',
-	representationId: 1,
-	status: 'VALID',
-	registerFor: undefined,
-	representationFrom: 'AGENT',
-	representationType: undefined,
-	representativeId: '10382',
-	representedId: '10381'
-};
+const rep1UpdatePayload = [
+	{
+		attachmentIds: [],
+		caseId: 200,
+		caseRef: 'BC0110001',
+		dateReceived: '2023-03-14T14:28:25.704Z',
+		examinationLibraryRef: '',
+		originalRepresentation: 'the original representation',
+		redactedRepresentation: 'redacted version',
+		redacted: true,
+		referenceId: 'BC0110001-2',
+		representationId: 1,
+		status: 'VALID',
+		registerFor: undefined,
+		representationFrom: 'AGENT',
+		representationType: undefined,
+		representativeId: '10382',
+		representedId: '10381'
+	}
+];
 
 const serviceUserUpdatePayload = [
 	{

--- a/apps/api/src/server/applications/application/representations/redact/__tests__/patch-redact.test.js
+++ b/apps/api/src/server/applications/application/representations/redact/__tests__/patch-redact.test.js
@@ -140,7 +140,7 @@ describe('Patch Application Representation Redact', () => {
 		// test event broadcasts
 		expect(eventClient.sendEvents).toHaveBeenCalledWith(
 			NSIP_REPRESENTATION,
-			rep1UpdatePayload,
+			[rep1UpdatePayload],
 			EventType.Update
 		);
 	});
@@ -230,7 +230,7 @@ describe('Patch Application Representation Redact', () => {
 		// test event broadcasts
 		expect(eventClient.sendEvents).toHaveBeenCalledWith(
 			NSIP_REPRESENTATION,
-			prevPublishedPayload,
+			[prevPublishedPayload],
 			EventType.Update
 		);
 	});

--- a/apps/api/src/server/applications/application/representations/representations.service.js
+++ b/apps/api/src/server/applications/application/representations/representations.service.js
@@ -62,7 +62,7 @@ export const sendRepresentationEventMessage = async (
 ) => {
 	const nsipRepresentationPayload = buildNsipRepresentationPayload(representation);
 	const serviceUsersPayload = buildRepresentationServiceUserPayload(representation);
-	await eventClient.sendEvents(NSIP_REPRESENTATION, nsipRepresentationPayload, eventType);
+	await eventClient.sendEvents(NSIP_REPRESENTATION, [nsipRepresentationPayload], eventType);
 
 	// and service users
 	await eventClient.sendEvents(SERVICE_USER, serviceUsersPayload, eventType, {

--- a/apps/api/src/server/applications/application/representations/status/__tests__/patch-status.test.js
+++ b/apps/api/src/server/applications/application/representations/status/__tests__/patch-status.test.js
@@ -70,24 +70,26 @@ const existingRepresentations = [
 	}
 ];
 
-const expectedRepresentationUpdatePayload = {
-	representationId: 1,
-	referenceId: 'BC0110001-2',
-	examinationLibraryRef: '',
-	caseRef: 'BC0110001',
-	caseId: 200,
-	status: 'VALID',
-	redacted: true,
-	originalRepresentation: 'the original representation',
-	representationType: undefined,
-	representedId: '10381',
-	representativeId: '10382',
-	representationFrom: 'AGENT',
-	registerFor: undefined,
-	dateReceived: '2023-03-14T14:28:25.704Z',
-	attachmentIds: [],
-	redactedRepresentation: 'redacted version'
-};
+const expectedRepresentationUpdatePayload = [
+	{
+		representationId: 1,
+		referenceId: 'BC0110001-2',
+		examinationLibraryRef: '',
+		caseRef: 'BC0110001',
+		caseId: 200,
+		status: 'VALID',
+		redacted: true,
+		originalRepresentation: 'the original representation',
+		representationType: undefined,
+		representedId: '10381',
+		representativeId: '10382',
+		representationFrom: 'AGENT',
+		registerFor: undefined,
+		dateReceived: '2023-03-14T14:28:25.704Z',
+		attachmentIds: [],
+		redactedRepresentation: 'redacted version'
+	}
+];
 
 const mockDate = new Date('2023-01-02');
 


### PR DESCRIPTION
## Describe your changes

Fix for publishing messages for representations.  Currently failing because the message is being sent as an object rather than a list.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/ASB-2258

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
