### PR TITLE
feat(applications/web): allow developers to simulate address lookup (BOAS-1721)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ dump.rdb
 
 # Dummy data
 dummy_user_data.json
+dummy_address_data.json

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -135,7 +135,8 @@ FEATURE_FLAG_BOAS_10_TEST_FEATURE= "true"
 
 ## Development #################################################################
 
+# Indicates the json file "dummy_address_data.json" will be used for dummy AD user data when OS_PLACES_API_KEY has not been set.
+DUMMY_ADDRESS_DATA=true
 
 # Indicates the json file "dummy_user_data.json" will be used for dummy AD user data when AUTH_DISABLED=true.
-DUMMY_USER_DATA="true"
-
+DUMMY_USER_DATA=true

--- a/apps/web/environment/README.md
+++ b/apps/web/environment/README.md
@@ -1,0 +1,80 @@
+# Environment
+
+## Simulating AD and OS places lookups
+
+When developing locally, it's likely you will not have access to the Active directory or OS places for looking up users or addresses.  It is possible through environment variables and json data files to simulate these two services.
+
+### Simulate AD with dummy data
+
+Add the file "./apps/web/dummy_user_data.json" containing the following:
+```json
+[
+	{
+		"id": "0d248a0d-ac83-4af9-a2e6-0087db8e01a1",
+		"surname": "Doe",
+		"givenName": "John",
+		"userPrincipalName": "john.doe@example.com"
+	},
+	{
+		"id": "76c8f6d4-adbb-47fc-88f6-d4adbb17fc0c",
+		"surname": "Admin",
+		"givenName": "Case Officer",
+		"userPrincipalName": "caseofficeradmin.test@planninginspectorate.gov.uk"
+	}
+
+]
+```
+
+Set the environment variables in "./apps/web/.env" as follows
+```.dotenv
+AUTH_DISABLED=true
+DUMMY_USER_DATA=true
+```
+
+### Simulate OS Places with dummy data
+
+Add the file "./apps/web/dummy_address_data.json" containing the following:
+```json
+{
+	"BS1 6PN": [
+		{
+			"apiReference": "1",
+			"addressLine1": "2 Temple Quay",
+			"addressLine2": "Planning Inspectorate",
+			"postcode": "BS1 6PN",
+			"county": "",
+			"town": "Bristol",
+			"displayAddress": "Planning Inspectorate, Temple Quay House, 2, The Square, Temple Quay, Bristol, BS1 6PN"
+		}
+	],
+	"GU21 3HB": [
+		{
+			"apiReference": "3",
+			"addressLine1": "1 Greenham Walk",
+			"addressLine2": "",
+			"postcode": "GU21 3HB",
+			"county": "",
+			"town": "Woking",
+			"displayAddress": "1, Greenham Walk, Woking, GU21 3HB"
+		}
+	],
+	"SW1P 4DF": [
+		{
+			"apiReference": "2",
+			"addressLine1": "2 Marsham Street",
+			"addressLine2": "Home Office",
+			"postcode": "SW1P 4DF",
+			"county": "",
+			"town": "London",
+			"displayAddress": "Home Office, 2, Marsham Street, London, SW1P 4DF"
+		}
+	]
+}
+```
+
+Set the environment variables in "./apps/web/.env" as follows
+```.dotenv
+OS_PLACES_API_KEY=
+DUMMY_ADDRESS_DATA=true
+```
+Note that the `OS_PLACES_API_KEY` should not be set to anything or removed altogether

--- a/apps/web/environment/config.d.ts
+++ b/apps/web/environment/config.d.ts
@@ -64,7 +64,8 @@ export interface EnvironmentConfig extends BaseEnvironmentConfig {
 	featureFlags: {
 		[key: string]: boolean;
 	};
-	dummyUserData: string;
+	dummyAddressData: boolean;
+	dummyUserData: boolean;
 }
 
 export function loadConfig(): EnvironmentConfig;

--- a/apps/web/environment/config.js
+++ b/apps/web/environment/config.js
@@ -51,6 +51,8 @@ export function loadConfig() {
 		SSL_KEY_FILE,
 		RETRY_MAX_ATTEMPTS,
 		RETRY_STATUS_CODES,
+		OS_PLACES_API_KEY,
+		DUMMY_ADDRESS_DATA,
 		DUMMY_USER_DATA
 	} = environment;
 
@@ -98,7 +100,10 @@ export function loadConfig() {
 		featureFlags: {
 			featureFlagBoas1TestFeature: FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
 		},
-		dummyUserData: (AUTH_DISABLED && DUMMY_USER_DATA) || ''
+		// Indicates the json file "dummy_address_data.json" will be used when true.
+		dummyAddressData: !OS_PLACES_API_KEY && DUMMY_ADDRESS_DATA,
+		// Indicates the json file "dummy_user_data.json" will be used when true.
+		dummyUserData: AUTH_DISABLED && DUMMY_USER_DATA
 	};
 
 	const { value: validatedConfig, error } = schema.validate(config);

--- a/apps/web/environment/schema.js
+++ b/apps/web/environment/schema.js
@@ -66,6 +66,7 @@ export default baseSchema
 			})
 			.options({ presence: 'required' }),
 		featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean()),
-		dummyUserData: joi.optional()
+		dummyAddressData: joi.boolean().optional(),
+		dummyUserData: joi.boolean().optional()
 	})
 	.options({ presence: 'required' }); // all required by default

--- a/apps/web/src/server/applications/case/representations/representation/address-details/utils/get-address-list.js
+++ b/apps/web/src/server/applications/case/representations/representation/address-details/utils/get-address-list.js
@@ -1,4 +1,4 @@
-import { findAddressListByPostcode } from '@planning-inspectorate/address-lookup';
+import findAddressListByPostcode from '../../../../../common/services/address.service.js';
 
 /**
  * @typedef {object} AddressList

--- a/apps/web/src/server/applications/common/components/form/form-applicant.component.js
+++ b/apps/web/src/server/applications/common/components/form/form-applicant.component.js
@@ -1,4 +1,4 @@
-import { findAddressListByPostcode } from '@planning-inspectorate/address-lookup';
+import findAddressListByPostcode from '../../services/address.service.js';
 import { updateCase } from '../../services/case.service.js';
 
 /** @typedef {import('@pins/express').ValidationErrors} ValidationErrors */

--- a/apps/web/src/server/applications/common/services/address.service.js
+++ b/apps/web/src/server/applications/common/services/address.service.js
@@ -14,12 +14,11 @@ import fs from 'node:fs/promises';
  * @returns {Promise<{addressList: address[]; errors?: AddressLookupValidationErrors}>}
  */
 export default async function (postcode, locals) {
-	if (config.dummyAddressData) {
-		const dummyAddressDataFile = path.join(process.cwd(), 'dummy_address_data.json');
-		const dummyAddressData = JSON.parse(await fs.readFile(dummyAddressDataFile, 'utf8'));
-		const matchingAddresses = { addressList: dummyAddressData[postcode] };
-		return Promise.resolve(matchingAddresses);
-	} else {
+	if (!config.dummyAddressData) {
 		return findAddressListByPostcode(postcode, locals);
 	}
+
+	const dummyAddressDataFile = path.join(process.cwd(), 'dummy_address_data.json');
+	const dummyAddressData = JSON.parse(await fs.readFile(dummyAddressDataFile, 'utf8'));
+	return { addressList: dummyAddressData[postcode] };
 }

--- a/apps/web/src/server/applications/common/services/address.service.js
+++ b/apps/web/src/server/applications/common/services/address.service.js
@@ -1,0 +1,25 @@
+import config from '@pins/applications.web/environment/config.js';
+import { findAddressListByPostcode } from '@planning-inspectorate/address-lookup';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+/** @typedef {import('@planning-inspectorate/address-lookup').address} address */
+/** @typedef {import('@planning-inspectorate/address-lookup').ValidationErrors} AddressLookupValidationErrors */
+
+/**
+ * Only lookup addresses when not in development *
+ *
+ * @param {string} postcode
+ * @param {any} locals
+ * @returns {Promise<{addressList: address[]; errors?: AddressLookupValidationErrors}>}
+ */
+export default async function (postcode, locals) {
+	if (config.dummyAddressData) {
+		const dummyAddressDataFile = path.join(process.cwd(), 'dummy_address_data.json');
+		const dummyAddressData = JSON.parse(await fs.readFile(dummyAddressDataFile, 'utf8'));
+		const matchingAddresses = { addressList: dummyAddressData[postcode] };
+		return Promise.resolve(matchingAddresses);
+	} else {
+		return findAddressListByPostcode(postcode, locals);
+	}
+}

--- a/docs/web-overview.md
+++ b/docs/web-overview.md
@@ -10,4 +10,5 @@ Designs follow the [GDS Design System](https://design-system.service.gov.uk/) in
 
 - [JS Styleguide](../apps/web/src/client/README.md)
 - [Sass / CSS Styleguide](../apps/web/src/styles/README.md)
+- [Simulating AD and OS places lookups](../apps/web/environment/README.md)
 - [Server docs](../apps/web/src/server/README.md)


### PR DESCRIPTION
## Describe your changes

These changes are also in part in preparation for allowing e2e tests to run locally as well as not requiring the developer to have the OS_PLACES_API_KEY set when running the application on localhost.

- Create wrapper around the address lookup function to allow simulation of address lookup
- Provide support for new DUMMY_ADDRESS_DATA environment variable
- Add documentation for how to use dummy data
- Tested manually 

## BOAS-1721 Allow developers to simulate address lookup
https://pins-ds.atlassian.net/browse/BOAS-1721

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
