### PR TITLE
fix(web): remove awaiting transfer notification banner from transferred appeals

### DIFF
--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -355,6 +355,14 @@ function mapStatusDependentNotifications(appealDetails, session, accordionCompon
 		default:
 			break;
 	}
+
+	if (
+		'notificationBanners' in session &&
+		'appealAwaitingTransfer' in session.notificationBanners &&
+		appealDetails.appealStatus !== 'awaiting_transfer'
+	) {
+		delete session.notificationBanners.appealAwaitingTransfer;
+	}
 }
 
 const caseDocumentationTableActionColumnIndex = 3;


### PR DESCRIPTION
## Describe your changes

remove awaiting transfer notification banner from transferred appeals

## Issue ticket number and link

BOAT-916

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
