### PR TITLE
chore(functions): remove nsip-representation status field mapping

### DIFF
--- a/apps/functions/applications-migration/nsip-representation-migration/src/nsip-representation-migration.js
+++ b/apps/functions/applications-migration/nsip-representation-migration/src/nsip-representation-migration.js
@@ -45,8 +45,7 @@ export const migrateRepresentations = async (logger, caseReferences) => {
 
 				return {
 					...row,
-					originalRepresentation: row.originalRepresentation || '',
-					status: mapStatus(row.status)
+					originalRepresentation: row.originalRepresentation || ''
 					// attachmentIds: row.attachmentIds?.split(',')
 				};
 			});
@@ -70,12 +69,3 @@ export const migrateRepresentations = async (logger, caseReferences) => {
 		}
 	}
 };
-
-const mapStatus = (status) =>
-	({
-		New: 'awaiting_review',
-		'In Progress': 'awaiting_review',
-		Complete: 'valid',
-		Published: 'published',
-		'Do Not Publish': 'invalid'
-	}[status]);


### PR DESCRIPTION
## Describe your changes

Remove mapping of `status` field value from Horizon to BO value. This is now being done in ODW curated layer so no longer required

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
