### PR TITLE
fix(appeals/web): BOAT-865 service name missing from page titles on various pages

### DIFF
--- a/appeals/web/src/server/views/app/layouts/app.layout.njk
+++ b/appeals/web/src/server/views/app/layouts/app.layout.njk
@@ -2,6 +2,7 @@
 {# see https://design-system.service.gov.uk/styles/page-template/#options #}
 {# to match the scss $govuk-assets-path variable in main.scss #}
 {% set assetPath = "" %}
+{% set serviceName = 'Planning inspectorate' %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}

--- a/appeals/web/src/server/views/appeals/documents/document-upload.njk
+++ b/appeals/web/src/server/views/appeals/documents/document-upload.njk
@@ -2,6 +2,7 @@
 
 {% from 'app/components/file-uploader.component.njk' import fileUploader %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% set serviceName = 'Planning inspectorate' %}
 
 {% block pageTitle %}
 	{{ pageTitle | default('GOV.UK') }} – {{ serviceName }}


### PR DESCRIPTION
## Describe your changes

[BOAT-865](https://pins-ds.atlassian.net/browse/BOAT-865)

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAT-865]: https://pins-ds.atlassian.net/browse/BOAT-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ