### PR TITLE
fix(applications/web): back button fails to return to project information (BOAS-1739)

### DIFF
--- a/apps/web/src/server/applications/applications.locals.js
+++ b/apps/web/src/server/applications/applications.locals.js
@@ -53,6 +53,7 @@ export const registerCaseWithQuery = (query, shouldBeDraft = false) => {
 		}
 
 		response.locals.currentCase = currentCase;
+		response.locals.isDraft = isDraft;
 		next();
 	};
 };

--- a/apps/web/src/server/views/applications/components/case-form/case-form-layout.njk
+++ b/apps/web/src/server/views/applications/components/case-form/case-form-layout.njk
@@ -36,7 +36,7 @@
 		{{ govukBackLink({
 		classes: 'govuk-!-margin-top-3',
 		text: "Back",
-		href: 'case-create'|url({caseId:caseId, step:'check-your-answers'}) if layout.isEdit else computedBackLink
+		href: 'case-create'|url({caseId:caseId, step:'check-your-answers'}) if layout.isEdit and isDraft else computedBackLink
 	}) }}
 	</aside>
 {% endblock %}


### PR DESCRIPTION
## Describe your changes

- Make back button return to project information when not in draft
- Tested manually 

## BOAS-1739 Back button when editing applicant details for a non-draft case fails to return to Project Information
https://pins-ds.atlassian.net/browse/BOAS-1739

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
