### PR TITLE
feat(applications/api): add event broadcasts nsip-folder (BOAS-1432)

### DIFF
--- a/apps/api/src/server/applications/application/application.service.js
+++ b/apps/api/src/server/applications/application/application.service.js
@@ -75,6 +75,8 @@ const verifyAllApplicationDetailsPresent = async (id) => {
 };
 
 /**
+ * This moves a case from draft into pre-application
+ *
  * @param {number} id
  * @returns {Promise<{id: number | undefined, reference: string | null | undefined, status: import('xstate').StateValue}>}
  */
@@ -112,7 +114,7 @@ export const startApplication = async (id) => {
 		throw new Error('Case does not exist');
 	}
 
-	await broadcastNsipProjectEvent(updatedCase, EventType.Update);
+	await broadcastNsipProjectEvent(updatedCase, EventType.Update, true);
 
 	return {
 		id: updatedCase.id,

--- a/apps/api/src/server/infrastructure/event-broadcasters.js
+++ b/apps/api/src/server/infrastructure/event-broadcasters.js
@@ -1,9 +1,12 @@
 import logger from '#utils/logger.js';
 import { eventClient } from './event-client.js';
 import { buildNsipProjectPayload } from './payload-builders/nsip-project.js';
-import { NSIP_PROJECT, SERVICE_USER } from './topics.js';
+import { NSIP_FOLDER, NSIP_PROJECT, SERVICE_USER } from './topics.js';
 import { buildServiceUserPayload } from './payload-builders/applicant.js';
 import { verifyNotTraining } from '../applications/application/application.validators.js';
+import { EventType } from '@pins/event-client';
+import { getAllByCaseId } from '#repositories/folder.repository.js';
+import { buildNsipFoldersPayload } from '#infrastructure/payload-builders/nsip-folder.js';
 
 const applicant = 'Applicant';
 
@@ -11,11 +14,13 @@ const applicant = 'Applicant';
  * Broadcast events for an updated NSIP Project entity.
  *
  * This will always publish an update/publish/un-publish to the associated Applicant entity.
+ * If we are starting a case, broadcast the folders create event.
  *
  * @param {import('@pins/applications.api').Schema.Case} project
  * @param {string} eventType
+ * @param {boolean} [isCaseStart]
  */
-export const broadcastNsipProjectEvent = async (project, eventType) => {
+export const broadcastNsipProjectEvent = async (project, eventType, isCaseStart = false) => {
 	try {
 		await verifyNotTraining(project.id);
 	} catch (/** @type {*} */ err) {
@@ -33,6 +38,16 @@ export const broadcastNsipProjectEvent = async (project, eventType) => {
 			[buildServiceUserPayload(project.applicant, project.reference, applicant)],
 			eventType,
 			{ entityType: applicant }
+		);
+	}
+
+	if (isCaseStart) {
+		// We can safely call get all by case as it will only be the folders we have created.
+		const caseFolders = await getAllByCaseId(project.id);
+		await eventClient.sendEvents(
+			NSIP_FOLDER,
+			buildNsipFoldersPayload(caseFolders, project.reference),
+			EventType.Create
 		);
 	}
 };

--- a/apps/api/src/server/infrastructure/payload-builders/nsip-folder.js
+++ b/apps/api/src/server/infrastructure/payload-builders/nsip-folder.js
@@ -1,0 +1,31 @@
+/**
+@param {import('@pins/applications.api').Schema.Folder} folderEntity
+@param {string} caseReference
+ *
+ * @returns {import('pins-data-model').Schemas.Folder} Folder
+ */
+export const buildNsipFolderPayload = (folderEntity, caseReference) => {
+	// TODO: displayNameCy needs to be in the folder db table
+	const { id, displayNameEn, displayNameCy = null, parentFolderId } = folderEntity || {};
+	return {
+		id,
+		caseReference,
+		displayNameEnglish: displayNameEn,
+		displayNameWelsh: displayNameCy,
+		parentFolderId
+	};
+};
+
+/**
+@param {import('@pins/applications.api').Schema.Folder[]} folderEntities
+@param {string} caseReference
+ *
+ * @returns {import('pins-data-model').Schemas.Folder[]} Folder[]
+ */
+export const buildNsipFoldersPayload = (folderEntities, caseReference) => {
+	return folderEntities
+		.map((folderEntity) => buildNsipFolderPayload(folderEntity, caseReference))
+		.sort(({ id: firstId }, { id: secondId }) => {
+			return firstId - secondId;
+		});
+};

--- a/apps/api/src/server/infrastructure/topics.js
+++ b/apps/api/src/server/infrastructure/topics.js
@@ -6,3 +6,4 @@ export const NSIP_SUBSCRIPTION = 'nsip-subscription';
 export const NSIP_EXAM_TIMETABLE = 'nsip-exam-timetable';
 export const NSIP_REPRESENTATION = 'nsip-representation';
 export const NSIP_S51_ADVICE = 'nsip-s51-advice';
+export const NSIP_FOLDER = 'nsip-folder';


### PR DESCRIPTION
## Describe your changes

- Added "nsip-folder" events for the folders and subfolders when a case is started.
- Added "nsip-folder" events for the folder and subfolders create, update and delete actions within the examination timetable pages.
- Amended unit tests to test for the existence of the events as above.
- Manually tested the creation of the "nsip-folder" events while starting a case..
- Manually tested the creation of the "nsip-folder" events while creating, updating and deleting examination timetable items.

## BOAS-1432 Add event broadcasts for nsip-folder
https://pins-ds.atlassian.net/browse/BOAS-1432

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
