### PR TITLE
feat(functions): add azure function for general s51 advice migration

### DIFF
--- a/apps/api/src/server/migration/migration.controller.js
+++ b/apps/api/src/server/migration/migration.controller.js
@@ -1,5 +1,5 @@
 import { getMigratorForModel } from './migrator.service.js';
-import { migrateFolders } from "./migrators/folder-migrator.js";
+import { migrateFolders } from './migrators/folder-migrator.js';
 
 /**
  * @type {import("express").RequestHandler<{modelType: string}, ?, any[]>}

--- a/apps/functions/applications-migration/common/constants.js
+++ b/apps/functions/applications-migration/common/constants.js
@@ -1,0 +1,2 @@
+export const ODW_GENERAL_CASE_REF = 'General';
+export const BO_GENERAL_CASE_REF = 'GS5110001';

--- a/apps/functions/applications-migration/common/constants.js
+++ b/apps/functions/applications-migration/common/constants.js
@@ -1,2 +1,0 @@
-export const ODW_GENERAL_CASE_REF = 'General';
-export const BO_GENERAL_CASE_REF = 'GS5110001';

--- a/apps/functions/applications-migration/common/migrators/general-s51-advice-migration.js
+++ b/apps/functions/applications-migration/common/migrators/general-s51-advice-migration.js
@@ -1,0 +1,53 @@
+import { QueryTypes } from 'sequelize';
+import { SynapseDB } from '../synapse-db.js';
+import { migrateS51AdviceForCase } from './s51-advice-migration.js';
+import { ODW_GENERAL_CASE_REF } from '../constants.js';
+
+/**
+ * @param {import('@azure/functions').Logger} logger
+ * @param {number} offset
+ */
+export const migrateGeneralS51Advice = async (logger, offset = 0) => {
+	const countQuery = `
+		SELECT COUNT(*) AS generalS51AdviceCount
+		FROM [odw_curated_db].[dbo].[nsip_s51_advice]
+		WHERE caseReference = '${ODW_GENERAL_CASE_REF}';
+	`;
+	const [{ generalS51AdviceCount }] = await SynapseDB.query(countQuery, {
+		type: QueryTypes.SELECT
+	});
+	logger.info(`Number of General S51 Advice found in odw_curated_db: ${generalS51AdviceCount}`);
+
+	const batchSize = 10;
+	while (offset < generalS51AdviceCount) {
+		const paginatedGeneralS51AdviceQuery = `
+			SELECT * FROM [odw_curated_db].[dbo].[nsip_s51_advice]
+			WHERE caseReference = '${ODW_GENERAL_CASE_REF}'
+			ORDER BY nsip_s51_advice.adviceId
+			OFFSET ${offset} ROWS
+			FETCH NEXT ${batchSize} ROWS ONLY;
+		`;
+
+		try {
+			await migrateS51AdviceForCase(logger, ODW_GENERAL_CASE_REF, paginatedGeneralS51AdviceQuery);
+		} catch (error) {
+			logger.error(`Batch with offset ${offset} failed to migrate.`, error?.response?.body, error);
+			throw error;
+		}
+		offset += batchSize;
+	}
+};
+
+/**
+ * @param {import('@azure/functions').Logger} logger
+ * @param {string[]} adviceIdList
+ */
+export const migrateSelectGeneralS51Advice = async (logger, adviceIdList) => {
+	for (const adviceId of adviceIdList) {
+		const query = `
+			SELECT * FROM [odw_curated_db].[dbo].[nsip_s51_advice]
+			WHERE adviceId = '${adviceId}'
+		`;
+		await migrateS51AdviceForCase(logger, ODW_GENERAL_CASE_REF, query);
+	}
+};

--- a/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
+++ b/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
@@ -1,7 +1,7 @@
 import { SynapseDB } from '../synapse-db.js';
 import { makePostRequest } from '../back-office-api-client.js';
 import { pick } from 'lodash-es';
-import { BO_GENERAL_CASE_REF, ODW_GENERAL_CASE_REF } from '../constants.js';
+import { BO_GENERAL_S51_CASE_REF, ODW_GENERAL_S51_CASE_REF } from '@pins/applications';
 
 const query = 'SELECT * FROM [odw_curated_db].[dbo].[nsip_s51_advice] WHERE caseReference = ?';
 
@@ -51,8 +51,12 @@ export async function migrateS51AdviceForCase(log, caseReference, synapseQuery =
 		});
 
 		const s51AdviceEntities = s51AdviceRows.map((row) => {
-			if (caseReference === ODW_GENERAL_CASE_REF) {
-				mapGeneralToBoCaseRef(row);
+			if (caseReference === ODW_GENERAL_S51_CASE_REF) {
+				row.adviceReference = row.adviceReference.replace(
+					ODW_GENERAL_S51_CASE_REF,
+					BO_GENERAL_S51_CASE_REF
+				);
+				row.caseReference = BO_GENERAL_S51_CASE_REF;
 			}
 			return {
 				...pick(row, s51AdviceProperties),
@@ -90,8 +94,3 @@ const mapStatus = (status) =>
 		'do not publish': 'donotpublish',
 		depublished: 'unchecked'
 	}[status]);
-
-const mapGeneralToBoCaseRef = (row) => {
-	row.adviceReference = row.adviceReference.replace(ODW_GENERAL_CASE_REF, BO_GENERAL_CASE_REF);
-	row.caseReference = BO_GENERAL_CASE_REF;
-};

--- a/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
+++ b/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
@@ -1,7 +1,7 @@
 import { SynapseDB } from '../synapse-db.js';
 import { makePostRequest } from '../back-office-api-client.js';
-import { removeValues } from '../utils.js';
 import { pick } from 'lodash-es';
+import { BO_GENERAL_CASE_REF, ODW_GENERAL_CASE_REF } from '../constants.js';
 
 const query = 'SELECT * FROM [odw_curated_db].[dbo].[nsip_s51_advice] WHERE caseReference = ?';
 
@@ -42,21 +42,22 @@ export const migrateS51Advice = async (logger, caseReferences) => {
  * @param {import('@azure/functions').Logger} log
  * @param {string} caseReference
  */
-export async function migrateS51AdviceForCase(log, caseReference) {
+export async function migrateS51AdviceForCase(log, caseReference, synapseQuery = query) {
 	try {
 		log.info(`reading S51 Advice with caseReference ${caseReference}`);
 
-		const [s51AdviceRows, count] = await SynapseDB.query(query, {
+		const [s51AdviceRows, count] = await SynapseDB.query(synapseQuery, {
 			replacements: [caseReference]
 		});
 
 		const s51AdviceEntities = s51AdviceRows.map((row) => {
-			removeValues(row, [null, 'None']);
-
+			if (caseReference === ODW_GENERAL_CASE_REF) {
+				mapGeneralToBoCaseRef(row);
+			}
 			return {
 				...pick(row, s51AdviceProperties),
 				status: mapStatus(row.status),
-				attachmentIds: row.attachmentIds?.split(',')
+				attachmentIds: row.attachmentIds ? row.attachmentIds?.split(',') : []
 			};
 		});
 
@@ -81,9 +82,16 @@ export async function migrateS51AdviceForCase(log, caseReference) {
 const mapStatus = (status) =>
 	({
 		checked: 'checked',
+		unchecked: 'unchecked',
 		'not checked': 'unchecked',
 		'ready to publish': 'readytopublish',
 		published: 'published',
+		donotpublish: 'donotpublish',
 		'do not publish': 'donotpublish',
 		depublished: 'unchecked'
 	}[status]);
+
+const mapGeneralToBoCaseRef = (row) => {
+	row.adviceReference = row.adviceReference.replace(ODW_GENERAL_CASE_REF, BO_GENERAL_CASE_REF);
+	row.caseReference = BO_GENERAL_CASE_REF;
+};

--- a/apps/functions/applications-migration/general-s51-advice-migration/debug.js
+++ b/apps/functions/applications-migration/general-s51-advice-migration/debug.js
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import {
+	migrateGeneralS51Advice,
+	migrateSelectGeneralS51Advice
+} from '../common/migrators/general-s51-advice-migration.js';
+
+if (process.argv[2]) {
+	migrateSelectGeneralS51Advice(
+		{
+			info: console.log,
+			error: console.error,
+			warn: console.warn,
+			verbose: console.log
+		},
+		process.argv.slice(2)
+	);
+} else {
+	migrateGeneralS51Advice({
+		info: console.log,
+		error: console.error,
+		warn: console.warn,
+		verbose: console.log
+	});
+}

--- a/apps/functions/applications-migration/general-s51-advice-migration/function.json
+++ b/apps/functions/applications-migration/general-s51-advice-migration/function.json
@@ -1,0 +1,16 @@
+{
+	"bindings": [
+		{
+			"authLevel": "function",
+			"type": "httpTrigger",
+			"direction": "in",
+			"name": "req",
+			"methods": ["post"]
+		},
+		{
+			"type": "http",
+			"direction": "out",
+			"name": "res"
+		}
+	]
+}

--- a/apps/functions/applications-migration/general-s51-advice-migration/index.js
+++ b/apps/functions/applications-migration/general-s51-advice-migration/index.js
@@ -1,0 +1,23 @@
+import {
+	migrateGeneralS51Advice,
+	migrateSelectGeneralS51Advice
+} from '../common/migrators/general-s51-advice-migration.js';
+
+/**
+ * @param {import('@azure/functions').Context} context
+ * @param {import('@azure/functions').HttpRequest} req
+ */
+export default async function (
+	context,
+	{ body: { migrationType, adviceIdList = [], offset = 0 } }
+) {
+	if (migrationType === 'select' && adviceIdList.length > 0) {
+		context.log('Migrating select General S51 Advice: ', adviceIdList);
+		await migrateSelectGeneralS51Advice(context.log, adviceIdList);
+	} else if (migrationType === 'all') {
+		context.log('Migrating all General S51 Advice: ');
+		await migrateGeneralS51Advice(context.log, offset);
+	} else {
+		throw Error('Request body did not contain expected parameters');
+	}
+}

--- a/apps/functions/applications-migration/general-s51-advice-migration/index.js
+++ b/apps/functions/applications-migration/general-s51-advice-migration/index.js
@@ -16,7 +16,7 @@ export default async function (
 		await migrateSelectGeneralS51Advice(context.log, adviceIdList);
 	} else if (migrationType === 'all') {
 		context.log('Migrating all General S51 Advice: ');
-		await migrateGeneralS51Advice(context.log, offset);
+		await migrateGeneralS51Advice(context.log, Number(offset));
 	} else {
 		throw Error('Request body did not contain expected parameters');
 	}

--- a/apps/functions/applications-migration/package.json
+++ b/apps/functions/applications-migration/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@azure/identity": "^3.0.1",
     "@pins/add-auth-headers-for-backend": "^0.0.0",
+    "@pins/applications": "^0.0.0",
     "@pins/blob-storage-client": "^0.0.0",
     "@pins/platform": "^0.0.0",
     "ajv": "^8.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2105,6 +2105,7 @@
 			"dependencies": {
 				"@azure/identity": "^3.0.1",
 				"@pins/add-auth-headers-for-backend": "^0.0.0",
+				"@pins/applications": "^0.0.0",
 				"@pins/blob-storage-client": "^0.0.0",
 				"@pins/platform": "^0.0.0",
 				"ajv": "^8.12.0",
@@ -9267,10 +9268,6 @@
 		},
 		"node_modules/@pins/add-auth-headers-for-backend": {
 			"resolved": "packages/add-auth-headers-for-backend",
-			"link": true
-		},
-		"node_modules/@pins/appeals": {
-			"resolved": "packages/appeals",
 			"link": true
 		},
 		"node_modules/@pins/applications": {
@@ -29611,23 +29608,12 @@
 		},
 		"packages/appeals": {
 			"version": "0.0.0",
+			"extraneous": true,
 			"devDependencies": {
 				"type-fest": "^2.12.2"
 			},
 			"engines": {
 				"node": ">=18.0.0 <19.0.0"
-			}
-		},
-		"packages/appeals/node_modules/type-fest": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"packages/applications": {
@@ -34722,20 +34708,6 @@
 				"node-cache": "^5.1.2"
 			}
 		},
-		"@pins/appeals": {
-			"version": "file:packages/appeals",
-			"requires": {
-				"type-fest": "^2.12.2"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "2.19.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-					"dev": true
-				}
-			}
-		},
 		"@pins/applications": {
 			"version": "file:packages/applications",
 			"requires": {
@@ -36452,6 +36424,7 @@
 			"requires": {
 				"@azure/identity": "^3.0.1",
 				"@pins/add-auth-headers-for-backend": "^0.0.0",
+				"@pins/applications": "^0.0.0",
 				"@pins/blob-storage-client": "^0.0.0",
 				"@pins/platform": "^0.0.0",
 				"ajv": "^8.12.0",

--- a/packages/applications/index.d.ts
+++ b/packages/applications/index.d.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './lib/application/project-update';
+export * from './lib/application/constants';

--- a/packages/applications/index.js
+++ b/packages/applications/index.js
@@ -1,0 +1,1 @@
+export * from './lib/application/constants.js';

--- a/packages/applications/lib/application/constants.js
+++ b/packages/applications/lib/application/constants.js
@@ -1,0 +1,3 @@
+export const ODW_GENERAL_S51_CASE_REF = 'General';
+export const BO_GENERAL_S51_CASE_REF = 'GS5110001';
+export const GENERAL_S51_FOLDER_NAME = 'S51 advice';

--- a/packages/applications/package.json
+++ b/packages/applications/package.json
@@ -3,14 +3,10 @@
     "description": "types and other common code for applications",
     "version": "0.0.0",
     "type": "module",
-    "main": "index.d.ts",
+    "main": "index.js",
     "private": true,
     "engines": {
       "node": ">=18.0.0 <19.0.0"
-    },
-    "exports": {
-      ".": "./index.d.ts",
-      "./lib/*": "./lib/*"
     },
     "scripts": {
     },


### PR DESCRIPTION
## Describe your changes
Adds capability to migrate general S51 advice from the curated db to the BO db.

Due to the high number of General S51 advices that need to be migrated (700-800), there is a paginated mechanism in place that returns (currently) 100 rows with each call. They are then sent to the api together to complete the migration before continuing with the rest of the advices.

This mechanism also allows for continuation of a migration process from the point it errored by noting the offset number and including it in the invocation request to the Azure Function.

Might not be necessary, but there is also a 'select' General S51 Advice migration function included in the same Azure Function, allowing for migration of a specific case.

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
