### PR TITLE
fix(api/applications): correct multiple valid case statuses (boas-1737)

### DIFF
--- a/apps/api/src/database/migrations/20240419120000_correct_multiple_valid_case_statuses/migration.sql
+++ b/apps/api/src/database/migrations/20240419120000_correct_multiple_valid_case_statuses/migration.sql
@@ -1,0 +1,55 @@
+/*
+  Warnings:
+
+ Where cases have been migrated more than once, multiple valid CaseStatus records can be created.
+ There should only be 1 valid CaseStatus record per case.
+
+	This script corrects those values.  to be run in all environments inc Prod
+	BOAS-1737 - Migrated cases have multiple valid case status records
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- show the bad records
+-- select all status records where valid=1 apart from the latest valid one
+/* SELECT cs.* FROM CaseStatus cs
+WHERE cs.valid = 1 AND cs.id NOT IN (
+    -- get the latest valid caseStatus record for each case
+    SELECT csLatest.id FROM CaseStatus csLatest
+    INNER JOIN
+        (SELECT caseId, MAX(createdAt) AS MaxDateTime
+        FROM CaseStatus
+        WHERE valid=1
+        GROUP BY caseId) groupedtt
+    ON csLatest.caseId = groupedtt.caseId
+    AND csLatest.createdAt = groupedtt.MaxDateTime
+) */
+
+-- correct bad records to valid=0
+UPDATE CaseStatus SET valid=0
+WHERE valid = 1 AND id NOT IN (
+    -- get the latest valid caseStatus record for each case
+    SELECT csLatest.id FROM CaseStatus csLatest
+    INNER JOIN
+        (SELECT caseId, MAX(createdAt) AS MaxDateTime
+        FROM CaseStatus
+        WHERE valid=1
+        GROUP BY caseId) groupedtt
+    ON csLatest.caseId = groupedtt.caseId
+    AND csLatest.createdAt = groupedtt.MaxDateTime
+)
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH


### PR DESCRIPTION
## Describe your changes

Case Migration, if run multiple times for a case, can create multiple case status records that are marked as valid.  This confuses the main app, as it expects only 1 CaseStatus record to be valid for any case.  The issue occurs in cases in Azure Prod and Test.

This fix does:
- add code to the migrator to set all previous CaseStatus records for a case to valid=0, before adding the latest CaseStatus record.
- SQL migration script to set all old CaseStatus records that are incorrectly marked as valid=1 to be 0.

## Migrated cases have multiple valid case status records
https://pins-ds.atlassian.net/browse/BOAS-1737

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
