### PR TITLE
fix(applications/api): case reference number does not increment for training (BOAS-1507)

### DIFF
--- a/apps/api/src/database/seed/data-static.js
+++ b/apps/api/src/database/seed/data-static.js
@@ -306,7 +306,7 @@ export const subSectors = [
 	{
 		subSector: {
 			name: 'training',
-			abbreviation: 'TRAI',
+			abbreviation: 'TRAIN01',
 			displayNameEn: 'Training',
 			displayNameCy: 'Training'
 		},

--- a/apps/api/src/database/seed/data-static.js
+++ b/apps/api/src/database/seed/data-static.js
@@ -306,7 +306,7 @@ export const subSectors = [
 	{
 		subSector: {
 			name: 'training',
-			abbreviation: 'TRAIN01',
+			abbreviation: 'TRAI',
 			displayNameEn: 'Training',
 			displayNameCy: 'Training'
 		},

--- a/apps/api/src/server/repositories/raw_sql_queries/update-application-reference.sql
+++ b/apps/api/src/server/repositories/raw_sql_queries/update-application-reference.sql
@@ -1,4 +1,4 @@
-declare @sub_sector_abbreviation nchar(4), @max_reference int, @reference_number int;
+declare @sub_sector_abbreviation nchar(7), @max_reference int, @reference_number int;
 
 declare @minimum_new_reference int = 10001;
 declare @id int = CASE_ID;
@@ -11,7 +11,7 @@ FROM [dbo].[Case] as case_table
     on application_details_table.subSectorId = sub_sector_table.id
 where case_table.id = @id;
 
-SELECT @max_reference = max(cast(SUBSTRING(case_table.reference, 5, len(case_table.reference)) as int))
+SELECT @max_reference = max(cast(SUBSTRING(case_table.reference, len(@sub_sector_abbreviation) + 1, len(case_table.reference)) as int))
 FROM [dbo].[Case] as case_table
     join [dbo].[ApplicationDetails] as application_details_table
     on case_table.id = application_details_table.caseId
@@ -22,5 +22,5 @@ FROM [dbo].[Case] as case_table
 if(@max_reference < @minimum_new_reference OR @max_reference IS NULL) select @reference_number = @minimum_new_reference else select @reference_number = @max_reference + 1;
 
 update [dbo].[Case]
-    set reference = CONCAT(@sub_sector_abbreviation, cast(@reference_number as nchar(5)))
+    set reference = CONCAT(SUBSTRING(@sub_sector_abbreviation, 0, len(@sub_sector_abbreviation) + 1), cast(@reference_number as nchar(5)))
     where id = @id;


### PR DESCRIPTION
## Describe your changes

The seeded data for a training sub sector abbreviation "TRAIN01" was more than 4 characters long causing issues with the query generating the next reference number.  The sql has been changed to allow for differing sub sector abbreviation lengths.

I tested the above manually to make sure new cases with a sub sector of training create new reference numbers as expected.

## BOAS-1507 Unable to publish the document when you select the sector as Training
https://pins-ds.atlassian.net/browse/BOAS-1507

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
