### PR TITLE
fix(applications/web): fix broken button styling in S51 document properties page (BOAS-1718)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/s51Advice.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/s51Advice.spec.js
@@ -22,10 +22,10 @@ const texts = {
 	successMessageText: 'Timetable item successfully created'
 };
 
-
 describe('Section 51 Advice', () => {
 	let projectInfo = projectInformation();
 	let caseRef;
+	let titleCount = 0;
 
 	before(() => {
 		cy.login(applicationsUsers.caseAdmin);
@@ -40,10 +40,11 @@ describe('Section 51 Advice', () => {
 		s51AdvicePage.clickLinkByText(texts.projectDocumentationLinkText);
 		s51AdvicePage.clickLinkByText(texts.s51AdviceLinkText);
 		s51AdvicePage.clickButtonByText(texts.createS51AdviceButtonText);
+		titleCount = titleCount + 1;
 	});
 
 	it('As a user able to create S51 Advice - Enquirer Full Details', () => {
-		const details = s51AdviceDetails();
+		const details = s51AdviceDetails(titleCount);
 		s51AdvicePage.completeS51Advice(details, {
 			organisation: details.organisation,
 			firstName: details.firstName,
@@ -52,7 +53,7 @@ describe('Section 51 Advice', () => {
 	});
 
 	it('As a user able to create S51 Advice - Enquirer Name Only', () => {
-		const details = s51AdviceDetails();
+		const details = s51AdviceDetails(titleCount);
 		s51AdvicePage.completeS51Advice(details, {
 			firstName: details.firstName,
 			lastName: details.lastName
@@ -60,7 +61,9 @@ describe('Section 51 Advice', () => {
 	});
 
 	it('As a user able to create S51 Advice - Enquirer Org Only', () => {
-		const details = s51AdviceDetails();
-		s51AdvicePage.completeS51Advice(details, { organisation: details.organisation });
+		const details = s51AdviceDetails(titleCount);
+		s51AdvicePage.completeS51Advice(details, {
+			organisation: details.organisation
+		});
 	});
 });

--- a/apps/e2e/cypress/page_objects/s51AdvicePage.js
+++ b/apps/e2e/cypress/page_objects/s51AdvicePage.js
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { Page } from './basePage';
 import { faker } from '@faker-js/faker';
+import { upperFirst } from 'lodash-es';
 import { S51AdvicePropertiesPage } from './s51AdviceProperties.js';
 import { enquirerString } from '../support/utils/utils.js';
 
@@ -24,11 +25,11 @@ export class S51AdvicePage extends Page {
 		answerCell: (question) => cy.contains(this.selectors.tableCell, new RegExp(question)).next(),
 		changeLink: (question) =>
 			cy.contains(this.selectors.tableCell, question, { matchCase: false }).nextUntil('a'),
-		changetitleLink: () => cy.get('#advice-properties > dl > div:nth-child(1) > dd.govuk-summary-list__actions > a'),
-        saveAndReturnTile: () => cy.get('#main-content > form > button'),
-        verifyTitleUpdated: () => cy.get('#advice-properties > dl > div:nth-child(1) > dd.govuk-summary-list__value')
-
-
+		changetitleLink: () =>
+			cy.get('#advice-properties > dl > div:nth-child(1) > dd.govuk-summary-list__actions > a'),
+		saveAndReturnTile: () => cy.get('#main-content > form > button'),
+		verifyTitleUpdated: () =>
+			cy.get('#advice-properties > dl > div:nth-child(1) > dd.govuk-summary-list__value')
 	};
 
 	checkAnswer(question, answer, strict = true) {
@@ -124,20 +125,20 @@ export class S51AdvicePage extends Page {
 
 		const propertiesPage = new S51AdvicePropertiesPage();
 		propertiesPage.checkAllProperties(mainDetails, enquirerDetails);
-		this.verifyTitleIsUpdated();
+		this.verifyTitleIsUpdated(upperFirst(title + ' Updated'));
 	}
-	verifyTitleIsUpdated(){
-        this.elements.changetitleLink().click();
-        this.elements.titleInput().clear();
-        this.elements.titleInput().type("Title Updated");
-        this.elements.saveAndReturnTile().click();
+	verifyTitleIsUpdated(newTitle) {
+		this.elements.changetitleLink().click();
+		this.elements.titleInput().clear();
+		this.elements.titleInput().type(newTitle);
+		this.elements.saveAndReturnTile().click();
 		cy.wait(3000);
-        this.elements.verifyTitleUpdated().then((text)=> {
-            let actualTitle=text.text();
-         expect(actualTitle).to.include("Title Updated");
-    });
-}
-    verifyS51IsDeleted(){
+		this.elements.verifyTitleUpdated().then((text) => {
+			let actualTitle = text.text();
+			expect(actualTitle).to.include(newTitle);
+		});
+	}
+	verifyS51IsDeleted() {
 		cy.get('.govuk-button--secondary').click();
 		cy.get('.govuk-button').click();
 		cy.get('.govuk-panel__title').contains('S51 advice item successfully deleted');

--- a/apps/e2e/cypress/support/utils/createS51Advice.js
+++ b/apps/e2e/cypress/support/utils/createS51Advice.js
@@ -2,8 +2,8 @@
 import { faker } from '@faker-js/faker';
 import { getShortMonthName } from './utils.js';
 
-export const s51AdviceDetails = () => {
-	const title = 'title';
+export const s51AdviceDetails = (titleCount) => {
+	const title = titleCount ? 'title-' + titleCount : 'title';
 	const enquiryDetails = 'enquiry details';
 	const adviceDetails = 'Advice details';
 	const firstName = 'S51firstname';
@@ -16,8 +16,8 @@ export const s51AdviceDetails = () => {
 
 	const year = new Date().getFullYear();
 	var todaydate = new Date();
-    var mon = todaydate.getMonth();
-    var month=mon.toString().padStart(2,'0');
+	var mon = todaydate.getMonth();
+	var month = mon.toString().padStart(2, '0');
 	const day = new Date().getDay().toString().padStart(2, '0');
 
 	const dateFullFormatted = `${day} ${getShortMonthName(month)} ${year}`;

--- a/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
+++ b/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
@@ -99,422 +99,421 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/upload\\"> Upload files</a>
             </div>
             <hr class=\\"govuk-section-break govuk-section-break--l govuk-section-break--visible\\">
-            <nav class=\\"govuk-grid-row govuk-!-margin-top-0\\">
-                <h4 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">S51 advice actions</h4>
-                <div class=\\"govuk-grid-column-one-half govuk-!-margin-top-0\\"><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/delete\\">Delete</a>
-                </div>
-                <div class=\\"govuk-grid-column-one-half govuk-!-text-align-right\\"><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/publishing-queue\\">View S51 publishing queue</a>
-                </div>
+            <nav class=\\"pins-nav-button-group\\">
+                <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">S51 advice actions</h4>
+                <div class=\\"govuk-button-group\\"><a href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/delete\\"
+                    role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
+                    data-module=\\"govuk-button\\"> Delete</a>
+                </div><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link\\"
+                href=\\"/applications-service/case/123/project-documentation/21/s51-advice/publishing-queue\\">View S51 publishing queue</a>
             </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#advice-properties\\"> S51 advice properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#s51-attachments\\"> Attachments</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"advice-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">S51 advice properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> S51 title</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/title\\"> Change<span class=\\"govuk-visually-hidden\\"> S51 title</span></a>
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#advice-properties\\"> S51 advice properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#s51-attachments\\"> Attachments</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"advice-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">S51 advice properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> S51 title</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/title\\"> Change<span class=\\"govuk-visually-hidden\\"> S51 title</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquirer</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Do Do, Do</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquirer\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquirer</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry method</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Post</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/method\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry method</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry date</dt>
+                            <dd class=\\"govuk-summary-list__value\\">07 Mar 2023</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquiry-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry date</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry details</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip
+                                ex ea commodo consequat</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquiry-details\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry details</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Advice given by (internal use only)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\">Do</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/adviser\\"> Change<span class=\\"govuk-visually-hidden\\"> Advice given by (internal use only)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquirer</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Do Do, Do</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquirer\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquirer</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry method</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Post</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/method\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry method</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry date</dt>
-                                <dd class=\\"govuk-summary-list__value\\">07 Mar 2023</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquiry-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry date</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry details</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip
-                                    ex ea commodo consequat</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquiry-details\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry details</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Advice given by (internal use only)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\">Do</dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/adviser\\"> Change<span class=\\"govuk-visually-hidden\\"> Advice given by (internal use only)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date advice given</dt>
-                                <dd class=\\"govuk-summary-list__value\\">07 Mar 2023</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/advice-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date advice given</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Advice given</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip
-                                    ex ea commodo consequat</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/advice-detail\\"> Change<span class=\\"govuk-visually-hidden\\"> Advice given</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Do not publish</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"s51-attachments\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Attachments</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Date added</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Minim veniam quis nostrud</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Nostrud exercitation ullamco laboris</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Elit sed</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Minim veniam quis nostrud</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Magna aliqua Ut</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Enim ad minim veniam</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Dolor sit</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Lorem ipsum</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Aliqua Ut enim</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Ullamco laboris nisi ut</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Quis nostrud exercitation ullamco</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Lorem ipsum</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Ad minim veniam quis</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Dolore magna aliqua</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Labore et dolore</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date advice given</dt>
+                            <dd class=\\"govuk-summary-list__value\\">07 Mar 2023</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/advice-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date advice given</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Advice given</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip
+                                ex ea commodo consequat</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/advice-detail\\"> Change<span class=\\"govuk-visually-hidden\\"> Advice given</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Do not publish</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"s51-attachments\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Attachments</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Date added</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Minim veniam quis nostrud</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Nostrud exercitation ullamco laboris</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Elit sed</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Minim veniam quis nostrud</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Magna aliqua Ut</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Enim ad minim veniam</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Dolor sit</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Lorem ipsum</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Aliqua Ut enim</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Ullamco laboris nisi ut</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Quis nostrud exercitation ullamco</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Lorem ipsum</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Ad minim veniam quis</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Dolore magna aliqua</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Labore et dolore</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
@@ -534,422 +533,421 @@ exports[`S51 Advice S51 Properties GET /case/123/project-documentation/21/s51-ad
             <div class=\\"display--flex govuk-!-margin-top-7 govuk-!-margin-bottom-7\\"><a class=\\"govuk-button govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/upload\\"> Upload files</a>
             </div>
             <hr class=\\"govuk-section-break govuk-section-break--l govuk-section-break--visible\\">
-            <nav class=\\"govuk-grid-row govuk-!-margin-top-0\\">
-                <h4 class=\\"govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4\\">S51 advice actions</h4>
-                <div class=\\"govuk-grid-column-one-half govuk-!-margin-top-0\\"><a class=\\"govuk-button govuk-button--secondary govuk-!-margin-0\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/delete\\">Delete</a>
-                </div>
-                <div class=\\"govuk-grid-column-one-half govuk-!-text-align-right\\"><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/publishing-queue\\">View S51 publishing queue</a>
-                </div>
+            <nav class=\\"pins-nav-button-group\\">
+                <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">S51 advice actions</h4>
+                <div class=\\"govuk-button-group\\"><a href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/delete\\"
+                    role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button govuk-button--secondary\\"
+                    data-module=\\"govuk-button\\"> Delete</a>
+                </div><a class=\\"govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link\\"
+                href=\\"/applications-service/case/123/project-documentation/21/s51-advice/publishing-queue\\">View S51 publishing queue</a>
             </nav>
-            <div class=\\"govuk-!-margin-top-7\\">
-                <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
-                    <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
-                    <ul class=\\"govuk-tabs__list\\">
-                        <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#advice-properties\\"> S51 advice properties</a>
-                        </li>
-                        <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#s51-attachments\\"> Attachments</a>
-                        </li>
-                    </ul>
-                    <div class=\\"govuk-tabs__panel\\" id=\\"advice-properties\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">S51 advice properties</h4>
-                        <dl class=\\"govuk-summary-list\\">
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> S51 title</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/title\\"> Change<span class=\\"govuk-visually-hidden\\"> S51 title</span></a>
+            <div class=\\"govuk-tabs\\" data-module=\\"govuk-tabs\\">
+                <h2 class=\\"govuk-tabs__title\\"> Contents</h2>
+                <ul class=\\"govuk-tabs__list\\">
+                    <li class=\\"govuk-tabs__list-item govuk-tabs__list-item--selected\\"><a class=\\"govuk-tabs__tab\\" href=\\"#advice-properties\\"> S51 advice properties</a>
+                    </li>
+                    <li class=\\"govuk-tabs__list-item\\"><a class=\\"govuk-tabs__tab\\" href=\\"#s51-attachments\\"> Attachments</a>
+                    </li>
+                </ul>
+                <div class=\\"govuk-tabs__panel\\" id=\\"advice-properties\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">S51 advice properties</h4>
+                    <dl class=\\"govuk-summary-list\\">
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> S51 title</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/title\\"> Change<span class=\\"govuk-visually-hidden\\"> S51 title</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquirer</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Do Do, Do</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquirer\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquirer</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry method</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Post</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/method\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry method</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry date</dt>
+                            <dd class=\\"govuk-summary-list__value\\">07 Mar 2023</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquiry-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry date</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry details</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip
+                                ex ea commodo consequat</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquiry-details\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry details</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Advice given by (internal use only)</dt>
+                            <dd                             class=\\"govuk-summary-list__value\\">Do</dd>
+                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/adviser\\"> Change<span class=\\"govuk-visually-hidden\\"> Advice given by (internal use only)</span></a>
                                 </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquirer</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Do Do, Do</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquirer\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquirer</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry method</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Post</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/method\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry method</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry date</dt>
-                                <dd class=\\"govuk-summary-list__value\\">07 Mar 2023</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquiry-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry date</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Enquiry details</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip
-                                    ex ea commodo consequat</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/enquiry-details\\"> Change<span class=\\"govuk-visually-hidden\\"> Enquiry details</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Advice given by (internal use only)</dt>
-                                <dd                                 class=\\"govuk-summary-list__value\\">Do</dd>
-                                    <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/adviser\\"> Change<span class=\\"govuk-visually-hidden\\"> Advice given by (internal use only)</span></a>
-                                    </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date advice given</dt>
-                                <dd class=\\"govuk-summary-list__value\\">07 Mar 2023</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/advice-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date advice given</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Advice given</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip
-                                    ex ea commodo consequat</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/advice-detail\\"> Change<span class=\\"govuk-visually-hidden\\"> Advice given</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
-                                </dd>
-                            </div>
-                            <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
-                                <dd class=\\"govuk-summary-list__value\\">Do not publish</dd>
-                                <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
-                                </dd>
-                            </div>
-                        </dl>
-                    </div>
-                    <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"s51-attachments\\">
-                        <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Attachments</h4>
-                        <table class=\\"govuk-table pins-file-versions-table\\">
-                            <thead class=\\"govuk-table__head\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\">Date added</th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
-                                    <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
-                                </tr>
-                            </thead>
-                            <tbody class=\\"govuk-table__body\\">
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Minim veniam quis nostrud</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Nostrud exercitation ullamco laboris</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Elit sed</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Minim veniam quis nostrud</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Magna aliqua Ut</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Enim ad minim veniam</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Dolor sit</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Lorem ipsum</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Aliqua Ut enim</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Ullamco laboris nisi ut</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Quis nostrud exercitation ullamco</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p class=\\"font-weight--700\\">Lorem ipsum</p>
-                                        <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Ad minim veniam quis</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Dolore magna aliqua</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                                <tr class=\\"govuk-table__row\\">
-                                    <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Labore et dolore</a>
-                                        <p                                         class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p>07/03/2023</p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\">
-                                        <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
-                                        </p>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
-                                    </td>
-                                    <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Date advice given</dt>
+                            <dd class=\\"govuk-summary-list__value\\">07 Mar 2023</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/advice-date\\"> Change<span class=\\"govuk-visually-hidden\\"> Date advice given</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Advice given</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip
+                                ex ea commodo consequat</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/advice-detail\\"> Change<span class=\\"govuk-visually-hidden\\"> Advice given</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Redaction</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Unredacted</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/redaction\\"> Change<span class=\\"govuk-visually-hidden\\"> Redaction</span></a>
+                            </dd>
+                        </div>
+                        <div class=\\"govuk-summary-list__row\\"><dt class=\\"govuk-summary-list__key\\"> Status</dt>
+                            <dd class=\\"govuk-summary-list__value\\">Do not publish</dd>
+                            <dd class=\\"govuk-summary-list__actions\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/123/project-documentation/21/s51-advice/1/edit/status\\"> Change<span class=\\"govuk-visually-hidden\\"> Status</span></a>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+                <div class=\\"govuk-tabs__panel govuk-tabs__panel--hidden\\" id=\\"s51-attachments\\">
+                    <h4 class=\\"govuk-heading-m govuk-!-margin-bottom-4\\">Attachments</h4>
+                    <table class=\\"govuk-table pins-file-versions-table\\">
+                        <thead class=\\"govuk-table__head\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">File name</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\">Date added</th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
+                                <th scope=\\"col\\" class=\\"govuk-table__header\\"></th>
+                            </tr>
+                        </thead>
+                        <tbody class=\\"govuk-table__body\\">
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Minim veniam quis nostrud</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Nostrud exercitation ullamco laboris</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Elit sed</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Minim veniam quis nostrud</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Magna aliqua Ut</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Enim ad minim veniam</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Dolor sit</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Lorem ipsum</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Aliqua Ut enim</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Ullamco laboris nisi ut</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Quis nostrud exercitation ullamco</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>MP3, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Do eiusmod</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\">
+                                    <p class=\\"font-weight--700\\">Lorem ipsum</p>
+                                    <p class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>DOC, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--red\\"> Failed virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Ad minim veniam quis</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Dolore magna aliqua</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>JPG, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Eiusmod tempor incididunt</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                            <tr class=\\"govuk-table__row\\">
+                                <td class=\\"govuk-table__cell\\"><a class=\\"govuk-link font-weight--700\\" href=\\"/documents/123/download/1/version/1/preview\\">Labore et dolore</a>
+                                    <p                                     class='govuk-!-margin-top-2 govuk-body-xs colour--secondary'>PDF, 7.7 KB</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p>07/03/2023</p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\">
+                                    <p><strong class=\\"govuk-tag govuk-tag--yellow\\"> Awaiting virus check</strong>
+                                    </p>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href=\\"/documents/123/download/1/version/1/\\"> Download</a>
+                                </td>
+                                <td class=\\"govuk-table__cell\\"><a class='govuk-link' href='/applications-service/case/123/project-documentation/21/s51-advice/1/attachments/1/delete'> Delete</a>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/apps/web/src/server/views/applications/case-s51/properties/s51-properties.njk
+++ b/apps/web/src/server/views/applications/case-s51/properties/s51-properties.njk
@@ -80,26 +80,36 @@
 
 				<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-				<nav class="govuk-grid-row govuk-!-margin-top-0">
-					<h4 class="govuk-heading-m govuk-!-margin-left-3 govuk-!-margin-bottom-4">{{ adviceActionsText }}</h4>
-					<div class="govuk-grid-column-one-half govuk-!-margin-top-0">
-						<a class="govuk-button govuk-button--secondary govuk-!-margin-0" href="{{'s51-item'|url({caseId: caseId, folderId: folderId, adviceId: s51Advice.id, step: 'delete'})}}">Delete</a>
+				<nav class="pins-nav-button-group">
+					<h3 class="govuk-heading-m govuk-!-margin-bottom-4">{{ adviceActionsText }}</h3>
+
+					<div class="govuk-button-group">
+						{{ govukButton({
+							element: 'a',
+							text: "Delete",
+							href: 's51-item'|url({caseId: caseId, folderId: folderId, adviceId: s51Advice.id, step: 'delete'}),
+							classes: "govuk-button--secondary"
+						}) }}
+
 						{% if isPublished %}
-							<a class="govuk-button govuk-button--secondary govuk-!-margin-0" href="{{'s51-unpublish'|url({caseId:caseId, folderId: folderId, adviceId: s51Advice.id })}}">Unpublish</a>
+							{{ govukButton({
+								element: 'a',
+								text: "Unpublish",
+								href: 's51-unpublish'|url({caseId:caseId, folderId: folderId, adviceId: s51Advice.id }),
+								classes: "govuk-button--secondary"
+							}) }}
 						{% endif %}
 					</div>
-					<div class="govuk-grid-column-one-half govuk-!-text-align-right">
-						<a class="govuk-link govuk-body-m govuk-!-text-align-right" href= "{{'s51-list'|url({caseId:caseId, folderId: folderId, step: 'publishing-queue'})}}">{{ publishingQueueLinkText }}</a>
-					</div>
+					<a class="govuk-link govuk-body-m govuk-!-text-align-right pins-nav-right-aligned-link" href= "{{'s51-list'|url({caseId:caseId, folderId: folderId, step: 'publishing-queue'})}}">{{ publishingQueueLinkText }}</a>
 				</nav>
 
 				{% if isPublished %}
 					{{ govukInsetText({
-						text: "This advice is currently published. To make changes, first unpublish the advice and republish once the changes have been made"
+						text: "This advice is currently published. To make changes, first unpublish the advice and republish once the changes have been made",
+						classes: "pins-properties-inset-text"
 					}) }}
 				{% endif %}
 
-				<div class="govuk-!-margin-top-7">
 					{{ govukTabs({
 						items: [
 							{
@@ -114,7 +124,6 @@
 							}
 						]
 					}) }}
-				</div>
 			{% endblock %}
 		</div>
 	</div>

--- a/apps/web/src/server/views/applications/case-s51/properties/s51-properties.njk
+++ b/apps/web/src/server/views/applications/case-s51/properties/s51-properties.njk
@@ -81,7 +81,7 @@
 				<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 				<nav class="pins-nav-button-group">
-					<h3 class="govuk-heading-m govuk-!-margin-bottom-4">{{ adviceActionsText }}</h3>
+					<h4 class="govuk-heading-m govuk-!-margin-bottom-4">{{ adviceActionsText }}</h4>
 
 					<div class="govuk-button-group">
 						{{ govukButton({

--- a/apps/web/src/styles/7-components/_properties-inset-text.scss
+++ b/apps/web/src/styles/7-components/_properties-inset-text.scss
@@ -1,0 +1,5 @@
+@media (min-width: 40.0625em) {
+	.pins-properties-inset-text {
+		margin-top: 0;
+	}
+}

--- a/apps/web/src/styles/main.scss
+++ b/apps/web/src/styles/main.scss
@@ -64,6 +64,7 @@
 @use "7-components/key-dates-section";
 @use "7-components/nav-button-group";
 @use "7-components/project-details-table";
+@use "7-components/properties-inset-text";
 
 // 8 - UTILITIES
 


### PR DESCRIPTION
## Describe your changes

- Updated buttons in view to use design system correctly like in the document properties view
- Added some CSS to fix the large gap between the inset text and the buttons while in desktop format 
- Updated unit test snapshots
- Tested manually including changing the width of the browser
- Fix S51 acceptance tests as title must be unique

## BOAS-1718 Broken button styling in S51 document properties page
https://pins-ds.atlassian.net/browse/BOAS-1718

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
