### PR TITLE
fix(appeals/api): disable lpaq import of other appeals

### DIFF
--- a/appeals/api/src/server/repositories/integrations.repository.js
+++ b/appeals/api/src/server/repositories/integrations.repository.js
@@ -117,9 +117,9 @@ export const createOrUpdateLpaQuestionnaire = async (
 			where: { reference: caseReference }
 		});
 
-		const otherAppeals = await tx.appeal.findMany({
-			where: { reference: { in: nearbyReferences } }
-		});
+		// const otherAppeals = await tx.appeal.findMany({
+		// 	where: { reference: { in: nearbyReferences } }
+		// });
 
 		if (appeal) {
 			appeal = await tx.appeal.update({
@@ -130,12 +130,13 @@ export const createOrUpdateLpaQuestionnaire = async (
 							create: data,
 							update: data
 						}
-					},
-					otherAppeals: {
-						set: otherAppeals.map((other) => {
-							return { id: other.id };
-						})
 					}
+					// ,
+					// otherAppeals: {
+					// 	set: otherAppeals.map((other) => {
+					// 		return { id: other.id };
+					// 	})
+					// }
 				}
 			});
 		}


### PR DESCRIPTION
When developing linked appeals, we introduced a bug in the LPAQ import, related to nearby case reference and `other appeals` functionality. As this was work in progress, that functionality has been removed until we have the full requirements for `other appeals`.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
