### PR TITLE
fix(api/applications): stringify object in error message in buildBlobUri

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.js
+++ b/apps/api/src/server/applications/application/documents/document.js
@@ -127,11 +127,11 @@ export const buildNsipDocumentPayload = (version) => {
 const buildBlobUri = (containerName, path) => {
 	if (!(config.blobStorageUrl && containerName && path)) {
 		logger.error(
-			`Failed to build blob URI. One of the required components was missing.\n${{
+			`Failed to build blob URI. One of the required components was missing.\n${JSON.stringify({
 				blobStorageUrl: config.blobStorageUrl,
 				containerName,
 				path
-			}}`
+			})}`
 		);
 		return null;
 	}


### PR DESCRIPTION
## Describe your changes

The object included in the error message is showing up as `[object Object]`. Stringifying it should help with debugging.

## Issue ticket number and link

[BOAS-1645](https://pins-ds.atlassian.net/browse/BOAS-1645)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1645]: https://pins-ds.atlassian.net/browse/BOAS-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ