### PR TITLE
chore(applications/api): reseed tables for migration

### DIFF
--- a/apps/api/src/database/migrations/20240228104443_reseed_tables_for_migration/migration.sql
+++ b/apps/api/src/database/migrations/20240228104443_reseed_tables_for_migration/migration.sql
@@ -1,0 +1,22 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- Add the new seeds for the identity columns to 100 million
+DBCC CHECKIDENT ('dbo.ExaminationTimetableItem', RESEED, 100000000);
+DBCC CHECKIDENT ('dbo.Representation', RESEED, 100000000);
+DBCC CHECKIDENT ('dbo.S51Advice', RESEED, 100000000);
+DBCC CHECKIDENT ('dbo.Folder', RESEED, 100000000);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH


### PR DESCRIPTION
## Describe your changes

Changes the value at which the ID column begins incrementing from, for tables which are having legacy data migrated in. New rows (i.e. those created via Back Office) will start from ID 100,000,000 and this allows manual insertion of migrated legacy data into rows 1 to 99,999,999.

Similar to https://github.com/Planning-Inspectorate/back-office/pull/1697/files

## Issue ticket number and link

BOAS-1403

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
