### PR TITLE
fix(applications/web): fix document properties button styling (BOAS-1427)

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -6878,121 +6878,119 @@ exports[`applications documentation Document properties page page should render 
                 </div><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link\\"
                 href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
             </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+                                Ut enim ad</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
-                                    Ut enim ad</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -7036,125 +7034,123 @@ exports[`applications documentation Document properties page page should render 
                     data-module=\\"govuk-button\\">Unpublish</a>
                 </div>
             </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">12 Ullamco laboris nisi ut</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">12 Ullamco laboris nisi ut</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Tempor incididunt</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ullamco Aliqua</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ut</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\"></dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Tempor incididunt</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ullamco Aliqua</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ut</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\"></dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Transcript (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/transcript\\"> Change<span class=\\"govuk-visually-hidden\\"> Transcript (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\">07/03/2023</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/published-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Published date</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Published</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Transcript (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/transcript\\"> Change<span class=\\"govuk-visually-hidden\\"> Transcript (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\">07/03/2023</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/published-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Published date</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Published</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -7200,121 +7196,119 @@ exports[`applications documentation Document properties page should not show pub
                 </div><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link\\"
                 href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
             </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+                                Ut enim ad</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
-                                    Ut enim ad</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -7358,125 +7352,123 @@ exports[`applications documentation Document properties page should not show pub
                     data-module=\\"govuk-button\\">Unpublish</a>
                 </div>
             </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">12 Ullamco laboris nisi ut</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">12 Ullamco laboris nisi ut</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Tempor incididunt</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ullamco Aliqua</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ut</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\"></dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Tempor incididunt</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ullamco Aliqua</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">withdrawn</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ut</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\"></dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Transcript (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/transcript\\"> Change<span class=\\"govuk-visually-hidden\\"> Transcript (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\">07/03/2023</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/published-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Published date</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Published</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Transcript (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/transcript\\"> Change<span class=\\"govuk-visually-hidden\\"> Transcript (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\">07/03/2023</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/published-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Published date</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/11/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Published</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -7522,121 +7514,119 @@ exports[`applications documentation Document properties page should show publish
                 </div><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link\\"
                 href=\\"/applications-service/case/123/project-documentation/publishing-queue\\">View publishing queue</a>
             </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
-                                <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-properties\\"> Document properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#document-history\\"> Document history</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"document-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> File name</dt>
+                            <dd class=\\"govuk-summary-list__value\\">4 Elit sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/name\\"> Change<span class=\\"govuk-visually-hidden\\"> File name</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+                                Ut enim ad</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
+                            <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Description</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
-                                    Ut enim ad</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/description\\"> Change<span class=\\"govuk-visually-hidden\\"> Description</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> From</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur adipiscing</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/author\\"> Change<span class=\\"govuk-visually-hidden\\"> From</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Agent (optional)</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Elit Sed</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/agent\\"> Change<span class=\\"govuk-visually-hidden\\"> Agent (optional)</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document case stage</dt>
-                                <dd class=\\"govuk-summary-list__value\\">pre-examination</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Webfilter</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Consectetur</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/webfilter\\"> Change<span class=\\"govuk-visually-hidden\\"> Webfilter</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Document type (optional)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\">Rule 8 letter</dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/type\\"> Change<span class=\\"govuk-visually-hidden\\"> Document type (optional)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
-                                <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
-                                <dd class=\\"govuk-summary-list__value\\"></dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">1</td>
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
-                                        class=\\"govuk-link\\">test-file-1.pdf</a>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">2</td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">test-file-1.pdf</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong>Uploaded:</strong> ,</p>
-                                        <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">Unredacted</td>
-                                    <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date received</dt>
+                            <dd class=\\"govuk-summary-list__value\\">01/12/2022</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/receipt-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date received</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Published date</dt>
+                            <dd class=\\"govuk-summary-list__value\\"></dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"\\"></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Redacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Ready to publish</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/document/3/edit/published-status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"document-history\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Document history</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Version</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Activity</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Redaction</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Download</th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">1</td>
+                                <td class=\\"govuk-table__cell\\"><a class=\\"font-weight--700\\" href=\\"/documents/123/download/123/version/1/preview\\"
+                                    class=\\"govuk-link\\">test-file-1.pdf</a>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF,3 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Unpublished:</strong> 14:09, 03 Jul 2023, John Doe</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/123/version/1/'> Download</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">2</td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">test-file-1.pdf</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP4,5 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong>Uploaded:</strong> ,</p>
+                                    <p class='govuk-!-margin-top-2'><strong>Published:</strong> Not published</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">Unredacted</td>
+                                <td class=\\"govuk-table__cell\\"><a href='/documents/123/download/456/version/2/'> Download</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
@@ -111,7 +111,6 @@
 						<a class="govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link" href= "{{'documents-queue'|url({caseId:caseId})}}">View publishing queue</a>
 					{% endif %}
 				</nav>
-                <div class="govuk-!-margin-top-7">
                     {{ govukTabs({
 						items: [
 							{
@@ -126,7 +125,6 @@
 							}
 						]
 					}) }}
-                </div>
             {% endblock %}
         </div>
     </div>


### PR DESCRIPTION
## Describe your changes

The alignment had already been done in a previous ticket as I could not reproduce.  I did remove the wrapper around the tabs to make sure the large gap between the buttons and the tabs is removed to match the image in the ticket.  

- Updated unit test snapshots
- Tested manually including changing the width of the browser

## BOAS-1427 Document properties: alignment of open/download/unpublish buttons
https://pins-ds.atlassian.net/browse/BOAS-1427

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
