### PR TITLE
fix(applications/web): fix e2e tests for document properties page (BOAS-1660)

### DIFF
--- a/apps/e2e/cypress/page_objects/documentPropertiesPage.js
+++ b/apps/e2e/cypress/page_objects/documentPropertiesPage.js
@@ -17,7 +17,7 @@ export class DocumentPropertiesPage extends Page {
 	fileName = () => 'Filename';
 	description = () => 'description';
 	from = () => 'From';
-	agent = () => "Agentname";
+	agent = () => 'Agentname';
 	webfilter = () => 'Webfilter name';
 	getDate = (received) => {
 		const today = new Date();
@@ -111,55 +111,56 @@ export class DocumentPropertiesPage extends Page {
 		this.clickTabByText('Document history');
 		cy.get(`${this.selectors.tableBody} > ${this.selectors.tableRow}`).should('have.length', count);
 	}
-	verifyUnpublishButtonIsNotVisible(){
-		cy.get('a.govuk-button:nth-child(5)').should('not.exist');
+	verifyUnpublishButtonIsNotVisible() {
+		this.basePageElements.buttonByLabelText('Unpublish').should('not.exist');
 	}
-	verifyUnpublishStatus(){
+	verifyUnpublishStatus() {
 		cy.get('#tab_document-history').click();
-	    cy.get('p:nth-child(3) strong').should('have.text','Unpublished:');
-
+		cy.get('p:nth-child(3) strong').should('have.text', 'Unpublished:');
 	}
-	verifyPublishStatus(){
+	verifyPublishStatus() {
 		cy.get('#tab_document-history').click();
-	    cy.get('p:nth-child(2) strong').should('have.text','Published:');
-
+		cy.get('p:nth-child(2) strong').should('have.text', 'Published:');
 	}
-	verifyDocumentIsDeleted(){
-		cy.get('a:nth-child(4)').click();
+	verifyDocumentIsDeleted() {
+		this.clickButtonByText('Delete');
 		cy.get('.govuk-button').click();
 		cy.get('.govuk-panel').contains('Document successfully deleted');
 	}
-	verifyNaviagtedBackToDocPropertiesPage(){
-		cy.get('a:nth-child(4)').click();
+	verifyNaviagtedBackToDocPropertiesPage() {
+		this.clickButtonByText('Delete');
 		cy.get('.govuk-back-link').click();
 		cy.get('#tab_document-history').should('exist');
 	}
-	getDocumentRefNumber(){
-		cy.get('li:nth-child(3)').then(($value)=>{
-		const getElementText = $value.text();
-		cy.log("printling the text value :-> "+getElementText);
-		Cypress.env('DocRef', getElementText);
+	getDocumentRefNumber() {
+		cy.get('li:nth-child(3)').then(($value) => {
+			const getElementText = $value.text();
+			cy.log('printling the text value :-> ' + getElementText);
+			Cypress.env('DocRef', getElementText);
 		});
-
 	}
-	enterDocumentRefNumber(docmentNumber){
-		cy.get('#document-properties > dl > div:nth-child(8) > dd.govuk-summary-list__actions > a').click();
+	enterDocumentRefNumber(docmentNumber) {
+		cy.get(
+			'#document-properties > dl > div:nth-child(8) > dd.govuk-summary-list__actions > a'
+		).click();
 		cy.get('#transcript').type(docmentNumber);
 		cy.get('.govuk-button').click();
 	}
-	validateTranscriptValue(){
+	validateTranscriptValue() {
 		const caseRef = Cypress.env('currentCreatedCase');
 		cy.get('.govuk-summary-list__row:nth-child(8) > dd:nth-child(2)').contains(caseRef);
 	}
-	enterIncorrectDocumentRefNumber(docmentNumber){
-		cy.get('#document-properties > dl > div:nth-child(8) > dd.govuk-summary-list__actions > a').click();
+	enterIncorrectDocumentRefNumber(docmentNumber) {
+		cy.get(
+			'#document-properties > dl > div:nth-child(8) > dd.govuk-summary-list__actions > a'
+		).click();
 		cy.get('#transcript').type(docmentNumber);
 		cy.get('.govuk-button').click();
 	}
-	validateDocumentErrorMessage(){
+	validateDocumentErrorMessage() {
 		cy.get('#transcript-error').contains('Please enter a valid document reference number.');
 	}
-	verifyDocumentPropertiesHeading(){
+	verifyDocumentPropertiesHeading() {
 		cy.get('.govuk-caption-xl').contains('Document properties');
 	}
 }

--- a/apps/e2e/cypress/page_objects/folderDocumentsPage.js
+++ b/apps/e2e/cypress/page_objects/folderDocumentsPage.js
@@ -43,16 +43,16 @@ export class FolderDocumentsPage extends Page {
 		cy.contains(projectInfo.projectName).should('exist');
 		cy.contains(caseRef).should('exist');
 	}
-	navigateToProjectFolder(){
+	navigateToProjectFolder() {
 		this.goToFolderDocumentPage();
 	}
 	unpublishDocument() {
-		this.basePageElements.unpublishLink().click();
+		this.clickButtonByText('Unpublish');
 		this.clickButtonByText('Unpublish documents');
 		this.validateSuccessPanelTitle('Document/s successfully unpublished');
 	}
-	verifyDeleteButtonIsVisible(){
-		cy.get('a.govuk-button:nth-child(4)').should('exist');
+	verifyDeleteButtonIsVisible() {
+		this.basePageElements.buttonByLabelText('Delete').should('exist');
 	}
 	applyChangesWithoutSelectingDocument() {
 		this.setOverallStatus('Ready to publish');
@@ -66,7 +66,7 @@ export class FolderDocumentsPage extends Page {
 	clickOnPublishButton() {
 		this.clickButtonByText('Publish documents');
 	}
-	verifyDocumentSelectError(){
-         cy.get('li:nth-child(1) > a').contains('You must select documents to publish');
+	verifyDocumentSelectError() {
+		cy.get('li:nth-child(1) > a').contains('You must select documents to publish');
 	}
 }

--- a/apps/e2e/cypress/page_objects/uploadFiles.js
+++ b/apps/e2e/cypress/page_objects/uploadFiles.js
@@ -59,20 +59,20 @@ export class FileUploadPage extends Page {
 				}
 			});
 	}
-	verifyDocumentSelectError(){
-		cy.get('.govuk-list > li:nth-child(1) > a:nth-child(1)').contains('Select documents to make changes to statuses');
+	verifyDocumentSelectError() {
+		cy.get('.govuk-list > li:nth-child(1) > a:nth-child(1)').contains(
+			'Select documents to make changes to statuses'
+		);
 	}
 
-	backToProjectDocumentationPage(){
+	backToProjectDocumentationPage() {
 		cy.get('li:nth-child(1) a:nth-child(1)').click();
-
 	}
 	verifyFileIsUploaded() {
 		cy.wait(5000);
 		cy.reload();
 	}
-	clickDownloadFile(){
-		cy.get('#main-content > div > div > nav > a:nth-child(3)').should('exist');
-		cy.get('#main-content > div > div > nav > a:nth-child(3)').click();
+	clickDownloadFile() {
+		this.clickButtonByText('Download');
 	}
 }


### PR DESCRIPTION
## Describe your changes

The PR https://github.com/Planning-Inspectorate/back-office/pull/2268 failed the tests as the styling and structure of the buttons in the page had changed.  This PR amends the tests to cope with the new structure of the page.

- Updated e2e tests to target elements via contained text rather than nth elements
- Successfully run against the DEV environment

## BOAS-1660 Broken styling in Document properties page
https://pins-ds.atlassian.net/browse/BOAS-1660

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
