### PR TITLE
fix(appeals/api): importing documents was not validating UUIDs

### DIFF
--- a/appeals/api/src/message-schemas/pins-appellant-case.schema.json
+++ b/appeals/api/src/message-schemas/pins-appellant-case.schema.json
@@ -7,6 +7,7 @@
 	"required": ["appeal"],
 	"properties": {
 		"appeal": {
+			"type": "object",
 			"$ref": "pins-root.schema.json#/definitions/AppellantCase",
 			"required": ["appellant"],
 			"properties": {

--- a/appeals/api/src/server/endpoints/integrations/integrations.mappers/document.mapper.js
+++ b/appeals/api/src/server/endpoints/integrations/integrations.mappers/document.mapper.js
@@ -10,7 +10,7 @@ export const mapDocumentIn = (doc) => {
 	const { originalFilename, originalGuid } = mapDocumentUrl(metadata.documentURI, filename);
 
 	let documentGuid = originalGuid;
-	if (!validateUuidParameter(documentGuid)) {
+	if (validateUuidParameter(documentGuid).isUUID()) {
 		documentGuid = randomUUID();
 	}
 


### PR DESCRIPTION
Small fix in validating (and reusing) the original UUID for an imported document.

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
