### PR TITLE
Feature/boas 1723 simulate document upload when auth disabled

### DIFF
--- a/apps/web/src/client/components/file-uploader/_server-actions.js
+++ b/apps/web/src/client/components/file-uploader/_server-actions.js
@@ -199,6 +199,11 @@ const serverActions = (uploadForm) => {
 	const uploadFiles = async (fileList, uploadInfo) => {
 		const { documents, blobStorageHost, privateBlobContainer, accessToken } = uploadInfo;
 
+		// Do not attempt to upload to blob storage when auth is disabled
+		if (accessToken?.token === 'AUTH_DISABLED') {
+			return failedUploads;
+		}
+
 		const blobStorageClient = BlobStorageClient.fromUrlAndToken(blobStorageHost, accessToken);
 
 		for (const documentUploadInfo of documents) {
@@ -246,6 +251,11 @@ const serverActions = (uploadForm) => {
 	 */
 	const uploadFile = async (fileList, uploadInfo) => {
 		const { fileRowId, blobStorageHost, privateBlobContainer, accessToken } = uploadInfo;
+
+		// Do not attempt to upload to blob storage when auth is disabled
+		if (accessToken?.token === 'AUTH_DISABLED') {
+			return failedUploads;
+		}
 
 		const { blobStoreUrl } = uploadInfo.document;
 

--- a/apps/web/src/server/lib/active-directory-token.js
+++ b/apps/web/src/server/lib/active-directory-token.js
@@ -1,5 +1,6 @@
 import { acquireTokenSilent } from '../app/auth/auth.service.js';
 import { getAccount } from '../app/auth/auth-session.service.js';
+import config from '../../../environment/config.js';
 
 /** @typedef {import('../app/auth/auth-session.service').SessionWithAuth} SessionWithAuth */
 /** @typedef {import('@azure/core-auth').AccessToken} AccessToken */
@@ -16,6 +17,11 @@ const getActiveDirectoryAccessToken = async (
 	session,
 	customScopes = ['https://storage.azure.com/user_impersonation']
 ) => {
+	// Return a fake access token when auth is disabled so that uploads and downloads can skip blob storage functionality when developing locally
+	if (config.authDisabled) {
+		return { token: 'AUTH_DISABLED', expiresOnTimestamp: 0 };
+	}
+
 	const sessionAccount = getAccount(session);
 
 	if (!sessionAccount) {


### PR DESCRIPTION
## Describe your changes

- Return a fake access token when AUTH_DISABLED is true
- Don't attempt to upload to, or download from, blob storage when fake access token is returned
- Return a fake file with dummy data when downloading a file
- Manually tested
- Tested against the e2e tests running locally using the changes in **PR** https://github.com/Planning-Inspectorate/back-office/pull/2352 
- Note that to pass the local e2e using the PR above, the following environment variables should be set:
   - AUTH_DISABLED in `apps/web/.env` should be true
   - VIRUS_SCANNING_DISABLED in `apps/api/.env` should be true
   - AUTH_DISABLED in` apps/e2e/.env` should be true

## BOAS-1723 Simulate document uploads and downloads when auth is disabled
https://pins-ds.atlassian.net/browse/BOAS-1723

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
