### PR TITLE
fix(applications/web): enter applicant address missing optional (APPLICS-43)

### DIFF
--- a/apps/web/src/server/applications/case/edit/applicant/__tests__/__snapshots__/applications-edit-applicant.test.js.snap
+++ b/apps/web/src/server/applications/case/edit/applicant/__tests__/__snapshots__/applications-edit-applicant.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`applications create applicant GET edit/applicant-address should render the form page 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address</h1>
+    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address (optional)</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <input type=\\"hidden\\" name='currentFormStage' value=\\"searchPostcode\\">
         <div class=\\"govuk-form-group\\">
@@ -23,7 +23,7 @@ exports[`applications create applicant GET edit/applicant-address should render 
 
 exports[`applications create applicant GET edit/applicant-address should render the read only page with the address 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address</h1>
+    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address (optional)</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <div class=\\"govuk-form-group\\">
             <p class=\\"govuk-body\\">Applicant address, London, ABC123</p>
@@ -51,7 +51,7 @@ exports[`applications create applicant GET edit/applicant-address should render 
 
 exports[`applications create applicant GET edit/applicant-address should render the read only page without the address 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address</h1>
+    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address (optional)</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <input type=\\"hidden\\" name='currentFormStage' value=\\"searchPostcode\\">
         <div class=\\"govuk-form-group\\">

--- a/apps/web/src/server/applications/case/edit/applicant/applications-edit-applicant.controller.js
+++ b/apps/web/src/server/applications/case/edit/applicant/applications-edit-applicant.controller.js
@@ -56,13 +56,13 @@ const applicantEmailLayout = {
 	isEdit: true
 };
 const addressLayout = {
-	pageTitle: 'Enter the Applicant’s address',
+	pageTitle: 'Enter the Applicant’s address (optional)',
 	components: ['address'],
 	isEdit: true
 };
 
 const addressReadOnlyLayout = {
-	pageTitle: 'Enter the Applicant’s address',
+	pageTitle: 'Enter the Applicant’s address (optional)',
 	components: ['address-view'],
 	isEdit: true
 };

--- a/apps/web/src/server/applications/create-new-case/applicant/__tests__/__snapshots__/applications-create-applicant.test.js.snap
+++ b/apps/web/src/server/applications/create-new-case/applicant/__tests__/__snapshots__/applications-create-applicant.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`applications create applicant Applicant address GET /applicant-address should render the page when resumed or if there is data in the session 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address</h1>
+    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address (optional)</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <input type=\\"hidden\\" name='currentFormStage' value=\\"searchPostcode\\">
         <div class=\\"govuk-form-group\\">
@@ -23,7 +23,7 @@ exports[`applications create applicant Applicant address GET /applicant-address 
 
 exports[`applications create applicant Applicant address GET /applicant-address should render the page with the manual inputs for address 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address</h1>
+    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address (optional)</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <input type=\\"hidden\\" name='currentFormStage' value=\\"manualAddress\\">
         <input type=\\"hidden\\" name=\\"postcode\\" value=\\"aa1xx2\\">
@@ -98,7 +98,7 @@ exports[`applications create applicant Applicant address POST /applicant-address
             </div>
         </div>
     </div>
-    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address</h1>
+    <h1 class=\\"govuk-heading-l\\"> Enter the Applicant’s address (optional)</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <input type=\\"hidden\\" name='currentFormStage' value=\\"searchPostcode\\">
         <div class=\\"govuk-form-group\\">

--- a/apps/web/src/server/applications/create-new-case/applicant/applications-create-applicant.controller.js
+++ b/apps/web/src/server/applications/create-new-case/applicant/applications-create-applicant.controller.js
@@ -59,7 +59,10 @@ const applicantEmailLayout = {
 	pageTitle: 'Enter the applicant’s email address (optional)',
 	components: ['applicant-email']
 };
-const addressLayout = { pageTitle: 'Enter the Applicant’s address', components: ['address'] };
+const addressLayout = {
+	pageTitle: 'Enter the Applicant’s address (optional)',
+	components: ['address']
+};
 
 /**
  * View the form step for the applicant information types


### PR DESCRIPTION
## Describe your changes

- Add optional to the pages for entering an Applicant's address

## APPLICS-43 Enter Applicant Address missing (optional)

https://pins-ds.atlassian.net/browse/APPLICS-43

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
