### PR TITLE
fix(applications/web): fix deadline static text missing (BOAS-1497)

### DIFF
--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -534,6 +534,8 @@ exports[`Create examination timetable page POST /case/123/examination-timetable/
                         </div>
                     </fieldset>
                 </div>
+                <div class=\\"govuk-inset-text\\">The portal for this deadline will open when the previous one closes or
+                    on your chosen start and end dates.</div>
                 <div class=\\"govuk-form-group govuk-form-group--error govuk-grid-column-full govuk-!-margin-top-4\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"description\\">Timetable item description</label>
                     <div id=\\"description-hint\\" class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
@@ -1919,6 +1921,8 @@ exports[`Create examination timetable page should display errors if start date a
                         </div>
                     </fieldset>
                 </div>
+                <div class=\\"govuk-inset-text\\">The portal for this deadline will open when the previous one closes or
+                    on your chosen start and end dates.</div>
                 <div class=\\"govuk-form-group govuk-grid-column-full govuk-!-margin-top-4\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"description\\">Timetable item description</label>
                     <div id=\\"description-hint\\" class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
@@ -2077,6 +2081,8 @@ exports[`Create examination timetable page should display errors if start time a
                         </div>
                     </fieldset>
                 </div>
+                <div class=\\"govuk-inset-text\\">The portal for this deadline will open when the previous one closes or
+                    on your chosen start and end dates.</div>
                 <div class=\\"govuk-form-group govuk-grid-column-full govuk-!-margin-top-4\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"description\\">Timetable item description</label>
                     <div id=\\"description-hint\\" class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>
@@ -2328,6 +2334,8 @@ exports[`Edit examination timetable GET /case/123/examination-timetable/item/1/e
                         </div>
                     </fieldset>
                 </div>
+                <div class=\\"govuk-inset-text\\">The portal for this deadline will open when the previous one closes or
+                    on your chosen start and end dates.</div>
                 <div class=\\"govuk-form-group govuk-grid-column-full govuk-!-margin-top-4\\">
                     <label class=\\"govuk-label font-weight--700 govuk-!-margin-bottom-4\\" for=\\"description\\">Timetable item description</label>
                     <div id=\\"description-hint\\" class=\\"govuk-hint\\">Use an asterix (*) to denote a new bullet point</div>

--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
@@ -106,21 +106,6 @@ export const timetableTemplatesSchema = {
 	}
 };
 
-export const uniqueTimeTableTypes = {
-	ACCOMPANIED_SITE_INSPECTION: 1,
-	COMPULSORY_ACQUISITION_HEARING: 2,
-	DEADLINE: 3,
-	DEADLINE_FOR_CLOSE_OF_EXAMINATION: 4,
-	ISSUED_BY: 5,
-	ISSUE_SPECIFIC_HEARING: 6,
-	OPEN_FLOOR_HEARING: 7,
-	OTHER_MEEETING: 8,
-	PRELIMINARY_MEEETING: 9,
-	PROCEDURAL_DEADLINE_PRE_EXAMINATION: 10,
-	PROCEDURAL_DECISION: 11,
-	PUBLICATION_OF: 12
-};
-
 /**
  * View the list of examination timetables for a single case
  *
@@ -307,8 +292,7 @@ export async function viewApplicationsCaseTimetableDetailsNew({ body }, response
 		selectedItemType,
 		templateFields,
 		values: body,
-		isEditing: !!body.timetableId,
-		uniqueTimeTableTypes
+		isEditing: !!body.timetableId
 	});
 }
 
@@ -338,8 +322,7 @@ export async function viewApplicationsCaseTimetableDetailsEdit({ params }, respo
 		isEditing: true,
 		values,
 		templateFields,
-		selectedItemType,
-		uniqueTimeTableTypes
+		selectedItemType
 	});
 }
 
@@ -360,8 +343,7 @@ export async function postApplicationsCaseTimetableDetails(
 			errors: validationErrors,
 			values: body,
 			selectedItemType,
-			templateFields,
-			uniqueTimeTableTypes
+			templateFields
 		});
 	}
 

--- a/apps/web/src/server/views/applications/case-timetable/timetable-details-form.njk
+++ b/apps/web/src/server/views/applications/case-timetable/timetable-details-form.njk
@@ -143,7 +143,7 @@
 					})  }}
 				{% endif %}
 
-				{% if selectedItemType.id in [uniqueTimeTableTypes.DEADLINE] %}
+				{% if selectedItemType.templateType == 'deadline' %}
 					{{ govukInsetText({
 						text: "The portal for this deadline will open when the previous one closes or on your chosen start and end dates."
 					}) }}


### PR DESCRIPTION
## Describe your changes

As the optional/mandatory fields were changing causing the generic template types not to be so generic, It was easier to implement the required changes by making the template types specific to each particular examination timetable type.

- Updated the view to create a new deadline timetable item to make sure the static text is displayed
- Removed the redundant code from the timetable controller
- Fixed the web tests to make sure the snapshot displays the static text

The create a new deadline timetable item page has been tested manually to make sure the static text is displayed as expected

## BOAS-1497 Amend some fields within the exam timetable item forms to/from mandatory/optional and amend explainer copy
https://pins-ds.atlassian.net/browse/BOAS-1497

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
