### PR TITLE
fix(appeals): fix horizon appeal links for linked and related appeals

### DIFF
--- a/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
+++ b/appeals/api/src/server/endpoints/link-appeals/__tests__/link-appeal.test.js
@@ -1,11 +1,15 @@
+// @ts-nocheck
 import { request } from '#tests/../app-test.js';
 import { jest } from '@jest/globals';
 import { azureAdUserId } from '#tests/shared/mocks.js';
 import { householdAppeal, linkedAppeals } from '#tests/appeals/mocks.js';
 import { linkedAppealRequest, linkedAppealLegacyRequest } from '#tests/linked-appeals/mocks.js';
 import { CASE_RELATIONSHIP_LINKED, CASE_RELATIONSHIP_RELATED } from '#endpoints/constants.js';
+import { horizonGetCaseSuccessResponse } from '#tests/horizon/mocks.js';
+import { parseHorizonGetCaseResponse } from '#utils/mapping/map-horizon.js';
 
 const { databaseConnector } = await import('#utils/database-connector.js');
+const { default: got } = await import('got');
 
 describe('appeal linked appeals routes', () => {
 	afterEach(() => {
@@ -122,6 +126,11 @@ describe('appeal linked appeals routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
 				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+				got.post.mockReturnValueOnce({
+					json: jest
+						.fn()
+						.mockResolvedValueOnce(parseHorizonGetCaseResponse(horizonGetCaseSuccessResponse))
+				});
 
 				const response = await request
 					.post(`/appeals/${householdAppeal.id}/link-legacy-appeal`)
@@ -135,8 +144,8 @@ describe('appeal linked appeals routes', () => {
 				expect(databaseConnector.appealRelationship.create).toHaveBeenCalledTimes(1);
 				expect(databaseConnector.appealRelationship.create).toHaveBeenCalledWith({
 					data: {
-						parentId: null,
-						parentRef: '123456',
+						parentId: 20486402,
+						parentRef: '1000000',
 						childRef: householdAppeal.reference,
 						childId: householdAppeal.id,
 						type: CASE_RELATIONSHIP_LINKED,
@@ -239,6 +248,11 @@ describe('appeal linked appeals routes', () => {
 				databaseConnector.appeal.findUnique.mockResolvedValue(householdAppeal);
 				// @ts-ignore
 				databaseConnector.appealRelationship.findMany.mockResolvedValue([]);
+				got.post.mockReturnValueOnce({
+					json: jest
+						.fn()
+						.mockResolvedValueOnce(parseHorizonGetCaseResponse(horizonGetCaseSuccessResponse))
+				});
 
 				const response = await request
 					.post(`/appeals/${householdAppeal.id}/associate-legacy-appeal`)
@@ -255,7 +269,7 @@ describe('appeal linked appeals routes', () => {
 						parentId: householdAppeal.id,
 						parentRef: householdAppeal.reference,
 						childRef: '123456',
-						childId: null,
+						childId: 20486402,
 						type: CASE_RELATIONSHIP_RELATED,
 						externalSource: true
 					}

--- a/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
+++ b/appeals/api/src/server/endpoints/link-appeals/link-appeals.controller.js
@@ -13,6 +13,8 @@ import {
 	CASE_RELATIONSHIP_RELATED,
 	ERROR_LINKING_APPEALS
 } from '#endpoints/constants.js';
+import { getAppealFromHorizon } from '#utils/horizon-gateway.js';
+import { formatHorizonGetCaseData } from '#utils//mapping/map-horizon.js';
 
 /** @typedef {import('express').Request} Request */
 /** @typedef {import('express').Response} Response */
@@ -91,19 +93,24 @@ export const linkExternalAppeal = async (req, res) => {
 		});
 	}
 
+	const linkedAppeal = await getAppealFromHorizon(linkedAppealReference);
+	const formattedLinkedAppeal = formatHorizonGetCaseData(linkedAppeal);
+	const linkedAppealId = formattedLinkedAppeal.appealId
+		? parseInt(formattedLinkedAppeal.appealId)
+		: undefined;
 	const relationship = isCurrentAppealParent
 		? {
 				parentId: currentAppeal.id,
 				parentRef: currentAppeal.reference,
-				childRef: linkedAppealReference,
-				childId: null,
+				childRef: formattedLinkedAppeal.appealReference || linkedAppealReference,
+				childId: linkedAppealId || null,
 				type: CASE_RELATIONSHIP_LINKED,
 				externalSource: true,
 				externalAppealType
 		  }
 		: {
-				parentId: null,
-				parentRef: linkedAppealReference,
+				parentId: linkedAppealId || null,
+				parentRef: formattedLinkedAppeal.appealReference || linkedAppealReference,
 				childRef: currentAppeal.reference,
 				childId: currentAppeal.id,
 				type: CASE_RELATIONSHIP_LINKED,
@@ -164,10 +171,17 @@ export const associateAppeal = async (req, res) => {
 export const associateExternalAppeal = async (req, res) => {
 	const { linkedAppealReference } = req.body;
 	const currentAppeal = req.appeal;
+
+	const linkedAppeal = await getAppealFromHorizon(linkedAppealReference);
+	const formattedLinkedAppeal = formatHorizonGetCaseData(linkedAppeal);
+	const linkedAppealId = formattedLinkedAppeal.appealId
+		? parseInt(formattedLinkedAppeal.appealId)
+		: undefined;
+
 	const relationship = {
 		parentId: currentAppeal.id,
 		parentRef: currentAppeal.reference,
-		childId: null,
+		childId: linkedAppealId || null,
 		childRef: linkedAppealReference,
 		type: CASE_RELATIONSHIP_RELATED,
 		externalSource: true

--- a/appeals/api/src/server/endpoints/linkable-appeals/__tests__/linkable-appeal.test.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/__tests__/linkable-appeal.test.js
@@ -59,7 +59,7 @@ describe('/appeals/linkable-appeal/:appealReference', () => {
 			expect(response.status).toEqual(200);
 			expect(response.body).toEqual({
 				appealId: '20486402',
-				appealReference: '3171066',
+				appealReference: '1000000',
 				appealType: 'Planning Appeal (W)',
 				appealStatus: 'Closed - Opened in Error',
 				siteAddress: {

--- a/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.service.js
+++ b/appeals/api/src/server/endpoints/linkable-appeals/linkable-appeal.service.js
@@ -1,3 +1,4 @@
+import logger from '#utils/logger.js';
 import appealRepository from '#repositories/appeal.repository.js';
 import { getAppealFromHorizon } from '#utils/horizon-gateway.js';
 import { formatLinkableAppealSummary } from './linkable-appeal.formatter.js';
@@ -11,6 +12,7 @@ import { formatHorizonGetCaseData } from '#utils//mapping/map-horizon.js';
 export const getLinkableAppealSummaryByCaseReference = async (appealReference) => {
 	let appeal = await appealRepository.getAppealByAppealReference(appealReference);
 	if (!appeal) {
+		logger.debug('Case not found in BO, now trying to query Horizon');
 		const horizonAppeal = await getAppealFromHorizon(appealReference).catch((error) => {
 			throw error;
 		});

--- a/appeals/api/src/server/tests/horizon/mocks.js
+++ b/appeals/api/src/server/tests/horizon/mocks.js
@@ -15,7 +15,7 @@ export const horizonGetCaseSuccessResponse = `{
 						}
 					},
 					"CaseReference":	{
-						"value":	"APP/Q9999/W/17/3171066"
+						"value":	"APP/Q9999/W/17/1000000"
 					},
 					"CaseType":	{
 						"value":	"Planning Appeal (W)"

--- a/appeals/api/src/server/utils/horizon-gateway.js
+++ b/appeals/api/src/server/utils/horizon-gateway.js
@@ -74,7 +74,6 @@ export const getAppealFromHorizon = async (caseReference) => {
 
 	const requestBody = horizonGetCaseRequestBody(caseReference);
 
-	logger.debug('Case not found in BO, now trying to query Horizon');
 	if (config.horizon.mock) {
 		switch (caseReference) {
 			//Case found
@@ -101,6 +100,7 @@ export const getAppealFromHorizon = async (caseReference) => {
 				break;
 		}
 	}
+
 	/**
 	 * @type {Promise<HorizonGetCaseSuccessResponse>}
 	 */
@@ -122,6 +122,7 @@ export const getAppealFromHorizon = async (caseReference) => {
 			logger.error(error.response.body);
 			throw 500;
 		});
+
 	logger.debug('Found case on Horizon.');
 	return appealData;
 };

--- a/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
+++ b/appeals/web/src/server/appeals/appeal-details/__tests__/__snapshots__/appeal-details.test.js.snap
@@ -277,9 +277,7 @@ exports[`appeal-details GET /:appealId should render a "horizon reference added"
     </div><strong class="govuk-tag govuk-tag--grey single-line govuk-!-margin-bottom-4">Transferred</strong>
     <div     class="govuk-inset-text govuk-!-margin-top-0">
         <p class="govuk-body">This appeal needed to change to a (C) Enforcement notice appeal</p>
-        <p         class="govuk-body">It has been transferred to Horizon with the reference <a target="_blank"
-            class="govuk-link" href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=12345">12345</a>
-            </p>
+        <p         class="govuk-body">It has been transferred to Horizon with the reference 12345</p>
             </div>
             <dl class="govuk-summary-list govuk-summary-list--no-border">
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Site address</dt>
@@ -1059,8 +1057,7 @@ exports[`appeal-details GET /:appealId should render a child tag next to the app
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list">
                                     <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                    <li><a href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=76215416"
-                                        class="govuk-link" aria-label="Appeal 7 6 2 1 5 4 1 6">76215416</a> (Lead)</li>
+                                    <li><span class="govuk-body">76215416</span> (Lead)</li>
                                 </ul>
                             </dd>
                             <dd class="govuk-summary-list__actions">
@@ -1313,8 +1310,7 @@ exports[`appeal-details GET /:appealId should render a lead tag next to the appe
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list">
                                     <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                    <li><a href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=87326527"
-                                        class="govuk-link" aria-label="Appeal 8 7 3 2 6 5 2 7">87326527</a> (Child)</li>
+                                    <li><span class="govuk-body">87326527</span> (Child)</li>
                                     <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                 </ul>
                             </dd>
@@ -3073,11 +3069,9 @@ exports[`appeal-details GET /:appealId should render action links to the manage 
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list">
                                     <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                    <li><a href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=87326527"
-                                        class="govuk-link" aria-label="Appeal 8 7 3 2 6 5 2 7">87326527</a> (Child)</li>
+                                    <li><span class="govuk-body">87326527</span> (Child)</li>
                                     <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                    <li><a href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=76215416"
-                                        class="govuk-link" aria-label="Appeal 7 6 2 1 5 4 1 6">76215416</a> (Lead)</li>
+                                    <li><span class="govuk-body">76215416</span> (Lead)</li>
                                     <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                 </ul>
                             </dd>
@@ -4302,11 +4296,9 @@ exports[`appeal-details GET /:appealId should render the case reference for each
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list">
                                     <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                    <li><a href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=87326527"
-                                        class="govuk-link" aria-label="Appeal 8 7 3 2 6 5 2 7">87326527</a> (Child)</li>
+                                    <li><span class="govuk-body">87326527</span> (Child)</li>
                                     <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                    <li><a href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=76215416"
-                                        class="govuk-link" aria-label="Appeal 7 6 2 1 5 4 1 6">76215416</a> (Lead)</li>
+                                    <li><span class="govuk-body">76215416</span> (Lead)</li>
                                     <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                 </ul>
                             </dd>
@@ -4702,11 +4694,9 @@ exports[`appeal-details GET /:appealId should render the lead or child status af
                             <dd class="govuk-summary-list__value">
                                 <ul class="govuk-list">
                                     <li><a href="/appeals-service/appeal-details/5449" class="govuk-link" aria-label="Appeal 7 8 4 7 0 6">784706</a> (Child)</li>
-                                    <li><a href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=87326527"
-                                        class="govuk-link" aria-label="Appeal 8 7 3 2 6 5 2 7">87326527</a> (Child)</li>
+                                    <li><span class="govuk-body">87326527</span> (Child)</li>
                                     <li><a href="/appeals-service/appeal-details/5464" class="govuk-link" aria-label="Appeal 1 4 0 0 7 9">140079</a> (Lead)</li>
-                                    <li><a href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=76215416"
-                                        class="govuk-link" aria-label="Appeal 7 6 2 1 5 4 1 6">76215416</a> (Lead)</li>
+                                    <li><span class="govuk-body">76215416</span> (Lead)</li>
                                     <li><a href="/appeals-service/appeal-details/5451" class="govuk-link" aria-label="Appeal 7 2 1 0 8 6">721086</a> (Child)</li>
                                 </ul>
                             </dd>

--- a/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
+++ b/appeals/web/src/server/appeals/appeal-details/appeal-details.mapper.js
@@ -306,7 +306,7 @@ export async function appealDetailsPage(appealDetails, currentRoute, session) {
 				type: 'inset-text',
 				parameters: {
 					html: `<p class="govuk-body">This appeal needed to change to a ${appealDetails.transferStatus.transferredAppealType}</p>
-						<p class="govuk-body">It has been transferred to Horizon with the reference <a target="_blank" class="govuk-link" href="https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=${appealDetails.transferStatus.transferredAppealReference}">${appealDetails.transferStatus.transferredAppealReference}</a></p>`,
+					<p class="govuk-body">It has been transferred to Horizon with the reference ${appealDetails.transferStatus.transferredAppealReference}</p>`,
 					classes: 'govuk-!-margin-top-0'
 				}
 			});

--- a/appeals/web/src/server/lib/display-page-formatter.js
+++ b/appeals/web/src/server/lib/display-page-formatter.js
@@ -71,12 +71,15 @@ export const formatListOfLinkedAppeals = (listOfAppeals) => {
 		for (let i = 0; i < listOfAppeals.length; i++) {
 			const shortAppealReference = appealShortReference(listOfAppeals[i].appealReference);
 			const linkUrl = listOfAppeals[i].externalSource
-				? `https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=${listOfAppeals[i].appealReference}`
+				? generateHorizonAppealUrl(listOfAppeals[i].appealId)
 				: `/appeals-service/appeal-details/${listOfAppeals[i].appealId}`;
 			const linkAriaLabel = `Appeal ${numberToAccessibleDigitLabel(shortAppealReference || '')}`;
 			const relationshipText = listOfAppeals[i].isParentAppeal ? ' (Lead)' : ' (Child)';
 
-			formattedLinks += `<li><a href="${linkUrl}" class="govuk-link" aria-label="${linkAriaLabel}">${shortAppealReference}</a> ${relationshipText}</li>`;
+			formattedLinks +=
+				linkUrl.length > 0
+					? `<li><a href="${linkUrl}" class="govuk-link" aria-label="${linkAriaLabel}">${shortAppealReference}</a> ${relationshipText}</li>`
+					: `<li><span class="govuk-body">${shortAppealReference}</span> ${relationshipText}</li>`;
 		}
 
 		return `<ul class="govuk-list">${formattedLinks}</ul>`;
@@ -97,11 +100,14 @@ export const formatListOfRelatedAppeals = (listOfAppeals) => {
 		for (let i = 0; i < listOfAppeals.length; i++) {
 			const shortAppealReference = appealShortReference(listOfAppeals[i].appealReference);
 			const linkUrl = listOfAppeals[i].externalSource
-				? `https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=${listOfAppeals[i].appealReference}`
+				? generateHorizonAppealUrl(listOfAppeals[i].appealId)
 				: `/appeals-service/appeal-details/${listOfAppeals[i].appealId}`;
 			const linkAriaLabel = `Appeal ${numberToAccessibleDigitLabel(shortAppealReference || '')}`;
 
-			formattedLinks += `<li><a href="${linkUrl}" class="govuk-link" aria-label="${linkAriaLabel}">${shortAppealReference}</a></li>`;
+			formattedLinks +=
+				linkUrl.length > 0
+					? `<li><a href="${linkUrl}" class="govuk-link" aria-label="${linkAriaLabel}">${shortAppealReference}</a></li>`
+					: `<li><span class="govuk-body">${shortAppealReference}</span></li>`;
 		}
 
 		return `<ul class="govuk-list">${formattedLinks}</ul>`;
@@ -338,4 +344,16 @@ export function formatListOfAddresses(arrayOfAddresses) {
 		return `<ul class="govuk-list govuk-list--bullet">${formattedList}</ul>`;
 	}
 	return '<span>None</span>';
+}
+
+/**
+ * @param {string|number|null|undefined} appealId
+ * @returns {string}
+ */
+export function generateHorizonAppealUrl(appealId) {
+	if (appealId === null || appealId === undefined) {
+		return '';
+	}
+
+	return `https://horizonweb.planninginspectorate.gov.uk/otcs/llisapi.dll?func=ll&objId=${appealId}`;
 }


### PR DESCRIPTION
## Describe your changes

Fix horizon appeal links for linked and related appeals. Also reverts the link for transferred appeals to plaintext (API fix required to return the horizon ID of transferred appeals - see BOAT-1079)

## Issue ticket number and link

BOAT-1060

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
