### PR TITLE
feat(appeals/web): display virus scan status on decision letter

### DIFF
--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -221,6 +221,7 @@ interface SingleAppealDetailsResponse {
 		outcome?: string;
 		documentId?: string;
 		letterDate?: Date;
+		virusCheckStatus?: string;
 	};
 	documentationSummary: DocumentationSummary;
 	healthAndSafety: {

--- a/appeals/api/src/server/endpoints/appeals/appeals.controller.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.controller.js
@@ -141,13 +141,18 @@ const getAppealById = async (req, res) => {
 		}
 	}
 
-	let decisionDate;
+	let decisionInfo;
 	if (
 		appeal.appealStatus[0].status === STATE_TARGET_COMPLETE &&
 		appeal.inspectorDecision?.decisionLetterGuid
 	) {
 		const document = await getDocumentById(appeal.inspectorDecision.decisionLetterGuid);
-		decisionDate = document?.latestDocumentVersion?.dateReceived;
+		if (document && document.latestDocumentVersion) {
+			decisionInfo = {
+				letterDate: document.latestDocumentVersion.dateReceived,
+				virusCheckStatus: document.latestDocumentVersion.virusCheckStatus
+			};
+		}
 	}
 
 	let formattedAppealWithLinkedTypes;
@@ -160,7 +165,7 @@ const getAppealById = async (req, res) => {
 		appeal,
 		folders,
 		transferAppealTypeInfo,
-		decisionDate,
+		decisionInfo,
 		formattedAppealWithLinkedTypes
 	);
 	return res.send(formattedAppeal);

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -93,8 +93,8 @@ const formatMyAppeals = (appeal, linkedAppeals) => ({
 /**
  * @param {RepositoryGetByIdResultItem} appeal
  * @param {Folder[]} folders
- * @param {{ transferredAppealType: string, transferredAppealReference: string} | null} transferAppealTypeInfo
- * @param {Date | null} completionDate
+ * @param {{ transferredAppealType: string, transferredAppealReference: string } | null} transferAppealTypeInfo
+ * @param {{ letterDate: Date|null, virusCheckStatus: string|null } | null} decisionInfo
  * @param { RepositoryGetAllResultItem[] | null} formattedAppealWithLinkedTypes
  * @returns {SingleAppealDetailsResponse | void}}
  */
@@ -102,7 +102,7 @@ const formatAppeal = (
 	appeal,
 	folders,
 	transferAppealTypeInfo = null,
-	completionDate = null,
+	decisionInfo = null,
 	formattedAppealWithLinkedTypes = null
 ) => {
 	if (appeal) {
@@ -151,12 +151,20 @@ const formatAppeal = (
 			appealType: appeal.appealType?.type,
 			appellantCaseId: appeal.appellantCase?.id || 0,
 			caseOfficer: appeal.caseOfficer?.azureAdUserId || null,
-			decision: {
-				folderId: folders[0].id,
-				outcome: appeal.inspectorDecision?.outcome,
-				documentId: appeal.inspectorDecision?.decisionLetterGuid || undefined,
-				letterDate: completionDate || undefined
-			},
+			decision:
+				decisionInfo &&
+				appeal.inspectorDecision?.outcome &&
+				appeal.inspectorDecision?.decisionLetterGuid
+					? {
+							folderId: folders[0].id,
+							outcome: appeal.inspectorDecision.outcome,
+							documentId: appeal.inspectorDecision?.decisionLetterGuid,
+							letterDate: decisionInfo.letterDate,
+							virusCheckStatus: decisionInfo.virusCheckStatus
+					  }
+					: {
+							folderId: folders[0].id
+					  },
 			healthAndSafety: {
 				appellantCase: {
 					details: appeal.appellantCase?.healthAndSafetyIssues || null,

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -10,7 +10,7 @@ exports[`appeal-details GET /:appealId should render a Decision inset panel when
     <div     class="govuk-inset-text">
         <p>Appeal completed: 25 December 2023</p>
         <p>Decision: dismissed</p>
-        <p><a class="govuk-link" target="_blank" href="/documents/1/download/e1e90a49-fab3-44b8-a21a-bb73af089f6b/preview/">View decision letter</a>
+        <p><span class="govuk-body">View decision letter</span><strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong>
         </p>
         </div>
         <dl class="govuk-summary-list govuk-summary-list--no-border">

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -5,7 +5,10 @@ import { isDefined } from '#lib/ts-utilities.js';
 import { removeActions } from '#lib/mappers/mapper-utilities.js';
 import { preRenderPageComponents } from '#lib/nunjucks-template-builders/page-component-rendering.js';
 import { appealShortReference } from '#lib/appeals-formatter.js';
-import { mapDocumentDownloadUrl } from '#appeals/appeal-documents/appeal-documents.mapper.js';
+import {
+	mapDocumentDownloadUrl,
+	mapVirusCheckStatus
+} from '#appeals/appeal-documents/appeal-documents.mapper.js';
 import { addNotificationBannerToSession } from '#lib/session-utilities.js';
 
 export const pageHeading = 'Case details';
@@ -216,29 +219,52 @@ export async function appealDetailsPage(appealDetails, currentRoute, session) {
 
 	const statusTagComponentGroup = statusTag ? [statusTag] : [];
 	const isAppealComplete = appealDetails.appealStatus === 'complete';
-	if (isAppealComplete && statusTagComponentGroup.length > 0) {
+	if (isAppealComplete && statusTagComponentGroup.length > 0 && appealDetails.decision.documentId) {
 		const letterDate = appealDetails.decision?.letterDate
 			? new Date(appealDetails.decision.letterDate)
 			: new Date();
 
+		const virusCheckStatus = mapVirusCheckStatus(
+			appealDetails.decision.virusCheckStatus || 'not_checked'
+		);
 		const letterDownloadUrl = appealDetails.decision?.documentId
 			? mapDocumentDownloadUrl(appealDetails.appealId, appealDetails.decision?.documentId)
 			: '#';
 
-		statusTagComponentGroup.push({
-			type: 'inset-text',
-			parameters: {
-				html: `<p>
-					Appeal completed: ${letterDate.toLocaleDateString('en-gb', {
-						day: 'numeric',
-						month: 'long',
-						year: 'numeric'
-					})}
-						</p>
-						<p>Decision: ${appealDetails.decision?.outcome}</p>
-						<p><a class="govuk-link" target="_blank" href="${letterDownloadUrl}">View decision letter</a></p>`
-			}
-		});
+		if (virusCheckStatus.checked && virusCheckStatus.safe) {
+			statusTagComponentGroup.push({
+				type: 'inset-text',
+				parameters: {
+					html: `<p>
+						Appeal completed: ${letterDate.toLocaleDateString('en-gb', {
+							day: 'numeric',
+							month: 'long',
+							year: 'numeric'
+						})}
+							</p>
+							<p>Decision: ${appealDetails.decision?.outcome}</p>
+							<p><a class="govuk-link" target="_blank" href="${letterDownloadUrl}">View decision letter</a></p>`
+				}
+			});
+		} else {
+			statusTagComponentGroup.push({
+				type: 'inset-text',
+				parameters: {
+					html: `<p>
+						Appeal completed: ${letterDate.toLocaleDateString('en-gb', {
+							day: 'numeric',
+							month: 'long',
+							year: 'numeric'
+						})}
+							</p>
+							<p>Decision: ${appealDetails.decision?.outcome}</p>
+							<p><span class="govuk-body">View decision letter</span>
+							<strong class="govuk-tag govuk-tag--yellow single-line">Virus scanning</strong></p>`
+				}
+			});
+		}
+
+		shortAppealReference;
 	}
 
 	const pageComponents = [

--- a/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-documents/appeal-documents.mapper.js
@@ -149,7 +149,7 @@ const mapDocumentFileTypeAndSize = (document) => {
  * @param {string} virusCheckStatus
  * @returns {DocumentVirusCheckStatus}
  */
-function mapVirusCheckStatus(virusCheckStatus) {
+export function mapVirusCheckStatus(virusCheckStatus) {
 	/** @type {DocumentVirusCheckStatus} */
 	const result = {
 		checked: false,


### PR DESCRIPTION
Display the Virus scanning status tag on the appeal decision.

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
