### PR TITLE
fix(applications/web): prevent duplicate unique roles in a project team (BOAS-1553)

### DIFF
--- a/apps/web/src/server/applications/applications.types.d.ts
+++ b/apps/web/src/server/applications/applications.types.d.ts
@@ -183,6 +183,7 @@ export interface ProjectTeamMember {
 	givenName: string;
 	surname: string;
 	id: string;
+	role: string;
 	// userPrincipalName is the email
 	userPrincipalName: string;
 }

--- a/apps/web/src/server/applications/case/project-team/__tests__/__snapshots__/applications-project-team.test.js.snap
+++ b/apps/web/src/server/applications/case/project-team/__tests__/__snapshots__/applications-project-team.test.js.snap
@@ -66,6 +66,67 @@ exports[`Project team Choose role page GET /case/123/project-team/1/choose-role 
 </main>"
 `;
 
+exports[`Project team Choose role page GET /case/123/project-team/1/choose-role should render the page with the name of the NEW user, no default option and no Case Manager option 1`] = `
+"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
+    <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-5\\"><span class=\\"govuk-caption-l\\"> Do
+			Do</span> Choose role</h1>
+    <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"govuk-!-margin-top-6\\">
+        <div class=\\"govuk-form-group\\">
+            <div class=\\"govuk-radios\\" data-module=\\"govuk-radios\\">
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"environmental_services\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role\\">Environmental Services</label>
+                </div>
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role-2\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"inspector\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role-2\\">Inspector</label>
+                </div>
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role-3\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"lead_inspector\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role-3\\">Lead Inspector</label>
+                </div>
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role-4\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"legal_officer\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role-4\\">Legal Officer</label>
+                </div>
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role-5\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"NSIP_administration_officer\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role-5\\">NSIP Administration Officer</label>
+                </div>
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role-6\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"NSIP_officer\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role-6\\">NSIP Officer</label>
+                </div>
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role-7\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"officer\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role-7\\">Officer</label>
+                </div>
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role-8\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"operations_lead\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role-8\\">Operations Lead</label>
+                </div>
+                <div class=\\"govuk-radios__item\\">
+                    <input class=\\"govuk-radios__input\\" id=\\"role-9\\" name=\\"role\\" type=\\"radio\\"
+                    value=\\"operations_manager\\">
+                    <label class=\\"govuk-label govuk-radios__label\\" for=\\"role-9\\">Operations Manager</label>
+                </div>
+            </div>
+        </div>
+        <button class=\\"govuk-button govuk-!-margin-top-4\\" data-module=\\"govuk-button\\">Save and return</button>
+        <button type=\\"submit\\" formaction=\\"?toSearchPage=1\\"
+        class=\\"govuk-button govuk-button--secondary govuk-!-margin-left-2 govuk-!-margin-top-4\\">Save and add another</button>
+    </form>
+</main>"
+`;
+
 exports[`Project team Choose role page GET /case/123/project-team/1/choose-role should render the page with the name of the existing user and default option 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-5\\"><span class=\\"govuk-caption-l\\"> Do
@@ -344,7 +405,7 @@ exports[`Project team List page GET /case/123/project-team/ should render the pa
                 </thead>
                 <tbody class=\\"govuk-table__body\\">
                     <tr class=\\"govuk-table__row\\">
-                        <td class=\\"govuk-table__cell\\"><strong></strong>
+                        <td class=\\"govuk-table__cell\\"><strong>Inspector</strong>
                         </td>
                         <td class=\\"govuk-table__cell\\">Do Do</td>
                         <td class=\\"govuk-table__cell\\"><a class='govuk-link govuk-!-margin-right-3' href='/applications-service/case/123/project-team/1/choose-role'>Change role </a>

--- a/apps/web/src/server/applications/case/project-team/__tests__/applications-project-team.test.js
+++ b/apps/web/src/server/applications/case/project-team/__tests__/applications-project-team.test.js
@@ -150,6 +150,9 @@ describe('Project team', () => {
 		describe('GET /case/123/project-team/1/choose-role', () => {
 			it('should render the page with the name of the NEW user and no default option', async () => {
 				nock('http://test/').get('/applications/123/project-team/1').reply(500, {});
+				nock('http://test/')
+					.get('/applications/123/project-team')
+					.reply(200, [{ userId: '3' }]);
 				installMockADToken(fixtureProjectTeamMembers);
 
 				const response = await request.get(`${baseUrl}/1/choose-role`);
@@ -157,6 +160,30 @@ describe('Project team', () => {
 
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).not.toContain('checked');
+				expect(element.innerHTML).toContain('case_manager');
+				expect(element.innerHTML).toContain('inspector');
+				expect(element.innerHTML).toContain('Choose role');
+				expect(element.innerHTML).toContain(fixtureProjectTeamMembers[0].givenName);
+				expect(element.innerHTML).toContain('another');
+			});
+
+			it('should render the page with the name of the NEW user, no default option and no Case Manager option', async () => {
+				nock('http://test/').get('/applications/123/project-team/1').reply(500, {});
+				nock('http://test/')
+					.get('/applications/123/project-team')
+					.reply(200, [
+						{ userId: '3', role: 'case_manager' },
+						{ userId: '5', role: 'inspector' }
+					]);
+				installMockADToken(fixtureProjectTeamMembers);
+
+				const response = await request.get(`${baseUrl}/1/choose-role`);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).not.toContain('checked');
+				expect(element.innerHTML).not.toContain('case_manager');
+				expect(element.innerHTML).toContain('inspector');
 				expect(element.innerHTML).toContain('Choose role');
 				expect(element.innerHTML).toContain(fixtureProjectTeamMembers[0].givenName);
 				expect(element.innerHTML).toContain('another');

--- a/apps/web/src/server/applications/case/project-team/application-project-team.azure-service.js
+++ b/apps/web/src/server/applications/case/project-team/application-project-team.azure-service.js
@@ -28,10 +28,10 @@ const getTokenOrFail = async (session) => {
 };
 
 /**
- *  Search the query in the azure Active Directory groups using Microsfot Graph REST API
+ *  Search the query in the azure Active Directory groups using Microsoft Graph REST API
  *
  * @param {string} ADToken
- * @returns {Promise<Array<ProjectTeamMember>>}
+ * @returns {Promise<Partial<ProjectTeamMember>[]>}
  */
 export const getAllADUsers = async (ADToken) => {
 	const containerGroupsIds = [
@@ -84,7 +84,7 @@ export const getAllADUsers = async (ADToken) => {
  * Retrieve Azure Directory Users via the execution of a ms graph api request unless the environment is development and dummy user data is available
  *
  * @param {SessionWithAuth} session
- * @returns {Promise<ProjectTeamMember[]>}
+ * @returns {Promise<Partial<ProjectTeamMember>[]>}
  */
 const getAzureDirectoryUsers = async (session) => {
 	if (config.authDisabled) {
@@ -104,7 +104,7 @@ const getAzureDirectoryUsers = async (session) => {
  * Retrieve all Azure Directory Users from cache or execute ms graph api request if cache empty
  *
  * @param {SessionWithAuth} session
- * @returns {Promise<ProjectTeamMember[]>}
+ * @returns {Promise<Partial<ProjectTeamMember>[]>}
  */
 const getAllCachedUsers = async (session) => {
 	const cacheName = `cache_applications_users`;

--- a/apps/web/src/server/applications/case/project-team/applications-project-team.controller.js
+++ b/apps/web/src/server/applications/case/project-team/applications-project-team.controller.js
@@ -1,8 +1,8 @@
 import projectTeamADService from './application-project-team.azure-service.js';
 import {
-	setSuccessBanner,
+	destroySuccessBanner,
 	getSuccessBanner,
-	destroySuccessBanner
+	setSuccessBanner
 } from '../../../applications/common/services/session.service.js';
 import {
 	getManyProjectTeamMembersInfo,
@@ -18,17 +18,42 @@ import {
 /** @typedef {import("../../../app/auth/auth-session.service.js").SessionWithAuth} SessionWithAuth */
 
 export const allRoles = [
-	{ value: 'case_manager', text: 'Case Manager' },
-	{ value: 'environmental_services', text: 'Environmental Services' },
-	{ value: 'inspector', text: 'Inspector' },
-	{ value: 'lead_inspector', text: 'Lead Inspector' },
-	{ value: 'legal_officer', text: 'Legal Officer' },
-	{ value: 'NSIP_administration_officer', text: 'NSIP Administration Officer' },
-	{ value: 'NSIP_officer', text: 'NSIP Officer' },
-	{ value: 'officer', text: 'Officer' },
-	{ value: 'operations_lead', text: 'Operations Lead' },
-	{ value: 'operations_manager', text: 'Operations Manager' }
+	{ value: 'case_manager', text: 'Case Manager', unique: true },
+	{ value: 'environmental_services', text: 'Environmental Services', unique: true },
+	{ value: 'inspector', text: 'Inspector', unique: false },
+	{ value: 'lead_inspector', text: 'Lead Inspector', unique: true },
+	{ value: 'legal_officer', text: 'Legal Officer', unique: true },
+	{ value: 'NSIP_administration_officer', text: 'NSIP Administration Officer', unique: false },
+	{ value: 'NSIP_officer', text: 'NSIP Officer', unique: false },
+	{ value: 'officer', text: 'Officer', unique: false },
+	{ value: 'operations_lead', text: 'Operations Lead', unique: true },
+	{ value: 'operations_manager', text: 'Operations Manager', unique: true }
 ];
+
+/**
+ * Returns available roles.
+ *
+ * Available roles include:
+ * - The role already assigned to the team member
+ * - The roles that can be assigned to multiple team members
+ * - The unassigned roles that cannot be assigned to multiple team members
+ *
+ * @param {Partial<ProjectTeamMember>} projectTeamMember
+ * @param {Partial<ProjectTeamMember>[]} projectTeamMembers
+ */
+function availableRoles(projectTeamMember, projectTeamMembers) {
+	const availableRoles = [projectTeamMember.role];
+
+	allRoles.forEach(({ value, unique }) => {
+		if (!unique || !projectTeamMembers.some((member) => member.role === value)) {
+			if (!availableRoles.includes(value)) {
+				availableRoles.push(value);
+			}
+		}
+	});
+
+	return allRoles.filter(({ value }) => availableRoles.includes(value));
+}
 
 /**
  * View all the project team members
@@ -67,11 +92,13 @@ export async function viewProjectTeamChooseRolePage({ params, session }, respons
 	const { caseId } = response.locals;
 	const { userId } = params;
 
+	const { projectTeamMembers = [] } = await getProjectTeamMembers(caseId);
+
 	const projectTeamMember = await getSingleProjectTeamMemberInfo(caseId, userId, session);
 
 	return response.render(`applications/case-project-team/project-team-choose-role.njk`, {
 		projectTeamMember,
-		allRoles
+		availableRoles: availableRoles(projectTeamMember, projectTeamMembers)
 	});
 }
 
@@ -137,11 +164,12 @@ export async function updateProjectTeamChooseRole(
 	}
 
 	if (validationErrors || apiErrors) {
+		const { projectTeamMembers = [] } = await getProjectTeamMembers(caseId);
 		const projectTeamMember = await getSingleProjectTeamMemberInfo(caseId, userId, session);
 
 		return response.render(`applications/case-project-team/project-team-choose-role.njk`, {
 			projectTeamMember,
-			allRoles,
+			availableRoles: availableRoles(projectTeamMember, projectTeamMembers),
 			errors: validationErrors || apiErrors
 		});
 	}
@@ -189,7 +217,7 @@ export async function viewProjectTeamSearchPage(
  * Search project team members and return results
  *
  * @param {string} searchTerm
- * @param {ProjectTeamMember[]} allAzureUsers
+ * @param {Partial<ProjectTeamMember>[]} allAzureUsers
  * @param {number} pageNumber
  * @param {number} caseId
  */

--- a/apps/web/src/server/applications/case/project-team/applications-project-team.controller.js
+++ b/apps/web/src/server/applications/case/project-team/applications-project-team.controller.js
@@ -42,17 +42,17 @@ export const allRoles = [
  * @param {Partial<ProjectTeamMember>[]} projectTeamMembers
  */
 function availableRoles(projectTeamMember, projectTeamMembers) {
-	const availableRoles = [projectTeamMember.role];
+	const rolesAvailable = [projectTeamMember.role];
 
 	allRoles.forEach(({ value, unique }) => {
 		if (!unique || !projectTeamMembers.some((member) => member.role === value)) {
-			if (!availableRoles.includes(value)) {
-				availableRoles.push(value);
+			if (!rolesAvailable.includes(value)) {
+				rolesAvailable.push(value);
 			}
 		}
 	});
 
-	return allRoles.filter(({ value }) => availableRoles.includes(value));
+	return allRoles.filter(({ value }) => rolesAvailable.includes(value));
 }
 
 /**

--- a/apps/web/src/server/applications/case/project-team/applications-project-team.service.js
+++ b/apps/web/src/server/applications/case/project-team/applications-project-team.service.js
@@ -4,13 +4,13 @@ import projectTeamADService from './application-project-team.azure-service.js';
 
 /** @typedef {import("../../../app/auth/auth-session.service.js").SessionWithAuth} SessionWithAuth */
 /** @typedef {import('../../applications.types').ProjectTeamMember} ProjectTeamMember */
-/** @typedef {import('../../applications.types').PaginatedResponse<ProjectTeamMember>} PaginatedProjectTeamMembers */
+/** @typedef {import('../../applications.types').PaginatedResponse<Partial<ProjectTeamMember>>} PaginatedProjectTeamMembers */
 
 /**
  * Retrieve the paginated list of the team members matching the query
  *
  * @param {string} searchTerm
- * @param {ProjectTeamMember[]} allAzureUsers
+ * @param {Partial<ProjectTeamMember>[]} allAzureUsers
  * @param {number} pageNumber
  * @returns {Promise<{results: PaginatedProjectTeamMembers}>}
  */

--- a/apps/web/src/server/views/applications/case-project-team/project-team-choose-role.njk
+++ b/apps/web/src/server/views/applications/case-project-team/project-team-choose-role.njk
@@ -35,7 +35,7 @@
 
 		{{ govukRadios({
 				name: "role",
-				items: allRoles | selectItems({valueKey: 'value', labelKey: 'text', selectedValue: projectTeamMember.role})
+				items: availableRoles | selectItems({valueKey: 'value', labelKey: 'text', selectedValue: projectTeamMember.role})
 
 			}) }}
 

--- a/apps/web/testing/app/mocks/project-team.js
+++ b/apps/web/testing/app/mocks/project-team.js
@@ -1,16 +1,17 @@
 import { jest } from '@jest/globals';
 import projectTeamADService from '../../../src/server/applications/case/project-team/application-project-team.azure-service.js';
+import { omit } from 'lodash-es';
 
 /** @typedef {import('../../../src/server/applications/applications.types').ProjectTeamMember} ProjectTeamMember */
 
 /**
  * Provide mocked value for the project team search page
  *
- * @param {ProjectTeamMember[]} mockedMembers
+ * @param {Partial<ProjectTeamMember>[]} mockedMembers
  */
 export const installMockADToken = (mockedMembers) => {
-	const mockGetMembers = () => Promise.resolve(mockedMembers);
+	const mockedADUsers = mockedMembers.map((mockedMember) => omit(mockedMember, 'role'));
 
-	jest.spyOn(projectTeamADService, 'getAllADUsers').mockImplementationOnce(mockGetMembers);
-	jest.spyOn(projectTeamADService, 'getAllCachedUsers').mockImplementationOnce(mockGetMembers);
+	jest.spyOn(projectTeamADService, 'getAllADUsers').mockResolvedValue(mockedADUsers);
+	jest.spyOn(projectTeamADService, 'getAllCachedUsers').mockResolvedValue(mockedADUsers);
 };

--- a/apps/web/testing/applications/factory/project-team.js
+++ b/apps/web/testing/applications/factory/project-team.js
@@ -20,10 +20,13 @@ export function createProjectTeamMember({ id = `${fake.createUniqueId()}` } = {}
 
 	const userPrincipalName = `${givenName}.${surname}@planninginspectorate.gov.uk`;
 
+	const role = 'inspector';
+
 	return {
 		givenName,
 		surname,
 		userPrincipalName,
-		id
+		id,
+		role
 	};
 }


### PR DESCRIPTION
## Describe your changes

- Make sure unique roles are not available in the choose/change role page when they have already been filled within the team.
- Update unit tests to handle and prove support of unique roles
- Manually tested the functionality

## BOAS-1553 Unique roles within a project team such as "Case manager" can be assigned to more than one member of the project team.
https://pins-ds.atlassian.net/browse/BOAS-1553

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
