### PR TITLE
feat(applications): add event broadcasts nsip-project case team (BOAS-1434)

### DIFF
--- a/apps/api/src/database/schema.prisma
+++ b/apps/api/src/database/schema.prisma
@@ -32,6 +32,7 @@ model Case {
   ExaminationTimetable  ExaminationTimetable?
   ProjectUpdate         ProjectUpdate[]
   S51Advice             S51Advice[]
+  ProjectTeam           ProjectTeam[]
 }
 
 // ServiceUser model which represents a person or oranisation who can have some role in a case
@@ -539,6 +540,7 @@ model ProjectTeam {
   userId    String
   role      String
   createdAt DateTime @default(now())
+  case      Case     @relation(fields: [caseId], references: [id])
 
   @@id([caseId, userId])
 }

--- a/apps/api/src/server/applications/application/application.service.js
+++ b/apps/api/src/server/applications/application/application.service.js
@@ -114,7 +114,7 @@ export const startApplication = async (id) => {
 		throw new Error('Case does not exist');
 	}
 
-	await broadcastNsipProjectEvent(updatedCase, EventType.Update, true);
+	await broadcastNsipProjectEvent(updatedCase, EventType.Update, { isCaseStart: true });
 
 	return {
 		id: updatedCase.id,

--- a/apps/api/src/server/applications/project-team/__tests__/project-team.test.js
+++ b/apps/api/src/server/applications/project-team/__tests__/project-team.test.js
@@ -1,7 +1,9 @@
 import { jest } from '@jest/globals';
-import { request } from '../../../app-test.js';
+import { request } from '#app-test';
+import { databaseConnector } from '#utils/database-connector.js';
+import { omit } from 'lodash-es';
 
-const { databaseConnector } = await import('#utils/database-connector.js');
+const { eventClient } = await import('#infrastructure/event-client.js');
 
 const projectTeamInDatabase = [
 	{
@@ -18,7 +20,53 @@ const projectTeamInDatabase = [
 	}
 ];
 
+const projectInDatabase = {
+	id: 1,
+	reference: 'REF',
+	applicantId: undefined,
+	description: 'DESC',
+	title: 'NAME',
+	sourceSystem: 'back-office-applications',
+	ProjectTeam: projectTeamInDatabase
+};
+
+const teamMembers = {
+	operationsLeadId: null,
+	operationsManagerId: null,
+	caseManagerId: null,
+	nsipOfficerIds: [],
+	nsipAdministrationOfficerIds: [],
+	leadInspectorId: null,
+	inspectorIds: [],
+	environmentalServicesOfficerId: null,
+	legalOfficerId: null
+};
+
+const expectedNSIPProjectEvent = (() => {
+	const {
+		id: caseId,
+		reference: caseReference,
+		description: projectDescription,
+		title: projectName,
+		...rest
+	} = projectInDatabase;
+	return {
+		...omit(rest, 'ProjectTeam'),
+		caseId,
+		caseReference,
+		projectName,
+		projectDescription,
+		publishStatus: 'unpublished',
+		...teamMembers,
+		inspectorIds: ['hilmn6789']
+	};
+})();
+
 describe('Test Project team members', () => {
+	beforeAll(() => {
+		databaseConnector.case.findUnique.mockResolvedValue(projectInDatabase);
+	});
+
 	afterAll(() => {
 		jest.resetAllMocks();
 	});
@@ -38,7 +86,7 @@ describe('Test Project team members', () => {
 		});
 	});
 
-	test('Project team members beloging to a case are returned', async () => {
+	test('Project team members belonging to a case are returned', async () => {
 		databaseConnector.projectTeam.findMany.mockResolvedValue(projectTeamInDatabase);
 
 		// WHEN
@@ -58,6 +106,8 @@ describe('Test Project team members', () => {
 				createdAt: '2023-11-17T14:43:49.808Z'
 			}
 		]);
+
+		expect(databaseConnector.projectTeam.findMany).toHaveBeenCalledTimes(1);
 	});
 
 	test('Team member is removed from project', async () => {
@@ -69,6 +119,28 @@ describe('Test Project team members', () => {
 			.send({ userId: 'abcdef1234' });
 
 		expect(response.status).toEqual(200);
+		expect(response.body).toEqual({
+			caseId: 1,
+			userId: 'abcdef1234',
+			role: 'officer',
+			createdAt: '2023-11-17T14:43:42.773Z'
+		});
+
 		expect(databaseConnector.projectTeam.delete).toHaveBeenCalledTimes(1);
+		expect(databaseConnector.projectTeam.delete).toHaveBeenCalledWith({
+			where: {
+				caseId_userId: {
+					userId: 'abcdef1234',
+					caseId: 1
+				}
+			}
+		});
+
+		expect(eventClient.sendEvents).toHaveBeenCalledTimes(1);
+		expect(eventClient.sendEvents).toHaveBeenCalledWith(
+			'nsip-project',
+			[expectedNSIPProjectEvent],
+			'Update'
+		);
 	});
 });

--- a/apps/api/src/server/applications/project-team/project-team.controller.js
+++ b/apps/api/src/server/applications/project-team/project-team.controller.js
@@ -1,6 +1,9 @@
 import * as projectTeamRepository from '#repositories/project-team.repository.js';
 import BackOfficeAppError from '#utils/app-error.js';
 import { mapProjectTeamMember, mapProjectTeamMembers } from '#utils/mapping/map-project-team.js';
+import * as caseRepository from '#repositories/case.repository.js';
+import { broadcastNsipProjectEvent } from '#infrastructure/event-broadcasters.js';
+import { EventType } from '@pins/event-client';
 
 /**
  * @type {import('express').RequestHandler}
@@ -42,13 +45,15 @@ export const updateProjectTeamMemberRole = async ({ params, body }, response) =>
 	const { role } = body;
 
 	const projectTeamMember = await projectTeamRepository.upsert(userId, Number(id), role);
+	const project = await caseRepository.getById(id, { projectTeam: true });
 
-	if (!projectTeamMember) {
+	if (!projectTeamMember || !project) {
 		throw new BackOfficeAppError(
 			`An error occured during the upsert of user id ${userId} for the case ${id}`,
 			500
 		);
 	}
+	await broadcastNsipProjectEvent(project, EventType.Update);
 
 	response.send(mapProjectTeamMember(projectTeamMember));
 };
@@ -59,6 +64,12 @@ export const updateProjectTeamMemberRole = async ({ params, body }, response) =>
 export const removeProjectTeamMember = async ({ params, body }, response) => {
 	const { id } = params;
 	const { userId } = body;
+
+	const project = await caseRepository.getById(id, { projectTeam: true });
+
+	if (!project) {
+		throw new BackOfficeAppError(`Error while removing user ${userId} for the case ${id}`, 500);
+	}
 
 	const projectTeamMember = await projectTeamRepository.getByUserIdRelatedToCaseId(
 		userId,
@@ -74,6 +85,9 @@ export const removeProjectTeamMember = async ({ params, body }, response) => {
 
 	try {
 		await projectTeamRepository.remove(userId, Number(id));
+
+		project.ProjectTeam = project.ProjectTeam.filter((member) => member.userId !== userId);
+		await broadcastNsipProjectEvent(project, EventType.Update);
 
 		response.send(projectTeamMember);
 	} catch {

--- a/apps/api/src/server/infrastructure/event-broadcasters.js
+++ b/apps/api/src/server/infrastructure/event-broadcasters.js
@@ -18,9 +18,9 @@ const applicant = 'Applicant';
  *
  * @param {import('@pins/applications.api').Schema.Case} project
  * @param {string} eventType
- * @param {boolean} [isCaseStart]
+ * @param {object} [options]
  */
-export const broadcastNsipProjectEvent = async (project, eventType, isCaseStart = false) => {
+export const broadcastNsipProjectEvent = async (project, eventType, options = {}) => {
 	try {
 		await verifyNotTraining(project.id);
 	} catch (/** @type {*} */ err) {
@@ -41,7 +41,7 @@ export const broadcastNsipProjectEvent = async (project, eventType, isCaseStart 
 		);
 	}
 
-	if (isCaseStart) {
+	if (options?.isCaseStart) {
 		// We can safely call get all by case as it will only be the folders we have created.
 		const caseFolders = await getAllByCaseId(project.id);
 		await eventClient.sendEvents(

--- a/apps/api/src/server/infrastructure/payload-builders/nsip-project.js
+++ b/apps/api/src/server/infrastructure/payload-builders/nsip-project.js
@@ -12,7 +12,9 @@ export const buildNsipProjectPayload = (projectEntity) => {
 
 	const sectorAndType = mapSectorAndType(projectEntity);
 
-  // @ts-ignore
+	const projectTeam = mapProjectTeam(projectEntity);
+
+	// @ts-ignore
 	return {
 		caseId: projectEntity.id,
 		caseReference: projectEntity.reference ?? undefined,
@@ -23,10 +25,7 @@ export const buildNsipProjectPayload = (projectEntity) => {
 		...application,
 		...sectorAndType,
 		applicantId: projectEntity.applicant?.id?.toString(),
-		// TODO: Will be added with Case Involvement work
-		nsipOfficerIds: [],
-		nsipAdministrationOfficerIds: [],
-		inspectorIds: []
+		...projectTeam
 	};
 };
 
@@ -93,4 +92,79 @@ const mapSectorAndType = (projectEntity) => {
 		sector: `${sectorAbbreviation} - ${sectorName}`,
 		projectType: `${subSectorAbbreviation} - ${subSectorName}`
 	};
+};
+
+/**
+ * @param {import('@pins/applications.api').Schema.Case} projectEntity
+ * @returns { {
+ * operationsLeadId: number | null,
+ * operationsManagerId: number | null,
+ * caseManagerId: number | null,
+ * nsipOfficerIds: number[],
+ * nsipAdministrationOfficerIds: number[],
+ * leadInspectorId: number | null,
+ * inspectorIds: number[],
+ * environmentalServicesOfficerId: number | null,
+ * legalOfficerId: number | null } | {
+ * nsipOfficerIds: number[],
+ * nsipAdministrationOfficerIds: number[],
+ * inspectorIds: number[],
+ * }}
+ */
+const mapProjectTeam = (projectEntity) => {
+	const projectTeam = projectEntity?.ProjectTeam;
+
+	if (!projectTeam) {
+		return {
+			nsipOfficerIds: [],
+			nsipAdministrationOfficerIds: [],
+			inspectorIds: []
+		};
+	}
+
+	const teamMembers = {
+		operationsLeadId: null,
+		operationsManagerId: null,
+		caseManagerId: null,
+		nsipOfficerIds: [],
+		nsipAdministrationOfficerIds: [],
+		leadInspectorId: null,
+		inspectorIds: [],
+		environmentalServicesOfficerId: null,
+		legalOfficerId: null
+	};
+
+	projectTeam.forEach((member) => {
+		switch (member.role) {
+			case 'operations_lead':
+				teamMembers.operationsLeadId = member.userId;
+				break;
+			case 'operations_manager':
+				teamMembers.operationsManagerId = member.userId;
+				break;
+			case 'case_manager':
+				teamMembers.caseManagerId = member.userId;
+				break;
+			case 'NSIP_officer':
+				teamMembers.nsipOfficerIds.push(member.userId);
+				break;
+			case 'NSIP_administration_officer':
+				teamMembers.nsipAdministrationOfficerIds.push(member.userId);
+				break;
+			case 'lead_inspector':
+				teamMembers.leadInspectorId = member.userId;
+				break;
+			case 'inspector':
+				teamMembers.inspectorIds.push(member.userId);
+				break;
+			case 'environmental_services':
+				teamMembers.environmentalServicesOfficerId = member.userId;
+				break;
+			case 'legal_officer':
+				teamMembers.legalOfficerId = member.userId;
+				break;
+		}
+	});
+
+	return teamMembers;
 };

--- a/apps/api/src/server/repositories/case.repository.js
+++ b/apps/api/src/server/repositories/case.repository.js
@@ -410,7 +410,8 @@ export const publishCase = async ({ caseId }) => {
 		caseStatus: true,
 		casePublishedState: true,
 		applicant: true,
-		gridReference: true
+		gridReference: true,
+		projectTeam: true
 	});
 };
 
@@ -439,14 +440,15 @@ export const unpublishCase = async ({ caseId }) => {
 		caseStatus: true,
 		casePublishedState: true,
 		applicant: true,
-		gridReference: true
+		gridReference: true,
+		projectTeam: true
 	});
 };
 
 /**
  *
  * @param {number} id
- * @param {{subSector?: boolean, sector?: boolean, applicationDetails?: boolean, zoomLevel?: boolean, regions?: boolean, caseStatus?: boolean, casePublishedState?: boolean, applicant?: boolean, gridReference?: boolean}} inclusions
+ * @param {{subSector?: boolean, sector?: boolean, applicationDetails?: boolean, zoomLevel?: boolean, regions?: boolean, caseStatus?: boolean, casePublishedState?: boolean, applicant?: boolean, gridReference?: boolean, projectTeam?: boolean}} inclusions
  * @returns {import('@prisma/client').PrismaPromise<import('@pins/applications.api').Schema.Case | null>}
  */
 export const getById = (
@@ -460,7 +462,8 @@ export const getById = (
 		caseStatus = false,
 		casePublishedState = false,
 		applicant = false,
-		gridReference = false
+		gridReference = false,
+		projectTeam = false
 	}
 ) => {
 	return databaseConnector.case.findUnique({
@@ -472,7 +475,8 @@ export const getById = (
 			regions ||
 			caseStatus ||
 			casePublishedState ||
-			applicant) && {
+			applicant ||
+			projectTeam) && {
 			include: {
 				...((applicationDetails || subSector || zoomLevel || regions || sector) && {
 					ApplicationDetails: {
@@ -490,7 +494,8 @@ export const getById = (
 				...(applicant && {
 					applicant: { include: { address: true } }
 				}),
-				...(gridReference && { gridReference: true })
+				...(gridReference && { gridReference: true }),
+				...(projectTeam && { ProjectTeam: { orderBy: { createdAt: 'desc' } } })
 			}
 		})
 	});

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -132,3 +132,23 @@ AZURE_BLOB_STORE_ACCOUNT_KEY=
 FEATURE_FLAG_BOAS_10_TEST_FEATURE= "true"
 
 
+
+## Development #################################################################
+
+
+# Optional location of a json file containing dummy AD user data when AUTH_DISABLED=true.
+#
+# An example of one user in the file is as follows:
+# [
+#   {
+#     "id": "8ada869a-d397-4656-bd99-bea186e0ba6e",
+#     "surname": "Doe",
+#     "givenName": "John",
+#     "userPrincipalName": "john.doe@example.com"
+#   }
+# ]
+#
+# Make sure to create the json file in a temp folder (as below in the example) as it will not be checked in with your branch.
+#
+DUMMY_USER_DATA="/temp/dummy_user_data.json"
+

--- a/apps/web/environment/config.d.ts
+++ b/apps/web/environment/config.d.ts
@@ -64,6 +64,7 @@ export interface EnvironmentConfig extends BaseEnvironmentConfig {
 	featureFlags: {
 		[key: string]: boolean;
 	};
+	dummyUserData: string;
 }
 
 export function loadConfig(): EnvironmentConfig;

--- a/apps/web/environment/config.js
+++ b/apps/web/environment/config.js
@@ -50,7 +50,8 @@ export function loadConfig() {
 		SSL_CERT_FILE,
 		SSL_KEY_FILE,
 		RETRY_MAX_ATTEMPTS,
-		RETRY_STATUS_CODES
+		RETRY_STATUS_CODES,
+		DUMMY_USER_DATA
 	} = environment;
 
 	const config = {
@@ -96,7 +97,8 @@ export function loadConfig() {
 		// set Feature Flag default val here [default: false] - will be overwritted by values cming from the .env file
 		featureFlags: {
 			featureFlagBoas1TestFeature: FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
-		}
+		},
+		dummyUserData: (AUTH_DISABLED && DUMMY_USER_DATA) || ''
 	};
 
 	const { value: validatedConfig, error } = schema.validate(config);

--- a/apps/web/environment/schema.js
+++ b/apps/web/environment/schema.js
@@ -65,6 +65,7 @@ export default baseSchema
 					.options({ presence: 'required' })
 			})
 			.options({ presence: 'required' }),
-		featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean())
+		featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean()),
+		dummyUserData: joi.optional()
 	})
 	.options({ presence: 'required' }); // all required by default

--- a/apps/web/src/server/applications/case/project-team/application-project-team.azure-service.js
+++ b/apps/web/src/server/applications/case/project-team/application-project-team.azure-service.js
@@ -3,6 +3,8 @@ import { fetchFromCache, storeInCache } from '../../../lib/cache-handler.js';
 import HttpError from '../../../lib/http-error.js';
 import { msGraphGet } from '../../../lib/msGraphRequest.js';
 import config from '@pins/applications.web/environment/config.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 
 /** @typedef {import('../../applications.types.js').ProjectTeamMember} ProjectTeamMember */
 /** @typedef {import('@pins/express').ValidationErrors} ValidationErrors */
@@ -79,6 +81,29 @@ export const getAllADUsers = async (ADToken) => {
 };
 
 /**
+ * Retrieve Azure Directory Users via the execution of a ms graph api request unless the environment is development and dummy user data is available
+ *
+ * @param {SessionWithAuth} session
+ * @returns {Promise<ProjectTeamMember[]>}
+ */
+const getAzureDirectoryUsers = async (session) => {
+	if (config.authDisabled) {
+		// In development only, do not trigger any Azure request
+		if (config.authDisabled) {
+			if (config.dummyUserData) {
+				// In development only, use dummy user data if available
+				const dummyUserDataFile = path.join(process.cwd(), config.dummyUserData);
+				return JSON.parse(await fs.readFile(dummyUserDataFile, 'utf8'));
+			}
+			return [];
+		}
+		const token = await getTokenOrFail(session);
+		return (await getAllADUsers(token)) || [];
+	}
+	return [];
+};
+
+/**
  * Retrieve all Azure Directory Users from cache or execute ms graph api request if cache empty
  *
  * @param {SessionWithAuth} session
@@ -87,6 +112,10 @@ export const getAllADUsers = async (ADToken) => {
 const getAllCachedUsers = async (session) => {
 	if (config.authDisabled) {
 		// In development only, do not trigger any Azure request
+		if (config.dummyUserData) {
+			const dummyUserDataFile = path.join(process.cwd(), config.dummyUserData);
+			return JSON.parse(await fs.readFile(dummyUserDataFile, 'utf8'));
+		}
 		return [];
 	}
 
@@ -96,9 +125,7 @@ const getAllCachedUsers = async (session) => {
 
 	if (!cachedUsers) {
 		try {
-			const token = await getTokenOrFail(session);
-
-			cachedUsers = (await getAllADUsers(token)) || [];
+			cachedUsers = await getAzureDirectoryUsers(session);
 		} catch (/** @type {*} */ error) {
 			throw new HttpError(
 				`[GRAPH MICROSOFT API] ${error?.response?.body?.error?.code || 'Unknown error'}`,


### PR DESCRIPTION
## Describe your changes

- Added a relation between Case and ProjectTeam in the prisma schema.
- Added an option to retrieve the related project team when getting the case data from the db.
- Amended building the nsip-project event data to include the project team data when available.
- Updated the api unit tests to support the changes.
- Added the ability to simulate the AD user data with dummy user data to make it easier to develop locally where AD is unavailable.

I have also tested the functionality above manually.
Reseeding has been tested to make sure it is unaffected.

## BOAS-1434 Add Event Broadcasts - nsip-project case team
https://pins-ds.atlassian.net/browse/BOAS-1434

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
