### PR TITLE
fix(applications/api): fix seed error retry delete (BOAS-1613)

### DIFF
--- a/apps/api/src/database/seed/seed-clear.js
+++ b/apps/api/src/database/seed/seed-clear.js
@@ -22,16 +22,6 @@ export async function deleteAllRecords(databaseConnector) {
 	const deleteDocumentActivityLog = databaseConnector.documentActivityLog.deleteMany();
 	const deletes51Advice = databaseConnector.s51Advice.deleteMany();
 	const deletes51AdviceDocument = databaseConnector.s51AdviceDocument.deleteMany();
-	const deleteFolders = databaseConnector.folder.deleteMany();
-	const deleteLowestFolders = databaseConnector.folder.deleteMany({
-		where: {
-			childFolders: {
-				every: {
-					parentFolder: null
-				}
-			}
-		}
-	});
 	const deleteRepresentationAttachment = databaseConnector.representationAttachment.deleteMany();
 	const deleteRepresentation = databaseConnector.representation.deleteMany();
 	const deleteRepresentationAction = databaseConnector.representationAction.deleteMany();
@@ -71,9 +61,10 @@ export async function deleteAllRecords(databaseConnector) {
 	// delete before cases
 	await deleteProjectUpdates;
 
-	await databaseConnector.$transaction([deleteLowestFolders, deleteRegionsOnApplicationDetails]);
+	await databaseConnector.$transaction([deleteRegionsOnApplicationDetails]);
 
-	await databaseConnector.$transaction([deleteFolders, deleteServiceUsers]);
+	await databaseConnector.$transaction(deleteFolders);
+	await databaseConnector.$transaction([deleteServiceUsers]);
 
 	await databaseConnector.$transaction([
 		deleteGridReference,
@@ -91,4 +82,37 @@ export async function deleteAllRecords(databaseConnector) {
 	await deleteRegion;
 	await deleteZoomLevel;
 	await deleteExaminationTimetableType;
+}
+
+/**
+ *
+ * @param {import('@prisma/client').PrismaClient} databaseConnector
+ */
+async function deleteFolders(databaseConnector) {
+	let exists = true;
+	let lastError = null;
+	let remainingRetries = 10;
+	do {
+		try {
+			await databaseConnector.folder.deleteMany({
+				where: {
+					childFolders: {
+						every: {
+							parentFolder: null
+						}
+					}
+				}
+			});
+			exists = await databaseConnector.folder.findFirst({
+				where: { NOT: { parentFolderId: null } }
+			});
+		} catch (err) {
+			remainingRetries -= 1;
+			lastError = err;
+		}
+	} while (exists && remainingRetries);
+	if (exists) {
+		throw lastError;
+	}
+	return databaseConnector.folder.deleteMany();
 }


### PR DESCRIPTION
## Describe your changes

- Changed seeding so that the deletion of folders is retried until there are none left to delete or it fails 10 times
- Manually tested the functionality locally

## BOAS-1613 Seed failed in Dev
https://pins-ds.atlassian.net/browse/BOAS-1613

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
