### PR TITLE
fix(functions): s51 status and agent mapping

### DIFF
--- a/apps/api/src/server/migration/migrators/s51-advice-migrator.js
+++ b/apps/api/src/server/migration/migrators/s51-advice-migrator.js
@@ -73,7 +73,7 @@ const mapModelToS51AdviceEntity = async ({
 	caseReference,
 	title,
 	from,
-	// agent,
+	agent,
 	method,
 	enquiryDate,
 	enquiryDetails,
@@ -99,6 +99,7 @@ const mapModelToS51AdviceEntity = async ({
 		id: Number(adviceId),
 		caseId: caseId,
 		title: title || '',
+		enquirer: agent,
 		firstName,
 		lastName,
 		enquiryMethod: method || '',
@@ -118,6 +119,7 @@ const parseAdviceReference = (adviceReference) => {
 	return match ? Number(match[0]) : 1;
 };
 
+// data-model defines status in a different format to what is stored in BO db, so some mapping needed
 const mapStatus = (status) =>
 	({
 		checked: 'checked',
@@ -125,5 +127,8 @@ const mapStatus = (status) =>
 		readytopublish: 'ready_to_publish',
 		published: 'published',
 		donotpublish: 'do_not_publish',
-		depublished: 'not_checked'
-	}[status]);
+
+		// TODO remove these values below once ODW has mapped them in curated layer (ODW-1122)
+		depublished: 'not_checked',
+		notchecked: 'not_checked'
+	}[status?.replaceAll(' ', '')]);


### PR DESCRIPTION
## Describe your changes

updates to s51 migration
- map the `agent` value into `enquirer` field (organisation name)
- update `status` mapping with some non-standard values coming from ODW. To be removed once ODW does this mapping in curated

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
