### PR TITLE
fix(applications/api): unable to publish the document due to errors (BOAS-1527)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -891,7 +891,10 @@ export const handleUpdateDocuments = async (guids, publishedStatus, redactedStat
 			}
 		}, updatedDocuments)
 	).map(buildNsipDocumentPayload);
-	await eventClient.sendEvents(NSIP_DOCUMENT, events, EventType.Update);
+
+	if (events.length) {
+		await eventClient.sendEvents(NSIP_DOCUMENT, events, EventType.Update);
+	}
 
 	return { errors, results };
 };


### PR DESCRIPTION
## Describe your changes

- Amended the document service to make sure there are nsip-document events (not created when training) before attempting to send them.
- Amended unit tests to include a training case as well as a non-training case too prove the changes work.
- Manually tested updating a document status to "ready to publish" for both a training case and a non-training case.

## BOAS-1527 Unable to published the document with caseofficer admin/inspector user due to an error
https://pins-ds.atlassian.net/browse/BOAS-1527

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
