### PR TITLE
fix(api): fix scenario where docs without a version1 do not get listed

### DIFF
--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -243,7 +243,7 @@ export const deleteDocument = (documentGuid) => {
  * @param {{folderId: number, skipValue: number, pageSize: number, documentVersion?: number}} folderId
  * @returns {import('@prisma/client').PrismaPromise<Document[]>}
  */
-export const getDocumentsInFolder = ({ folderId, skipValue, pageSize, documentVersion = 1 }) => {
+export const getDocumentsInFolder = ({ folderId, skipValue, pageSize }) => {
 	return databaseConnector.document.findMany({
 		include: {
 			documentVersion: true,
@@ -259,11 +259,6 @@ export const getDocumentsInFolder = ({ folderId, skipValue, pageSize, documentVe
 		],
 		where: {
 			folderId,
-			documentVersion: {
-				some: {
-					version: documentVersion
-				}
-			},
 			isDeleted: false
 		}
 	});


### PR DESCRIPTION
## Describe your changes
Fixed a scenario where docs without a version1 would not get listed in the folders. This was tested in the following manner:
- upload 2 versions of a document
- manually delete version1 of a document from the SQL
- observe that the file is no longer listed in the list of files despite there being a version2 still active (still accessible via direct URL)

Fixed by removing the WHERE clause that filtered out docs without a version1

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
