### PR TITLE
fix(api/applications): use datePublished from DocumentVersion

### DIFF
--- a/apps/api/src/server/utils/mapping/map-document-details.js
+++ b/apps/api/src/server/utils/mapping/map-document-details.js
@@ -1,4 +1,5 @@
 import { mapDateStringToUnixTimestamp } from './map-date-string-to-unix-timestamp.js';
+import { mapDateToUnixTimestamp } from './map-date-to-unix-timestamp.js';
 
 /**
  * @typedef {import('@prisma/client').Document} Document
@@ -14,7 +15,6 @@ import { mapDateStringToUnixTimestamp } from './map-date-string-to-unix-timestam
  */
 export const mapSingleDocumentDetailsFromVersion = ({
 	Document,
-	DocumentActivityLog,
 	publishedStatus,
 	...documentVersion
 }) => {
@@ -45,10 +45,9 @@ export const mapSingleDocumentDetailsFromVersion = ({
 
 		redactedStatus: documentVersion.redactedStatus ?? '',
 
-		datePublished:
-			DocumentActivityLog?.[0].status === 'published'
-				? mapDateStringToUnixTimestamp(DocumentActivityLog[0].createdAt)
-				: null,
+		datePublished: documentVersion.datePublished
+			? mapDateToUnixTimestamp(documentVersion.datePublished)
+			: null,
 
 		description: documentVersion?.description,
 		version: documentVersion?.version,


### PR DESCRIPTION
## Describe your changes

Use `datePublished` from `DocumentVersion` table instead of querying the `ActivityLog`.

When a user updates the `datePublished`, only the value in `DocumentVersion` changes, not the value in `ActivityLog`.

## Issue ticket number and link

[BOAS-1564](https://pins-ds.atlassian.net/browse/BOAS-1564)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
