### PR TITLE
fix(applications/web): publishing queue link incorrectly placed (BOAS-1282)

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -6818,7 +6818,7 @@ exports[`applications documentation Document properties page page should render 
             </ul>
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/new-version\\"> Upload new version</a>
             </div>
-            <nav>
+            <nav class=\\"pins-nav-button-group\\">
                 <h3 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document actions</h3>
                 <input type='hidden' value='11' name='selectedFilesIds[]'>
                 <div class=\\"govuk-button-group\\"><a href=\\"/documents/123/download/11/version//\\" role=\\"button\\" draggable=\\"false\\"
@@ -6981,16 +6981,16 @@ exports[`applications documentation Document properties page should not show pub
             </ul>
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/new-version\\"> Upload new version</a>
             </div>
-            <nav>
+            <nav class=\\"pins-nav-button-group\\">
                 <h3 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document actions</h3>
                 <div class=\\"govuk-button-group\\"><a href=\\"/documents/123/download/3/version//preview\\" role=\\"button\\" draggable=\\"false\\"
                     class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\"> Open</a>
                     <a                     href=\\"/documents/123/download/3/version//\\" role=\\"button\\" draggable=\\"false\\"
                     class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\">Download</a><a href=\\"/applications-service/case/123/project-documentation/21/document/3/delete\\"
                         role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
-                        data-module=\\"govuk-button\\"> Delete</a><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right\\"
-                        href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
-                </div>
+                        data-module=\\"govuk-button\\"> Delete</a>
+                </div><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link\\"
+                href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
             </nav>
             <div class=\\"govuk-!-margin-top-7\\">
                 <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
@@ -7141,7 +7141,7 @@ exports[`applications documentation Document properties page should not show pub
             </ul>
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/new-version\\"> Upload new version</a>
             </div>
-            <nav>
+            <nav class=\\"pins-nav-button-group\\">
                 <h3 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document actions</h3>
                 <input type='hidden' value='11' name='selectedFilesIds[]'>
                 <div class=\\"govuk-button-group\\"><a href=\\"/documents/123/download/11/version//\\" role=\\"button\\" draggable=\\"false\\"
@@ -7304,16 +7304,16 @@ exports[`applications documentation Document properties page should show publish
             </ul>
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/new-version\\"> Upload new version</a>
             </div>
-            <nav>
+            <nav class=\\"pins-nav-button-group\\">
                 <h3 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document actions</h3>
                 <div class=\\"govuk-button-group\\"><a href=\\"/documents/123/download/3/version//preview\\" role=\\"button\\" draggable=\\"false\\"
                     class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\"> Open</a>
                     <a                     href=\\"/documents/123/download/3/version//\\" role=\\"button\\" draggable=\\"false\\"
                     class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\">Download</a><a href=\\"/applications-service/case/123/project-documentation/21/document/3/delete\\"
                         role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
-                        data-module=\\"govuk-button\\"> Delete</a><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right\\"
-                        href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
-                </div>
+                        data-module=\\"govuk-button\\"> Delete</a>
+                </div><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link\\"
+                href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
             </nav>
             <div class=\\"govuk-!-margin-top-7\\">
                 <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">

--- a/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
@@ -65,7 +65,7 @@
                     </a>
                 </div>
 				{% endif %}
-                <nav>
+                <nav class="pins-nav-button-group">
 					<h3 class="govuk-heading-m govuk-!-margin-bottom-4">Document actions</h3>
 
 					{% if documentationFile.publishedStatus === 'published' %}
@@ -104,11 +104,10 @@
 								classes: "govuk-button--secondary"
 							}) }}
 						{% endif %}
-
-						{% if documentationFile.publishedStatus == 'ready_to_publish' %}
-							<a class="govuk-link govuk-body-m govuk-!-text-align-right" href= "{{'documents-queue'|url({caseId:caseId})}}">View publishing queue</a>
-						{% endif %}
 					</div>
+					{% if documentationFile.publishedStatus == 'ready_to_publish' %}
+						<a class="govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link" href= "{{'documents-queue'|url({caseId:caseId})}}">View publishing queue</a>
+					{% endif %}
 				</nav>
                 <div class="govuk-!-margin-top-7">
                     {{ govukTabs({

--- a/apps/web/src/styles/7-components/_nav-button-group.scss
+++ b/apps/web/src/styles/7-components/_nav-button-group.scss
@@ -1,0 +1,11 @@
+@media (min-width: 40.0625em) {
+	nav.pins-nav-button-group {
+		.govuk-button-group {
+			display: inline-flex;
+		}
+
+		.pins-nav-right-aligned-link {
+			float: inline-end;
+		}
+	}
+}

--- a/apps/web/src/styles/main.scss
+++ b/apps/web/src/styles/main.scss
@@ -62,6 +62,7 @@
 @use "7-components/html-content-editor";
 @use "7-components/project-update";
 @use "7-components/key-dates-section";
+@use "7-components/nav-button-group";
 
 // 8 - UTILITIES
 


### PR DESCRIPTION
## Describe your changes

- Changed Document properties layout and styling for the 'publishing queue' link
- Unit tests updated
- Manually tested the functionality

## BOAS-1282 'Publishing queue' link is not in the correct place on the 'Document properties' page
https://pins-ds.atlassian.net/browse/BOAS-1282

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
