### PR TITLE
fix(applications): warn on uploading existing deleted file (BOAS-1568)

### DIFF
--- a/apps/api/src/server/applications/application/documents/__tests__/create-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/create-document.test.js
@@ -139,7 +139,8 @@ describe('Create documents', () => {
 				}
 			],
 			failedDocuments: [],
-			duplicates: []
+			duplicates: [],
+			deleted: []
 		});
 
 		const metadata = {
@@ -216,6 +217,9 @@ describe('Create documents', () => {
 		databaseConnector.case.findUnique.mockResolvedValue(application);
 
 		databaseConnector.folder.findUnique.mockResolvedValue({ id: 1, caseId: 1 });
+		databaseConnector.document.findFirst
+			.mockResolvedValueOnce({ isDeleted: false })
+			.mockResolvedValueOnce({ isDeleted: true });
 		databaseConnector.document.create.mockImplementation(() => {
 			throw new Error();
 		});
@@ -228,12 +232,22 @@ describe('Create documents', () => {
 				documentName: 'test doc',
 				documentType: 'application/pdf',
 				documentSize: 1024
+			},
+			{
+				folderId: 1,
+				documentName: 'test doc deleted',
+				documentType: 'application/pdf',
+				documentSize: 1024
 			}
 		]);
 
 		// THEN
 		expect(response.status).toEqual(409);
-		expect(response.body).toEqual({ failedDocuments: [], duplicates: ['test doc'] });
+		expect(response.body).toEqual({
+			failedDocuments: [],
+			duplicates: ['test doc'],
+			deleted: ['test doc deleted']
+		});
 	});
 
 	test('throws error if folder id does not belong to case', async () => {

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -13,7 +13,7 @@ import {
 } from '#utils/mapping/map-document-details.js';
 import {
 	getDocumentsInCase,
-	extractDuplicates,
+	extractDuplicatesAndDeleted,
 	getIndexFromReference,
 	handleUpdateDocuments,
 	makeDocumentReference,
@@ -72,7 +72,7 @@ export const createDocumentsOnCase = async ({ params, body }, response) => {
 		: 1;
 	let nextReferenceIndex = lastReferenceIndex ? lastReferenceIndex + 1 : 1;
 
-	const { duplicates, remainder } = await extractDuplicates(documentsToUpload);
+	const { duplicates, deleted, remainder } = await extractDuplicatesAndDeleted(documentsToUpload);
 	const filteredToUpload = /** @type {DocumentToSaveExtended[]} */ (documentsToUpload).filter(
 		(doc) => remainder.includes(doc.documentName)
 	);
@@ -90,7 +90,7 @@ export const createDocumentsOnCase = async ({ params, body }, response) => {
 	);
 
 	if (dbResponse === null) {
-		response.status(409).send({ failedDocuments, duplicates });
+		response.status(409).send({ failedDocuments, duplicates, deleted });
 		return;
 	}
 
@@ -102,12 +102,13 @@ export const createDocumentsOnCase = async ({ params, body }, response) => {
 	});
 
 	// Send response with blob storage host, container, and documents with URLs
-	response.status([...failedDocuments, ...duplicates].length > 0 ? 206 : 200).send({
+	response.status([...failedDocuments, ...duplicates, ...deleted].length > 0 ? 206 : 200).send({
 		blobStorageHost,
 		privateBlobContainer,
 		documents: documentsWithUrls,
 		failedDocuments,
-		duplicates
+		duplicates,
+		deleted
 	});
 };
 

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -17,7 +17,7 @@ import { getCaseDetails } from '../application/application.service.js';
 import { verifyNotTraining } from '../application/application.validators.js';
 import {
 	checkCanPublish,
-	extractDuplicates,
+	extractDuplicatesAndDeleted,
 	formatS51AdviceUpdateResponseBody,
 	getManyS51AdviceOnCase,
 	getS51AdviceDocuments,
@@ -186,7 +186,7 @@ export const addDocuments = async ({ params, body }, response) => {
 		? existingS51ForCase.referenceNumber + 1
 		: 1;
 
-	const { duplicates, remainder } = await extractDuplicates(
+	const { duplicates, deleted, remainder } = await extractDuplicatesAndDeleted(
 		adviceId,
 		/** @type {DocumentToSaveExtended[]} */ (documentsToUpload).map((doc) => doc.documentName)
 	);
@@ -241,12 +241,13 @@ export const addDocuments = async ({ params, body }, response) => {
 		logger.info(`Blocked sending event for S51 ${s51Advice.id}:`, err.message);
 	}
 
-	response.status([...failedDocuments, ...duplicates].length > 0 ? 206 : 200).send({
+	response.status([...failedDocuments, ...duplicates, ...deleted].length > 0 ? 206 : 200).send({
 		blobStorageHost,
 		privateBlobContainer,
 		documents: documentsWithUrls,
 		failedDocuments,
-		duplicates
+		duplicates,
+		deleted
 	});
 };
 

--- a/apps/web/src/client/components/file-uploader/_html.js
+++ b/apps/web/src/client/components/file-uploader/_html.js
@@ -20,7 +20,7 @@ export const errorMessage = (type, replaceValue) => {
 		CONFLICT:
 			'{REPLACE_VALUE} could not be added, check if the file does not already exist and try again.',
 		DELETED:
-			'{REPLACE_VALUE} could not be added as it was previously uploaded and deleted. Rename the file and try and upload again.',
+			'{REPLACE_VALUE} could not be added as a file with the same name was previously uploaded and deleted.',
 		BAD_HTML_FILE:
 			'{REPLACE_VALUE} is not valid for upload. HTML files must contain a YouTube iframe.'
 	};

--- a/apps/web/src/client/components/file-uploader/_html.js
+++ b/apps/web/src/client/components/file-uploader/_html.js
@@ -19,6 +19,8 @@ export const errorMessage = (type, replaceValue) => {
 		TYPE_SINGLE_FILE: `{REPLACE_VALUE} could not be added because it is not an allowed file type`,
 		CONFLICT:
 			'{REPLACE_VALUE} could not be added, check if the file does not already exist and try again.',
+		DELETED:
+			'{REPLACE_VALUE} could not be added as it was previously uploaded and deleted. Rename the file and try and upload again.',
 		BAD_HTML_FILE:
 			'{REPLACE_VALUE} is not valid for upload. HTML files must contain a YouTube iframe.'
 	};

--- a/apps/web/src/client/components/file-uploader/_server-actions.js
+++ b/apps/web/src/client/components/file-uploader/_server-actions.js
@@ -55,9 +55,10 @@ const serverActions = (uploadForm) => {
 		})
 			.then((response) => response.json())
 			.then((uploadsInfos) => {
-				if (uploadsInfos.failedDocuments || uploadsInfos.duplicates) {
-					const failedDocuments = /** @type {string[]} */ (uploadsInfos.failedDocuments);
-					const duplicates = /** @type {string[]} */ (uploadsInfos.duplicates);
+				if (uploadsInfos.failedDocuments || uploadsInfos.duplicates || uploadsInfos.deleted) {
+					const failedDocuments = /** @type {string[]} */ (uploadsInfos.failedDocuments || []);
+					const duplicates = /** @type {string[]} */ (uploadsInfos.duplicates || []);
+					const deleted = /** @type {string[]} */ (uploadsInfos.deleted || []);
 
 					failedUploads.push(
 						...failedDocuments.map((name, idx) => ({
@@ -67,6 +68,11 @@ const serverActions = (uploadForm) => {
 						})),
 						...duplicates.map((name, idx) => ({
 							message: 'CONFLICT',
+							name,
+							fileRowId: `failedUpload${idx}`
+						})),
+						...deleted.map((name, idx) => ({
+							message: 'DELETED',
 							name,
 							fileRowId: `failedUpload${idx}`
 						}))


### PR DESCRIPTION
## Describe your changes

- Split duplicate list into deleted and duplicates where the files have been previously deleted.
- Warn the user that a file has previously been deleted and will need to be renamed to upload
- Tested manually for both S51 Advice as well as other document uploads

## BOAS-1568 Cannot re-upload same file after deleting it
https://pins-ds.atlassian.net/browse/BOAS-1568

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
