### PR TITLE
fix(applications/web): deadline static text missing (BOAS-1497)

### DIFF
--- a/apps/web/src/server/views/applications/case-timetable/timetable-details-form.njk
+++ b/apps/web/src/server/views/applications/case-timetable/timetable-details-form.njk
@@ -143,7 +143,7 @@
 					})  }}
 				{% endif %}
 
-				{% if selectedItemType.id === uniqueTimeTableTypes.DEADLINE %}
+				{% if selectedItemType.id in [uniqueTimeTableTypes.DEADLINE] %}
 					{{ govukInsetText({
 						text: "The portal for this deadline will open when the previous one closes or on your chosen start and end dates."
 					}) }}


### PR DESCRIPTION
## Describe your changes

As the optional/mandatory fields were changing causing the generic template types not to be so generic, It was easier to implement the required changes by making the template types specific to each particular examination timetable type.

- Updated the view to create a new deadline timetable item to make sure the static text is displayed

The create a new deadline timetable item page has been tested manually to make sure the static text is displayed as expected

## BOAS-1497 Amend some fields within the exam timetable item forms to/from mandatory/optional and amend explainer copy
https://pins-ds.atlassian.net/browse/BOAS-1497

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
