### PR TITLE
fix(applications/web): hide open button in document properties correctly (BOAS-1485)

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -6910,7 +6910,167 @@ exports[`applications documentation Document properties delete page POST /case/1
 </main>"
 `;
 
-exports[`applications documentation Document properties page page should render 1`] = `
+exports[`applications documentation Document properties page page should render with Open button 1`] = `
+"<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
+    <div class=\\"govuk-grid-row\\">
+        <div class=\\"govuk-grid-column-full govuk-!-margin-top-0\\">
+            <div class=\\"govuk-breadcrumbs govuk-!-margin-top-0\\">
+                <ol class=\\"govuk-breadcrumbs__list\\">
+                    <li class=\\"govuk-breadcrumbs__list-item\\"><a class=\\"govuk-breadcrumbs__link\\" href=\\"/applications-service/case/123/project-documentation\\">Project documentation</a>
+                    </li>
+                    <li class=\\"govuk-breadcrumbs__list-item\\"><a class=\\"govuk-breadcrumbs__link\\" href=\\"/applications-service/case/123/project-documentation/1/project-management/\\">Project management</a>
+                    </li>
+                    <li class=\\"govuk-breadcrumbs__list-item\\"><a class=\\"govuk-breadcrumbs__link\\" href=\\"/applications-service/case/123/project-documentation/21/sub-folder-level-2/\\">Sub folder level 2</a>
+                    </li>
+                </ol>
+            </div>
+            <h1 class=\\"govuk-heading-xl govuk-!-margin-top-4\\"><span class=\\"govuk-caption-xl\\">Document properties</span> 4 Elit sed</h1>
+            <ul class=\\"govuk-list\\">
+                <li class=\\"govuk-!-margin-top-4\\"><strong>Description:</strong> Elit sed do eiusmod tempor incididunt ut
+                    labore et dolore magna aliqua Ut enim ad</li>
+                <li class=\\"govuk-!-margin-top-4\\"><strong>Case reference:</strong> CASE/04</li>
+                <li class=\\"govuk-!-margin-top-4\\"><strong>Document reference number:</strong>
+                </li>
+                <li class=\\"govuk-!-margin-top-4\\"><strong>File type and size:</strong> PDF, 2.6 MB</li>
+                <li class=\\"govuk-!-margin-top-4\\"><strong>Version:</strong>
+                </li>
+            </ul>
+            <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/new-version\\"> Upload new version</a>
+            </div>
+            <nav class=\\"pins-nav-button-group\\">
+                <h3 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document actions</h3>
+                <div class=\\"govuk-button-group\\"><a href=\\"/documents/123/download/3/version//preview\\" role=\\"button\\" draggable=\\"false\\"
+                    class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\"> Open</a>
+                    <a                     href=\\"/documents/123/download/3/version//\\" role=\\"button\\" draggable=\\"false\\"
+                    class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\">Download</a><a href=\\"/applications-service/case/123/project-documentation/21/document/3/delete\\"
+                        role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
+                        data-module=\\"govuk-button\\"> Delete</a>
+                </div><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link\\"
+                href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
+            </nav>
+            <div class=\\"govuk-!-margin-top-7\\">
+                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                    <ul class=\\"govuk-tabs__list\\">
+                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                        </li>
+                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                        </li>
+                    </ul>
+                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                        <dl class=\\"govuk-summary-list\\">
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                                <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                                <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+                                    Ut enim ad</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                                <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                                <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                                <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                                <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                                <dd                                 class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
+                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
+                                    </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                                <dd class=\\"govuk-summary-list__value\\"></dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                                <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                                </dd>
+                            </div>
+                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                                <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
+                                </dd>
+                            </div>
+                        </dl>
+                    </div>
+                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                        <table class=\\"govuk-table pins-file-versions-table\\">
+                            <thead class=\\"govuk-table__head\\">
+                                <tr class=\\"govuk-table__row\\">
+                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                                </tr>
+                            </thead>
+                            <tbody class=\\"govuk-table__body\\">
+                                <tr class=\\"govuk-table__row\\">
+                                    <td class=\\"govuk-table__cell\\">1</td>
+                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                        class=\\"govuk-link\\">test-file-1.pdf</a>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                    </td>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p><strong>Uploaded:</strong> ,</p>
+                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    </td>
+                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                    </td>
+                                </tr>
+                                <tr class=\\"govuk-table__row\\">
+                                    <td class=\\"govuk-table__cell\\">2</td>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                    </td>
+                                    <td class=\\"govuk-table__cell\\">
+                                        <p><strong>Uploaded:</strong> ,</p>
+                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                    </td>
+                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>"
+`;
+
+exports[`applications documentation Document properties page page should render without Open button 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row\\">
         <div class=\\"govuk-grid-column-full govuk-!-margin-top-0\\">
@@ -6941,10 +7101,9 @@ exports[`applications documentation Document properties page page should render 
                 <h3 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document actions</h3>
                 <input type='hidden' value='11' name='selectedFilesIds[]'>
                 <div class=\\"govuk-button-group\\"><a href=\\"/documents/123/download/11/version//\\" role=\\"button\\" draggable=\\"false\\"
-                    class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\"> Open</a>
-                    <a                     href=\\"/documents/123/download/11/version//\\" role=\\"button\\" draggable=\\"false\\"
-                    class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\">Download</a><a href=\\"./unpublish\\" role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
-                        data-module=\\"govuk-button\\"> Unpublish</a>
+                    class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\"> Download</a>
+                    <a                     href=\\"./unpublish\\" role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
+                    data-module=\\"govuk-button\\">Unpublish</a>
                 </div>
             </nav>
             <div class=\\"govuk-!-margin-top-7\\">
@@ -7264,10 +7423,9 @@ exports[`applications documentation Document properties page should not show pub
                 <h3 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document actions</h3>
                 <input type='hidden' value='11' name='selectedFilesIds[]'>
                 <div class=\\"govuk-button-group\\"><a href=\\"/documents/123/download/11/version//\\" role=\\"button\\" draggable=\\"false\\"
-                    class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\"> Open</a>
-                    <a                     href=\\"/documents/123/download/11/version//\\" role=\\"button\\" draggable=\\"false\\"
-                    class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\">Download</a><a href=\\"./unpublish\\" role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
-                        data-module=\\"govuk-button\\"> Unpublish</a>
+                    class=\\"govuk-button govuk-button--secondary\\" data-module=\\"govuk-button\\"> Download</a>
+                    <a                     href=\\"./unpublish\\" role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
+                    data-module=\\"govuk-button\\">Unpublish</a>
                 </div>
             </nav>
             <div class=\\"govuk-!-margin-top-7\\">

--- a/apps/web/src/server/applications/case/documentation/__tests__/applications-documentation.test.js
+++ b/apps/web/src/server/applications/case/documentation/__tests__/applications-documentation.test.js
@@ -6,7 +6,8 @@ import {
 	fixtureDocumentFileVersions,
 	fixturePaginatedDocumentationFiles,
 	fixturePublishedDocumentationFile,
-	fixtureReadyToPublishDocumentationFile
+	fixtureReadyToPublishDocumentationFile,
+	fixtureReadyToPublishDocumentationPdfFile
 } from '../../../../../../testing/applications/fixtures/documentation-files.js';
 import {
 	fixtureDocumentationFolderPath,
@@ -45,6 +46,16 @@ const nocks = () => {
 
 	nock('http://test/')
 		.get('/applications/document/100/versions')
+		.times(2)
+		.reply(200, fixtureDocumentFileVersions);
+
+	nock('http://test/')
+		.get('/applications/123/documents/95/properties')
+		.times(2)
+		.reply(200, fixtureReadyToPublishDocumentationPdfFile);
+
+	nock('http://test/')
+		.get('/applications/document/95/versions')
 		.times(2)
 		.reply(200, fixtureDocumentFileVersions);
 
@@ -241,7 +252,7 @@ describe('applications documentation', () => {
 			await request.get('/applications-service/');
 		});
 
-		it('page should render', async () => {
+		it('page should render without Open button', async () => {
 			const response = await request.get(
 				`${baseUrl}/project-documentation/21/document/100/properties`
 			);
@@ -251,6 +262,22 @@ describe('applications documentation', () => {
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('Document properties');
 			expect(element.innerHTML).toContain('/edit/published-date');
+			expect(element.innerHTML).toContain('Download');
+			expect(element.innerHTML).not.toContain('Open');
+		});
+
+		it('page should render with Open button', async () => {
+			const response = await request.get(
+				`${baseUrl}/project-documentation/21/document/95/properties`
+			);
+
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('Document properties');
+			expect(element.innerHTML).toContain('/edit/receipt-date');
+			expect(element.innerHTML).toContain('Download');
+			expect(element.innerHTML).toContain('Open');
 		});
 
 		it('should not show publishedDate edit link if document is not published', async () => {

--- a/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
@@ -73,14 +73,16 @@
 					{% endif %}
 
 					<div class="govuk-button-group">
-						{% if isNotDisabled %}
+						{% if isPreviewActive %}
 							{{ govukButton({
 								element: 'a',
 								text: "Open",
 								href: 'document-download'|url({caseId: caseId, documentGuid: documentationFile.documentGuid, version: documentationFile.version, isPreviewActive: isPreviewActive}),
 								classes: "govuk-button--secondary"
 							}) }}
+						{% endif %}
 
+						{% if isNotDisabled %}
 							{{ govukButton({
 								element: 'a',
 								text: "Download",

--- a/apps/web/testing/applications/fixtures/documentation-files.js
+++ b/apps/web/testing/applications/fixtures/documentation-files.js
@@ -22,6 +22,13 @@ export const fixtureReadyToPublishDocumentationFile =
 	fixtureDocumentationFiles[0];
 
 /** @type {DocumentationFile} */
+export const fixtureReadyToPublishDocumentationPdfFile =
+	fixtureDocumentationFiles.find(
+		(document) =>
+			document.publishedStatus === 'ready_to_publish' && document.mime === 'application/pdf'
+	) || fixtureDocumentationFiles[0];
+
+/** @type {DocumentationFile} */
 export const fixtureNotCheckedDocumentationFile =
 	fixtureDocumentationFiles.find((document) => document.publishedStatus === 'not_checked') ||
 	fixtureDocumentationFiles[0];


### PR DESCRIPTION
## Describe your changes

- Update template to only show "Open" button when a preview available mime type
- Added web unit test
- Updated web unit test snapshots

## BOAS-1485 Correspondence (.msg): Hide 'Open' button in document properties
https://pins-ds.atlassian.net/browse/BOAS-1485

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
