### PR TITLE
fix(applications/web): pre-examination items not appearing in pre exam section (BOAS-1563)

### DIFF
--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -2409,9 +2409,47 @@ exports[`Examination timetable page GET /case/123/examination-timetable should s
             <hr class=\\"govuk-section-break govuk-section-break--l govuk-section-break--visible\\">
             <div class='timetable-table'>
                 <h3 class=\\"govuk-heading-m\\">Pre-examination</h3>
-                <p class='govuk-body'>No timetable items</p>
-                <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\"
-                id=\\"accordion-pre-examination\\"></div>
+                <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-pre-examination\\">
+                    <div class=\\"govuk-accordion__section\\">
+                        <div class=\\"govuk-accordion__section-header\\">
+                            <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-pre-examination-heading-1\\"> 10 Oct 2023 - Test</span></h2>
+                        </div>
+                        <div id=\\"accordion-pre-examination-content-1\\" class=\\"govuk-accordion__section-content\\"
+                        aria-labelledby=\\"accordion-pre-examination-heading-1\\">
+                            <div class='top-right-link'><a class='govuk-link' href=\\"/applications-service/case/123/examination-timetable/item/edit/2\\">Edit timetable item</a>
+                            </div>
+                            <dl class=\\"govuk-summary-list\\">
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Type</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">Procedural Deadline (Pre-Examination)</dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Name</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">Test</dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start Date</dt>
+                                    <dd class=\\"govuk-summary-list__value\\"></dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start time</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">10:10</dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Date</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">10 Oct 2023</dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Time</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">10:10</dd>
+                                </div>
+                                <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                                    <dd class=\\"govuk-summary-list__value\\">
+                                        <p class=\\"govuk-body\\">test</p>
+                                        <ul class='govuk-list govuk-list--bullet'>
+                                            <li>ponintone</li>
+                                            <li>pointtwo</li>
+                                        </ul>
+                                    </dd>
+                                </div>
+                            </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/2'>Delete timetable item</a>
+                        </div>
+                    </div>
+                </div>
                 <div class='govuk-!-margin-top-8'>
                     <h3 class=\\"govuk-heading-m\\">Examination</h3>
                     <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-examination\\">
@@ -2452,45 +2490,6 @@ exports[`Examination timetable page GET /case/123/examination-timetable should s
                                         </dd>
                                     </div>
                                 </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/1'>Delete timetable item</a>
-                            </div>
-                        </div>
-                        <div class=\\"govuk-accordion__section\\">
-                            <div class=\\"govuk-accordion__section-header\\">
-                                <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-examination-heading-2\\"> - Test</span></h2>
-                            </div>
-                            <div id=\\"accordion-examination-content-2\\" class=\\"govuk-accordion__section-content\\"
-                            aria-labelledby=\\"accordion-examination-heading-2\\">
-                                <div class='top-right-link'><a class='govuk-link' href=\\"/applications-service/case/123/examination-timetable/item/edit/2\\">Edit timetable item</a>
-                                </div>
-                                <dl class=\\"govuk-summary-list\\">
-                                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Type</dt>
-                                        <dd class=\\"govuk-summary-list__value\\">Procedural Deadline (Pre-Examination)</dd>
-                                    </div>
-                                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Name</dt>
-                                        <dd class=\\"govuk-summary-list__value\\">Test</dd>
-                                    </div>
-                                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start Date</dt>
-                                        <dd class=\\"govuk-summary-list__value\\"></dd>
-                                    </div>
-                                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start time</dt>
-                                        <dd class=\\"govuk-summary-list__value\\">10:10</dd>
-                                    </div>
-                                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Date</dt>
-                                        <dd class=\\"govuk-summary-list__value\\">10 Oct 2023</dd>
-                                    </div>
-                                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Time</dt>
-                                        <dd class=\\"govuk-summary-list__value\\">10:10</dd>
-                                    </div>
-                                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                        <dd class=\\"govuk-summary-list__value\\">
-                                            <p class=\\"govuk-body\\">test</p>
-                                            <ul class='govuk-list govuk-list--bullet'>
-                                                <li>ponintone</li>
-                                                <li>pointtwo</li>
-                                            </ul>
-                                        </dd>
-                                    </div>
-                                </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/2'>Delete timetable item</a>
                             </div>
                         </div>
                     </div>
@@ -2742,9 +2741,47 @@ exports[`Publish examination timetable preview page GET /case/123/examination-ti
     <p class=\\"govuk-body\\">Check before publishing</p>
     <div class='timetable-table'>
         <h3 class=\\"govuk-heading-m\\">Pre-examination</h3>
-        <p class='govuk-body'>No timetable items</p>
-        <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\"
-        id=\\"accordion-pre-examination\\"></div>
+        <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-pre-examination\\">
+            <div class=\\"govuk-accordion__section\\">
+                <div class=\\"govuk-accordion__section-header\\">
+                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-pre-examination-heading-1\\"> 10 Oct 2023 - Test</span></h2>
+                </div>
+                <div id=\\"accordion-pre-examination-content-1\\" class=\\"govuk-accordion__section-content\\"
+                aria-labelledby=\\"accordion-pre-examination-heading-1\\">
+                    <div class='top-right-link'><a class='govuk-link' href=\\"/applications-service/case/123/examination-timetable/item/edit/2\\">Edit timetable item</a>
+                    </div>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Type</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Procedural Deadline (Pre-Examination)</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Test</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start Date</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start time</dt>
+                            <dd class=\\"govuk-summary-list__value\\">10:10</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Date</dt>
+                            <dd class=\\"govuk-summary-list__value\\">10 Oct 2023</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Time</dt>
+                            <dd class=\\"govuk-summary-list__value\\">10:10</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">
+                                <p class=\\"govuk-body\\">test</p>
+                                <ul class='govuk-list govuk-list--bullet'>
+                                    <li>ponintone</li>
+                                    <li>pointtwo</li>
+                                </ul>
+                            </dd>
+                        </div>
+                    </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/2'>Delete timetable item</a>
+                </div>
+            </div>
+        </div>
         <div class='govuk-!-margin-top-8'>
             <h3 class=\\"govuk-heading-m\\">Examination</h3>
             <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-examination\\">
@@ -2785,45 +2822,6 @@ exports[`Publish examination timetable preview page GET /case/123/examination-ti
                                 </dd>
                             </div>
                         </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/1'>Delete timetable item</a>
-                    </div>
-                </div>
-                <div class=\\"govuk-accordion__section\\">
-                    <div class=\\"govuk-accordion__section-header\\">
-                        <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-examination-heading-2\\"> - Test</span></h2>
-                    </div>
-                    <div id=\\"accordion-examination-content-2\\" class=\\"govuk-accordion__section-content\\"
-                    aria-labelledby=\\"accordion-examination-heading-2\\">
-                        <div class='top-right-link'><a class='govuk-link' href=\\"/applications-service/case/123/examination-timetable/item/edit/2\\">Edit timetable item</a>
-                        </div>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Type</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Procedural Deadline (Pre-Examination)</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Test</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start Date</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start time</dt>
-                                <dd class=\\"govuk-summary-list__value\\">10:10</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Date</dt>
-                                <dd class=\\"govuk-summary-list__value\\">10 Oct 2023</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Time</dt>
-                                <dd class=\\"govuk-summary-list__value\\">10:10</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">
-                                    <p class=\\"govuk-body\\">test</p>
-                                    <ul class='govuk-list govuk-list--bullet'>
-                                        <li>ponintone</li>
-                                        <li>pointtwo</li>
-                                    </ul>
-                                </dd>
-                            </div>
-                        </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/2'>Delete timetable item</a>
                     </div>
                 </div>
             </div>
@@ -2895,9 +2893,47 @@ exports[`Unpublish examination timetable preview page GET /case/123/examination-
     <p class=\\"govuk-body\\">Check before unpublishing</p>
     <div class='timetable-table'>
         <h3 class=\\"govuk-heading-m\\">Pre-examination</h3>
-        <p class='govuk-body'>No timetable items</p>
-        <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\"
-        id=\\"accordion-pre-examination\\"></div>
+        <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-pre-examination\\">
+            <div class=\\"govuk-accordion__section\\">
+                <div class=\\"govuk-accordion__section-header\\">
+                    <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-pre-examination-heading-1\\"> 10 Oct 2023 - Test</span></h2>
+                </div>
+                <div id=\\"accordion-pre-examination-content-1\\" class=\\"govuk-accordion__section-content\\"
+                aria-labelledby=\\"accordion-pre-examination-heading-1\\">
+                    <div class='top-right-link'><a class='govuk-link' href=\\"/applications-service/case/123/examination-timetable/item/edit/2\\">Edit timetable item</a>
+                    </div>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Type</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Procedural Deadline (Pre-Examination)</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Test</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start Date</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start time</dt>
+                            <dd class=\\"govuk-summary-list__value\\">10:10</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Date</dt>
+                            <dd class=\\"govuk-summary-list__value\\">10 Oct 2023</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Time</dt>
+                            <dd class=\\"govuk-summary-list__value\\">10:10</dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">
+                                <p class=\\"govuk-body\\">test</p>
+                                <ul class='govuk-list govuk-list--bullet'>
+                                    <li>ponintone</li>
+                                    <li>pointtwo</li>
+                                </ul>
+                            </dd>
+                        </div>
+                    </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/2'>Delete timetable item</a>
+                </div>
+            </div>
+        </div>
         <div class='govuk-!-margin-top-8'>
             <h3 class=\\"govuk-heading-m\\">Examination</h3>
             <div class=\\"govuk-accordion\\" data-module=\\"govuk-accordion\\" id=\\"accordion-examination\\">
@@ -2938,45 +2974,6 @@ exports[`Unpublish examination timetable preview page GET /case/123/examination-
                                 </dd>
                             </div>
                         </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/1'>Delete timetable item</a>
-                    </div>
-                </div>
-                <div class=\\"govuk-accordion__section\\">
-                    <div class=\\"govuk-accordion__section-header\\">
-                        <h2 class=\\"govuk-accordion__section-heading\\"><span class=\\"govuk-accordion__section-button\\" id=\\"accordion-examination-heading-2\\"> - Test</span></h2>
-                    </div>
-                    <div id=\\"accordion-examination-content-2\\" class=\\"govuk-accordion__section-content\\"
-                    aria-labelledby=\\"accordion-examination-heading-2\\">
-                        <div class='top-right-link'><a class='govuk-link' href=\\"/applications-service/case/123/examination-timetable/item/edit/2\\">Edit timetable item</a>
-                        </div>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Type</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Procedural Deadline (Pre-Examination)</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Item Name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Test</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start Date</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Start time</dt>
-                                <dd class=\\"govuk-summary-list__value\\">10:10</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Date</dt>
-                                <dd class=\\"govuk-summary-list__value\\">10 Oct 2023</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> End Time</dt>
-                                <dd class=\\"govuk-summary-list__value\\">10:10</dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">
-                                    <p class=\\"govuk-body\\">test</p>
-                                    <ul class='govuk-list govuk-list--bullet'>
-                                        <li>ponintone</li>
-                                        <li>pointtwo</li>
-                                    </ul>
-                                </dd>
-                            </div>
-                        </dl><a class='govuk-link colour--red' href='/applications-service/case/123/examination-timetable/item/delete/2'>Delete timetable item</a>
                     </div>
                 </div>
             </div>

--- a/apps/web/src/server/views/applications/case-timetable/components/timetable-items-list.component.njk
+++ b/apps/web/src/server/views/applications/case-timetable/components/timetable-items-list.component.njk
@@ -8,7 +8,7 @@
 		{% set accordionItemsPreExamination = [] %}
 
 		{% for timetableItem in timetableItems %}
-			{% if (timetableItem.templateType in ['deadline-startdate-mandatory', 'deadline']) %}
+			{% if (timetableItem.templateType in ['procedural-deadline', 'deadline', 'deadline-for-close-of-examination']) %}
 				{% set heading = [timetableItem.endDate, ' - ', timetableItem.name] | join %}
 			{% else %}
 				{% set heading = [timetableItem.date if timetableItem.date else timetableItem.startDate, ' - ', timetableItem.name] | join %}
@@ -42,7 +42,7 @@
 				}
 			} %}
 
-			{% if (timetableItem.templateType == 'deadline-startdate-mandatory') %}
+			{% if (timetableItem.templateType == 'procedural-deadline') %}
 				{% set accordionItemsPreExamination = accordionItemsPreExamination.concat([row]) %}
 			{% else %}
 				{% set accordionItemsExamination = accordionItemsExamination.concat([row]) %}


### PR DESCRIPTION
## Describe your changes

- Make sure examination item types 'Procedural Deadline (Pre-Examination)' are displayed in the Pre-examination section
- Update unit test snap shots to match above correctly
- Manually tested the functionality

## BOAS-1563 Examination Timetable page - Pre Examination items not appearing in Pre Exam section
https://pins-ds.atlassian.net/browse/BOAS-1563

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
