### PR TITLE
fix(applications/api): do not send publish document events when training (BOAS-1503)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -581,17 +581,19 @@ export const publishDocumentVersions = async (documentVersionIds) => {
 		}, publishedDocuments)
 	).map(buildNsipDocumentPayload);
 
-	await eventClient.sendEvents(
-		NSIP_DOCUMENT,
-		events,
-		EventType.Update,
-		// This is an additional flag which triggers the Azure Function that publishes documents.
-		// It essentially means we can create a subscription to this topic with a filter, and saves us from managing a distinct publishing queue
-		// It has to be a string because the Terraform module for configuring subscription filters only seems to support string value
-		{
-			publishing: 'true'
-		}
-	);
+	if (events.length) {
+		await eventClient.sendEvents(
+			NSIP_DOCUMENT,
+			events,
+			EventType.Update,
+			// This is an additional flag which triggers the Azure Function that publishes documents.
+			// It essentially means we can create a subscription to this topic with a filter, and saves us from managing a distinct publishing queue
+			// It has to be a string because the Terraform module for configuring subscription filters only seems to support string value
+			{
+				publishing: 'true'
+			}
+		);
+	}
 
 	return publishedDocuments;
 };
@@ -899,9 +901,11 @@ export const unpublishDocuments = async (guids) => {
 		}, unpublishedDocuments)
 	).map(buildNsipDocumentPayload);
 
-	await eventClient.sendEvents(NSIP_DOCUMENT, events, EventType.Update, {
-		unpublishing: 'true'
-	});
+	if (events.length) {
+		await eventClient.sendEvents(NSIP_DOCUMENT, events, EventType.Update, {
+			unpublishing: 'true'
+		});
+	}
 
 	return unpublishedDocuments.map((doc) => doc.documentGuid);
 };

--- a/packages/event-client/src/local-event-client.js
+++ b/packages/event-client/src/local-event-client.js
@@ -12,6 +12,9 @@ export class LocalEventClient {
 		/** @type {any[]} */ events,
 		/** @type {import('./event-type.js').EventType}*/ type
 	) => {
+		if (events?.length < 1) {
+			throw Error(`No events provided for type ${type} and topic ${topic}`);
+		}
 		this.logger.info(
 			`Dummy publishing events ${JSON.stringify(events)} with type ${type} to topic ${topic}`
 		);

--- a/packages/event-client/src/service-bus-event-client.js
+++ b/packages/event-client/src/service-bus-event-client.js
@@ -62,7 +62,7 @@ export class ServiceBusEventClient {
 	 */
 	sendEvents = async (topic, events, eventType, additionalProperties = {}) => {
 		if (events?.length < 1) {
-			throw Error('No events provided');
+			throw Error(`No events provided for type ${eventType} and topic ${topic}`);
 		}
 
 		const sender = this.#createSender(topic);


### PR DESCRIPTION
## Describe your changes

- Suppress the events for publishing and unpublishing when the sector is training
- Add more information the "No events provided" error thrown in the service-bus-event-client
- Make the local-event-client throw like the service-bus-event-client does to make it easier to debug

I tested the above manually to make sure the publishing and unpublishing of documents do not fail when the sector is training

## BOAS-1503 Unable to publish the document when you select the sector as Training
https://pins-ds.atlassian.net/browse/BOAS-1503

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
