### PR TITLE
fix(web/applications): leave empty field if RR has no received date

### DIFF
--- a/apps/web/src/server/applications/case/representations/application-representations.view-model.js
+++ b/apps/web/src/server/applications/case/representations/application-representations.view-model.js
@@ -43,9 +43,15 @@ const getStatus = ({ status }) => ({
  *
  * @param {object} arg
  * @param {string} arg.received
- * @returns {string}
+ * @returns {string | null}
  */
-const formatDate = ({ received }) => format(new Date(received), 'dd MMM yyyy');
+const formatDate = ({ received }) => {
+	if (!received) {
+		return null;
+	}
+
+	return format(new Date(received), 'dd MMM yyyy');
+};
 
 /**
  *


### PR DESCRIPTION
## Describe your changes

Currently the 'Date received' field shows 01/01/1970 if there is no date in the DB. This change leaves the field empty in this case.

## Issue ticket number and link

[BOAS-1567](https://pins-ds.atlassian.net/browse/BOAS-1567)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[BOAS-1567]: https://pins-ds.atlassian.net/browse/BOAS-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ