### PR TITLE
fix(applications/web): remove extra hr on preview review pages (BOAS-1251)

### DIFF
--- a/apps/web/src/server/applications/case/project-updates/__tests__/__snapshots__/project-updates.test.js.snap
+++ b/apps/web/src/server/applications/case/project-updates/__tests__/__snapshots__/project-updates.test.js.snap
@@ -112,7 +112,7 @@ exports[`project-updates GET /applications-service/:caseId/project-updates/:proj
         <div class=\\"govuk-grid-column-two-thirds\\">
             <div class=\\"govuk-form-group\\">
                 <dl class=\\"govuk-summary-list\\">
-                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"><h2 class=\\"govuk-heading-m govuk-!-margin-top-3\\">Content</h2></dt>
+                    <div class=\\"govuk-summary-list__row no-border\\"><dt class=\\"govuk-summary-list__key\\"><h2 class=\\"govuk-heading-m govuk-!-margin-top-3\\">Content</h2></dt>
                         <dd                         class=\\"govuk-summary-list__value\\"></dd>
                             <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates/1/content\\"> Change<span class=\\"govuk-visually-hidden\\"> content</span></a>
                             </dd>
@@ -198,7 +198,7 @@ exports[`project-updates GET /applications-service/:caseId/project-updates/:proj
         <div class=\\"govuk-grid-column-two-thirds\\">
             <div class=\\"govuk-form-group\\">
                 <dl class=\\"govuk-summary-list\\">
-                    <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"><h2 class=\\"govuk-heading-m govuk-!-margin-top-3\\">Content</h2></dt>
+                    <div class=\\"govuk-summary-list__row no-border\\"><dt class=\\"govuk-summary-list__key\\"><h2 class=\\"govuk-heading-m govuk-!-margin-top-3\\">Content</h2></dt>
                         <dd                         class=\\"govuk-summary-list__value\\"></dd>
                             <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates/1/content\\"> Change<span class=\\"govuk-visually-hidden\\"> content</span></a>
                             </dd>

--- a/apps/web/src/server/applications/case/project-updates/project-updates.view-model.js
+++ b/apps/web/src/server/applications/case/project-updates/project-updates.view-model.js
@@ -208,6 +208,7 @@ export function createDetailsView({
 			rows: [
 				...rows,
 				{
+					classes: 'no-border',
 					key: {
 						html: '<h2 class="govuk-heading-m govuk-!-margin-top-3">Content</h2>'
 					},


### PR DESCRIPTION
## Describe your changes

- Removed the extra \<hr\> on preview/review pages by adding the class no-border
- Updated affected snapshots
- Tested manually, extra hr no longer appears

## BOAS-1251 Extra \<hr\> on preview/review pages
https://pins-ds.atlassian.net/browse/BOAS-1251

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
