### PR TITLE
fix(applications/api): case stage should be added to deadline sub folders (BOAS-1558)

### DIFF
--- a/apps/api/src/server/applications/application/project-updates/project-updates.service.js
+++ b/apps/api/src/server/applications/application/project-updates/project-updates.service.js
@@ -11,7 +11,7 @@ import {
 	projectUpdateCreateReq,
 	projectUpdateUpdateReq
 } from './project-updates.mapper.js';
-import { NSIP_PROJECT_UPDATE } from '../../../infrastructure/topics.js';
+import { NSIP_PROJECT_UPDATE } from '#infrastructure/topics.js';
 import logger from '../../../utils/logger.js';
 import { ProjectUpdate } from '@pins/applications/lib/application/project-update.js';
 import { verifyNotTraining } from '../application.validators.js';

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.service.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.service.js
@@ -171,12 +171,14 @@ export async function sendUpdateEvent(id) {
  *
  * @param {import('@pins/applications.api').Schema.ExaminationTimetableItem} examinationTimetableItem
  * @param {Number} parentFolderId
+ * @param {String} stage
  * @param {Number} caseId
  * @returns
  */
 export const createDeadlineSubFolders = async (
 	examinationTimetableItem,
 	parentFolderId,
+	stage,
 	caseId
 ) => {
 	if (!examinationTimetableItem?.description) {
@@ -207,6 +209,7 @@ export const createDeadlineSubFolders = async (
 		displayNameEn: 'Other',
 		caseId,
 		parentFolderId: parentFolderId,
+		stage,
 		displayOrder: 100
 	};
 	createFolderPromise.push(folderRepository.createFolder(otherFolder));
@@ -220,7 +223,8 @@ export const createDeadlineSubFolders = async (
 		const subFolder = {
 			displayNameEn: folderName?.trim(),
 			caseId,
-			parentFolderId: parentFolderId,
+			parentFolderId,
+			stage,
 			displayOrder: 100
 		};
 		createFolderPromise.push(folderRepository.createFolder(subFolder));


### PR DESCRIPTION
## Describe your changes

- Make sure the deadline subfolders are saved with the parent folder case stage
- Update the examination-timetable unit tests to handle and prove the above
- Manually tested the functionality

## BOAS-1558 Documents published from the 'Have your say' journey
https://pins-ds.atlassian.net/browse/BOAS-1558

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
