### PR TITLE
fix(appeals/api): remove final states from personal list

### DIFF
--- a/appeals/api/src/server/repositories/appeal.repository.js
+++ b/appeals/api/src/server/repositories/appeal.repository.js
@@ -5,8 +5,11 @@ import {
 	DATABASE_ORDER_BY_DESC,
 	STATE_TARGET_CLOSED,
 	STATE_TARGET_COMPLETE,
+	STATE_TARGET_TRANSFERRED,
 	CASE_RELATIONSHIP_LINKED,
-	CASE_RELATIONSHIP_RELATED
+	CASE_RELATIONSHIP_RELATED,
+	STATE_TARGET_INVALID,
+	STATE_TARGET_WITHDRAWN
 } from '#endpoints/constants.js';
 
 /** @typedef {import('@pins/appeals.api').Appeals.RepositoryGetAllResultItem} RepositoryGetAllResultItem */
@@ -110,7 +113,18 @@ const getUserAppeals = (userId, pageNumber, pageSize, status) => {
 		],
 		AND: {
 			appealStatus: {
-				some: { valid: true, status: { notIn: [STATE_TARGET_COMPLETE, STATE_TARGET_CLOSED] } }
+				some: {
+					valid: true,
+					status: {
+						notIn: [
+							STATE_TARGET_COMPLETE,
+							STATE_TARGET_CLOSED,
+							STATE_TARGET_TRANSFERRED,
+							STATE_TARGET_INVALID,
+							STATE_TARGET_WITHDRAWN
+						]
+					}
+				}
 			}
 		}
 	};


### PR DESCRIPTION
Removes the current final states from the personal list. Appeals in final states can only be found on the all cases.

`
status: {
		notIn: [
			STATE_TARGET_COMPLETE,
			STATE_TARGET_CLOSED,
			STATE_TARGET_TRANSFERRED,
			STATE_TARGET_INVALID,
			STATE_TARGET_WITHDRAWN
		]
	}
`

## Issue ticket number and link
[BOAT-917](https://pins-ds.atlassian.net/browse/BOAT-917)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAT-917]: https://pins-ds.atlassian.net/browse/BOAT-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ