### PR TITLE
Feature/boat 639

### DIFF
--- a/appeals/api/src/database/migrations/20240216141024_related_appeals/migration.sql
+++ b/appeals/api/src/database/migrations/20240216141024_related_appeals/migration.sql
@@ -1,0 +1,21 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[AppealRelationship] ADD [externaAppealType] NVARCHAR(1000),
+[externalSource] BIT,
+[type] NVARCHAR(1000) NOT NULL CONSTRAINT [AppealRelationship_type_df] DEFAULT 'linked';
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/appeals/api/src/database/schema.prisma
+++ b/appeals/api/src/database/schema.prisma
@@ -50,13 +50,20 @@ model Appeal {
   auditTrail                   AuditTrail[]
 }
 
+/// AppealRelationship table
+/// Stores case relationships, where at least one of the cases is on the beta system
+/// Both linked and related appeals are stored here
+/// Related appeals ignore the parent / child relationship
 model AppealRelationship {
-  id          Int      @id @default(autoincrement())
-  parentRef   String
-  childRef    String
-  parentId    Int?
-  childId     Int?
-  linkingDate DateTime @default(now())
+  id                Int      @id @default(autoincrement())
+  type              String   @default("linked") // or 'related' see endpoints/contants.js
+  parentRef         String
+  childRef          String
+  parentId          Int?
+  childId           Int?
+  externalSource    Boolean?
+  externaAppealType String?
+  linkingDate       DateTime @default(now())
 }
 
 /// AppealType model

--- a/appeals/api/src/database/seed/data-test.js
+++ b/appeals/api/src/database/seed/data-test.js
@@ -19,12 +19,13 @@ import {
 import isFPA from '#utils/is-fpa.js';
 import { calculateTimetable } from '#utils/business-days.js';
 import {
-	//APPEAL_TYPE_SHORTHAND_FPA,
 	APPEAL_TYPE_SHORTHAND_HAS,
 	STATE_TARGET_COMPLETE,
 	STATE_TARGET_ISSUE_DETERMINATION,
 	STATE_TARGET_READY_TO_START,
-	STATE_TARGET_ASSIGN_CASE_OFFICER
+	STATE_TARGET_ASSIGN_CASE_OFFICER,
+	CASE_RELATIONSHIP_LINKED,
+	CASE_RELATIONSHIP_RELATED
 } from '#endpoints/constants.js';
 
 import { mapDefaultCaseFolders } from '#endpoints/documents/documents.mapper.js';
@@ -57,34 +58,6 @@ function generateAppealReference() {
  * @returns {number}
  */
 const pickRandom = (list) => Math.floor(Math.random() * list.length);
-
-/**
- *
- * @param {string} lpaQuestionnaireAndInspectorPickupState
- * @param {string} statementsAndFinalCommentsState
- * @param {Date} createdAt
- * @returns {{status: string, createdAt: Date, subStateMachineName: string, compoundStateName: string}[]}
- */
-// const buildCompoundState = (
-// 	lpaQuestionnaireAndInspectorPickupState,
-// 	statementsAndFinalCommentsState,
-// 	createdAt = new Date()
-// ) => {
-// 	return [
-// 		{
-// 			status: lpaQuestionnaireAndInspectorPickupState,
-// 			createdAt,
-// 			subStateMachineName: 'lpaQuestionnaireAndInspectorPickup',
-// 			compoundStateName: 'awaiting_lpa_questionnaire_and_statements'
-// 		},
-// 		{
-// 			status: statementsAndFinalCommentsState,
-// 			createdAt,
-// 			subStateMachineName: 'statementsAndFinalComments',
-// 			compoundStateName: 'awaiting_lpa_questionnaire_and_statements'
-// 		}
-// 	];
-// };
 
 /**
  *
@@ -208,20 +181,6 @@ const newAppeals = [
 		siteAddressList: addressListForTrainers,
 		assignCaseOfficer: false
 	}),
-	/*
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	appealFactory({ typeShorthand: APPEAL_TYPE_SHORTHAND_FPA, assignCaseOfficer: false }),
-	*/
 	appealFactory({
 		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
 		statuses: { status: 'ready_to_start', createdAt: getDateTwoWeeksAgo() },
@@ -365,367 +324,9 @@ const appealsLpaQuestionnaireDue = [
 		siteAddressList: addressListForTrainers,
 		assignCaseOfficer: true
 	})
-	/*
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: buildCompoundState(
-			'lpa_questionnaire_due',
-			'available_for_statements',
-			getDateTwoWeeksAgo()
-		),
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	})
-	*/
 ];
 
-/*
-const appealsStatementReview = [
-
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'statement_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'statement_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'statement_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'statement_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'statement_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	})
-];
-
-const appealsFinalCommentReview = [
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'final_comment_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'final_comment_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'final_comment_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'final_comment_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_FPA,
-		statuses: { status: 'final_comment_review', valid: true },
-		completeValidationDecision: true,
-		completeReviewQuestionnaire: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(),
-		assignCaseOfficer: true
-	})
-];
-
-
-const appealsArrangeSiteVisit = [
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'lpa_questionnaire_due' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 3, 1, 10),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'lpa_questionnaire_due' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 4, 2, 10),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'lpa_questionnaire_due' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 5, 3, 10),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'lpa_questionnaire_due' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 6, 4, 9),
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'lpa_questionnaire_due' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 7, 5, 8),
-		assignCaseOfficer: true
-	})
-];
-
-const appealsIssueDetermination = [
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'issue_determination' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 4, 1, 11),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'issue_determination' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 5, 2, 10),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'issue_determination' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 6, 3, 9),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'issue_determination' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 7, 4, 8),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'issue_determination' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 8, 5, 7),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	})
-];
-
-const appealsComplete = [
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'complete' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 4, 1, 11),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'complete' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 5, 2, 10),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'complete' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 6, 3, 9),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'complete' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 7, 4, 8),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	}),
-	appealFactory({
-		typeShorthand: APPEAL_TYPE_SHORTHAND_HAS,
-		statuses: { status: 'complete' },
-		completeValidationDecision: true,
-		lpaQuestionnaire: true,
-		startedAt: new Date(2022, 8, 5, 7),
-		completeReviewQuestionnaire: true,
-		assignCaseOfficer: true
-	})
-];
-
-*/
-
-const appealsData = [
-	...newAppeals,
-	...appealsLpaQuestionnaireDue
-	//...appealsStatementReview,
-	//...appealsFinalCommentReview,
-	//...appealsArrangeSiteVisit,
-	//...appealsIssueDetermination,
-	//...appealsComplete
-];
+const appealsData = [...newAppeals, ...appealsLpaQuestionnaireDue];
 
 /**
  * @param {import('#db-client').PrismaClient} databaseConnector
@@ -784,37 +385,87 @@ export async function seedTestData(databaseConnector) {
 			parentRef: appeals[0].reference,
 			parentId: appeals[0].id,
 			childRef: appeals[1].reference,
-			childId: appeals[1].id
+			childId: appeals[1].id,
+			type: CASE_RELATIONSHIP_LINKED
 		},
 		{
 			parentRef: appeals[0].reference,
 			parentId: appeals[0].id,
 			childRef: appeals[2].reference,
-			childId: appeals[2].id
+			childId: appeals[2].id,
+			type: CASE_RELATIONSHIP_LINKED
 		},
 		{
 			parentRef: appeals[0].reference,
 			parentId: appeals[0].id,
 			childRef: appeals[16].reference,
-			childId: appeals[16].id
+			childId: appeals[16].id,
+			type: CASE_RELATIONSHIP_LINKED
 		},
-		{ parentRef: appeals[0].reference, parentId: appeals[0].id, childRef: '76215416' },
+		{
+			parentRef: appeals[0].reference,
+			parentId: appeals[0].id,
+			childRef: '76215416',
+			externalSource: true,
+			type: CASE_RELATIONSHIP_LINKED
+		},
 		{
 			parentRef: appeals[4].reference,
 			parentId: appeals[4].id,
 			childRef: appeals[19].reference,
-			childId: appeals[19].id
+			childId: appeals[19].id,
+			type: CASE_RELATIONSHIP_LINKED
 		},
 		{
 			parentRef: appeals[4].reference,
 			parentId: appeals[4].id,
 			childRef: appeals[20].reference,
-			childId: appeals[20].id
+			childId: appeals[20].id,
+			type: CASE_RELATIONSHIP_LINKED
 		},
-		{ parentRef: '96215416', childRef: appeals[21].reference, childId: appeals[21].id }
+		{
+			parentRef: '96215416',
+			childRef: appeals[21].reference,
+			childId: appeals[21].id,
+			externalSource: true,
+			type: CASE_RELATIONSHIP_LINKED
+		}
 	];
 
-	await databaseConnector.appealRelationship.createMany({ data: linkedAppeals });
+	const relatedAppeals = [
+		{
+			parentRef: appeals[11].reference,
+			parentId: appeals[11].id,
+			childRef: appeals[12].reference,
+			childId: appeals[12].id,
+			type: CASE_RELATIONSHIP_RELATED
+		},
+		{
+			parentRef: appeals[12].reference,
+			parentId: appeals[12].id,
+			childRef: appeals[13].reference,
+			childId: appeals[13].id,
+			type: CASE_RELATIONSHIP_RELATED
+		},
+		{
+			parentRef: appeals[0].reference,
+			parentId: appeals[0].id,
+			childRef: '76215416',
+			externalSource: true,
+			type: CASE_RELATIONSHIP_RELATED
+		},
+		{
+			parentRef: '96215416',
+			childRef: appeals[21].reference,
+			childId: appeals[21].id,
+			externalSource: true,
+			type: CASE_RELATIONSHIP_RELATED
+		}
+	];
+
+	await databaseConnector.appealRelationship.createMany({
+		data: [...linkedAppeals, ...relatedAppeals]
+	});
 
 	const appealTypes = await databaseConnector.appealType.findMany();
 	const appealStatus = await databaseConnector.appealStatus.findMany();

--- a/appeals/api/src/database/seed/seed-clear.js
+++ b/appeals/api/src/database/seed/seed-clear.js
@@ -58,6 +58,7 @@ export async function deleteAllRecords(databaseConnector) {
 	const deleteLPAQuestionnaireValidationOutcome =
 		databaseConnector.lPAQuestionnaireValidationOutcome.deleteMany();
 	const deleteAppealAllocationLevels = databaseConnector.appealAllocation.deleteMany();
+	const deleteAppealRelationships = databaseConnector.appealRelationship.deleteMany();
 	const deleteAppealSpecialisms = databaseConnector.appealSpecialism.deleteMany();
 	const deleteSpecialisms = databaseConnector.specialism.deleteMany();
 	const deleteLPAQUestionnaireIncompleteReason =
@@ -88,6 +89,7 @@ export async function deleteAllRecords(databaseConnector) {
 		deleteUsers,
 		deleteAppealAllocationLevels,
 		deleteAppealSpecialisms,
+		deleteAppealRelationships,
 		deleteAppellantCaseIncompleteReasonText,
 		deleteAppellantCaseIncompleteReasonOnAppellantCase,
 		deleteAppellantCaseInvalidReasonText,

--- a/appeals/api/src/server/endpoints/appeals.d.ts
+++ b/appeals/api/src/server/endpoints/appeals.d.ts
@@ -38,6 +38,16 @@ interface LinkedAppeal {
 	linkingDate: Date;
 	appealType?: string;
 	relationshipId: number;
+	externalSource: boolean;
+	externalAppealType?: string;
+}
+
+interface RelatedAppeal {
+	appealId: number | null;
+	appealReference: string;
+	linkingDate: Date;
+	relationshipId: number;
+	externalSource: boolean;
 }
 
 interface AppealSite {
@@ -91,6 +101,7 @@ interface RepositoryGetByIdResultItem {
 	resubmitTypeId?: number | null;
 	inspectorDecision?: Schema.InspectorDecision | null;
 	linkedAppeals: Schema.AppealRelationship[] | null;
+	relatedAppeals: Schema.AppealRelationship[] | null;
 	lpa: LPA;
 	lpaQuestionnaire: Schema.LPAQuestionnaire | null;
 	planningApplicationReference: string;
@@ -251,7 +262,7 @@ interface SingleAppealDetailsResponse {
 	isParentAppeal: boolean | null;
 	isChildAppeal: boolean | null;
 	linkedAppeals: LinkedAppeal[];
-	otherAppeals: string[];
+	otherAppeals: RelatedAppeal[];
 	localPlanningDepartment: string;
 	lpaQuestionnaireId: number | null;
 	neighbouringSite: {
@@ -672,6 +683,7 @@ export {
 	IncompleteInvalidReasons,
 	IncompleteInvalidReasonsResponse,
 	LinkedAppeal,
+	RelatedAppeal,
 	ListedBuildingDetailsResponse,
 	LookupTables,
 	NeighbouringSiteContactsResponse,

--- a/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
+++ b/appeals/api/src/server/endpoints/appeals/__tests__/appeals.test.js
@@ -747,7 +747,8 @@ describe('appeals routes', () => {
 							appealReference: a.childRef,
 							isParentAppeal: false,
 							linkingDate: a.linkingDate,
-							appealType: 'Unknown'
+							appealType: 'Unknown',
+							externalSource: true
 						};
 					}),
 					otherAppeals: [],
@@ -1468,95 +1469,106 @@ describe('mapAppealStatuses Tests', () => {
 });
 
 describe('getRelevantLinkedAppealIds Tests', () => {
-	const linkedAppeals = [
+	const moreLinkedAppeals = [
 		{
-			id: 1,
-			parentRef: 'TEST/396994',
-			childRef: 'TEST/100071',
+			id: 101,
+			parentRef: 'TEST-396994',
+			childRef: 'TEST-100071',
 			parentId: 1027,
 			childId: 1028,
 			linkingDate: new Date('2024-01-30T13:44:39.655Z'),
-			relationshipId: 101
+			type: 'linked',
+			externalSource: false
 		},
 		{
-			id: 2,
-			parentRef: 'TEST/396994',
-			childRef: 'TEST/123813',
+			id: 102,
+			parentRef: 'TEST-396994',
+			childRef: 'TEST-123813',
 			parentId: 1027,
 			childId: 1029,
 			linkingDate: new Date('2024-01-30T13:44:39.655Z'),
-			relationshipId: 102
+			type: 'linked',
+			externalSource: false
 		},
 		{
-			id: 3,
-			parentRef: 'TEST/396994',
-			childRef: 'TEST/864955',
+			id: 103,
+			parentRef: 'TEST-396994',
+			childRef: 'TEST-864955',
 			parentId: 1027,
 			childId: 1043,
 			linkingDate: new Date('2024-01-30T13:44:39.655Z'),
-			relationshipId: 103
+			type: 'linked',
+			externalSource: false
 		},
 		{
-			id: 4,
-			parentRef: 'TEST/396994',
+			id: 104,
+			parentRef: 'TEST-396994',
 			childRef: '76215416',
 			parentId: 1027,
 			childId: null,
 			linkingDate: new Date('2024-01-30T13:44:39.655Z'),
-			relationshipId: 104
+			type: 'linked',
+			externalSource: true
 		}
 	];
 
 	test('should return correct child IDs when current appeal is a parent', () => {
-		const currentAppealRef = 'TEST/396994';
-		const result = getRelevantLinkedAppealIds(linkedAppeals, currentAppealRef);
+		const currentAppealRef = 'TEST-396994';
+		// @ts-ignore
+		const result = getRelevantLinkedAppealIds(moreLinkedAppeals, currentAppealRef);
 		expect(result).toEqual([1028, 1029, 1043]);
 	});
 
 	test('should return correct parent ID when current appeal is a child', () => {
-		const currentAppealRef = 'TEST/100071';
-		const result = getRelevantLinkedAppealIds(linkedAppeals, currentAppealRef);
+		const currentAppealRef = 'TEST-100071';
+		// @ts-ignore
+		const result = getRelevantLinkedAppealIds(moreLinkedAppeals, currentAppealRef);
 		expect(result).toEqual([1027]);
 	});
 
 	test('should return an empty array when there are no linked appeals', () => {
 		const currentAppealRef = 'TEST/999999';
-		const result = getRelevantLinkedAppealIds(linkedAppeals, currentAppealRef);
+		// @ts-ignore
+		const result = getRelevantLinkedAppealIds(moreLinkedAppeals, currentAppealRef);
 		expect(result).toEqual([]);
 	});
 
 	test('should exclude linked appeals with null child IDs', () => {
 		const linkedAppealsWithNullChildId = [
-			...linkedAppeals,
+			...moreLinkedAppeals,
 			{
-				id: 5,
-				parentRef: 'TEST/396994',
-				childRef: 'TEST/100071',
+				id: 105,
+				parentRef: 'TEST-396994',
+				childRef: 'TEST-100071',
 				parentId: 1027,
 				childId: null,
 				linkingDate: new Date('2024-01-30T13:44:39.655Z'),
-				relationshipId: 105
+				type: 'linked',
+				externalSource: true
 			}
 		];
-		const currentAppealRef = 'TEST/396994';
+		const currentAppealRef = 'TEST-396994';
+		// @ts-ignore
 		const result = getRelevantLinkedAppealIds(linkedAppealsWithNullChildId, currentAppealRef);
 		expect(result).toEqual([1028, 1029, 1043]);
 	});
 
 	test('should exclude duplicate row ids in the output', () => {
 		const linkedAppealsWithDuplucate = [
-			...linkedAppeals,
+			...moreLinkedAppeals,
 			{
-				id: 5,
-				parentRef: 'TEST/396994',
-				childRef: 'TEST/100071',
+				id: 105,
+				parentRef: 'TEST-396994',
+				childRef: 'TEST-100071',
 				parentId: 1027,
 				childId: 1028,
 				linkingDate: new Date('2024-01-30T13:44:39.655Z'),
-				relationshipId: 105
+				type: 'linked',
+				externalSource: false
 			}
 		];
-		const currentAppealRef = 'TEST/396994';
+		const currentAppealRef = 'TEST-396994';
+		// @ts-ignore
 		const result = getRelevantLinkedAppealIds(linkedAppealsWithDuplucate, currentAppealRef);
 		expect(result).toEqual([1028, 1029, 1043]);
 	});

--- a/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
+++ b/appeals/api/src/server/endpoints/appeals/appeals.formatter.js
@@ -1,6 +1,6 @@
 import formatAddress from '#utils/format-address.js';
 import isFPA from '#utils/is-fpa.js';
-import formatLinkedAppeals from '#utils/format-linked-appeals.js';
+import { formatLinkedAppeals, formatRelatedAppeals } from '#utils/format-linked-appeals.js';
 import {
 	formatAppellantCaseDocumentationStatus,
 	formatLpaQuestionnaireDocumentationStatus
@@ -189,7 +189,7 @@ const formatAppeal = (
 					isRequired: appeal.lpaQuestionnaire?.doesSiteRequireInspectorAccess || null
 				}
 			},
-			otherAppeals: [],
+			otherAppeals: formatRelatedAppeals(appeal.relatedAppeals || [], appeal.id),
 			linkedAppeals: formatLinkedAppeals(
 				appeal.linkedAppeals || [],
 				appeal.reference,

--- a/appeals/api/src/server/endpoints/constants.js
+++ b/appeals/api/src/server/endpoints/constants.js
@@ -144,6 +144,9 @@ export const STATE_TYPE_FINAL = 'final';
 export const USER_TYPE_CASE_OFFICER = 'caseOfficer';
 export const USER_TYPE_INSPECTOR = 'inspector';
 
+export const CASE_RELATIONSHIP_LINKED = 'linked';
+export const CASE_RELATIONSHIP_RELATED = 'related';
+
 export const STATUSES = {
 	STATE_TARGET_COMPLETE,
 	STATE_TARGET_FINAL_COMMENT_REVIEW,
@@ -161,6 +164,7 @@ export const STATUSES = {
 
 // Static config
 export const CONFIG_BANKHOLIDAYS_FEED_URL = 'https://www.gov.uk/bank-holidays.json';
+
 export const CONFIG_APPEAL_TIMETABLE = {
 	W: {
 		lpaQuestionnaireDueDate: {

--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 import { azureAdUserId } from '#tests/shared/mocks.js';
 import { householdAppeal, linkedAppeals } from '#tests/appeals/mocks.js';
 import { linkedAppealRequest, linkedAppealLegacyRequest } from '#tests/linked-appeals/mocks.js';
+import { CASE_RELATIONSHIP_LINKED, CASE_RELATIONSHIP_RELATED } from '#endpoints/constants.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
 
@@ -11,108 +12,255 @@ describe('appeal linked appeals routes', () => {
 		jest.clearAllMocks();
 	});
 	describe('POST', () => {
-		test('returns 400 when the ID in the request is null', async () => {
-			// @ts-ignore
-			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-			// @ts-ignore
-			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+		describe('Linked appeals', () => {
+			test('returns 400 when the ID in the request is null', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
 
-			const response = await request
-				.post(`/appeals/${householdAppeal.id}/link-appeal`)
-				.send({
-					...linkedAppealRequest,
-					linkedAppealId: null
-				})
-				.set('azureAdUserId', azureAdUserId);
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/link-appeal`)
+					.send({
+						...linkedAppealRequest,
+						linkedAppealId: null
+					})
+					.set('azureAdUserId', azureAdUserId);
 
-			expect(response.status).toEqual(400);
+				expect(response.status).toEqual(400);
+			});
+
+			test('returns 400 when the ID in the request is not a number', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/link-appeal`)
+					.send({
+						...linkedAppealRequest,
+						linkedAppealId: 'a string'
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(400);
+			});
+
+			test('returns 404 when an internal appeal to link is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValueOnce(null);
+
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/link-appeal`)
+					.send({
+						...linkedAppealRequest,
+						linkedAppealId: 100
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(404);
+			});
+
+			test('returns 400 when an external appeal reference is empty', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/link-legacy-appeal`)
+					.send({
+						...linkedAppealLegacyRequest,
+						linkedAppealReference: ''
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(400);
+			});
+
+			test('returns 400 when an external appeal reference is null', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/link-legacy-appeal`)
+					.send({
+						...linkedAppealLegacyRequest,
+						linkedAppealReference: null
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(400);
+			});
+
+			test('returns 400 when an internal appeal is already a parent', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValueOnce(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValueOnce(linkedAppeals);
+
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/link-appeal`)
+					.send({
+						...linkedAppealRequest,
+						isCurrentAppealParent: false
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(400);
+			});
+
+			test('returns 200 when an external appeal reference is received', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/link-legacy-appeal`)
+					.send({
+						...linkedAppealLegacyRequest,
+						linkedAppealReference: '123456'
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(200);
+				expect(databaseConnector.appealRelationship.create).toHaveBeenCalledTimes(1);
+				expect(databaseConnector.appealRelationship.create).toHaveBeenCalledWith({
+					data: {
+						parentId: null,
+						parentRef: '123456',
+						childRef: householdAppeal.reference,
+						childId: householdAppeal.id,
+						type: CASE_RELATIONSHIP_LINKED,
+						externalSource: true
+					}
+				});
+			});
 		});
 
-		test('returns 400 when the ID in the request is not a number', async () => {
-			// @ts-ignore
-			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-			// @ts-ignore
-			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+		describe('Related appeals', () => {
+			test('returns 400 when the ID in the request is null', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
 
-			const response = await request
-				.post(`/appeals/${householdAppeal.id}/link-appeal`)
-				.send({
-					...linkedAppealRequest,
-					linkedAppealId: 'a string'
-				})
-				.set('azureAdUserId', azureAdUserId);
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/associate-appeal`)
+					.send({
+						...linkedAppealRequest,
+						linkedAppealId: null
+					})
+					.set('azureAdUserId', azureAdUserId);
 
-			expect(response.status).toEqual(400);
-		});
+				expect(response.status).toEqual(400);
+			});
 
-		test('returns 404 when an internal appeal to link is not found', async () => {
-			// @ts-ignore
-			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-			// @ts-ignore
-			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
-			// @ts-ignore
-			databaseConnector.appeal.findUnique.mockResolvedValueOnce(null);
+			test('returns 400 when the ID in the request is not a number', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
 
-			const response = await request
-				.post(`/appeals/${householdAppeal.id}/link-appeal`)
-				.send({
-					...linkedAppealRequest,
-					linkedAppealId: 100
-				})
-				.set('azureAdUserId', azureAdUserId);
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/associate-appeal`)
+					.send({
+						...linkedAppealRequest,
+						linkedAppealId: 'a string'
+					})
+					.set('azureAdUserId', azureAdUserId);
 
-			expect(response.status).toEqual(404);
-		});
+				expect(response.status).toEqual(400);
+			});
 
-		test('returns 400 when an external appeal reference is empty', async () => {
-			// @ts-ignore
-			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-			// @ts-ignore
-			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+			test('returns 404 when an internal appeal to link is not found', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValueOnce(null);
 
-			const response = await request
-				.post(`/appeals/${householdAppeal.id}/link-legacy-appeal`)
-				.send({
-					...linkedAppealLegacyRequest,
-					linkedAppealReference: ''
-				})
-				.set('azureAdUserId', azureAdUserId);
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/associate-appeal`)
+					.send({
+						...linkedAppealRequest,
+						linkedAppealId: 100
+					})
+					.set('azureAdUserId', azureAdUserId);
 
-			expect(response.status).toEqual(400);
-		});
+				expect(response.status).toEqual(404);
+			});
 
-		test('returns 400 when an external appeal reference is null', async () => {
-			// @ts-ignore
-			databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
-			// @ts-ignore
-			databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+			test('returns 400 when an external appeal reference is empty', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
 
-			const response = await request
-				.post(`/appeals/${householdAppeal.id}/link-legacy-appeal`)
-				.send({
-					...linkedAppealLegacyRequest,
-					linkedAppealReference: null
-				})
-				.set('azureAdUserId', azureAdUserId);
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/associate-legacy-appeal`)
+					.send({
+						...linkedAppealLegacyRequest,
+						linkedAppealReference: ''
+					})
+					.set('azureAdUserId', azureAdUserId);
 
-			expect(response.status).toEqual(400);
-		});
+				expect(response.status).toEqual(400);
+			});
 
-		test('returns 400 when an internal appeal is already a parent', async () => {
-			// @ts-ignore
-			databaseConnector.appeal.findUnique.mockResolvedValueOnce(householdAppeal);
-			// @ts-ignore
-			databaseConnector.appealRelationship.findMany.mockResolvedValueOnce(linkedAppeals);
+			test('returns 400 when an external appeal reference is null', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
 
-			const response = await request
-				.post(`/appeals/${householdAppeal.id}/link-appeal`)
-				.send({
-					...linkedAppealRequest,
-					isCurrentAppealParent: false
-				})
-				.set('azureAdUserId', azureAdUserId);
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/associate-legacy-appeal`)
+					.send({
+						...linkedAppealLegacyRequest,
+						linkedAppealReference: null
+					})
+					.set('azureAdUserId', azureAdUserId);
 
-			expect(response.status).toEqual(400);
+				expect(response.status).toEqual(400);
+			});
+
+			test('returns 200 when an external appeal reference is received', async () => {
+				// @ts-ignore
+				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
+				// @ts-ignore
+				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+
+				const response = await request
+					.post(`/appeals/${householdAppeal.id}/associate-legacy-appeal`)
+					.send({
+						...linkedAppealLegacyRequest,
+						linkedAppealReference: '123456'
+					})
+					.set('azureAdUserId', azureAdUserId);
+
+				expect(response.status).toEqual(200);
+				expect(databaseConnector.appealRelationship.create).toHaveBeenCalledTimes(1);
+				expect(databaseConnector.appealRelationship.create).toHaveBeenCalledWith({
+					data: {
+						parentId: householdAppeal.id,
+						parentRef: householdAppeal.reference,
+						childRef: '123456',
+						childId: null,
+						type: CASE_RELATIONSHIP_RELATED,
+						externalSource: true
+					}
+				});
+			});
 		});
 	});
 });

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -1,6 +1,10 @@
 import appealRepository from '#repositories/appeal.repository.js';
 import { canLinkAppeals } from './link-appeals.service.js';
-import { ERROR_LINKING_APPEALS } from '#endpoints/constants.js';
+import {
+	CASE_RELATIONSHIP_LINKED,
+	CASE_RELATIONSHIP_RELATED,
+	ERROR_LINKING_APPEALS
+} from '#endpoints/constants.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -35,13 +39,17 @@ export const linkAppeal = async (req, res) => {
 					parentId: currentAppeal.id,
 					parentRef: currentAppeal.reference,
 					childId: linkedAppeal.id,
-					childRef: linkedAppeal.reference
+					childRef: linkedAppeal.reference,
+					type: CASE_RELATIONSHIP_LINKED,
+					externalSource: false
 			  }
 			: {
 					parentId: linkedAppeal.id,
 					parentRef: linkedAppeal.reference,
 					childId: currentAppeal.id,
-					childRef: currentAppeal.reference
+					childRef: currentAppeal.reference,
+					type: CASE_RELATIONSHIP_LINKED,
+					externalSource: false
 			  };
 
 		const result = await appealRepository.linkAppeal(relationship);
@@ -57,7 +65,7 @@ export const linkAppeal = async (req, res) => {
  * @returns {Promise<Response>}
  */
 export const linkExternalAppeal = async (req, res) => {
-	const { isCurrentAppealParent, linkedAppealReference } = req.body;
+	const { isCurrentAppealParent, linkedAppealReference, externalAppealType } = req.body;
 	const currentAppeal = req.appeal;
 	const currentAppealType = isCurrentAppealParent ? 'lead' : 'child';
 	if (!canLinkAppeals(currentAppeal, currentAppealType)) {
@@ -73,13 +81,19 @@ export const linkExternalAppeal = async (req, res) => {
 				parentId: currentAppeal.id,
 				parentRef: currentAppeal.reference,
 				childRef: linkedAppealReference,
-				childId: null
+				childId: null,
+				type: CASE_RELATIONSHIP_LINKED,
+				externalSource: true,
+				externalAppealType
 		  }
 		: {
 				parentId: null,
 				parentRef: linkedAppealReference,
 				childRef: currentAppeal.reference,
-				childId: currentAppeal.id
+				childId: currentAppeal.id,
+				type: CASE_RELATIONSHIP_LINKED,
+				externalSource: true,
+				externalAppealType
 		  };
 
 	const result = await appealRepository.linkAppeal(relationship);
@@ -91,10 +105,56 @@ export const linkExternalAppeal = async (req, res) => {
  * @param {Response} res
  * @returns {Promise<Response>}
  */
-export const unlinkAppeal = async (req, res) => {
+export const associateAppeal = async (req, res) => {
+	const { linkedAppealId } = req.body;
+	const currentAppeal = req.appeal;
+	const appealToRelate = await appealRepository.getAppealById(Number(linkedAppealId));
+
+	if (appealToRelate) {
+		const relationship = {
+			parentId: currentAppeal.id,
+			parentRef: currentAppeal.reference,
+			childId: appealToRelate.id,
+			childRef: appealToRelate.reference,
+			type: CASE_RELATIONSHIP_RELATED,
+			externalSource: false
+		};
+
+		const result = await appealRepository.linkAppeal(relationship);
+		return res.send(result);
+	}
+
+	return res.status(404).send({});
+};
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const associateExternalAppeal = async (req, res) => {
 	const { linkedAppealReference } = req.body;
 	const currentAppeal = req.appeal;
-	await appealRepository.unlinkAppeal(currentAppeal.id, linkedAppealReference);
+	const relationship = {
+		parentId: currentAppeal.id,
+		parentRef: currentAppeal.reference,
+		childId: null,
+		childRef: linkedAppealReference,
+		type: CASE_RELATIONSHIP_RELATED,
+		externalSource: true
+	};
+	const result = await appealRepository.linkAppeal(relationship);
+	return res.send(result);
+};
+
+/**
+ * @param {Request} req
+ * @param {Response} res
+ * @returns {Promise<Response>}
+ */
+export const unlinkAppeal = async (req, res) => {
+	const { relationshipId } = req.body;
+	await appealRepository.unlinkAppeal(relationshipId);
 
 	return res.status(200).send(true);
 };

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.routes.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.routes.js
@@ -5,7 +5,13 @@ import {
 	postLinkAppealValidator,
 	postLinkLegacyAppealValidator
 } from './link-appeals.validators.js';
-import { linkExternalAppeal, linkAppeal, unlinkAppeal } from './link-appeals.controller.js';
+import {
+	linkAppeal,
+	linkExternalAppeal,
+	associateAppeal,
+	associateExternalAppeal,
+	unlinkAppeal
+} from './link-appeals.controller.js';
 
 const router = createRouter();
 
@@ -57,12 +63,60 @@ router.post(
 	asyncHandler(linkExternalAppeal)
 );
 
+router.post(
+	'/:appealId/associate-appeal',
+	/*
+		#swagger.tags = ['Linked Appeals']
+		#swagger.path = '/appeals/{appealId}/associate-appeal'
+		#swagger.description = 'Associate an appeal to the current appeal, as related'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Related Appeal Request',
+			schema: { $ref: '#/definitions/RelatedAppealRequest' },
+			required: true
+		}
+		#swagger.responses[400] = {}
+	 */
+	checkAppealExistsAndAddToRequest,
+	postLinkAppealValidator,
+	asyncHandler(associateAppeal)
+);
+
+router.post(
+	'/:appealId/associate-legacy-appeal',
+	/*
+		#swagger.tags = ['Linked Appeals']
+		#swagger.path = '/appeals/{appealId}/associate-legacy-appeal'
+		#swagger.description = 'Links a legacy appeal (on Horizon) to the current appeal'
+		#swagger.parameters['azureAdUserId'] = {
+			in: 'header',
+			required: true,
+			example: '434bff4e-8191-4ce0-9a0a-91e5d6cdd882'
+		}
+		#swagger.requestBody = {
+			in: 'body',
+			description: 'Related Appeal Request (legacy)',
+			schema: { $ref: '#/definitions/RelatedAppealLegacyRequest' },
+			required: true
+		}
+		#swagger.responses[400] = {}
+	 */
+	checkAppealExistsAndAddToRequest,
+	postLinkLegacyAppealValidator,
+	asyncHandler(associateExternalAppeal)
+);
+
 router.delete(
 	'/:appealId/unlink-appeal',
 	/*
 		#swagger.tags = ['Linked Appeals']
 		#swagger.path = '/appeals/{appealId}/unlink-appeal'
-		#swagger.description = 'Remove a linked appeal from the current appeal'
+		#swagger.description = 'Remove an appeal relationship by ID'
 		#swagger.parameters['azureAdUserId'] = {
 			in: 'header',
 			required: true,

--- a/appeals/api/src/server/openapi-types.ts
+++ b/appeals/api/src/server/openapi-types.ts
@@ -12,9 +12,19 @@ export interface LinkedAppealLegacyRequest {
 	isCurrentAppealParent?: boolean;
 }
 
-export interface UnlinkAppealRequest {
+export interface RelatedAppealRequest {
+	/** @example 25 */
+	linkedAppealId?: number;
+}
+
+export interface RelatedAppealLegacyRequest {
 	/** @example "51243165" */
 	linkedAppealReference?: string;
+}
+
+export interface UnlinkAppealRequest {
+	/** @example 1002 */
+	relationshipId?: number;
 }
 
 export interface ValidateDate {

--- a/appeals/api/src/server/openapi.json
+++ b/appeals/api/src/server/openapi.json
@@ -2526,10 +2526,104 @@
 				}
 			}
 		},
+		"/appeals/{appealId}/associate-appeal": {
+			"post": {
+				"tags": ["Linked Appeals"],
+				"description": "Associate an appeal to the current appeal, as related",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"400": {
+						"description": "Bad Request"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Related Appeal Request",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/RelatedAppealRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/RelatedAppealRequest"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/appeals/{appealId}/associate-legacy-appeal": {
+			"post": {
+				"tags": ["Linked Appeals"],
+				"description": "Links a legacy appeal (on Horizon) to the current appeal",
+				"parameters": [
+					{
+						"name": "appealId",
+						"in": "path",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "azureAdUserId",
+						"in": "header",
+						"required": true,
+						"example": "434bff4e-8191-4ce0-9a0a-91e5d6cdd882",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"400": {
+						"description": "Bad Request"
+					}
+				},
+				"requestBody": {
+					"in": "body",
+					"description": "Related Appeal Request (legacy)",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/RelatedAppealLegacyRequest"
+							}
+						},
+						"application/xml": {
+							"schema": {
+								"$ref": "#/components/schemas/RelatedAppealLegacyRequest"
+							}
+						}
+					}
+				}
+			}
+		},
 		"/appeals/{appealId}/unlink-appeal": {
 			"delete": {
 				"tags": ["Linked Appeals"],
-				"description": "Remove a linked appeal from the current appeal",
+				"description": "Remove an appeal relationship by ID",
 				"parameters": [
 					{
 						"name": "appealId",
@@ -2941,12 +3035,36 @@
 					"name": "LinkedAppealLegacyRequest"
 				}
 			},
-			"UnlinkAppealRequest": {
+			"RelatedAppealRequest": {
+				"type": "object",
+				"properties": {
+					"linkedAppealId": {
+						"type": "number",
+						"example": 25
+					}
+				},
+				"xml": {
+					"name": "RelatedAppealRequest"
+				}
+			},
+			"RelatedAppealLegacyRequest": {
 				"type": "object",
 				"properties": {
 					"linkedAppealReference": {
 						"type": "string",
 						"example": "51243165"
+					}
+				},
+				"xml": {
+					"name": "RelatedAppealLegacyRequest"
+				}
+			},
+			"UnlinkAppealRequest": {
+				"type": "object",
+				"properties": {
+					"relationshipId": {
+						"type": "number",
+						"example": 1002
 					}
 				},
 				"xml": {

--- a/appeals/api/src/server/swagger.js
+++ b/appeals/api/src/server/swagger.js
@@ -13,6 +13,8 @@ import {
 import {
 	linkedAppealRequest,
 	linkedAppealLegacyRequest,
+	relatedAppealRequest,
+	relatedAppealLegacyRequest,
 	unlinkAppealRequest
 } from '#tests/linked-appeals/mocks.js';
 
@@ -53,6 +55,12 @@ export const spec = {
 		},
 		LinkedAppealLegacyRequest: {
 			...linkedAppealLegacyRequest
+		},
+		RelatedAppealRequest: {
+			...relatedAppealRequest
+		},
+		RelatedAppealLegacyRequest: {
+			...relatedAppealLegacyRequest
 		},
 		UnlinkAppealRequest: {
 			...unlinkAppealRequest

--- a/appeals/api/src/server/tests/appeals/mocks.js
+++ b/appeals/api/src/server/tests/appeals/mocks.js
@@ -329,6 +329,8 @@ export const linkedAppeals = [
 		childRef: '76215416',
 		linkingDate: '2024-01-01',
 		appealType: householdAppeal.appealType,
-		relationshipId: 1
+		relationshipId: 1,
+		type: 'linked',
+		externalSource: true
 	}
 ];

--- a/appeals/api/src/server/tests/linked-appeals/mocks.js
+++ b/appeals/api/src/server/tests/linked-appeals/mocks.js
@@ -8,6 +8,14 @@ export const linkedAppealLegacyRequest = {
 	isCurrentAppealParent: false
 };
 
-export const unlinkAppealRequest = {
+export const relatedAppealRequest = {
+	linkedAppealId: 25
+};
+
+export const relatedAppealLegacyRequest = {
 	linkedAppealReference: '51243165'
+};
+
+export const unlinkAppealRequest = {
+	relationshipId: 1002
 };

--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.controller.js
@@ -57,13 +57,13 @@ export const postUnlinkAppeal = async (request, response) => {
 			);
 		}
 		if (unlinkAppeal === 'yes') {
+			const appealRelationshipId = parseInt(relationshipId, 10);
 			const appealData = await getAppealDetailsFromId(request.apiClient, appealId);
 			const childRef =
-				appealData.linkedAppeals.find(
-					(appeal) => appeal.relationshipId === parseInt(relationshipId, 10)
-				)?.appealReference || '';
+				appealData.linkedAppeals.find((appeal) => appeal.relationshipId === appealRelationshipId)
+					?.appealReference || '';
 
-			await postUnlinkRequest(request.apiClient, appealId, childRef);
+			await postUnlinkRequest(request.apiClient, appealId, appealRelationshipId);
 			addNotificationBannerToSession(
 				request.session,
 				'appealUnlinked',

--- a/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.service.js
+++ b/appeals/web/src/server/appeals/appeal-details/manage-linked-appeals/manage-linked-appeals.service.js
@@ -12,13 +12,13 @@ export function getAppealDetailsFromId(apiClient, appealId) {
  *
  * @param {import('got').Got} apiClient
  * @param {string} appealId
- * @param {string} linkedAppealReference
+ * @param {number} relationshipId
  * @returns {Promise<{}>}
  */
-export function postUnlinkRequest(apiClient, appealId, linkedAppealReference) {
+export function postUnlinkRequest(apiClient, appealId, relationshipId) {
 	return apiClient
 		.delete(`appeals/${appealId}/unlink-appeal`, {
-			json: { linkedAppealReference: linkedAppealReference }
+			json: { relationshipId }
 		})
 		.json();
 }


### PR DESCRIPTION
Related appeals API, adding a different relationship type but similar to the way linked appeals work (no parent/child relationship).

Changed the delete from WEB to use the relationshipID. Also modified the DB table so it can store:

- externalSource (a boolean indicating the linked/related appeal is not on the beta system)
- externalType (to story a Horizon appeal type, if needed)

## Issue ticket number and link
[BOAT-639](https://pins-ds.atlassian.net/browse/BOAT-639)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAT-639]: https://pins-ds.atlassian.net/browse/BOAT-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ