### PR TITLE
fix(api/applications): rename stage to documentcasestage in doc schema (boas-1429)

### DIFF
--- a/apps/api/src/server/applications/application/documents/__tests__/document-payload.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document-payload.test.js
@@ -81,7 +81,7 @@ describe('validateNsipDocument', () => {
 			representative: 'ZZZ Agency',
 			description:
 				'Attachments to the letter to Department for Business, Energy & Industrial Strategy',
-			stage: 'examination',
+			documentCaseStage: 'examination',
 			filter1: 'Deadline 2',
 			filter2: 'Scoping Option Report'
 		};

--- a/apps/api/src/server/applications/application/documents/document.js
+++ b/apps/api/src/server/applications/application/documents/document.js
@@ -1,9 +1,39 @@
 import { pick, omitBy, isNull } from 'lodash-es';
 import config from '#config/config.js';
+import { folderDocumentCaseStageMappings } from '../../constants.js';
 
 /**
  * @typedef {import('pins-data-model').Schemas.NSIPDocument} NSIPDocumentSchema
  * */
+
+/**
+ * convert our DB Document Version stage value into the event schema value
+ *
+ * @param {string |null} stage
+ * @returns
+ */
+export const mapDocumentCaseStageToSchema = (stage) => {
+	// conversion is mostly just changing to all lower case
+	let schemaValue = null;
+
+	if (stage) {
+		switch (stage) {
+			case folderDocumentCaseStageMappings.DEVELOPERS_APPLICATION:
+				schemaValue = 'developers_application';
+				break;
+			case folderDocumentCaseStageMappings.POST_DECISION:
+				// note that post decision has inconsistent format in the schema, it uses underscore instead of hyphen
+				// our DB 'Post-decision' maps to 'post_decision'
+				schemaValue = stage.toLowerCase().replace('-', '_');
+				break;
+			default:
+				schemaValue = stage.toLowerCase();
+				break;
+		}
+	}
+
+	return schemaValue;
+};
 
 /**
  * Returns document in event message schema format
@@ -39,7 +69,7 @@ export const buildNsipDocumentPayload = (version) => {
 		);
 	}
 
-	return {
+	let payload = {
 		documentId: document.guid,
 		...(document.case?.reference ? { caseRef: document.case.reference.toString() } : {}),
 		version: version.version,
@@ -72,20 +102,25 @@ export const buildNsipDocumentPayload = (version) => {
 				'author',
 				'representative',
 				'description',
-				'stage',
 				'filter1',
 				'filter2'
 			]),
 			isNull
 		)
 	};
+
+	if (version.stage) {
+		payload.documentCaseStage = mapDocumentCaseStageToSchema(version.stage);
+	}
+
+	return payload;
 };
 
 /**
  * return the document blob uri, eg config.blobStorageUrl/containerName/path
  *
- * @param {string} containerName
- * @param {string} path
+ * @param {string |null} containerName
+ * @param {string |null} path
  *
  * @returns {string}
  */


### PR DESCRIPTION
## Rename stage attribute to documentCaseStage in the payload for document event broadcasts

- rename the field in the payload creation
- added mapping fn to map our DB values to the values expected in the schema

## BOAS-1429 Value of stage in NSIP Document message
https://pins-ds.atlassian.net/browse/BOAS-1429

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
