### PR TITLE
feat(api/applications): event broadcasts nsip document (boas-1431)

### DIFF
--- a/apps/api/src/server/applications/application/application.validators.js
+++ b/apps/api/src/server/applications/application/application.validators.js
@@ -332,3 +332,14 @@ export const verifyNotTraining = async (caseId) => {
 		throw new Error(`Case with ID ${caseId} is a training case.`);
 	}
 };
+
+/**
+ * Is this a "Training" case? - checks the reference name and/or the sector name, without querying DB
+ *
+ * @param {string} [reference]
+ * @param {string} [sector]
+ * @returns {boolean}
+ */
+export const isTrainingCase = (reference, sector) => {
+	return /^TRAIN/.test(reference ?? '') || (sector ?? '') === 'training';
+};

--- a/apps/api/src/server/applications/application/documents/__tests__/create-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/create-document.test.js
@@ -1,10 +1,75 @@
-import { request } from '../../../../app-test.js';
+import { request } from '#app-test';
 import config from '#config/config.js';
-const { databaseConnector } = await import('../../../../utils/database-connector.js');
+const { databaseConnector } = await import('#utils/database-connector.js');
+import { EventType } from '@pins/event-client';
+import { NSIP_DOCUMENT } from '#infrastructure/topics.js';
+import { buildNsipDocumentPayload } from '../document.js';
+const { eventClient } = await import('#infrastructure/event-client.js');
 
 const application = {
 	id: 1,
 	reference: 'case reference'
+};
+
+const updatedDocResponse = {
+	guid: 'a24f43d4-a3d1-4b38-8633-cb78fc5cc67c',
+	reference: 'BC0110001-000016',
+	folderId: 28,
+	createdAt: '2024-01-31T18:09:40.765Z',
+	isDeleted: false,
+	latestVersionId: 1,
+	caseId: 100000000,
+	documentType: 'document',
+	fromFrontOffice: false
+};
+const upsertedDocVersionResponse = {
+	documentGuid: 'a24f43d4-a3d1-4b38-8633-cb78fc5cc67c',
+	version: 1,
+	lastModified: null,
+	documentType: null,
+	published: false,
+	sourceSystem: 'back-office',
+	origin: null,
+	originalFilename: 'Small1.pdf',
+	fileName: 'Small1',
+	representative: null,
+	description: null,
+	owner: 'Rodrick Shanahan',
+	author: null,
+	securityClassification: null,
+	mime: 'application/pdf',
+	horizonDataID: null,
+	fileMD5: null,
+	virusCheckStatus: null,
+	size: 7945,
+	stage: 'Correspondence',
+	filter1: null,
+	privateBlobContainer: null,
+	privateBlobPath: '/application/BC0110001/a24f43d4-a3d1-4b38-8633-cb78fc5cc67c/1',
+	publishedBlobContainer: null,
+	publishedBlobPath: null,
+	dateCreated: new Date('2024-01-31T18:17:12.692Z'),
+	datePublished: null,
+	isDeleted: false,
+	examinationRefNo: null,
+	filter2: null,
+	publishedStatus: 'awaiting_upload',
+	publishedStatusPrev: null,
+	redactedStatus: null,
+	redacted: false,
+	transcriptGuid: null,
+	Document: {
+		guid: 'a24f43d4-a3d1-4b38-8633-cb78fc5cc67c',
+		reference: 'BC0110001-000017',
+		folderId: 28,
+		createdAt: new Date('2024-01-31T18:17:12.673Z'),
+		isDeleted: false,
+		latestVersionId: 1,
+		caseId: 100000000,
+		documentType: 'document',
+		fromFrontOffice: false,
+		folder: []
+	}
 };
 
 /**
@@ -23,7 +88,7 @@ const restoreEnvVars = () => {
 	}
 };
 
-describe('Provide document upload URLs', () => {
+describe('Create documents', () => {
 	beforeAll(() => {
 		saveEnvVars();
 
@@ -34,7 +99,7 @@ describe('Provide document upload URLs', () => {
 		restoreEnvVars();
 	});
 
-	test('saves documents information and returns upload URL', async () => {
+	test('saves documents information and returns create documents with Blob Storage URLs', async () => {
 		const guid = 'some-guid';
 
 		// GIVEN
@@ -43,7 +108,8 @@ describe('Provide document upload URLs', () => {
 		databaseConnector.folder.findUnique.mockResolvedValue({ id: 1, caseId: 1 });
 		databaseConnector.document.create.mockResolvedValue({ id: 1, guid, name: 'test doc' });
 		databaseConnector.document.findFirst.mockResolvedValueOnce(null);
-		databaseConnector.documentVersion.upsert.mockResolvedValue({});
+		databaseConnector.documentVersion.upsert.mockResolvedValue(upsertedDocVersionResponse);
+		databaseConnector.document.update.mockResolvedValue(updatedDocResponse);
 
 		// WHEN
 		const response = await request.post('/applications/1/documents').send([
@@ -56,9 +122,12 @@ describe('Provide document upload URLs', () => {
 		]);
 
 		const blobPath = `/application/${application.reference}/${guid}/1`;
+		// @ts-ignore
+		const eventPayload = buildNsipDocumentPayload(upsertedDocVersionResponse);
 
 		// THEN
 		expect(response.status).toEqual(200);
+
 		expect(response.body).toEqual({
 			blobStorageHost: 'blob-store-host',
 			privateBlobContainer: 'blob-store-container',
@@ -133,6 +202,13 @@ describe('Provide document upload URLs', () => {
 				}
 			}
 		});
+
+		// // EXPECT event broadcast
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			NSIP_DOCUMENT,
+			[eventPayload],
+			EventType.Create
+		);
 	});
 
 	test('returns file names which failed to upload', async () => {

--- a/apps/api/src/server/applications/application/documents/__tests__/delete-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/delete-document.test.js
@@ -1,8 +1,145 @@
-const { databaseConnector } = await import('../../../../utils/database-connector.js');
-
+const { databaseConnector } = await import('#utils/database-connector.js');
 import { jest } from '@jest/globals';
-import { request } from '../../../../app-test.js';
-import { applicationStates } from '../../../state-machine/application.machine.js';
+import { request } from '#app-test';
+import { eventClient } from '#infrastructure/event-client.js';
+import { NSIP_DOCUMENT } from '#infrastructure/topics.js';
+import { EventType } from '@pins/event-client';
+
+const application1 = {
+	id: 100000000,
+	reference: 'BC0110001',
+	modifiedAt: '2024-01-17T14:32:37.530Z',
+	createdAt: '2024-01-16T16:44:26.710Z',
+	description:
+		'A description of test case 1 which is a case of subsector type Office Use. A David case',
+	title: 'Office Use Test Application 1',
+	hasUnpublishedChanges: true,
+	applicantId: 100000000,
+	ApplicationDetails: {
+		id: 100000000,
+		caseId: 100000000,
+		subSectorId: 1,
+		locationDescription: null,
+		zoomLevelId: 4,
+		caseEmail: null,
+		subSector: {
+			id: 1,
+			abbreviation: 'BC01',
+			name: 'office_use',
+			displayNameEn: 'Office Use',
+			displayNameCy: 'Office Use',
+			sectorId: 1,
+			sector: {
+				id: 1,
+				abbreviation: 'BC',
+				name: 'business_and_commercial',
+				displayNameEn: 'Business and Commercial',
+				displayNameCy: 'Business and Commercial'
+			}
+		}
+	}
+};
+const DocumentToDelete = {
+	guid: '1111-2222-3333',
+	reference: 'BC0110001-000004',
+	folderId: 10003,
+	createdAt: '2024-01-31T14:18:26.834Z',
+	isDeleted: true,
+	latestVersionId: 1,
+	caseId: 100000000,
+	documentType: 'document',
+	fromFrontOffice: false
+};
+
+const documentVersionWithDocumentToDelete = {
+	guid: '1111-2222-3333',
+	version: 1,
+	lastModified: null,
+	documentType: null,
+	published: false,
+	sourceSystem: 'back-office',
+	origin: null,
+	originalFilename: 'Small.pdf',
+	fileName: 'Small',
+	representative: null,
+	description: 'desc',
+	owner: 'Genoveva Glover',
+	author: 'Billy',
+	securityClassification: null,
+	mime: 'application/pdf',
+	horizonDataID: null,
+	fileMD5: null,
+	virusCheckStatus: null,
+	size: 7945,
+	stage: null,
+	filter1: 'Filter 1',
+	privateBlobContainer: 'document-service-uploads',
+	privateBlobPath: '/application/BC010001/1111-2222-3333/1',
+	publishedBlobContainer: 'published-documents',
+	publishedBlobPath: 'published/BC010001-Small.pdf',
+	dateCreated: new Date('2023-02-27T10:00:00Z'),
+	datePublished: new Date('2023-02-27T10:00:00Z'),
+	isDeleted: false,
+	examinationRefNo: null,
+	filter2: null,
+	publishedStatus: 'not_checked',
+	publishedStatusPrev: 'not_checked',
+	redactedStatus: null,
+	redacted: false,
+	transcriptGuid: null,
+	Document: {
+		guid: '1111-2222-3333',
+		reference: 'BC010001-000002',
+		folderId: 1,
+		createdAt: '2022-12-12 17:12:25.9610000',
+		isDeleted: false,
+		latestVersionId: 1,
+		caseId: 100000001,
+		documentType: 'document',
+		fromFrontOffice: false,
+		folder: {
+			id: 10003,
+			displayNameEn: 'Project management',
+			displayOrder: 100,
+			parentFolderId: null,
+			caseId: 100000001,
+			stage: null,
+			case: {
+				id: 100000001,
+				reference: 'BC010001'
+			}
+		}
+	},
+	DocumentActivityLog: [],
+	transcript: null
+};
+const publishedDoc = {
+	...documentVersionWithDocumentToDelete,
+	published: true,
+	publishedStatus: 'published'
+};
+
+const expectedDeleteMessagePayload = {
+	documentId: '1111-2222-3333',
+	version: 1,
+	filename: 'Small',
+	originalFilename: 'Small.pdf',
+	size: 7945,
+	documentURI:
+		'https://127.0.0.1:10000/document-service-uploads/application/BC010001/1111-2222-3333/1',
+	publishedDocumentURI: 'https://127.0.0.1:10000/published-documents/published/BC010001-Small.pdf',
+	dateCreated: '2023-02-27T10:00:00.000Z',
+	datePublished: '2023-02-27T10:00:00.000Z',
+	caseId: 100000001,
+	reference: 'BC010001-000002',
+	mime: 'application/pdf',
+	publishedStatus: 'not_checked',
+	sourceSystem: 'back-office',
+	owner: 'Genoveva Glover',
+	author: 'Billy',
+	description: 'desc',
+	filter1: 'Filter 1'
+};
 
 describe('delete Document', () => {
 	beforeEach(() => {
@@ -11,32 +148,50 @@ describe('delete Document', () => {
 
 	test('The test case involves deleting a document setting its "isDeleted" property to "true".', async () => {
 		// GIVEN
-		databaseConnector.document.findFirst.mockResolvedValue({
-			guid: '1111-2222-3333',
-			folderId: 1,
-			privateBlobContainer: 'document-service-uploads',
-			privateBlobPath: '/application/BC010001/1111-2222-3333/my_doc.doc',
-			status: applicationStates.draft,
-			createdAt: '2022-12-12 17:12:25.9610000',
-			redacted: true
-		});
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(
+			documentVersionWithDocumentToDelete
+		);
+		databaseConnector.document.findUnique.mockResolvedValue(DocumentToDelete);
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
 
 		const isDeleted = true;
 
 		// WHEN
-		const response = await request.post('/applications/1/documents/1111-2222-3333/delete').send({});
+		const response = await request
+			.post('/applications/100000001/documents/1111-2222-3333/delete')
+			.send({});
 
 		// THEN
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual({ isDeleted });
-		expect(databaseConnector.document.findFirst).toHaveBeenCalledWith({
-			include: { documentVersion: true },
-			where: {
-				guid: '1111-2222-3333',
-				isDeleted: false,
-				folder: {
-					caseId: 1
+		expect(databaseConnector.documentVersion.findUnique).toHaveBeenCalledWith({
+			include: {
+				Document: {
+					include: {
+						folder: {
+							include: {
+								case: {
+									include: {
+										CaseStatus: true
+									}
+								}
+							}
+						}
+					}
+				},
+				DocumentActivityLog: {
+					orderBy: {
+						createdAt: 'desc'
+					}
+				},
+				transcript: {
+					select: {
+						reference: true
+					}
 				}
+			},
+			where: {
+				documentGuid_version: { documentGuid: '1111-2222-3333', version: 1 }
 			}
 		});
 
@@ -45,42 +200,45 @@ describe('delete Document', () => {
 				guid: '1111-2222-3333'
 			}
 		});
+
+		// and test broadcast event message
+		expect(eventClient.sendEvents).toHaveBeenLastCalledWith(
+			NSIP_DOCUMENT,
+			[expectedDeleteMessagePayload],
+			EventType.Delete
+		);
 	});
 
 	test('should fail to delete document because document is published', async () => {
 		// GIVEN
-		databaseConnector.document.findFirst.mockResolvedValue({
-			guid: '1111-2222-3333',
-			folderId: 1,
-			privateBlobContainer: 'document-service-uploads',
-			privateBlobPath: '/application/BC010001/1111-2222-3333/my_doc.doc',
-			status: applicationStates.published,
-			createdAt: '2022-12-12 17:12:25.9610000',
-			redacted: true
-		});
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(publishedDoc);
 
 		// WHEN
-		const response = await request.post('/applications/1/documents/1111-2222-3333/delete').send({});
+		const response = await request
+			.post('/applications/100000001/documents/1111-2222-3333/delete')
+			.send({});
 
 		// THEN
 		expect(response.status).toEqual(400);
 		expect(response.body).toEqual({
-			errors: 'unable to delete document guid 1111-2222-3333 related to caseId 1'
+			errors: 'unable to delete document guid 1111-2222-3333 related to caseId 100000001'
 		});
 	});
 
 	test('should fail if document is not found', async () => {
 		// GIVEN
-		databaseConnector.document.findFirst.mockResolvedValue(null);
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(null);
 
 		// WHEN
-		const response = await request.post('/applications/1/documents/1111-2222-3333/delete').send({});
+		const response = await request
+			.post('/applications/100000001/documents/1111-2222-3333/delete')
+			.send({});
 
 		// THEN
 		expect(response.status).toEqual(404);
 
 		expect(response.body).toEqual({
-			errors: 'document not found: guid 1111-2222-3333 related to caseId 1'
+			errors: 'document not found: guid 1111-2222-3333 related to caseId 100000001'
 		});
 	});
 });

--- a/apps/api/src/server/applications/application/documents/__tests__/document-payload.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document-payload.test.js
@@ -1,5 +1,5 @@
 import { buildNsipDocumentPayload } from '../document.js';
-import { validateNsipDocument } from '../../../../utils/schema-test-utils.js';
+import { validateNsipDocument } from '#utils/schema-test-utils.js';
 
 describe('validateNsipDocument', () => {
 	test('validateNsipDocument maps NSIP Document to NSIP Document Payload', () => {

--- a/apps/api/src/server/applications/application/documents/__tests__/document.service.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document.service.test.js
@@ -2,7 +2,7 @@ import { jest } from '@jest/globals';
 import config from '#config/config.js';
 const { databaseConnector } = await import('#utils/database-connector.js');
 
-import { obtainURLForDocumentVersion } from '../document.service.js';
+import { createDocumentVersion } from '../document.service.js';
 
 /**
  * @type {Object<string, any>}
@@ -21,8 +21,38 @@ const restoreEnvVars = () => {
 };
 
 const application = {
-	id: 1,
-	reference: 'case reference'
+	id: 100000000,
+	reference: 'BC0110001',
+	modifiedAt: '2024-01-17T14:32:37.530Z',
+	createdAt: '2024-01-16T16:44:26.710Z',
+	description:
+		'A description of test case 1 which is a case of subsector type Office Use. A David case',
+	title: 'Office Use Test Application 1',
+	hasUnpublishedChanges: true,
+	applicantId: 100000000,
+	ApplicationDetails: {
+		id: 100000000,
+		caseId: 100000000,
+		subSectorId: 1,
+		locationDescription: null,
+		zoomLevelId: 4,
+		caseEmail: null,
+		subSector: {
+			id: 1,
+			abbreviation: 'BC01',
+			name: 'office_use',
+			displayNameEn: 'Office Use',
+			displayNameCy: 'Office Use',
+			sectorId: 1,
+			sector: {
+				id: 1,
+				abbreviation: 'BC',
+				name: 'business_and_commercial',
+				displayNameEn: 'Business and Commercial',
+				displayNameCy: 'Business and Commercial'
+			}
+		}
+	}
 };
 
 const caseId = 1234;
@@ -38,20 +68,34 @@ const document = {
 
 const documentWithVersions = {
 	guid: documentGuid,
+	reference: 'BC0110001-000003',
 	documentName: 'test',
 	folderId: 1111,
+	caseId: caseId,
 	documentSize: 1111,
 	documentType: 'test',
 	latestVersionId: 1,
+	fromFrontOffice: false,
 	documentVersion: [
 		{
+			documentGuid: documentGuid + '1',
 			version: 1,
 			author: 'test',
-			publishedStatus: 'published'
+			publishedStatus: 'published',
+			fileName: 'Small',
+			mime: 'application/pdf',
+			size: 7945,
+			owner: 'William Wordsworth'
 		},
 		{
+			documentGuid: documentGuid,
 			version: 2,
-			author: 'test'
+			author: 'test',
+			fileName: 'Small1',
+			publishedStatus: 'not_checked',
+			mime: 'application/pdf',
+			size: 7945,
+			owner: 'William Wordsworth'
 		}
 	]
 };
@@ -76,6 +120,65 @@ const documentWithVersionsUnpublished = {
 	]
 };
 
+const docVersionAfterUpdate = {
+	documentGuid: documentGuid,
+	version: 2,
+	lastModified: null,
+	documentType: null,
+	published: false,
+	sourceSystem: 'back-office',
+	origin: null,
+	originalFilename: 'Small7.pdf',
+	fileName: 'Small',
+	representative: null,
+	description: null,
+	owner: 'Annamae Moore',
+	author: null,
+	securityClassification: null,
+	mime: 'application/pdf',
+	horizonDataID: null,
+	fileMD5: null,
+	virusCheckStatus: null,
+	size: 7945,
+	stage: null,
+	filter1: null,
+	privateBlobContainer: null,
+	privateBlobPath: '/application/BC0110001/5d4826de-40f5-4b01-a72b-fa507c818799/2',
+	publishedBlobContainer: null,
+	publishedBlobPath: null,
+	dateCreated: new Date('2024-01-31T14:18:26.889Z'),
+	datePublished: null,
+	isDeleted: false,
+	examinationRefNo: null,
+	filter2: null,
+	publishedStatus: 'not_checked',
+	publishedStatusPrev: null,
+	redactedStatus: 'redacted',
+	redacted: false,
+	transcriptGuid: null,
+	Document: {
+		guid: documentGuid,
+		reference: 'BC0110001-000004',
+		folderId: 8,
+		createdAt: '2024-01-31T14:18:26.834Z',
+		isDeleted: false,
+		latestVersionId: 1,
+		caseId: caseId,
+		documentType: 'document',
+		fromFrontOffice: false,
+		case: {
+			id: caseId,
+			reference: 'BC0110001',
+			modifiedAt: '2024-01-17T14:32:37.530Z',
+			createdAt: '2024-01-16T16:44:26.710Z',
+			description: 'A description of test case 1 which is a case of subsector type Office Use.',
+			title: 'Office Use Test Application 1',
+			hasUnpublishedChanges: true,
+			applicantId: 100000000
+		}
+	}
+};
+
 describe('Document service test', () => {
 	beforeAll(() => {
 		saveEnvVars();
@@ -90,30 +193,27 @@ describe('Document service test', () => {
 		restoreEnvVars();
 	});
 
-	test('obtainURLForDocumentVersion throws error when case not exist', async () => {
+	test('createDocumentVersion throws error when case not exist', async () => {
 		databaseConnector.case.findUnique.mockResolvedValue(null);
-		await expect(obtainURLForDocumentVersion(document, caseId, documentGuid)).rejects.toThrow(
-			Error
-		);
+		await expect(createDocumentVersion(document, caseId, documentGuid)).rejects.toThrow(Error);
 	});
 
-	test('obtainURLForDocumentVersion throws error when document not exist', async () => {
+	test('createDocumentVersion throws error when document not exist', async () => {
 		databaseConnector.case.findUnique.mockResolvedValue(application);
 		databaseConnector.document.findUnique.mockResolvedValue(null);
-		await expect(obtainURLForDocumentVersion(document, caseId, documentGuid)).rejects.toThrow(
-			Error
-		);
+		await expect(createDocumentVersion(document, caseId, documentGuid)).rejects.toThrow(Error);
 	});
 
-	test('obtainURLForDocumentVersion uploads new version of document', async () => {
+	test('createDocumentVersion uploads new version of document', async () => {
 		databaseConnector.case.findUnique.mockResolvedValue(application);
 		databaseConnector.document.findUnique.mockResolvedValue(documentWithVersions);
+		databaseConnector.documentVersion.update.mockResolvedValue(docVersionAfterUpdate);
 
-		const ressponse = await obtainURLForDocumentVersion(document, caseId, documentGuid);
+		const response = await createDocumentVersion(document, caseId, documentGuid);
 
-		expect(ressponse.blobStorageHost).toEqual('blob-store-host');
-		expect(ressponse.privateBlobContainer).toEqual('blob-store-container');
-		expect(ressponse.documents).toEqual([
+		expect(response.blobStorageHost).toEqual('blob-store-host');
+		expect(response.privateBlobContainer).toEqual('blob-store-container');
+		expect(response.documents).toEqual([
 			{
 				GUID: documentGuid,
 				blobStoreUrl: `/application/${application.reference}/${documentGuid}/2`,
@@ -130,11 +230,11 @@ describe('Document service test', () => {
 		expect(databaseConnector.documentActivityLog.create).toHaveBeenCalledTimes(1);
 	});
 
-	test('obtainURLForDocumentVersion uploads new version of document and does not unblish the document', async () => {
+	test('createDocumentVersion uploads new version of document and does not unblish the document', async () => {
 		databaseConnector.case.findUnique.mockResolvedValue(application);
 		databaseConnector.document.findUnique.mockResolvedValue(documentWithVersionsUnpublished);
 
-		const ressponse = await obtainURLForDocumentVersion(document, caseId, documentGuid);
+		const ressponse = await createDocumentVersion(document, caseId, documentGuid);
 
 		expect(ressponse.blobStorageHost).toEqual('blob-store-host');
 		expect(ressponse.privateBlobContainer).toEqual('blob-store-container');

--- a/apps/api/src/server/applications/application/documents/__tests__/publish-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/publish-document.test.js
@@ -1,80 +1,111 @@
-import { request } from '../../../../app-test.js';
-import { applicationFactoryForTests } from '../../../../utils/application-factory-for-tests.js';
-const { databaseConnector } = await import('../../../../utils/database-connector.js');
+import { jest } from '@jest/globals';
+import { request } from '#app-test';
+const { databaseConnector } = await import('#utils/database-connector.js');
+const { eventClient } = await import('#infrastructure/event-client.js');
+import { EventType } from '@pins/event-client';
+import { NSIP_DOCUMENT } from '#infrastructure/topics.js';
 
-const application1 = applicationFactoryForTests({
+const dateDocCreated = '2022-01-01T11:59:38.129Z';
+const dateDocLastModified = '2024-02-05T11:59:38.129Z';
+const docGuid = 'D1234';
+const application1 = {
 	id: 1,
-	title: 'EN010003 - NI Case 3 Name',
-	description: 'EN010003 - NI Case 3 Name Description',
-	caseStatus: 'pre-application'
-});
+	reference: 'EN0110001',
+	title: 'EN0110001 - NI Case 3 Name',
+	description: 'test',
+	createdAt: '2022-01-01T11:59:38.129Z',
+	modifiedAt: '2023-03-10T13:49:09.666Z',
+	publishedAt: null,
+	CaseStatus: [{ id: 1, status: 'draft' }]
+};
 
-const { eventClient } = await import('../../../../infrastructure/event-client.js');
+const document1 = {
+	guid: docGuid,
+	folderId: 2,
+	privateBlobContainer: 'test-container',
+	privateBlobPath: 'test-path',
+	caseId: 1,
+	latestVersionNo: 1,
+	reference: null,
+	folder: {
+		id: 1,
+		displayNameEn: 'Project management',
+		displayOrder: 100,
+		parentFolderId: null,
+		caseId: 1,
+		case: application1
+	},
+	case: application1
+};
+const documentVersion1 = {
+	version: 1,
+	documentId: 12,
+	caseId: 1,
+	documentGuid: docGuid,
+	description: 'a test document',
+	documentType: 'Doc Category',
+	publishedStatus: 'ready_to_publish',
+	redactedStatus: 'redacted',
+	fileName: 'test-filename',
+	originalFilename: 'test-original-filename',
+	mime: 'image/png',
+	size: 23452,
+	author: 'Billy B',
+	privateBlobContainer: 'test-container',
+	privateBlobPath: 'test-path',
+	publishedBlobContainer: 'test-container',
+	publishedBlobPath: 'test-path',
+	dateCreated: new Date(dateDocCreated),
+	lastModified: new Date(dateDocLastModified),
+	filter1: 'Filter Category 1',
+	filter2: null,
+	stage: null,
+	representative: null
+};
 
-/**
- * @type {any[]}
- */
-const documents = [
-	{
-		guid: '688fad5e-b41c-45d5-8fb3-dcad37d38092',
-		folderId: 1,
-		privateBlobContainer: null,
-		privateBlobPath: null,
-		status: 'awaiting_upload',
-		createdAt: '2023-03-13T16:54:09.282Z',
-		redacted: false,
-		fileSize: 0,
-		fileType: null,
-		isDeleted: false,
-		versionId: null,
-		latestDocumentVersion: {
-			documentGuid: '688fad5e-b41c-45d5-8fb3-dcad37d38092',
-			version: 1,
-			lastModified: null,
-			documentType: '',
-			published: false,
-			sourceSystem: 'back-office',
-			stage: null,
-			origin: null,
-			originalFilename: '8883cbfd43ed5b261961cd258d2f6fcb (1)',
-			fileName: '8883cbfd43ed5b261961cd258d2f6fcb (1)',
-			representative: null,
-			description: null,
-			owner: null,
-			author: null,
-			securityClassification: null,
-			mime: 'image/png',
-			horizonDataID: null,
-			fileMD5: null,
-			privateBlobPath: null,
-			virusCheckStatus: null,
-			size: 4375,
-			filter1: null,
-			privateBlobContainer: null,
-			dateCreated: '2023-03-13T16:54:09.398Z',
-			datePublished: null,
-			isDeleted: false,
-			examinationRefNo: null,
-			filter2: null,
-			publishedStatus: 'awaiting_upload',
-			redactedStatus: null,
-			redacted: false
-		},
-		folder: {
-			id: 1,
-			displayNameEn: 'Project management',
-			displayOrder: 100,
-			parentFolderId: null,
-			caseId: 1
-		}
-	}
-];
+const documentWithDocumentVersionWithLatest = {
+	...document1,
+	documentVersion: [documentVersion1],
+	latestDocumentVersion: documentVersion1
+};
 
+const documentVersionWithDocument = {
+	...documentVersion1,
+	Document: document1
+};
+
+const expectedEventPayload = {
+	documentId: docGuid,
+	caseId: 1,
+	caseRef: 'EN0110001',
+	reference: null,
+	version: 1,
+	filename: 'test-filename',
+	originalFilename: 'test-original-filename',
+	size: 23452,
+	documentURI: 'https://127.0.0.1:10000/test-container/test-path',
+	dateCreated: dateDocCreated,
+	lastModified: dateDocLastModified,
+	author: 'Billy B',
+	publishedStatus: 'ready_to_publish',
+	redactedStatus: 'redacted',
+	publishedDocumentURI: 'https://127.0.0.1:10000/test-container/test-path',
+	filter1: 'Filter Category 1',
+	description: 'a test document',
+	documentType: 'Doc Category',
+	mime: 'image/png'
+};
+
+// -------   TESTS   ---------------------------------------------------------------
 describe('Ready-to-publish-documents', () => {
 	test('returns ready-to-publish documents metadata on a case', async () => {
 		// GIVEN
+		let findManyDocs = [documentWithDocumentVersionWithLatest];
+		findManyDocs[0].documentVersion[0].publishedStatus = 'ready_to_publish';
+		findManyDocs[0].latestDocumentVersion.publishedStatus = 'ready_to_publish';
+
 		databaseConnector.case.findUnique.mockResolvedValue(application1);
-		databaseConnector.document.findMany.mockResolvedValue(documents);
+		databaseConnector.document.findMany.mockResolvedValue(findManyDocs);
 		databaseConnector.document.count.mockResolvedValue(1);
 
 		// WHEN
@@ -112,29 +143,29 @@ describe('Ready-to-publish-documents', () => {
 			itemCount: 1,
 			items: [
 				{
-					documentGuid: '688fad5e-b41c-45d5-8fb3-dcad37d38092',
-					documentId: null,
+					documentGuid: docGuid,
+					documentId: 12,
 					documentRef: null,
 					folderId: 1,
-					caseRef: null,
-					sourceSystem: 'back-office',
+					caseRef: 'EN0110001',
+					sourceSystem: 'Back Office',
 					stage: null,
-					privateBlobContainer: '',
-					privateBlobPath: '',
-					author: '',
-					fileName: '8883cbfd43ed5b261961cd258d2f6fcb (1)',
-					originalFilename: '8883cbfd43ed5b261961cd258d2f6fcb (1)',
-					dateCreated: 1_678_726_449,
-					size: 4375,
+					privateBlobContainer: 'test-container',
+					privateBlobPath: 'test-path',
+					author: 'Billy B',
+					fileName: 'test-filename',
+					originalFilename: 'test-original-filename',
+					dateCreated: 1641038378,
+					size: 23452,
 					mime: 'image/png',
-					publishedStatus: 'awaiting_upload',
-					redactedStatus: '',
+					publishedStatus: 'ready_to_publish',
+					redactedStatus: 'redacted',
 					datePublished: null,
-					description: null,
+					description: 'a test document',
 					version: 1,
 					representative: null,
-					documentType: '',
-					filter1: null,
+					documentType: 'Doc Category',
+					filter1: 'Filter Category 1',
 					filter2: null,
 					examinationRefNo: '',
 					fromFrontOffice: false,
@@ -146,119 +177,158 @@ describe('Ready-to-publish-documents', () => {
 });
 
 describe('Publish documents', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
 	test('publishes selected documents on a case from ready-to-publish queue', async () => {
 		// GIVEN
-		const updatedPublishedDocument = {
-			Document: {
-				guid: 'document_to_publish_guid'
-			},
-			documentGuid: 'document_to_publish_guid',
-			version: 1,
-			originalFilename: 'original_filename.pdf',
-			fileName: 'filename.pdf',
-			size: 23452,
-			dateCreated: new Date('2023-03-26T00:00:00.000Z'),
-			privateBlobContainer: 'document-uploads',
-			privateBlobPath: 'en010120/filename.pdf',
-			publishedBlobContainer: 'test-container',
-			publishedBlobPath: 'test-path',
-			publishedStatus: 'publishing'
-		};
-
-		databaseConnector.document.findMany.mockResolvedValue([
-			{
-				guid: 'document_to_publish_guid',
-				latestVersionId: 1
-			}
-		]);
-
 		databaseConnector.case.findUnique.mockResolvedValue(application1);
+		let docBeforeUpdate = documentWithDocumentVersionWithLatest;
+		docBeforeUpdate.documentVersion[0].publishedStatus = 'ready_to_publish';
 
+		let docVersionWithDocumentBeforeUpdate = {
+			...documentVersionWithDocument,
+			publishedStatus: 'ready_to_publish'
+		};
+		let documentVersionWithDocumentAfterUpdate = {
+			...docVersionWithDocumentBeforeUpdate,
+			publishedStatus: 'publishing',
+			publishedStatusPrev: 'not_checked'
+		};
+		let findManyDocs = [
+			{
+				guid: docGuid,
+				latestVersionId: 1,
+				latestDocumentVersion: documentVersion1
+			}
+		];
+		databaseConnector.document.findUnique.mockResolvedValue(docBeforeUpdate);
 		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
-		databaseConnector.documentVersion.update.mockResolvedValue(updatedPublishedDocument);
-		databaseConnector.documentVersion.findMany.mockResolvedValue([updatedPublishedDocument]);
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(
+			docVersionWithDocumentBeforeUpdate
+		);
+		databaseConnector.document.findMany.mockResolvedValue(findManyDocs);
+		databaseConnector.documentVersion.update.mockResolvedValue(
+			documentVersionWithDocumentAfterUpdate
+		);
 
 		// WHEN
 		const response = await request.patch('/applications/1/documents/publish').send({
-			documents: [{ guid: 'document_to_publish_guid' }]
+			documents: [{ guid: docGuid }]
 		});
 
 		// THEN
 		expect(response.body).toEqual([
 			{
-				guid: 'document_to_publish_guid',
+				guid: docGuid,
 				publishedStatus: 'publishing'
 			}
 		]);
 		expect(response.status).toEqual(200);
 
+		// expect event broadcast
+		let expectedEventPayloadAmended = {
+			...expectedEventPayload,
+			publishedStatus: 'publishing'
+		};
 		expect(eventClient.sendEvents).toHaveBeenCalledTimes(1);
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			NSIP_DOCUMENT,
+			[expectedEventPayloadAmended],
+			EventType.Update,
+			{ publishing: 'true' }
+		);
 	});
 
 	test('throws error if document missing properties required for publishing', async () => {
 		// GIVEN
-		databaseConnector.document.findMany.mockResolvedValueOnce([]);
-		databaseConnector.documentVersion.update.mockResolvedValue({
-			Document: {
-				guid: 'document_to_publish_guid',
-				reference: 'document-reference',
-				case: {
-					id: 1,
-					reference: 'case-reference'
-				}
-			}
-		});
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
+		let docBeforeUpdate = documentWithDocumentVersionWithLatest;
+		docBeforeUpdate.documentVersion[0].publishedStatus = 'not_checked';
+
+		let docVersionWithDocumentBeforeUpdate = {
+			...documentVersionWithDocument,
+			publishedStatus: 'not_checked',
+			filter1: null,
+			author: null
+		};
+
+		databaseConnector.document.findUnique.mockResolvedValue(docBeforeUpdate);
+		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(
+			docVersionWithDocumentBeforeUpdate
+		);
+		databaseConnector.document.findMany.mockResolvedValue([]); // no matching publishable docs returned
 
 		// WHEN
 		const response = await request.patch('/applications/1/documents/publish').send({
-			documents: [{ guid: 'bad_document_to_publish_guid' }]
+			documents: [{ guid: docGuid }]
 		});
 
 		// THEN
 		expect(response.status).toEqual(400);
 		expect(response.body).toEqual({
-			errors: [{ guid: 'bad_document_to_publish_guid' }]
+			errors: [{ guid: docGuid }]
 		});
 	});
 
 	test('returns partial success if some documents missing properties required for publishing', async () => {
 		// GIVEN
-		databaseConnector.document.findMany.mockResolvedValueOnce([
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
+
+		let docBeforeUpdate = documentWithDocumentVersionWithLatest;
+		docBeforeUpdate.documentVersion[0].publishedStatus = 'ready_to_publish';
+
+		let docVersionWithDocumentBeforeUpdate = {
+			...documentVersionWithDocument,
+			publishedStatus: 'ready_to_publish'
+		};
+		let documentVersionWithDocumentAfterUpdate = {
+			...docVersionWithDocumentBeforeUpdate,
+			publishedStatus: 'publishing'
+		};
+		let findManyDocs = [
 			{
-				guid: 'document_to_publish_guid',
-				latestVersionId: 1
+				guid: docGuid,
+				latestVersionId: 1,
+				latestDocumentVersion: documentVersion1
 			}
-		]);
-		databaseConnector.documentVersion.update.mockResolvedValue({
-			documentGuid: 'document_to_publish_guid',
-			fileName: 'test-file-name',
-			originalFilename: 'test-original-filename',
-			size: 1,
-			privateBlobContainer: 'test-container',
-			privateBlobPath: 'test-path',
-			publishedBlobContainer: 'test-container',
-			publishedBlobPath: 'test-path',
-			dateCreated: new Date(),
-			Document: {
-				guid: 'document_to_publish_guid',
-				reference: 'document-reference',
-				case: {
-					id: 1,
-					reference: 'case-reference'
-				}
-			}
-		});
+		];
+
+		databaseConnector.document.findUnique.mockResolvedValue(docBeforeUpdate);
+		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(
+			docVersionWithDocumentBeforeUpdate
+		);
+		databaseConnector.document.findMany.mockResolvedValue(findManyDocs);
+		databaseConnector.documentVersion.update.mockResolvedValue(
+			documentVersionWithDocumentAfterUpdate
+		);
 
 		// WHEN
 		const response = await request.patch('/applications/1/documents/publish').send({
-			documents: [{ guid: 'document_to_publish_guid' }, { guid: 'bad_document_to_publish_guid' }]
+			documents: [{ guid: docGuid }, { guid: 'bad_document_to_publish_guid' }]
 		});
 
 		// THEN
 		expect(response.status).toEqual(207);
 		expect(response.body).toEqual({
-			successful: [{ guid: 'document_to_publish_guid', publishedStatus: 'publishing' }],
+			successful: [{ guid: docGuid, publishedStatus: 'publishing' }],
 			errors: [{ guid: 'bad_document_to_publish_guid' }]
 		});
+
+		// expect event broadcast
+		let expectedEventPayloadAmended = {
+			...expectedEventPayload,
+			publishedStatus: 'publishing'
+		};
+		expect(eventClient.sendEvents).toHaveBeenCalledTimes(1);
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			NSIP_DOCUMENT,
+			[expectedEventPayloadAmended],
+			EventType.Update,
+			{ publishing: 'true' }
+		);
 	});
 });

--- a/apps/api/src/server/applications/application/documents/__tests__/update-document-status.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/update-document-status.test.js
@@ -1,48 +1,94 @@
-import { request } from '../../../../app-test.js';
-const { databaseConnector } = await import('../../../../utils/database-connector.js');
+import { jest } from '@jest/globals';
+import { request } from '#app-test';
+const { databaseConnector } = await import('#utils/database-connector.js');
+const { eventClient } = await import('#infrastructure/event-client.js');
+import { EventType } from '@pins/event-client';
+import { NSIP_DOCUMENT } from '#infrastructure/topics.js';
 
-const document1 = {
-	guid: 'D1234',
-	folderId: 2,
-	privateBlobContainer: 'Container',
-	privateBlobPath: 'Container',
-	caseId: 1,
-	latestVersionNo: 1
+const dateDocCreated = '2022-01-01T11:59:38.129Z';
+const dateDocLastModified = '2024-02-05T11:59:38.129Z';
+const docGuid = 'D1234';
+const application1 = {
+	id: 1,
+	reference: 'EN0110001',
+	title: 'EN0110001 - NI Case 3 Name',
+	description: 'test',
+	createdAt: '2022-01-01T11:59:38.129Z',
+	modifiedAt: '2023-03-10T13:49:09.666Z',
+	publishedAt: null,
+	CaseStatus: [{ id: 1, status: 'draft' }]
 };
 
-const documentVersion1 = {
+const document1 = {
+	guid: docGuid,
+	folderId: 2,
+	privateBlobContainer: 'test-container',
+	privateBlobPath: 'test-path',
 	caseId: 1,
-	documentGuid: 'D1234',
-	publishedStatus: 'awaiting_virus_check',
-	Document: document1,
+	latestVersionNo: 1,
+	reference: null,
+	folder: {
+		case: application1
+	},
+	case: application1
+};
+const documentVersion1 = {
+	version: 1,
+	documentId: 12,
+	caseId: 1,
+	documentGuid: docGuid,
+	publishedStatus: 'not_checked',
+	redactedStatus: 'redacted',
 	fileName: 'test-filename',
 	originalFilename: 'test-original-filename',
-	size: 1,
+	size: 23452,
+	author: 'Billy B',
 	privateBlobContainer: 'test-container',
 	privateBlobPath: 'test-path',
 	publishedBlobContainer: 'test-container',
 	publishedBlobPath: 'test-path',
-	dateCreated: new Date()
+	dateCreated: new Date(dateDocCreated),
+	lastModified: new Date(dateDocLastModified),
+	filter1: 'Filter Category 1'
 };
 
-const documentToUpdate1 = {
+const documentWithDocumentVersionWithLatest = {
+	...document1,
+	documentVersion: [documentVersion1],
+	latestDocumentVersion: documentVersion1
+};
+
+const documentVersionWithDocument = {
+	...documentVersion1,
+	Document: document1
+};
+
+const expectedEventPayload = {
+	documentId: docGuid,
 	caseId: 1,
-	documentGuid: 'documenttoupdate_1_guid',
-	description: 'doc with all required fields for publishing',
+	caseRef: 'EN0110001',
+	reference: null,
+	version: 1,
+	filename: 'test-filename',
+	originalFilename: 'test-original-filename',
+	size: 23452,
+	documentURI: 'https://127.0.0.1:10000/test-container/test-path',
+	dateCreated: dateDocCreated,
+	lastModified: dateDocLastModified,
+	author: 'Billy B',
 	publishedStatus: 'not_checked',
-	filter1: 'Filter Category 1',
 	redactedStatus: 'redacted',
-	author: 'David'
+	publishedDocumentURI: 'https://127.0.0.1:10000/test-container/test-path',
+	filter1: 'Filter Category 1'
 };
 
-// --------------------------------------------------------------------------------------------------
+// -------   TESTS   ---------------------------------------------------------------
 
 describe('Update document status when awaiting_virus_check', () => {
 	test('updates document status when awaiting_virus_check', async () => {
 		// GIVEN
 		databaseConnector.document.findUnique.mockResolvedValue({
-			guid: 'D1234',
-
+			guid: docGuid,
 			folderId: 2,
 			privateBlobContainer: 'Container',
 			privateBlobPath: 'Container',
@@ -54,10 +100,16 @@ describe('Update document status when awaiting_virus_check', () => {
 				}
 			]
 		});
-		databaseConnector.documentVersion.update.mockResolvedValue(documentVersion1);
+		let documentVersionWithDocumentAfterUpdate = {
+			...documentVersionWithDocument,
+			publishedStatus: 'awaiting_virus_check'
+		};
+		databaseConnector.documentVersion.update.mockResolvedValue(
+			documentVersionWithDocumentAfterUpdate
+		);
 
 		// WHEN
-		const response = await request.patch('/applications/documents/D1234/status').send({
+		const response = await request.patch(`/applications/documents/${docGuid}/status`).send({
 			machineAction: 'awaiting_virus_check'
 		});
 
@@ -65,11 +117,11 @@ describe('Update document status when awaiting_virus_check', () => {
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual({
 			caseId: 1,
-			guid: 'D1234',
+			guid: docGuid,
 			status: 'awaiting_virus_check'
 		});
 		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
-			where: { documentGuid_version: { documentGuid: 'D1234', version: 1 } },
+			where: { documentGuid_version: { documentGuid: docGuid, version: 1 } },
 			data: {
 				publishedStatus: 'awaiting_virus_check'
 			},
@@ -85,50 +137,47 @@ describe('Update document status when awaiting_virus_check', () => {
 });
 
 describe('Update document statuses and redacted statuses', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
 	test('updates document status to not_checked AND redacted status to redacted', async () => {
 		// GIVEN
-		databaseConnector.document.findUnique.mockResolvedValue({
-			guid: 'documenttoupdate_1_guid',
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
 
-			folderId: 2,
-			privateBlobContainer: 'Container',
-			privateBlobPath: 'Container',
-			documentVersion: [
-				{
-					documentGuid: 'documenttoupdate_1_guid',
-					version: 1,
-					description: 'davids doc',
-					author: 'David',
-					filter1: 'filter category',
-					publishedStatus: 'awaiting_upload',
-					redactedStatus: 'unredacted'
-				}
-			],
-			latestDocumentVersion: documentToUpdate1
-		});
-		databaseConnector.folder.findUnique.mockResolvedValue({
-			caseId: 1
-		});
-		databaseConnector.documentVersion.update.mockResolvedValue(documentToUpdate1);
+		let docBeforeUpdate = documentWithDocumentVersionWithLatest;
+		docBeforeUpdate.documentVersion[0].publishedStatus = 'awaiting_virus_check';
+		docBeforeUpdate.documentVersion[0].redactedStatus = 'unredacted';
+
+		let documentVersionWithDocumentAfterUpdate = {
+			...documentVersionWithDocument,
+			publishedStatus: 'not_checked',
+			redactedStatus: 'redacted'
+		};
+		databaseConnector.document.findUnique.mockResolvedValue(docBeforeUpdate);
+		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
+		databaseConnector.documentVersion.update.mockResolvedValue(
+			documentVersionWithDocumentAfterUpdate
+		);
 
 		// WHEN
 		const response = await request.patch('/applications/1/documents').send({
 			status: 'not_checked',
 			redacted: true,
-			documents: [{ guid: 'documenttoupdate_1_guid' }]
+			documents: [{ guid: docGuid }]
 		});
 
 		// THEN
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual([
 			{
-				guid: 'documenttoupdate_1_guid',
+				guid: docGuid,
 				redactedStatus: 'redacted',
 				status: 'not_checked'
 			}
 		]);
 		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
-			where: { documentGuid_version: { documentGuid: 'documenttoupdate_1_guid', version: 1 } },
+			where: { documentGuid_version: { documentGuid: docGuid, version: 1 } },
 			include: {
 				Document: {
 					include: {
@@ -138,296 +187,70 @@ describe('Update document statuses and redacted statuses', () => {
 			},
 			data: {
 				publishedStatus: 'not_checked',
+				publishedStatusPrev: 'awaiting_virus_check',
 				redactedStatus: 'redacted'
 			}
 		});
+
+		// expect event broadcast
+		expect(eventClient.sendEvents).toHaveBeenCalledTimes(1);
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			NSIP_DOCUMENT,
+			[expectedEventPayload],
+			EventType.Update
+		);
 	});
 
 	test('updates document status only to ready_to_publish', async () => {
 		// GIVEN
-		const documentResponseReadyToPublish = {
-			caseId: 1,
-			documentGuid: 'documenttoupdate_1a_guid',
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
 
-			description: 'doc with all required fields for publishing',
-			publishedStatus: 'ready_to_publish',
-			filter1: 'Filter Category 1',
-			redactedStatus: 'unredacted',
-			author: 'David'
-		};
-		const documentVersionPreResponseReadyToPublish = {
-			documentGuid: 'documenttoupdate_1a_guid',
-			version: 1,
-			description: 'doc with all required fields for publishing',
-			author: 'David',
-			filter1: 'Filter Category 1',
-			redactedStatus: 'unredacted'
-		};
+		let docBeforeUpdate = documentWithDocumentVersionWithLatest;
+		docBeforeUpdate.documentVersion[0].publishedStatus = 'not_checked';
 
-		databaseConnector.document.findMany.mockResolvedValue([
-			{
-				guid: 'documenttoupdate_1a_guid',
-
-				folderId: 2,
-				privateBlobContainer: 'Container',
-				privateBlobPath: 'Container',
-				latestVersionId: 1,
-				documentVersion: [
-					{
-						documentGuid: 'documenttoupdate_1a_guid',
-						version: 1,
-						description: 'davids doc',
-						author: 'David',
-						filter1: 'filter category',
-						publishedStatus: 'awaiting_upload',
-						redactedStatus: 'unredacted'
-					}
-				],
-				latestDocumentVersion: documentVersionPreResponseReadyToPublish
-			}
-		]);
-		databaseConnector.document.findUnique.mockResolvedValue({
-			guid: 'documenttoupdate_1a_guid',
-
-			folderId: 2,
-			privateBlobContainer: 'Container',
-			privateBlobPath: 'Container',
-			latestVersionId: 1,
-			documentVersion: [
-				{
-					documentGuid: 'documenttoupdate_1a_guid',
-					version: 1,
-					description: 'davids doc',
-					author: 'David',
-					filter1: 'filter category',
-					publishedStatus: 'awaiting_upload',
-					redactedStatus: 'unredacted'
-				}
-			],
-			latestDocumentVersion: documentVersionPreResponseReadyToPublish
-		});
-		databaseConnector.documentVersion.findUnique.mockResolvedValue(
-			documentVersionPreResponseReadyToPublish
-		);
-		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
-		databaseConnector.documentVersion.update.mockResolvedValue(documentResponseReadyToPublish);
-
-		// WHEN
-		const response = await request.patch('/applications/1/documents').send({
-			status: 'ready_to_publish',
-			documents: [{ guid: 'documenttoupdate_1a_guid' }]
-		});
-
-		// THEN
-		expect(response.status).toEqual(200);
-		expect(response.body).toEqual([
-			{
-				guid: 'documenttoupdate_1a_guid',
-				redactedStatus: 'unredacted',
-				status: 'ready_to_publish'
-			}
-		]);
-		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
-			where: { documentGuid_version: { documentGuid: 'documenttoupdate_1a_guid', version: 1 } },
-			include: {
-				Document: {
-					include: {
-						case: true
-					}
-				}
-			},
-			data: {
-				publishedStatus: 'ready_to_publish'
-			}
-		});
-	});
-
-	test('updates document status only to not_checked - redacted status remains unchanged', async () => {
-		// GIVEN
-		const documentResponseUnredacted = {
-			caseId: 1,
-			documentGuid: 'documenttoupdate_2_guid',
-
-			description: 'doc with all required fields for publishing',
+		let docVersionWithDocumentBeforeUpdate = {
+			...documentVersionWithDocument,
 			publishedStatus: 'not_checked',
-			filter1: 'Filter Category 1',
-			redactedStatus: 'unredacted',
-			author: 'David'
-		};
-
-		databaseConnector.document.findUnique.mockResolvedValue({
-			guid: 'documenttoupdate_2_guid',
-
-			folderId: 2,
-			privateBlobContainer: 'Container',
-			privateBlobPath: 'Container',
-			documentVersion: [
-				{
-					documentGuid: 'documenttoupdate_2_guid',
-					version: 1,
-					description: 'davids doc',
-					author: 'David',
-					filter1: 'filter category',
-					publishedStatus: 'awaiting_upload',
-					redactedStatus: 'unredacted'
-				}
-			],
-			latestDocumentVersion: documentToUpdate1
-		});
-		databaseConnector.folder.findUnique.mockResolvedValue({
-			caseId: 1
-		});
-		databaseConnector.documentVersion.update.mockResolvedValue(documentResponseUnredacted);
-
-		// WHEN
-		const response = await request.patch('/applications/1/documents').send({
-			status: 'not_checked',
-			documents: [{ guid: 'documenttoupdate_2_guid' }]
-		});
-
-		// THEN
-		expect(response.status).toEqual(200);
-		expect(response.body).toEqual([
-			{
-				guid: 'documenttoupdate_2_guid',
-				redactedStatus: 'unredacted',
-				status: 'not_checked'
-			}
-		]);
-		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
-			where: { documentGuid_version: { documentGuid: 'documenttoupdate_2_guid', version: 1 } },
-			include: {
-				Document: {
-					include: {
-						case: true
-					}
-				}
-			},
-			data: {
-				publishedStatus: 'not_checked'
-			}
-		});
-	});
-
-	test('updates redacted status only to redacted - document status remains unchanged', async () => {
-		// GIVEN
-		const documentResponseStatusUnchanged = {
-			caseId: 1,
-			documentGuid: 'documenttoupdate_3_guid',
-
-			description: 'doc with all required fields for publishing',
-			publishedStatus: 'awaiting_upload',
-			redactedStatus: 'redacted'
-		};
-
-		databaseConnector.document.findUnique.mockResolvedValue({
-			guid: 'documenttoupdate_3_guid',
-
-			folderId: 2,
-			privateBlobContainer: 'Container',
-			privateBlobPath: 'Container',
-			documentVersion: [
-				{
-					documentGuid: 'documenttoupdate_3_guid',
-					version: 1,
-					description: 'davids doc',
-					publishedStatus: 'awaiting_upload',
-					redactedStatus: 'unredacted'
-				}
-			],
-			latestDocumentVersion: documentToUpdate1
-		});
-		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
-		databaseConnector.documentVersion.update.mockResolvedValue(documentResponseStatusUnchanged);
-
-		// WHEN
-		const response = await request.patch('/applications/1/documents').send({
-			redacted: true,
-			documents: [{ guid: 'documenttoupdate_3_guid' }]
-		});
-
-		// THEN
-		expect(response.status).toEqual(200);
-		expect(response.body).toEqual([
-			{
-				guid: 'documenttoupdate_3_guid',
-				redactedStatus: 'redacted',
-				status: 'awaiting_upload'
-			}
-		]);
-		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
-			where: { documentGuid_version: { documentGuid: 'documenttoupdate_3_guid', version: 1 } },
-			include: {
-				Document: {
-					include: {
-						case: true
-					}
-				}
-			},
-			data: {
-				redactedStatus: 'redacted'
-			}
-		});
-	});
-
-	test('updates published status, and sets previous published status', async () => {
-		// GIVEN
-		const updatedDocument = {
-			caseId: 1,
-			guid: 'documenttoupdate_1a_guid',
-
-			description: 'doc with all required fields for publishing',
-			publishedStatus: 'ready_to_publish',
-			filter1: 'Filter Category 1',
-			redactedStatus: 'unredacted',
-			author: 'David',
-			latestVersionId: 1
-		};
-		const documentVersion = {
-			documentGuid: 'documenttoupdate_1a_guid',
-			version: 1,
-			description: 'doc with all required fields for publishing',
-			author: 'David',
-			filter1: 'Filter Category 1',
-			publishedStatus: 'checked',
 			redactedStatus: 'unredacted'
 		};
-		const document = {
-			...updatedDocument,
-			documentVersion
+		let documentVersionWithDocumentAfterUpdate = {
+			...docVersionWithDocumentBeforeUpdate,
+			publishedStatus: 'ready_to_publish'
 		};
-		const updatedVersion = {
-			...documentVersion,
-			publishedStatus: 'ready_to_publish',
-			publishedStatusPrev: 'checked'
-		};
-
-		databaseConnector.document.findMany.mockResolvedValue([document]);
-		databaseConnector.document.findUnique.mockResolvedValue({
-			...document,
-			latestDocumentVersion: documentVersion
-		});
-		databaseConnector.documentVersion.findUnique.mockResolvedValue(documentVersion);
+		let findManyDocs = [
+			{
+				guid: docGuid,
+				latestVersionId: 1,
+				latestDocumentVersion: documentVersion1
+			}
+		];
+		databaseConnector.document.findUnique.mockResolvedValue(docBeforeUpdate);
 		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
-		databaseConnector.documentVersion.update.mockResolvedValue(updatedVersion);
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(
+			docVersionWithDocumentBeforeUpdate
+		);
+		databaseConnector.document.findMany.mockResolvedValue(findManyDocs);
+		databaseConnector.documentVersion.update.mockResolvedValue(
+			documentVersionWithDocumentAfterUpdate
+		);
 
 		// WHEN
 		const response = await request.patch('/applications/1/documents').send({
 			status: 'ready_to_publish',
-			documents: [{ guid: 'documenttoupdate_1a_guid' }]
+			documents: [{ guid: docGuid }]
 		});
 
 		// THEN
 		expect(response.status).toEqual(200);
 		expect(response.body).toEqual([
 			{
-				guid: 'documenttoupdate_1a_guid',
+				guid: docGuid,
 				redactedStatus: 'unredacted',
 				status: 'ready_to_publish'
 			}
 		]);
 		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
-			where: { documentGuid_version: { documentGuid: 'documenttoupdate_1a_guid', version: 1 } },
+			where: { documentGuid_version: { documentGuid: docGuid, version: 1 } },
 			include: {
 				Document: {
 					include: {
@@ -437,14 +260,271 @@ describe('Update document statuses and redacted statuses', () => {
 			},
 			data: {
 				publishedStatus: 'ready_to_publish',
-				publishedStatusPrev: 'checked'
+				publishedStatusPrev: 'not_checked',
+				redactedStatus: undefined
 			}
 		});
+
+		// expect event broadcast
+		let expectedEventPayloadAmended = {
+			...expectedEventPayload,
+			publishedStatus: 'ready_to_publish',
+			redactedStatus: 'unredacted'
+		};
+		expect(eventClient.sendEvents).toHaveBeenCalledTimes(1);
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			NSIP_DOCUMENT,
+			[expectedEventPayloadAmended],
+			EventType.Update
+		);
+	});
+
+	test('updates document status only to not_checked - redacted status remains unchanged', async () => {
+		// GIVEN
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
+
+		let docBeforeUpdate = documentWithDocumentVersionWithLatest;
+		docBeforeUpdate.documentVersion[0].publishedStatus = 'awaiting_virus_check';
+		docBeforeUpdate.documentVersion[0].redactedStatus = 'unredacted';
+
+		let docVersionWithDocumentBeforeUpdate = {
+			...documentVersionWithDocument,
+			publishedStatus: 'awaiting_virus_check',
+			redactedStatus: 'unredacted'
+		};
+		let documentVersionWithDocumentAfterUpdate = {
+			...docVersionWithDocumentBeforeUpdate,
+			publishedStatus: 'not_checked',
+			redactedStatus: 'unredacted'
+		};
+		let findManyDocs = [
+			{
+				guid: docGuid,
+				latestVersionId: 1,
+				latestDocumentVersion: documentVersion1
+			}
+		];
+		databaseConnector.document.findUnique.mockResolvedValue(docBeforeUpdate);
+		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(
+			docVersionWithDocumentBeforeUpdate
+		);
+		databaseConnector.document.findMany.mockResolvedValue(findManyDocs);
+		databaseConnector.documentVersion.update.mockResolvedValue(
+			documentVersionWithDocumentAfterUpdate
+		);
+
+		// WHEN
+		const response = await request.patch('/applications/1/documents').send({
+			status: 'not_checked',
+			documents: [{ guid: docGuid }]
+		});
+
+		// THEN
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual([
+			{
+				guid: docGuid,
+				redactedStatus: 'unredacted',
+				status: 'not_checked'
+			}
+		]);
+		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
+			where: { documentGuid_version: { documentGuid: docGuid, version: 1 } },
+			include: {
+				Document: {
+					include: {
+						case: true
+					}
+				}
+			},
+			data: {
+				publishedStatus: 'not_checked',
+				publishedStatusPrev: 'awaiting_virus_check',
+				redactedStatus: undefined
+			}
+		});
+
+		// expect event broadcast
+		let expectedEventPayloadAmended = {
+			...expectedEventPayload,
+			publishedStatus: 'not_checked',
+			redactedStatus: 'unredacted'
+		};
+		expect(eventClient.sendEvents).toHaveBeenCalledTimes(1);
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			NSIP_DOCUMENT,
+			[expectedEventPayloadAmended],
+			EventType.Update
+		);
+	});
+
+	test('updates redacted status only to redacted - document status remains unchanged', async () => {
+		// GIVEN
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
+
+		let docBeforeUpdate = documentWithDocumentVersionWithLatest;
+		docBeforeUpdate.documentVersion[0].publishedStatus = 'not_checked';
+		docBeforeUpdate.documentVersion[0].redactedStatus = 'unredacted';
+
+		let docVersionWithDocumentBeforeUpdate = {
+			...documentVersionWithDocument,
+			publishedStatus: 'not_checked',
+			redactedStatus: 'unredacted'
+		};
+		let documentVersionWithDocumentAfterUpdate = {
+			...docVersionWithDocumentBeforeUpdate,
+			publishedStatus: 'not_checked',
+			redactedStatus: 'redacted'
+		};
+		let findManyDocs = [
+			{
+				guid: docGuid,
+				latestVersionId: 1,
+				latestDocumentVersion: documentVersion1
+			}
+		];
+		databaseConnector.document.findUnique.mockResolvedValue(docBeforeUpdate);
+		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(
+			docVersionWithDocumentBeforeUpdate
+		);
+		databaseConnector.document.findMany.mockResolvedValue(findManyDocs);
+		databaseConnector.documentVersion.update.mockResolvedValue(
+			documentVersionWithDocumentAfterUpdate
+		);
+
+		// WHEN
+		const response = await request.patch('/applications/1/documents').send({
+			redacted: true,
+			documents: [{ guid: docGuid }]
+		});
+
+		// THEN
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual([
+			{
+				guid: docGuid,
+				redactedStatus: 'redacted',
+				status: 'not_checked'
+			}
+		]);
+		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
+			where: { documentGuid_version: { documentGuid: docGuid, version: 1 } },
+			include: {
+				Document: {
+					include: {
+						case: true
+					}
+				}
+			},
+			data: {
+				redactedStatus: 'redacted'
+			}
+		});
+
+		// expect event broadcast
+		let expectedEventPayloadAmended = {
+			...expectedEventPayload,
+			publishedStatus: 'not_checked',
+			redactedStatus: 'redacted'
+		};
+		expect(eventClient.sendEvents).toHaveBeenCalledTimes(1);
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			NSIP_DOCUMENT,
+			[expectedEventPayloadAmended],
+			EventType.Update
+		);
+	});
+
+	test('updates published status, and sets previous published status', async () => {
+		// GIVEN
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
+
+		let docBeforeUpdate = documentWithDocumentVersionWithLatest;
+		docBeforeUpdate.documentVersion[0].publishedStatus = 'not_checked';
+		docBeforeUpdate.documentVersion[0].redactedStatus = 'unredacted';
+
+		let docVersionWithDocumentBeforeUpdate = {
+			...documentVersionWithDocument,
+			publishedStatus: 'not_checked',
+			redactedStatus: 'unredacted'
+		};
+		let documentVersionWithDocumentAfterUpdate = {
+			...docVersionWithDocumentBeforeUpdate,
+			publishedStatus: 'ready_to_publish',
+			redactedStatus: 'unredacted',
+			publishedStatusPrev: 'not_checked'
+		};
+		let findManyDocs = [
+			{
+				guid: docGuid,
+				latestVersionId: 1,
+				latestDocumentVersion: documentVersion1
+			}
+		];
+		databaseConnector.document.findUnique.mockResolvedValue(docBeforeUpdate);
+		databaseConnector.folder.findUnique.mockResolvedValue({ caseId: 1 });
+		databaseConnector.documentVersion.findUnique.mockResolvedValue(
+			docVersionWithDocumentBeforeUpdate
+		);
+		databaseConnector.document.findMany.mockResolvedValue(findManyDocs);
+		databaseConnector.documentVersion.update.mockResolvedValue(
+			documentVersionWithDocumentAfterUpdate
+		);
+
+		// WHEN
+		const response = await request.patch('/applications/1/documents').send({
+			status: 'ready_to_publish',
+			documents: [{ guid: docGuid }]
+		});
+
+		// THEN
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual([
+			{
+				guid: docGuid,
+				redactedStatus: 'unredacted',
+				status: 'ready_to_publish'
+			}
+		]);
+		expect(databaseConnector.documentVersion.update).toHaveBeenCalledWith({
+			where: { documentGuid_version: { documentGuid: docGuid, version: 1 } },
+			include: {
+				Document: {
+					include: {
+						case: true
+					}
+				}
+			},
+			data: {
+				publishedStatus: 'ready_to_publish',
+				publishedStatusPrev: 'not_checked'
+			}
+		});
+
+		// expect event broadcast
+		let expectedEventPayloadAmended = {
+			...expectedEventPayload,
+			publishedStatus: 'ready_to_publish',
+			redactedStatus: 'unredacted'
+		};
+		expect(eventClient.sendEvents).toHaveBeenCalledTimes(1);
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			NSIP_DOCUMENT,
+			[expectedEventPayloadAmended],
+			EventType.Update
+		);
 	});
 
 	describe('revert document published status', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+		});
+
 		const tests = [
 			{
+				name: 'not-a-document-guid',
 				guid: 'not-a-document-guid',
 				want: {
 					status: 404,
@@ -455,6 +535,7 @@ describe('Update document statuses and redacted statuses', () => {
 				}
 			},
 			{
+				name: 'document guid not found',
 				guid: 'document-guid',
 				document: {},
 				documentVersion: null,
@@ -467,6 +548,7 @@ describe('Update document statuses and redacted statuses', () => {
 				}
 			},
 			{
+				name: 'no previous state to revert to',
 				guid: 'document-guid',
 				document: {},
 				documentVersion: {},
@@ -479,6 +561,7 @@ describe('Update document statuses and redacted statuses', () => {
 				}
 			},
 			{
+				name: 'successful revert to checked status',
 				guid: 'document-guid',
 				document: {},
 				documentVersion: {
@@ -499,6 +582,7 @@ describe('Update document statuses and redacted statuses', () => {
 		for (const { name, guid, document, documentVersion, want } of tests) {
 			test('' + name, async () => {
 				// setup
+				databaseConnector.case.findUnique.mockResolvedValue(application1);
 				databaseConnector.document.findUnique.mockReset();
 				databaseConnector.documentVersion.findUnique.mockReset();
 

--- a/apps/api/src/server/applications/application/documents/document.js
+++ b/apps/api/src/server/applications/application/documents/document.js
@@ -2,12 +2,14 @@ import { pick, omitBy, isNull } from 'lodash-es';
 import config from '#config/config.js';
 
 /**
- * @typedef {import('pins-data-model').Schemas.NSIPDocument} NSIPDocument
+ * @typedef {import('pins-data-model').Schemas.NSIPDocument} NSIPDocumentSchema
  * */
 
 /**
+ * Returns document in event message schema format
+ *
  * @param {import('@pins/applications.api').Schema.DocumentVersionWithDocument} version
- * @returns {NSIPDocument}
+ * @returns {NSIPDocumentSchema}
  */
 export const buildNsipDocumentPayload = (version) => {
 	const { Document: document } = version;

--- a/apps/api/src/server/applications/application/documents/document.routes.js
+++ b/apps/api/src/server/applications/application/documents/document.routes.js
@@ -10,8 +10,8 @@ import {
 	getDocumentProperties,
 	getDocumentVersions,
 	getReadyToPublishDocuments,
-	provideDocumentUploadURLs,
-	provideDocumentVersionUploadURL,
+	createDocumentsOnCase,
+	createDocumentVersionOnCase,
 	publishDocuments,
 	revertDocumentPublishedStatus,
 	storeDocumentVersion,
@@ -81,7 +81,7 @@ router.post(
 	/*
         #swagger.tags = ['Applications']
         #swagger.path = '/applications/{id}/documents'
-        #swagger.description = 'Saves new documents to database and returns location in Blob Storage'
+        #swagger.description = 'Saves new documents to database and returns document info and location in Blob Storage'
         #swagger.parameters['id'] = {
             in: 'path',
 			description: 'Application ID',
@@ -122,7 +122,7 @@ router.post(
 	validateDocumentsToUploadProvided,
 	validateFolderIds,
 	trimUnexpectedRequestParameters,
-	asyncHandler(provideDocumentUploadURLs)
+	asyncHandler(createDocumentsOnCase)
 );
 
 router.patch(
@@ -217,7 +217,7 @@ router.post(
 	validateApplicationId,
 	validateDocumentToUploadProvided,
 	validateFolderId,
-	asyncHandler(provideDocumentVersionUploadURL)
+	asyncHandler(createDocumentVersionOnCase)
 );
 
 router.patch(
@@ -557,7 +557,7 @@ router.get(
 	/*
         #swagger.tags = ['Applications']
         #swagger.path = '/applications/documents/{guid}/path'
-        #swagger.description = 'Gets the array of folders containing a document'
+        #swagger.description = 'Gets the folder path of a document, as an array'
 		#swagger.parameters['guid'] = {
             in: 'path',
 			description: 'guid of the required document here',

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -27,12 +27,15 @@ import {
 	verifyAllDocumentsHaveRequiredPropertiesForPublishing,
 	verifyNotTrainingAttachment
 } from './document.validators.js';
+import { applicationStates } from '../../state-machine/application.machine.js';
+import { isTrainingCase } from '../application.validators.js';
 
 /**
  * @typedef {import('@prisma/client').DocumentVersion} DocumentVersion
  * @typedef {import('@prisma/client').Document} Document
  * @typedef {import('@prisma/client').Document & {documentName: string}} DocumentWithDocumentName
  * @typedef {import('@pins/applications.api').Schema.DocumentDetails} DocumentDetails
+ * @typedef {import('@pins/applications.api').Schema.DocumentVersionWithDocument} DocumentVersionWithDocument
  * @typedef {import('@pins/applications.api').Api.DocumentAndBlobInfoManyResponse} DocumentAndBlobInfoManyResponse
  * @typedef {import('@pins/applications.api').Api.DocumentAndBlobStorageDetail} DocumentAndBlobStorageDetail
  * @typedef {import('@pins/applications.api').Api.DocumentToSave} DocumentToSave
@@ -151,7 +154,6 @@ const attemptInsertDocuments = async (caseId, documents, isS51) => {
 			let stage = await getCaseStageMapping(documentToDB.folderId);
 
 			logger.info(`Upserting metadata for document with guid: ${document.guid}`);
-
 			await documentVersionRepository.upsert({
 				documentGuid: document.guid,
 				fileName,
@@ -190,7 +192,7 @@ const attemptInsertDocuments = async (caseId, documents, isS51) => {
  * @param {string} caseReference
  * @returns {DocumentBlobStoragePayload[]}
  */
-const mapDocumentsToSendToBlobStorage = (documents, caseReference) => {
+const mapDocumentsToGetBlobStorageProperties = (documents, caseReference) => {
 	return documents.map((document) => {
 		return {
 			caseType: 'application',
@@ -208,7 +210,7 @@ const mapDocumentsToSendToBlobStorage = (documents, caseReference) => {
  *
  * @param {DocumentAndBlobStorageDetail[]} blobStorageDocuments - Array of documents containing metadata to upsert.
  * @param {string} privateBlobContainer - Name of the blob storage container where documents are stored.
- * @returns {Promise<void>}
+ * @returns {Promise<DocumentVersionWithDocument[]>}
  */
 const upsertDocumentVersionsMetadataToDatabase = async (
 	blobStorageDocuments,
@@ -225,7 +227,7 @@ const upsertDocumentVersionsMetadataToDatabase = async (
 	});
 
 	// Use PromisePool to concurrently process the documents metadata with a concurrency of 5.
-	await PromisePool.withConcurrency(5)
+	const upsertedDocumentsResponse = await PromisePool.withConcurrency(5)
 		.for(documentsMetadataToSendToDatabase)
 		.handleError((error) => {
 			// Log any errors that occur during the upsert process and re-throw the error.
@@ -236,21 +238,24 @@ const upsertDocumentVersionsMetadataToDatabase = async (
 			// Log the metadata being upserted for debugging purposes
 			logger.info(`Upserting document metadata: ${JSON.stringify(metadata)}`);
 
-			// Upsert the metadata using the documentVerisonRepository
+			// Upsert the metadata using the documentVersionRepository
 			return documentVersionRepository.upsert(metadata);
 		});
+	return upsertedDocumentsResponse.results;
 };
 
 /**
+ * creates document, document version, and activity log records for an array of new documents on a case
+ *
  * @param {DocumentToSaveExtended[]} documentsToUpload
  * @param {number} caseId
  * @param {boolean} [isS51]
  * @returns {Promise<{response: DocumentAndBlobInfoManyResponse | null, failedDocuments: string[]}>}}
  */
-export const obtainURLsForDocuments = async (documentsToUpload, caseId, isS51) => {
+export const createDocuments = async (documentsToUpload, caseId, isS51) => {
 	// Step 1: Retrieve the case object associated with the provided caseId
 	logger.info(`Retrieving case for caseId ${caseId}...`);
-	const caseForDocuments = await caseRepository.getById(Number(caseId), {});
+	const caseForDocuments = await caseRepository.getById(Number(caseId), { sector: true });
 	logger.info(`Case retrieved: ${JSON.stringify(caseForDocuments)}`);
 
 	// Step 2: Check if the case object is found and has a reference
@@ -263,7 +268,6 @@ export const obtainURLsForDocuments = async (documentsToUpload, caseId, isS51) =
 	// Step 3: Map documents to the format expected by the database
 	logger.info(`Mapping documents to database format...`);
 	const documentsToSendToDatabase = mapDocumentsToSendToDatabase(caseId, documentsToUpload);
-	//throw Error(JSON.stringify(documentsToSendToDatabase));
 	logger.info(`Documents mapped: ${JSON.stringify(documentsToSendToDatabase)}`);
 
 	// Step 4: Add documents to the database if all are new
@@ -279,29 +283,34 @@ export const obtainURLsForDocuments = async (documentsToUpload, caseId, isS51) =
 	}
 	logger.info(`Documents inserted: ${JSON.stringify(successful)}`);
 
-	// Step 5: Map documents to the format expected by the blob storage service
+	// Step 5: Map documents to the format expected to get blob storage properties
 	logger.info(`Mapping documents to blob storage format...`);
-	const requestToDocumentStorage = mapDocumentsToSendToBlobStorage(
+	const requestToGetDocumentStorageProperties = mapDocumentsToGetBlobStorageProperties(
 		successful,
 		caseForDocuments.reference
 	);
-	logger.info(`Documents mapped: ${JSON.stringify(requestToDocumentStorage)}`);
+	logger.info(`Documents mapped: ${JSON.stringify(requestToGetDocumentStorageProperties)}`);
 
-	// Step 6: Send a request to the blob storage service to get the storage location for each document
-	logger.info(`Sending request to blob storage service...`);
-	const responseFromDocumentStorage = await getStorageLocation(requestToDocumentStorage);
-	logger.info(`Response from blob storage service: ${JSON.stringify(responseFromDocumentStorage)}`);
+	// Step 6: generate the blob storage service properties
+	const documentsWithBlobStorageInfo = await getStorageLocation(
+		requestToGetDocumentStorageProperties
+	);
+	logger.info(
+		`Documents with Blob storage service properties: ${JSON.stringify(
+			documentsWithBlobStorageInfo
+		)}`
+	);
 
 	// Step 7: Upsert document versions metadata to the database
 	logger.info(`Upserting document versions metadata to database...`);
-	await upsertDocumentVersionsMetadataToDatabase(
-		responseFromDocumentStorage.documents,
-		responseFromDocumentStorage.privateBlobContainer
+	const upsertedDocuments = await upsertDocumentVersionsMetadataToDatabase(
+		documentsWithBlobStorageInfo.documents,
+		documentsWithBlobStorageInfo.privateBlobContainer
 	);
 
 	/** @type {Promise<import('@prisma/client').DocumentActivityLog>[]} */
 	// TODO: refactor to use createMany instead?
-	const documentActivityLogs = requestToDocumentStorage.map((document) =>
+	const documentActivityLogs = requestToGetDocumentStorageProperties.map((document) =>
 		documentActivityLogRepository.create({
 			documentGuid: document.GUID,
 			version: document.version,
@@ -312,58 +321,59 @@ export const obtainURLsForDocuments = async (documentsToUpload, caseId, isS51) =
 
 	await Promise.all(documentActivityLogs);
 
-	// Step 8: Return the response from the blob storage service, including information about the uploaded documents and their storage location
-	logger.info(`Returning response from blob storage service...`);
-	return { response: responseFromDocumentStorage, failedDocuments: failed };
+	// now send broadcast events for doc creations - ignoring docs on training cases.
+	if (
+		!isTrainingCase(
+			caseForDocuments.reference,
+			caseForDocuments.ApplicationDetails?.subSector?.sector?.name
+		)
+	) {
+		const events = upsertedDocuments.map(buildNsipDocumentPayload);
+		await eventClient.sendEvents(NSIP_DOCUMENT, events, EventType.Create);
+	}
+
+	// Step 8: Return information about the uploaded documents and their storage location
+	logger.info(`Returning created and failed documents with blob storage properties...`);
+	return { response: documentsWithBlobStorageInfo, failedDocuments: failed };
 };
 
 /**
- * Used when uploading a new document version
+ * creates a new document version on a document, creating doc version records, activity log records, updating Document latest version, and broadcast event
  *
  * @param {{documentName: string, folderId: number, documentType: string, documentSize: number, username: string, documentReference: string}} documentToUpload
  * @param {number} caseId
  * @param {string} documentId
  * @returns {Promise<DocumentAndBlobInfoManyResponse>}}
  */
-export const obtainURLForDocumentVersion = async (documentToUpload, caseId, documentId) => {
+export const createDocumentVersion = async (documentToUpload, caseId, documentId) => {
 	// Step 1: Retrieve the case object associated with the provided caseId
 	logger.info(`Retrieving case for caseId ${caseId} ${documentId}...`);
-
-	const caseForDocuments = await caseRepository.getById(caseId, {});
-
+	const caseForDocuments = await caseRepository.getById(caseId, { sector: true });
 	logger.info(`Case retrieved: ${JSON.stringify(caseForDocuments)}`);
 
 	// Step 2: Check if the case object is found and has a reference
 	logger.info(`Checking if case has reference...`);
-
 	if (caseForDocuments == null || caseForDocuments.reference == null) {
 		throw new Error('Case not found or has no reference');
 	}
 
 	// Step 3: Finding existing document from database
 	logger.info(`Finding existing document from database...`);
-
 	const documentFromDatabase = await documentRepository.getByIdWithVersion(documentId);
 
 	if (!documentFromDatabase) {
 		throw new Error('Document not found');
 	}
 
-	logger.info(`Case has reference`);
-
-	// Step 4: Map documents to the format expected by the database
-	logger.info(`Mapping documents to database format...`);
-
+	// Step 4: Map document to the format expected by the database
+	logger.info(`Mapping document to database format...`);
 	const documentToSendToDatabase = mapDocumentToSendToDatabase(documentToUpload);
-
 	logger.info(`Document mapped: ${JSON.stringify(documentToSendToDatabase)}`);
 
 	// Step 5: upsert the document to the database
-
 	logger.info(`Document found from database: ${JSON.stringify(documentFromDatabase)}`);
-
 	const fileName = documentName(documentToSendToDatabase.documentName);
-	const version = documentFromDatabase.latestVersionId + 1;
+	const version = (documentFromDatabase.latestVersionId ?? 0) + 1;
 
 	const { documentVersion } = documentFromDatabase;
 
@@ -387,56 +397,75 @@ export const obtainURLForDocumentVersion = async (documentToUpload, caseId, docu
 		status: 'uploaded'
 	});
 
-	// Step 6: Map documents to the format expected by the blob storage service
-	logger.info(`Mapping documents to blob storage format...`);
-
-	const requestToDocumentStorage = [
+	// Step 6: Map document to the format expected to get blob storage properties
+	logger.info(`Mapping document to blob storage format...`);
+	const requestToGetDocumentStorageProperties = [
 		{
-			caseType: 'application',
+			/** @type {'appeal' | 'application'} */ caseType: 'application',
 			caseReference: caseForDocuments.reference,
 			GUID: documentFromDatabase.guid,
 			documentName: documentToSendToDatabase.documentName,
 			version
 		}
 	];
+	logger.info(`Documents mapped: ${JSON.stringify(requestToGetDocumentStorageProperties)}`);
 
-	logger.info(`Documents mapped: ${JSON.stringify(requestToDocumentStorage)}`);
+	// Step 7: generate the blob storage service properties
+	logger.info(`Generate the blob storage properties...`);
+	const documentWithBlobStorageInfo = await getStorageLocation(
+		requestToGetDocumentStorageProperties
+	);
+	logger.info(
+		`Documents with Blob storage service properties: ${JSON.stringify(documentWithBlobStorageInfo)}`
+	);
 
-	// Step 7: Send a request to the blob storage service to get the storage location for each document
+	// Step 8: Upsert document version metadata to the database
+	logger.info(`Upserting document version metadata to database...`);
 
-	logger.info(`Sending request to blob storage service...`);
-
-	const responseFromDocumentStorage = await getStorageLocation(requestToDocumentStorage);
-
-	logger.info(`Response from blob storage service: ${JSON.stringify(responseFromDocumentStorage)}`);
-
-	// Step 8: Upsert document versions metadata to the database
-	logger.info(`Upserting document versions metadata to database...`);
-
-	await documentVersionRepository.update(documentId, {
-		privateBlobContainer: responseFromDocumentStorage.privateBlobContainer,
+	let createdVersionWithDocInfo = await documentVersionRepository.update(documentId, {
+		privateBlobContainer: documentWithBlobStorageInfo.privateBlobContainer,
 		version,
-		privateBlobPath: responseFromDocumentStorage.documents[0].blobStoreUrl
+		privateBlobPath: documentWithBlobStorageInfo.documents[0].blobStoreUrl
 	});
 
+	const thisVersionId = (documentFromDatabase.latestVersionId ?? 0) + 1;
 	await documentRepository.update(documentId, {
-		latestVersionId: documentFromDatabase.latestVersionId + 1
+		latestVersionId: thisVersionId
 	});
 
-	// Step 8: Return the response from the blob storage service, including information about the uploaded documents and their storage location
-	logger.info(`Returning response from blob storage service...`);
-	return responseFromDocumentStorage;
+	// broadcast event - ignoring if doc is on non Training cases
+	if (
+		!isTrainingCase(
+			caseForDocuments.reference,
+			caseForDocuments.ApplicationDetails?.subSector?.sector?.name
+		)
+	) {
+		// 1st fix the doc latestversionId in the payload to match (saves having to get the whole doc+version again after the doc update)
+		// @ts-ignore
+		createdVersionWithDocInfo.Document.latestVersionId = thisVersionId;
+		await eventClient.sendEvents(
+			NSIP_DOCUMENT,
+			[buildNsipDocumentPayload(createdVersionWithDocInfo)],
+			EventType.Update
+		);
+	}
+
+	// Step 8: Return information about the uploaded document version and its storage location
+	logger.info(`Returning updated document with blob storage properties...`);
+	return documentWithBlobStorageInfo;
 };
 
 /**
  * Upserts the metadata for a document with the provided GUID using the provided metadata body.
  *
+ * @param {string} caseId - The case id this document is in
  * @param {string} documentGuid - The GUID of the document to upsert metadata for.
  * @param {DocumentVersion} documentVersionBody - The metadata body to use for upserting.
  * @param {number} version
  * @returns {Promise<DocumentDetails>} A promise that resolves with the document details after the upsert.
  */
 export const upsertDocumentVersionAndReturnDetails = async (
+	caseId,
 	documentGuid,
 	documentVersionBody,
 	version
@@ -446,6 +475,22 @@ export const upsertDocumentVersionAndReturnDetails = async (
 		documentGuid,
 		version
 	});
+
+	// broadcast event - ignoring if doc is on non Training cases
+	const caseWithThisDocument = await caseRepository.getById(Number(caseId), { sector: true });
+	if (
+		caseWithThisDocument &&
+		!isTrainingCase(
+			caseWithThisDocument.reference ?? '',
+			caseWithThisDocument.ApplicationDetails?.subSector?.sector?.name
+		)
+	) {
+		await eventClient.sendEvents(
+			NSIP_DOCUMENT,
+			[buildNsipDocumentPayload(documentVersion)],
+			EventType.Update
+		);
+	}
 
 	return mapSingleDocumentDetailsFromVersion(documentVersion);
 };
@@ -768,12 +813,14 @@ export const separatePublishableDocuments = async (guids) => {
  * @param {'redacted' | 'not_redacted'} [redactedStatus]
  * @returns {Promise<{ errors: ItemError[], results: Record<string, any>[] }>}
  * */
-export const handleUpdateDocument = async (guids, publishedStatus, redactedStatus) => {
+export const handleUpdateDocuments = async (guids, publishedStatus, redactedStatus) => {
 	/** @type {ItemError[]} */
 	let errors = [];
 
 	/** @type {Record<string, any>[]} */
 	let results = [];
+
+	let updatedDocuments = [];
 
 	for (const guid of guids) {
 		logger.info(
@@ -821,6 +868,7 @@ export const handleUpdateDocument = async (guids, publishedStatus, redactedStatu
 			version: documentVersion.version,
 			...documentVersionUpdates
 		});
+		updatedDocuments.push(updateResponseInTable);
 
 		const formattedResponse = formatDocumentUpdateResponseBody(
 			updateResponseInTable.documentGuid ?? '',
@@ -830,6 +878,20 @@ export const handleUpdateDocument = async (guids, publishedStatus, redactedStatu
 
 		results.push(formattedResponse);
 	}
+
+	// broadcast an update event for each of the updated documents
+	const events = (
+		await filterAsync(async (doc) => {
+			try {
+				await verifyNotTrainingAttachment(doc.documentGuid);
+				return true;
+			} catch (/** @type {*} */ err) {
+				logger.info('Blocked sending event for document:', err.message);
+				return false;
+			}
+		}, updatedDocuments)
+	).map(buildNsipDocumentPayload);
+	await eventClient.sendEvents(NSIP_DOCUMENT, events, EventType.Update);
 
 	return { errors, results };
 };
@@ -955,4 +1017,87 @@ export const getDocumentsInCase = async (
 		itemCount: documentsCount,
 		items: mapDocumentVersionDetails(mapDocument)
 	};
+};
+
+/**
+ * soft deletes a document
+ *
+ * @param {string} guid
+ * @param {string} caseId
+ * @throws {BackOfficeAppError} If the document is published, or if the document cannot be deleted for any other reason.
+ * @returns {Promise<Document>}
+ * */
+export const deleteDocument = async (guid, caseId) => {
+	// Step 1: Fetch the document to be deleted from the database
+	const documentToDelete = await documentVersionRepository.getById(guid);
+
+	if (documentToDelete === null || typeof documentToDelete === 'undefined') {
+		throw new BackOfficeAppError(
+			`document not found: guid ${guid} related to caseId ${caseId}`,
+			404
+		);
+	}
+
+	// Step 2: Check if the document is published; if so, throw an error as it cannot be deleted
+	const documentIsPublished =
+		documentToDelete.publishedStatus?.toLowerCase() === applicationStates.published?.toLowerCase();
+
+	if (documentIsPublished) {
+		throw new BackOfficeAppError(
+			`unable to delete document guid ${guid} related to caseId ${caseId}`,
+			400
+		);
+	}
+
+	// step 3: mark the document as deleted
+	const deletedDocument = await documentRepository.deleteDocument(guid);
+
+	// Step 4: broadcast event message - ignoring training cases
+	try {
+		await verifyNotTrainingAttachment(guid);
+
+		await eventClient.sendEvents(
+			NSIP_DOCUMENT,
+			[buildNsipDocumentPayload(documentToDelete)],
+			EventType.Delete
+		);
+	} catch (/** @type {*} */ err) {
+		logger.info('Blocked sending event for document:', err.message);
+	}
+
+	return deletedDocument;
+};
+
+/**
+ * reverts a document status to its previous status - eg ready_to_publish back to not_checked
+ *
+ * @param {string} guid
+ * @param {string} newPublishedStatus
+ * @param {string |null} newPublishedStatusPrev
+ * @returns {Promise<DocumentVersionWithDocument>}
+ * */
+export const revertDocumentStatusToPrevious = async (
+	guid,
+	newPublishedStatus,
+	newPublishedStatusPrev
+) => {
+	const updatedDocument = await documentVersionRepository.update(guid, {
+		publishedStatus: newPublishedStatus,
+		publishedStatusPrev: newPublishedStatusPrev
+	});
+
+	// broadcast event message - ignore training cases
+	try {
+		await verifyNotTrainingAttachment(guid);
+
+		await eventClient.sendEvents(
+			NSIP_DOCUMENT,
+			[buildNsipDocumentPayload(updatedDocument)],
+			EventType.Update
+		);
+	} catch (/** @type {*} */ err) {
+		logger.info('Blocked sending event for document:', err.message);
+	}
+
+	return updatedDocument;
 };

--- a/apps/api/src/server/applications/documents/documents.controller.js
+++ b/apps/api/src/server/applications/documents/documents.controller.js
@@ -1,35 +1,9 @@
 import BackOfficeAppError from '#utils/app-error.js';
-import { obtainURLsForDocuments } from '../application/documents/document.service.js';
 import {
 	extractYouTubeURLFromHTML,
 	renderYouTubeTemplate,
 	updateStatus
 } from './documents.service.js';
-
-/**
- * Provides document upload URLs.
- *
- * @type {import('express').RequestHandler<any, any, any, any>}
- */
-export const provideDocumentUploadURLs = async ({ params, body }, response) => {
-	const documentsToUpload = body[''];
-
-	const { blobStorageHost, privateBlobContainer, documents } = await obtainURLsForDocuments(
-		documentsToUpload,
-		params.id
-	);
-
-	const documentsWithUrls = documents.map(({ documentName, blobStoreUrl }) => ({
-		documentName,
-		blobStoreUrl
-	}));
-
-	response.send({
-		blobStorageHost,
-		privateBlobContainer,
-		documents: documentsWithUrls
-	});
-};
 
 /**
  * @type {import('express').RequestHandler<{caseId: string, documentGUID: string }>}

--- a/apps/api/src/server/applications/documents/documents.service.js
+++ b/apps/api/src/server/applications/documents/documents.service.js
@@ -1,9 +1,9 @@
 import { EventType } from '@pins/event-client';
-import { eventClient } from '../../infrastructure/event-client.js';
-import { NSIP_DOCUMENT } from '../../infrastructure/topics.js';
+import { eventClient } from '#infrastructure/event-client.js';
+import { NSIP_DOCUMENT } from '#infrastructure/topics.js';
 import { buildNsipDocumentPayload } from '../application/documents/document.js';
-import * as documentRepository from '../../repositories/document.repository.js';
-import * as documentVersionRepository from '../../repositories/document-metadata.repository.js';
+import * as documentRepository from '#repositories/document.repository.js';
+import * as documentVersionRepository from '#repositories/document-metadata.repository.js';
 import logger from '#utils/logger.js';
 import { YouTubeHTMLTemplate } from './youtube-html-template.js';
 

--- a/apps/api/src/server/applications/s51advice/__tests__/s51-advice-update.test.js
+++ b/apps/api/src/server/applications/s51advice/__tests__/s51-advice-update.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { request } from '../../../app-test.js';
+import { request } from '#app-test';
 import { applicationFactoryForTests } from '#utils/application-factory-for-tests.js';
 import { EventType } from '@pins/event-client';
 import { NSIP_S51_ADVICE } from '#infrastructure/topics.js';
@@ -71,13 +71,39 @@ const s51AdviceDocuments = [
 	}
 ];
 
-const application1 = applicationFactoryForTests({
+const applicationBase = applicationFactoryForTests({
 	id: 1,
 	reference: 'BC0110001',
 	title: 'BC010001 - NI Case 1 Name',
 	description: 'BC010001 - NI Case 1 Name Description',
 	caseStatus: 'pre-application'
 });
+const application1 = {
+	...applicationBase,
+	ApplicationDetails: {
+		id: 100000000,
+		caseId: 1,
+		subSectorId: 1,
+		locationDescription: null,
+		zoomLevelId: 4,
+		caseEmail: null,
+		subSector: {
+			id: 1,
+			abbreviation: 'BC01',
+			name: 'office_use',
+			displayNameEn: 'Office Use',
+			displayNameCy: 'Office Use',
+			sectorId: 1,
+			sector: {
+				id: 1,
+				abbreviation: 'BC',
+				name: 'business_and_commercial',
+				displayNameEn: 'Business and Commercial',
+				displayNameCy: 'Business and Commercial'
+			}
+		}
+	}
+};
 
 describe('Test S51 advice update status and redacted status', () => {
 	afterEach(() => {
@@ -97,7 +123,7 @@ describe('Test S51 advice update status and redacted status', () => {
 		databaseConnector.s51Advice.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([1]);
 		databaseConnector.s51Advice.update.mockResolvedValue(validS51AdviceUpdated);
 		databaseConnector.s51AdviceDocument.findMany.mockResolvedValue([]);
-		databaseConnector.case.findUnique.mockResolvedValue({ id: 1, reference: 'TEST' });
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
 
 		// WHEN
 		const response = await request.patch('/applications/1/s51-advice').send({
@@ -140,7 +166,7 @@ describe('Test S51 advice update status and redacted status', () => {
 			publishedStatusPrev: 'not_checked'
 		};
 
-		databaseConnector.case.findUnique.mockResolvedValue({ id: 1, reference: 'TEST' });
+		databaseConnector.case.findUnique.mockResolvedValue(application1);
 		databaseConnector.s51Advice.findUnique.mockResolvedValue(validS51AdviceBody);
 		databaseConnector.s51Advice.findMany.mockResolvedValueOnce([1]).mockResolvedValueOnce([]);
 		databaseConnector.s51Advice.update.mockResolvedValue(validS51AdviceUpdated);

--- a/apps/api/src/server/applications/s51advice/__tests__/s51-advice.test.js
+++ b/apps/api/src/server/applications/s51advice/__tests__/s51-advice.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import { request } from '../../../app-test.js';
+import { request } from '#app-test';
 import { applicationFactoryForTests } from '#utils/application-factory-for-tests.js';
 import { EventType } from '@pins/event-client';
 import { NSIP_S51_ADVICE } from '#infrastructure/topics.js';
@@ -67,13 +67,40 @@ const inValidS51AdviceBody = {
 	adviceDetails: 'adviceDetails'
 };
 
-const application1 = applicationFactoryForTests({
+const applicationBase = applicationFactoryForTests({
 	id: 100000000,
 	reference: 'BC0110001',
 	title: 'BC010001 - NI Case 1 Name',
 	description: 'BC010001 - NI Case 1 Name Description',
 	caseStatus: 'pre-application'
 });
+const application1 = {
+	...applicationBase,
+	ApplicationDetails: {
+		id: 100000000,
+		caseId: 1,
+		subSectorId: 1,
+		locationDescription: null,
+		zoomLevelId: 4,
+		caseEmail: null,
+		subSector: {
+			id: 1,
+			abbreviation: 'BC01',
+			name: 'office_use',
+			displayNameEn: 'Office Use',
+			displayNameCy: 'Office Use',
+			sectorId: 1,
+			sector: {
+				id: 1,
+				abbreviation: 'BC',
+				name: 'business_and_commercial',
+				displayNameEn: 'Business and Commercial',
+				displayNameCy: 'Business and Commercial'
+			}
+		}
+	}
+};
+
 const s51AdvicesInApplication1Count = 1;
 
 const s51AdvicesOnCase1 = [

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -31,7 +31,7 @@ import * as caseRepository from '#repositories/case.repository.js';
 import * as documentRepository from '#repositories/document.repository.js';
 import {
 	makeDocumentReference,
-	obtainURLsForDocuments
+	createDocuments
 } from './../application/documents/document.service.js';
 import BackOfficeAppError from '#utils/app-error.js';
 import { mapDateStringToUnixTimestamp } from '#utils/mapping/map-date-string-to-unix-timestamp.js';
@@ -202,8 +202,8 @@ export const addDocuments = async ({ params, body }, response) => {
 		nextReferenceIndex++;
 	}
 
-	// Obtain URLs for documents from blob storage
-	const { response: dbResponse, failedDocuments } = await obtainURLsForDocuments(
+	// create document records
+	const { response: dbResponse, failedDocuments } = await createDocuments(
 		filteredToUpload,
 		caseId,
 		true

--- a/apps/api/src/server/repositories/document-metadata.repository.js
+++ b/apps/api/src/server/repositories/document-metadata.repository.js
@@ -87,21 +87,6 @@ export const updateDocumentPublishedStatus = ({ guid, status, version = 1, dateP
 };
 
 /**
- *  Hard-Deletes a document from the database based on its `guid`
- *
- * @async
- * @param {string} documentGuid
- * @returns {import('@prisma/client').PrismaPromise<Document>}
- */
-export const deleteDocument = (documentGuid) => {
-	return databaseConnector.document.delete({
-		where: {
-			guid: documentGuid
-		}
-	});
-};
-
-/**
 
  * Get a document metadata by documentGuid
  *
@@ -201,7 +186,7 @@ export const getAllByDocumentGuid = (guid) => {
  *
  * @param {string} documentGuid
  * @param {import('@pins/applications.api').Schema.DocumentVersionUpdateInput} documentDetails
- * @returns {import('@prisma/client').PrismaPromise<DocumentVersion>}
+ * @returns {import('@prisma/client').PrismaPromise<DocumentVersionWithDocument>}
  */
 export const update = (documentGuid, { version = 1, ...documentDetails }) => {
 	return databaseConnector.documentVersion.update({

--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -224,8 +224,7 @@ export const update = (documentId, documentDetails) => {
 };
 
 /**
- *  Deletes a document from the database based on its `guid`
- * TODO: check - this does an actual delete, not a soft delete, is that correct?
+ *  Soft-Deletes a document from the database based on its `guid`
  *
  * @async
  * @param {string} documentGuid


### PR DESCRIPTION
## Describe your changes
## A better replacement for the failed commit of BOAS-1431
(bad commit here: https://github.com/Planning-Inspectorate/back-office/pull/2105)

Ensure events are broadcast for NSIP Documents, for all CRUD action and other changes

- create event broadcast and and tests added - works for Normal docs and S51 Advice docs
- update event broadcast and tests for:
-- new doc version
-- normal metatdata property updates
-- status and redaction status changes
-- reverting document publish status
-- publishing
- delete - event broadcast and tests added
- Also refactored some document records function names

## BOAS-1431 Event Broadcasts for NSIP Documents
https://pins-ds.atlassian.net/browse/BOAS-1431

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
