### PR TITLE
fix(applications): editing application address should show all address parts (BOAS-1706)

### DIFF
--- a/apps/api/src/server/applications/application/__tests__/get-application-details.test.js
+++ b/apps/api/src/server/applications/application/__tests__/get-application-details.test.js
@@ -90,6 +90,7 @@ describe('Get Application details', () => {
 					addressLine1: 'Addr Line 1',
 					addressLine2: 'Addr Line 2',
 					county: 'County',
+					country: 'Country',
 					postCode: 'Postcode',
 					town: 'Town'
 				},

--- a/apps/api/src/server/applications/application/application.mapper.js
+++ b/apps/api/src/server/applications/application/application.mapper.js
@@ -51,6 +51,7 @@ export const mapCreateApplicationRequestToRepository = (applicationDetails) => {
 		'addressLine2',
 		'town',
 		'county',
+		'country',
 		'postcode'
 	]);
 

--- a/apps/api/src/server/utils/address-block-formtter.js
+++ b/apps/api/src/server/utils/address-block-formtter.js
@@ -1,6 +1,6 @@
 /**
  * @param {import('@pins/applications.api').Schema.Address | null | undefined} address
- * @returns {{addressLine1?: string, addressLine2?: string, town?: string, county?: string, postCode?: string | null}}
+ * @returns {{addressLine1?: string, addressLine2?: string, town?: string, county?: string, country?: string, postCode?: string | null}}
  */
 function formatAddress(address) {
 	if (address) {
@@ -9,6 +9,7 @@ function formatAddress(address) {
 			...(address.addressLine2 && { addressLine2: address.addressLine2 }),
 			...(address.town && { town: address.town }),
 			...(address.county && { county: address.county }),
+			...(address.country && { country: address.country }),
 			postCode: address.postcode
 		};
 	}

--- a/apps/api/src/server/utils/address-formatter-lowercase.js
+++ b/apps/api/src/server/utils/address-formatter-lowercase.js
@@ -1,7 +1,7 @@
 /**
  *
  * @param {{addressLine1: string, addressLine2: string, town: string, county: string, postcode: string}} address
- * @returns {{addressLine1?: string, addressLine2?: string, town?: string, county?: string, postCode: string}}
+ * @returns {{addressLine1?: string, addressLine2?: string, town?: string, county?: string, country?: string, postCode: string}}
  */
 const formatAddressLowerCase = (address) => {
 	return {
@@ -9,6 +9,7 @@ const formatAddressLowerCase = (address) => {
 		...(address?.addressLine2 && { addressLine2: address.addressLine2 }),
 		...(address?.town && { town: address.town }),
 		...(address?.county && { county: address.county }),
+		...(address?.country && { country: address.country }),
 		postCode: address?.postcode
 	};
 };

--- a/apps/web/src/server/applications/common/components/form/form-applicant.component.js
+++ b/apps/web/src/server/applications/common/components/form/form-applicant.component.js
@@ -216,7 +216,9 @@ export async function applicantAddressDataUpdate({ errors: validationErrors, bod
 							postcode,
 							addressLine1: body['applicant.address.addressLine1'],
 							addressLine2: body['applicant.address.addressLine2'],
-							town: body['applicant.address.town']
+							town: body['applicant.address.town'],
+							county: body['applicant.address.county'],
+							country: body['applicant.address.country']
 						}
 					}
 				};

--- a/apps/web/src/server/applications/create-new-case/applicant/__tests__/__snapshots__/applications-create-applicant.test.js.snap
+++ b/apps/web/src/server/applications/create-new-case/applicant/__tests__/__snapshots__/applications-create-applicant.test.js.snap
@@ -62,6 +62,16 @@ exports[`applications create applicant Applicant address GET /applicant-address 
             <input class=\\"govuk-input govuk-!-width-one-half\\"
             id=\\"applicant.address.town\\" name=\\"applicant.address.town\\" type=\\"text\\">
         </div>
+        <div class=\\"govuk-form-group\\">
+            <label class=\\"govuk-label\\" for=\\"applicant.address.county\\">County</label>
+            <input class=\\"govuk-input govuk-!-width-one-half\\" id=\\"applicant.address.county\\"
+            name=\\"applicant.address.county\\" type=\\"text\\">
+        </div>
+        <div class=\\"govuk-form-group\\">
+            <label class=\\"govuk-label\\" for=\\"applicant.address.country\\">Country</label>
+            <input class=\\"govuk-input govuk-!-width-one-half\\" id=\\"applicant.address.country\\"
+            name=\\"applicant.address.country\\" type=\\"text\\">
+        </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
                 <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and continue</button>

--- a/apps/web/src/server/views/applications/components/case-form/applicant/address.njk
+++ b/apps/web/src/server/views/applications/components/case-form/applicant/address.njk
@@ -71,6 +71,20 @@
 				<input class="govuk-input govuk-!-width-one-half" id="applicant.address.town" name="applicant.address.town"
 					   type="text">
 			</div>
+			<div class="govuk-form-group">
+				<label class="govuk-label" for="applicant.address.county">
+					County
+				</label>
+				<input class="govuk-input govuk-!-width-one-half" id="applicant.address.county" name="applicant.address.county"
+					   type="text">
+			</div>
+			<div class="govuk-form-group">
+				<label class="govuk-label" for="applicant.address.country">
+					Country
+				</label>
+				<input class="govuk-input govuk-!-width-one-half" id="applicant.address.country" name="applicant.address.country"
+					   type="text">
+			</div>
 		{% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
## Describe your changes

- Added county and country to applicant address edit page
- Tested manually adding county and country details
- Updated unit tests
- Fixed the unit test snapshots

## BOAS-1706 Edit application address doesn't show all address parts
https://pins-ds.atlassian.net/browse/BOAS-1706

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
