### PR TITLE
fix(applications): correct invalid stage values in db (boas-1651)

### DIFF
--- a/apps/api/src/database/migrations/20240417160000_correct_migrated_case_stages/migration.sql
+++ b/apps/api/src/database/migrations/20240417160000_correct_migrated_case_stages/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  Some migrated cases / case shells made migrating project-updates have invalid case stage statuses,
+	eg 'Pre-application' when it should be 'pre_application'.
+	This script corrects those values.  to be run in all environments inc Prod
+	BOAS-1651 - Arundel case not appearing in dashboard
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+UPDATE CaseStatus SET [status] = 'acceptance' WHERE status = 'Acceptance (review of the application)';
+UPDATE CaseStatus SET [status] = 'post_decision' WHERE status = 'Decided';
+UPDATE CaseStatus SET [status] = 'decision' WHERE status = 'Decision';
+UPDATE CaseStatus SET [status] = 'examination' WHERE status = 'Examination';
+UPDATE CaseStatus SET [status] = 'pre_application' WHERE status = 'Pre-application';
+UPDATE CaseStatus SET [status] = 'pre_examination' WHERE status = 'Pre-examination';
+UPDATE CaseStatus SET [status] = 'recommendation' WHERE status = 'Recommendation';
+UPDATE CaseStatus SET [status] = 'withdrawn' WHERE status = 'Withdrawn';
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/server/utils/create-enums.js
+++ b/apps/api/src/server/utils/create-enums.js
@@ -84,7 +84,7 @@ export const sourceSystemEnum = new Enum([
 
 export const originEnum = new Enum(['pins', 'citizen', 'lpa', 'ogd']);
 
-export const stageEnum = new Enum([
+export const documentStageEnum = new Enum([
 	'draft',
 	'pre-application',
 	'acceptance',

--- a/apps/functions/applications-migration/project-updates-migration/src/project-updates-migration.js
+++ b/apps/functions/applications-migration/project-updates-migration/src/project-updates-migration.js
@@ -122,6 +122,8 @@ const getProjectSubscriptions = async (log, caseReference) => {
 };
 
 /**
+ * Maps the NSIP Website stage id to our internal CBOS DB string value
+ *
  * @param {number} caseStageId
  *
  * @returns {string} caseStage
@@ -140,14 +142,14 @@ const getCaseStageFromId = (caseStageId) => {
 };
 
 const projectStages = {
-	1: 'Pre-application',
-	2: 'Acceptance (review of the application)',
-	3: 'Pre-examination',
-	4: 'Examination',
-	5: 'Recommendation',
-	6: 'Decision',
-	7: 'Decided',
-	8: 'Withdrawn'
+	1: 'pre_application',
+	2: 'acceptance',
+	3: 'pre_examination',
+	4: 'examination',
+	5: 'recommendation',
+	6: 'decision',
+	7: 'post_decision',
+	8: 'withdrawn'
 };
 
 const subscriptionTypes = {


### PR DESCRIPTION
## Describe your changes

There were invalid case stage values in the caseStatus table.  Believe this was caused when shell cases were created for Project Updates, possibly taking the values the the old NSIP website used.  An example is "Acceptance (review of the application)" - our db does not have this, it has "acceptance".

These invalid values stop the cases displaying in the dashboard, which filters to only display a selection from the valid list.  The bug was raised on the "Arundel" case in Prod, which had a value "Pre-application" where it should have been "pre_application".

- changed the project update migration code to set the correct db values
- added a DB migration script to update all incorrect values to the correct valid ones.  This will be run in each environment upon delivery.

**Developer Instruction:**
- developers should run `npm run db:migrate` on their local instance

## BOAS-1651 A27 Arundel Bypass Case not showing on dashboard
https://pins-ds.atlassian.net/browse/BOAS-1651

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
