### PR TITLE
fix(appeals/web): BOAT-843 clicking on "back to your list" navigates to national list as opposed to personal list on Appeal Closed page

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/__snapshots__/change-appeal-type.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/__snapshots__/change-appeal-type.test.js.snap
@@ -396,7 +396,7 @@ exports[`change-appeal-type POST /change-appeal-type/confirm-resubmit should re-
                 </div>
                 <p class="govuk-body">The appellant has been emailed to ask them to resubmit their appeal with
                     the correct type.</p>
-                <p class="govuk-body">You can go <a href="/appeals-service/appeals-list" class="govuk-link">back to your list</a> or
+                <p class="govuk-body">You can go <a href="/appeals-service/personal-list" class="govuk-link">back to your list</a> or
                     <a                     href="/appeals-service/appeal-details/1" class="govuk-link">view the closed case</a>.</p>
             </div>
         </div>

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.mapper.js
@@ -373,7 +373,7 @@ export function resubmitConfirmationPage(appealData) {
 			{
 				type: 'html',
 				parameters: {
-					html: `<p class="govuk-body">You can go <a href="/appeals-service/appeals-list" class="govuk-link">back to your list</a> or <a href="/appeals-service/appeal-details/${appealData.appealId}" class="govuk-link">view the closed case</a>.</p>`
+					html: `<p class="govuk-body">You can go <a href="/appeals-service/personal-list" class="govuk-link">back to your list</a> or <a href="/appeals-service/appeal-details/${appealData.appealId}" class="govuk-link">view the closed case</a>.</p>`
 				}
 			}
 		]


### PR DESCRIPTION
## Describe your changes

[BOAT-843](https://pins-ds.atlassian.net/browse/BOAT-843)

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes



[BOAT-843]: https://pins-ds.atlassian.net/browse/BOAT-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ