### PR TITLE
fix(applications/api): nsip-project projectEmailAddress can not be empty string (BOAS-1647)

### DIFF
--- a/apps/api/src/server/applications/application/__tests__/update-application.test.js
+++ b/apps/api/src/server/applications/application/__tests__/update-application.test.js
@@ -307,7 +307,7 @@ describe('Update application', () => {
 	});
 
 	test(`update-application with new applicant using first and last name,
-			address line, map zoom level`, async () => {
+			address line, map zoom level, blank case email`, async () => {
 		// GIVEN
 		databaseConnector.case.findUnique.mockResolvedValue({
 			id: 1,
@@ -331,7 +331,8 @@ describe('Update application', () => {
 			},
 			geographicalInformation: {
 				mapZoomLevelName: 'some-known-map-zoom-level'
-			}
+			},
+			caseEmail: ''
 		});
 
 		// THEN
@@ -344,9 +345,11 @@ describe('Update application', () => {
 				ApplicationDetails: {
 					upsert: {
 						create: {
+							caseEmail: null,
 							zoomLevel: { connect: { name: 'some-known-map-zoom-level' } }
 						},
 						update: {
+							caseEmail: null,
 							zoomLevel: { connect: { name: 'some-known-map-zoom-level' } }
 						}
 					}

--- a/apps/api/src/server/applications/application/application.mapper.js
+++ b/apps/api/src/server/applications/application/application.mapper.js
@@ -22,6 +22,11 @@ export const mapCreateApplicationRequestToRepository = (applicationDetails) => {
 		['locationDescription', 'submissionAtInternal', 'submissionAtPublished', 'caseEmail']
 	);
 
+	if (formattedApplicationDetails.caseEmail === '') {
+		// Make sure caseEmail is saved as a null if blank
+		formattedApplicationDetails.caseEmail = null;
+	}
+
 	const applicant = applicationDetails?.applicant;
 	const formattedApplicantDetails = pick(applicant, [
 		'organisationName',


### PR DESCRIPTION
## Describe your changes

- Make sure the caseEmail is set to null if an empty string is received before updating the application details
- Manually tested locally, checking event messages output in the terminal and the caseEmail column in the ApplicationDetails table

## BOAS-1647 Schema Validation Error - nsip-project projectEmailAddress can not be empty string
https://pins-ds.atlassian.net/browse/BOAS-1647

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes

