### PR TITLE
fix(test/e2e): allow e2e tests to pass on localhost (BOAS-1726)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -4,6 +4,7 @@ import * as documentRepository from '#repositories/document.repository.js';
 import * as documentVersionRepository from '#repositories/document-metadata.repository.js';
 import * as folderRepository from '#repositories/folder.repository.js';
 import BackOfficeAppError from '#utils/app-error.js';
+import config from '#config/config.js';
 import { getPageCount, getSkipValue } from '#utils/database-pagination.js';
 import logger from '#utils/logger.js';
 import { mapDateStringToUnixTimestamp } from '#utils/mapping/map-date-string-to-unix-timestamp.js';
@@ -572,7 +573,7 @@ export const publishDocuments = async ({ body }, response) => {
 	response.send(
 		successful.map((/** @type {string} */ guid) => ({
 			guid,
-			publishedStatus: 'publishing'
+			publishedStatus: config.authDisabled ? 'published' : 'publishing'
 		}))
 	);
 };

--- a/apps/api/src/server/config/config.js
+++ b/apps/api/src/server/config/config.js
@@ -30,6 +30,7 @@ const { value, error } = schema.validate({
 			? false
 			: environment.FEATURE_FLAG_BOAS_1_TEST_FEATURE === 'true'
 	},
+	authDisabled: environment.AUTH_DISABLED === 'true',
 	serviceBusEnabled: environment.SERVICE_BUS_ENABLED && environment.SERVICE_BUS_ENABLED === 'true',
 	azureKeyVaultEnabled: environment.KEY_VAULT_ENABLED && environment.KEY_VAULT_ENABLED === 'true'
 });

--- a/apps/api/src/server/config/schema.js
+++ b/apps/api/src/server/config/schema.js
@@ -23,6 +23,7 @@ export default joi
 		}),
 		cwd: joi.string(),
 		featureFlags: joi.object().pattern(/featureFlagBoas\d+[A-Za-z]+/, joi.boolean()),
+		authDisabled: joi.boolean().optional(),
 		serviceBusEnabled: joi.boolean().optional(),
 		azureKeyVaultEnabled: joi.boolean().optional()
 	})

--- a/apps/api/src/server/repositories/document-metadata.repository.js
+++ b/apps/api/src/server/repositories/document-metadata.repository.js
@@ -1,4 +1,5 @@
 import { databaseConnector } from '#utils/database-connector.js';
+import config from '#config/config.js';
 
 /**
  * @typedef {import('@prisma/client').Document} Document
@@ -257,7 +258,7 @@ export const publishMany = async (documentVersionIds) => {
 		const result = await databaseConnector.documentVersion.update({
 			where: { documentGuid_version },
 			data: {
-				publishedStatus: isTraining ? 'published' : 'publishing',
+				publishedStatus: isTraining || config.authDisabled ? 'published' : 'publishing',
 				publishedStatusPrev: current?.publishedStatus
 			},
 			include: includeClauseDocVersionFull
@@ -308,7 +309,7 @@ export const unpublishMany = async (documentVersionIds) => {
 		const result = await databaseConnector.documentVersion.update({
 			where: { documentGuid_version },
 			data: {
-				publishedStatus: isTraining ? 'unpublished' : 'unpublishing',
+				publishedStatus: isTraining || config.authDisabled ? 'unpublished' : 'unpublishing',
 				publishedStatusPrev: current?.publishedStatus
 			},
 			include: includeClauseDocVersionFull

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -25,7 +25,7 @@ It is now possible to run the e2e tests against your local branch running in htt
 - Simulate looking up users required in the tests
 - Simulate looking up addresses required in the tests
 
-### Set up your local .env files as follows:
+### Make sure your local .env files have the following:
 
 #### apps/e2e/.env
 - AUTH_DISABLED=true
@@ -44,7 +44,8 @@ It is now possible to run the e2e tests against your local branch running in htt
 - DUMMY_ADDRESS_DATA=true
 
 #### apps/api/.env
-- VIRUS_SCANNER_DISABLED=true
+- AUTH_DISABLED=true
+- VIRUS_SCANNING_DISABLED=true
 - AZURE_BLOB_STORE_HOST=blob-store-host
 - AZURE_BLOB_STORE_CONTAINER=blob-store-container
 


### PR DESCRIPTION
## Describe your changes

Allows unpublishing and publishing document e2e tests to run locally against http://localhost:8080

- Updated environment variables in e2e Readme
- Automatically set publishing to published and unpublishing to unpublished when NODE_ENV is development
- Tested manually 

See the description within the ticket below for the full setup for how to run the e2e tests locally against http://localhost:8080 in dev.

## BOAS-1726 Allow all cypress e2e tests to pass when running locally against localhost
https://pins-ds.atlassian.net/browse/BOAS-1726

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes

## Linked to
https://pins-ds.atlassian.net/browse/BOAS-1721