### PR TITLE
fix(applications/api): relevant representations - issue with sorting (BOAS-1559)

### DIFF
--- a/apps/api/src/server/repositories/__tests__/representation.repository.test.js
+++ b/apps/api/src/server/repositories/__tests__/representation.repository.test.js
@@ -67,7 +67,7 @@ describe('Representation repository', () => {
 						status: 'asc'
 					},
 					{
-						received: 'asc'
+						received: 'desc'
 					},
 					{
 						id: 'asc'
@@ -121,7 +121,7 @@ describe('Representation repository', () => {
 						status: 'asc'
 					},
 					{
-						received: 'asc'
+						received: 'desc'
 					},
 					{
 						id: 'asc'
@@ -221,7 +221,7 @@ describe('Representation repository', () => {
 						status: 'asc'
 					},
 					{
-						received: 'asc'
+						received: 'desc'
 					},
 					{
 						id: 'asc'
@@ -293,7 +293,7 @@ describe('Representation repository', () => {
 						status: 'asc'
 					},
 					{
-						received: 'asc'
+						received: 'desc'
 					},
 					{
 						id: 'asc'
@@ -350,7 +350,7 @@ describe('Representation repository', () => {
 						reference: 'desc'
 					},
 					{
-						received: 'asc'
+						received: 'desc'
 					},
 					{
 						id: 'asc'

--- a/apps/api/src/server/repositories/representation.repository.js
+++ b/apps/api/src/server/repositories/representation.repository.js
@@ -825,7 +825,7 @@ function buildOrderBy(sort) {
 	const secondarySort =
 		sort && sort.some((sortObject) => Object.keys(sortObject)[0] === 'received')
 			? []
-			: [{ received: 'asc' }];
+			: [{ received: 'desc' }];
 
 	return [...primarySort, ...secondarySort, { id: 'asc' }];
 }


### PR DESCRIPTION
## Describe your changes

- Make sure sorting relevant representations is [{ "status": "asc", "received": "desc", "id": "asc" }] 
- Manually tested the functionality

## BOAS-1559 Relevant representations - issue with sorting
https://pins-ds.atlassian.net/browse/BOAS-1559

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
