### PR TITLE
fix(appeals/api): correct the logic in showing related appeals

### DIFF
--- a/appeals/api/src/server/utils/format-linked-appeals.js
+++ b/appeals/api/src/server/utils/format-linked-appeals.js
@@ -49,8 +49,8 @@ const formatLinkedAppeals = (linkedAppeals, reference, formattedAppealWithLinked
  */
 const formatRelatedAppeals = (relatedAppeals, currentAppealId) => {
 	return relatedAppeals.map((rel) => {
-		const appealId = currentAppealId === rel.parentId ? rel.parentId : rel.childId;
-		const appealReference = currentAppealId === rel.parentId ? rel.parentRef : rel.childRef;
+		const appealId = currentAppealId === rel.parentId ? rel.childId : rel.parentId;
+		const appealReference = currentAppealId === rel.parentId ? rel.childRef : rel.parentRef;
 		return {
 			appealId,
 			appealReference,


### PR DESCRIPTION
A small fix which corrects the logic of which information to return in related appeals: `appealId` and `appealRef` are the identifiers for the related appeal, not the current one. `appealId` can be null if the related appeal is on Horizon, in which case the relationship will be marked as `externalSource=true`.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
