### PR TITLE
fix(web): update transfer appeal flow to display custom error page when horizon is down

### DIFF
--- a/appeals/api/src/server/utils/horizon-gateway.js
+++ b/appeals/api/src/server/utils/horizon-gateway.js
@@ -89,6 +89,10 @@ export const getAppealFromHorizon = async (caseReference) => {
 					.post('/horizon', requestBody)
 					.reply(500, parseHorizonGetCaseResponse(horizonGetCaseNotPublishedResponse));
 				break;
+			// Horizon down
+			case '3000000':
+				nock(config.horizon.url).post('/horizon', requestBody).reply(500);
+				break;
 			//Case not found
 			default:
 				nock(config.horizon.url)

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/__snapshots__/change-appeal-type.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/__snapshots__/change-appeal-type.test.js.snap
@@ -265,6 +265,19 @@ exports[`change-appeal-type POST /change-appeal-type/add-horizon-reference shoul
 </main>"
 `;
 
+exports[`change-appeal-type POST /change-appeal-type/add-horizon-reference should render a custom error page stating that there is a problem with Horizon, if the transferred-appeal endpoint returns a 500 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Sorry, there is a problem with Horizon</h1>
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body"><a href="/appeals-service/appeal-details/1" class="govuk-link">Go back to case overview</a>
+            </p>
+        </div>
+    </div>
+</main>"
+`;
+
 exports[`change-appeal-type POST /change-appeal-type/appeal-type should re-render the appeal type page with an error message if required field is missing 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <div class="govuk-grid-row">

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/change-appeal-type.test.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/__tests__/change-appeal-type.test.js
@@ -279,6 +279,20 @@ describe('change-appeal-type', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 		});
 
+		it('should render a custom error page stating that there is a problem with Horizon, if the transferred-appeal endpoint returns a 500', async () => {
+			nock('http://test/').get('/appeals/transferred-appeal/123').reply(500);
+
+			const response = await request
+				.post(`${baseUrl}/1${changeAppealTypePath}${addHorizonReferencePath}`)
+				.send({
+					'horizon-reference': '123'
+				});
+
+			expect(response.statusCode).toBe(200);
+			const element = parseHtml(response.text);
+			expect(element.innerHTML).toMatchSnapshot();
+		});
+
 		it('should redirect to the check transfer page if an appeal matching the provided horizon reference was found in horizon', async () => {
 			nock('http://test/').get('/appeals/transferred-appeal/123').reply(200, {
 				caseFound: true

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.controller.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.controller.js
@@ -275,6 +275,19 @@ export const postAddHorizonReference = async (request, response) => {
 			body: { 'horizon-reference': horizonReference }
 		} = request;
 
+		if (request.body.problemWithHorizon) {
+			return response.render('app/500.njk', {
+				titleCopy: 'Sorry, there is a problem with Horizon',
+				additionalCtas: [
+					{
+						href: `/appeals-service/appeal-details/${appealId}`,
+						text: 'Go back to case overview'
+					}
+				],
+				hideDefaultCta: true
+			});
+		}
+
 		if (errors) {
 			return renderAddHorizonReference(request, response);
 		}

--- a/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.validators.js
+++ b/appeals/web/src/server/appeals/appeal-details/change-appeal-type/change-appeal-type.validators.js
@@ -45,16 +45,25 @@ export const validateHorizonReference = createValidator(
 				return Promise.reject();
 			}
 
-			const horizonReferenceValidationResult = await checkAppealReferenceExistsInHorizon(
-				req.apiClient,
-				bodyFields['horizon-reference']
-			);
+			try {
+				const horizonReferenceValidationResult = await checkAppealReferenceExistsInHorizon(
+					req.apiClient,
+					bodyFields['horizon-reference']
+				);
 
-			if (horizonReferenceValidationResult.caseFound === false) {
-				return Promise.reject();
+				if (horizonReferenceValidationResult.caseFound === false) {
+					return Promise.reject();
+				}
+
+				return horizonReferenceValidationResult.caseFound;
+			} catch (/** @type {any} */ error) {
+				if (error.response.statusCode === 500) {
+					req.body.problemWithHorizon = true;
+					return true; // avoids failing validation chain (scenario where Horizon is down is handled by rendering a special error page instead of a validation error)
+				}
 			}
 
-			return horizonReferenceValidationResult.caseFound;
+			return Promise.reject();
 		})
 		.withMessage('Enter a valid Horizon appeal reference')
 );

--- a/appeals/web/src/server/views/app/500.njk
+++ b/appeals/web/src/server/views/app/500.njk
@@ -1,12 +1,19 @@
 {% extends "app/layouts/app-two-column.layout.njk" %}
 
-{% set pageTitle = 'Sorry, there is a problem with the service' %}
+{% set pageTitle = titleCopy if titleCopy else 'Sorry, there is a problem with the service' %}
 
 {% block pageContent %}
-	<p class="govuk-body">Try again later.</p>
-	<p class="govuk-body">
-		<a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if the problem persists.
-	</p>
+	<p class="govuk-body">{{ bodyCopy if bodyCopy else 'Try again later.' }}</p>
+	{%- for additionalCta in additionalCtas -%}
+		<p class="govuk-body">
+			<a href="{{ additionalCta.href }}" class="govuk-link">{{ additionalCta.text }}</a>
+		</p>
+	{%- endfor -%}
+	{%- if not hideDefaultCta -%}
+		<p class="govuk-body">
+			<a href="https://has-appeal.herokuapp.com/help/contact" class="govuk-link">Contact the Planning Inspectorate Customer Support</a> if the problem persists.
+		</p>
+	{%- endif -%}
 
 	{% if error and isDevelopment %}
 		<hr>


### PR DESCRIPTION
## Describe your changes

fix(web): update transfer appeal flow to display custom error page when horizon is down

## Issue ticket number and link

BOAT-920

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
