### PR TITLE
feat(api/applications): change folder name mail merges (boas-1719)

### DIFF
--- a/apps/api/src/database/migrations/20240422160000_rename_mail_merges_folder/migration.sql
+++ b/apps/api/src/database/migrations/20240422160000_rename_mail_merges_folder/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+	BOAS-1719 - correct folder 'Mail merge spreadsheet' to 'Mail merges'
+
+	Sub folder name change:
+
+	This script corrects those values in all existing records.
+	To be run in all environments inc Prod
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+	UPDATE [Folder] SET displayNameEn = 'Mail merges'
+	WHERE displayNameEn = 'Mail merge spreadsheet'
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/server/applications/application/__tests__/start-case.test.js
+++ b/apps/api/src/server/applications/application/__tests__/start-case.test.js
@@ -157,7 +157,7 @@ describe('Start case', () => {
 							}
 						},
 						{
-							displayNameEn: 'Mail merge spreadsheet',
+							displayNameEn: 'Mail merges',
 							displayOrder: 200,
 							caseId: 1,
 							stage: null

--- a/apps/api/src/server/migration/migrators/folder/__tests__/folder.test.js
+++ b/apps/api/src/server/migration/migrators/folder/__tests__/folder.test.js
@@ -544,7 +544,7 @@ const folders = [
 	},
 	{
 		id: 100011464,
-		displayNameEn: 'Mail merge spreadsheet',
+		displayNameEn: 'Mail merges',
 		displayOrder: 200,
 		parentFolderId: 100011415,
 		caseId: 15360347,

--- a/apps/api/src/server/migration/migrators/folder/folder.js
+++ b/apps/api/src/server/migration/migrators/folder/folder.js
@@ -81,7 +81,7 @@ export const defaultCaseFoldersForMigration = [
 					}
 				},
 				{
-					displayNameEn: 'Mail merge spreadsheet',
+					displayNameEn: 'Mail merges',
 					displayOrder: 200,
 					stage: folderDocumentCaseStageMappings.PROJECT_MANAGEMENT
 				},

--- a/apps/api/src/server/repositories/folder.repository.js
+++ b/apps/api/src/server/repositories/folder.repository.js
@@ -306,7 +306,7 @@ const defaultCaseFolders = [
 					}
 				},
 				{
-					displayNameEn: 'Mail merge spreadsheet',
+					displayNameEn: 'Mail merges',
 					displayOrder: 200,
 					stage: folderDocumentCaseStageMappings.PROJECT_MANAGEMENT
 				},

--- a/apps/e2e/cypress/fixtures/folder-structure.json
+++ b/apps/e2e/cypress/fixtures/folder-structure.json
@@ -17,7 +17,7 @@
 				]
 			},
 			{
-				"name": "Mail merge spreadsheet",
+				"name": "Mail merges",
 				"subfolders": [],
 				"documents": []
 			},


### PR DESCRIPTION
## Describe your changes

Change name of the folder Mail merge spreadsheet to Mail merges
- applies to newly created cases, and migrated cases
- add SQL migrate script to correct all old folders on existing cases
- also amended E2E scripts

## BOAS-1719 change folder name mail merges

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
