### PR TITLE
feat(functions): allow blob URIs to include custom domain

### DIFF
--- a/apps/functions/applications-background-jobs/common/config.js
+++ b/apps/functions/applications-background-jobs/common/config.js
@@ -6,6 +6,7 @@ const schema = joi.object({
 	BLOB_PUBLISH_CONTAINER: joi.string(),
 	BLOB_SOURCE_CONTAINER: joi.string(),
 	BLOB_STORAGE_ACCOUNT_HOST: joi.string(),
+	BLOB_STORAGE_ACCOUNT_DOMAIN: joi.string(),
 	log: joi.object({
 		levelStdOut: joi.string()
 	}),
@@ -19,6 +20,7 @@ const { value, error } = schema.validate({
 	BLOB_PUBLISH_CONTAINER: environment.BLOB_PUBLISH_CONTAINER,
 	BLOB_SOURCE_CONTAINER: environment.BLOB_SOURCE_CONTAINER,
 	BLOB_STORAGE_ACCOUNT_HOST: environment.BLOB_STORAGE_ACCOUNT_HOST,
+	BLOB_STORAGE_ACCOUNT_DOMAIN: environment.BLOB_STORAGE_ACCOUNT_DOMAIN,
 	log: {
 		levelStdOut: environment.LOG_LEVEL_STDOUT || 'debug'
 	},

--- a/apps/functions/applications-background-jobs/publish-document/src/util.js
+++ b/apps/functions/applications-background-jobs/publish-document/src/util.js
@@ -31,7 +31,11 @@ export const trimSlashes = (uri) => uri?.replace(/^\/+|\/+$/g, '');
 export const parseBlobName = (documentURI) => {
 	const [storageAccountHost, blobName] = documentURI.split(config.BLOB_SOURCE_CONTAINER);
 
-	if (trimSlashes(storageAccountHost) != trimSlashes(config.BLOB_STORAGE_ACCOUNT_HOST)) {
+	if (
+		![config.BLOB_STORAGE_ACCOUNT_HOST, config.BLOB_STORAGE_ACCOUNT_DOMAIN]
+			.map(trimSlashes)
+			.includes(trimSlashes(storageAccountHost))
+	) {
 		throw Error(`Attempting to copy from unknown storage account host ${storageAccountHost}`);
 	}
 


### PR DESCRIPTION
## Describe your changes

Allow blob URIs to include either the custom domain or the generated primary blob endpoint.

## Issue ticket number and link

[BOAS-1693](https://pins-ds.atlassian.net/browse/BOAS-1693)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1693]: https://pins-ds.atlassian.net/browse/BOAS-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ