### PR TITLE
fix(applications/api): set api docker build to node 18.19 (BOAS-1704)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:18-alpine3.17
 WORKDIR /src/app
 COPY package*.json ./
 


### PR DESCRIPTION
## Describe your changes

Set API Docker build to `Node 18.19` as `Node 18.20` is currently creating issues

## Issue ticket number and link

https://pins-ds.atlassian.net/browse/BOAS-1704

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
