### PR TITLE
fix(applications/web): day and month date fields not big enough (BOAS-1415)

### DIFF
--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
@@ -552,7 +552,7 @@ exports[`Edit applications documentation metadata Edit published date GET /case/
                         <fieldset class=\\"govuk-fieldset\\">
                             <legend class=\\"govuk-fieldset__legend govuk-label font-weight--700 govuk-!-margin-bottom-4\\">Date document published</legend>
                             <div id=\\"datePublished-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.day\\">Day</label>
@@ -613,7 +613,7 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                             <div id=\\"datePublished-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"datePublished-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the published
                                 date</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.day\\">Day</label>
@@ -680,7 +680,7 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                             <div id=\\"datePublished-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"datePublished-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The published date cannot
                                 be in the future</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.day\\">Day</label>
@@ -747,7 +747,7 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                             <div id=\\"datePublished-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"datePublished-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter a valid day for
                                 the published date</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.day\\">Day</label>
@@ -814,7 +814,7 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                             <div id=\\"datePublished-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"datePublished-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter a valid month for
                                 the published date</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.day\\">Day</label>
@@ -881,7 +881,7 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                             <div id=\\"datePublished-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"datePublished-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter a valid year for
                                 the published date</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.day\\">Day</label>
@@ -931,7 +931,7 @@ exports[`Edit applications documentation metadata Edit receipt date GET /case/12
                         <fieldset class=\\"govuk-fieldset\\">
                             <legend class=\\"govuk-fieldset__legend govuk-label font-weight--700 govuk-!-margin-bottom-4\\">Date document received</legend>
                             <div id=\\"dateCreated-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.day\\">Day</label>
@@ -992,7 +992,7 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                             <div id=\\"dateCreated-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"dateCreated-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter the receipt
                                 date</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.day\\">Day</label>
@@ -1059,7 +1059,7 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                             <div id=\\"dateCreated-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"dateCreated-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The receipt date cannot
                                 be in the future</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.day\\">Day</label>
@@ -1126,7 +1126,7 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                             <div id=\\"dateCreated-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"dateCreated-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter a valid day for
                                 the receipt date</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.day\\">Day</label>
@@ -1193,7 +1193,7 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                             <div id=\\"dateCreated-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"dateCreated-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter a valid month for
                                 the receipt date</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.day\\">Day</label>
@@ -1260,7 +1260,7 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                             <div id=\\"dateCreated-hint\\" class=\\"govuk-hint\\">for example, 27 03 2023</div>
                             <p id=\\"dateCreated-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter a valid year for
                                 the receipt date</p>
-                            <div class=\\"govuk-grid-column-one-third\\">
+                            <div class=\\"govuk-grid-column-two-thirds\\">
                                 <div class=\\"govuk-grid-row pins-date-form-group\\">
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.day\\">Day</label>

--- a/apps/web/src/server/views/applications/case-documentation/documentation-edit.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-edit.njk
@@ -51,7 +51,7 @@
 
 {% macro renderComponent(componentName) %}
     {% if(componentName === 'dateCreated' or componentName === 'datePublished') %}
-		{% set dateLayout = layout|setAttribute('classes', 'govuk-grid-column-one-third') %}
+		{% set dateLayout = layout|setAttribute('classes', 'govuk-grid-column-two-thirds') %}
 		{% set dateLayout = dateLayout|setAttribute('fieldName', layout.metaDataName) %}
 
 		<div class='govuk-grid-row'>


### PR DESCRIPTION
## Describe your changes

- Increased size of date input components with a class.
- Tested manually including changing the width of the browser
- Fixed the unit test snapshots

## BOAS-1415 Day and Month date fields not big enough when on the 'Enter the document published date' change page
https://pins-ds.atlassian.net/browse/BOAS-1415

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
