### PR TITLE
fix(applications/web): align misaligned navigation menu (APPLICS-41)

### DIFF
--- a/apps/web/src/server/applications/case/__tests__/__snapshots__/applications-case.test.js.snap
+++ b/apps/web/src/server/applications/case/__tests__/__snapshots__/applications-case.test.js.snap
@@ -415,7 +415,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>
@@ -595,7 +595,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>
@@ -775,7 +775,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>
@@ -955,7 +955,7 @@ exports[`Applications case pages Project overview page GET /case/123 should rend
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>
@@ -1035,7 +1035,7 @@ exports[`Applications case pages Project overview page GET /case/123 should rend
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>
@@ -1113,7 +1113,7 @@ exports[`Applications case pages Project overview page GET /case/123 should rend
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>

--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -76,7 +76,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class=\\"pins-files-list\\" method=\\"post\\">
                 <caption><span class=\\"display--sr-only\\">Manage Documents in this location</span>
                 </caption>
-                <div class=\\"govuk-grid-row display--flex\\">
+                <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
                     <div class=\\"govuk-grid-column-two-thirds\\">
                         <div class=\\"pins-files-list__statuses\\">
                             <h3 class=\\"govuk-heading-s\\">Statuses</h3>
@@ -910,7 +910,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class=\\"pins-files-list\\" method=\\"post\\">
                 <caption><span class=\\"display--sr-only\\">Manage Documents in this location</span>
                 </caption>
-                <div class=\\"govuk-grid-row display--flex\\">
+                <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
                     <div class=\\"govuk-grid-column-two-thirds\\">
                         <div class=\\"pins-files-list__statuses\\">
                             <h3 class=\\"govuk-heading-s\\">Statuses</h3>
@@ -2225,7 +2225,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class=\\"pins-files-list\\" method=\\"post\\">
                 <caption><span class=\\"display--sr-only\\">Manage Documents in this location</span>
                 </caption>
-                <div class=\\"govuk-grid-row display--flex\\">
+                <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
                     <div class=\\"govuk-grid-column-two-thirds\\">
                         <div class=\\"pins-files-list__statuses\\">
                             <h3 class=\\"govuk-heading-s\\">Statuses</h3>
@@ -3081,7 +3081,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class=\\"pins-files-list\\" method=\\"post\\">
                 <caption><span class=\\"display--sr-only\\">Manage Documents in this location</span>
                 </caption>
-                <div class=\\"govuk-grid-row display--flex\\">
+                <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
                     <div class=\\"govuk-grid-column-two-thirds\\">
                         <div class=\\"pins-files-list__statuses\\">
                             <h3 class=\\"govuk-heading-s\\">Statuses</h3>
@@ -4336,7 +4336,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class=\\"pins-files-list\\" method=\\"post\\">
                 <caption><span class=\\"display--sr-only\\">Manage Documents in this location</span>
                 </caption>
-                <div class=\\"govuk-grid-row display--flex\\">
+                <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
                     <div class=\\"govuk-grid-column-two-thirds\\">
                         <div class=\\"pins-files-list__statuses\\">
                             <h3 class=\\"govuk-heading-s\\">Statuses</h3>
@@ -5589,7 +5589,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class=\\"pins-files-list\\" method=\\"post\\">
                 <caption><span class=\\"display--sr-only\\">Manage Documents in this location</span>
                 </caption>
-                <div class=\\"govuk-grid-row display--flex\\">
+                <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
                     <div class=\\"govuk-grid-column-two-thirds\\">
                         <div class=\\"pins-files-list__statuses\\">
                             <h3 class=\\"govuk-heading-s\\">Statuses</h3>
@@ -22115,7 +22115,7 @@ exports[`applications documentation GET /case/123/project-documentation should r
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"govuk-grid-column-full\\">
             <h2 class=\\"govuk-heading-m\\">Project documentation</h2>
             <p class=\\"govuk-body-s colour--secondary\\">All documents relating to the project</p>

--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -2360,7 +2360,7 @@ exports[`Examination timetable page GET /case/123/examination-timetable should s
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>

--- a/apps/web/src/server/applications/case/key-dates/__tests__/__snapshots__/applications-key-dates.test.js.snap
+++ b/apps/web/src/server/applications/case/key-dates/__tests__/__snapshots__/applications-key-dates.test.js.snap
@@ -15,7 +15,7 @@ exports[`S51 Advice Key dates page GET /case/123/key-dates/ should render the pa
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>

--- a/apps/web/src/server/applications/case/project-team/__tests__/__snapshots__/applications-project-team.test.js.snap
+++ b/apps/web/src/server/applications/case/project-team/__tests__/__snapshots__/applications-project-team.test.js.snap
@@ -363,7 +363,7 @@ exports[`Project team List page GET /case/123/project-team/ should render the pa
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>
@@ -429,7 +429,7 @@ exports[`Project team List page GET /case/123/project-team/ should render the pa
             </div>
         </div>
     </div>
-    <div class=\\"govuk-grid-row display--flex\\">
+    <div class=\\"govuk-grid-row govuk-!-margin-left-0 display--flex\\">
         <div class=\\"pins-list-menu-container\\">
             <aside class=\\"govuk-!-margin-bottom-8 pins-list-menu\\">
                 <h2 class=\\"govuk-visually-hidden\\">Case Details Menu</h2>

--- a/apps/web/src/server/views/applications/case/layouts/applications-case-layout.njk
+++ b/apps/web/src/server/views/applications/case/layouts/applications-case-layout.njk
@@ -46,7 +46,7 @@
 {% endblock %}
 
 {% block pageContent %}
-	<div class="govuk-grid-row display--flex">
+	<div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
 		{% block sectionMenu %}
 			<div class="pins-list-menu-container">
 				{{ casePageNavigation({ case: case, selectedPageType: selectedPageType }) }}

--- a/apps/web/src/server/views/applications/components/folder/folder-actions.component.njk
+++ b/apps/web/src/server/views/applications/components/folder/folder-actions.component.njk
@@ -3,7 +3,7 @@
 
 {% macro folderActions(isS51folder) %}
 
-	<div class="govuk-grid-row display--flex">
+	<div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
 		<div class="govuk-grid-column-two-thirds">
 			<div class="pins-files-list__statuses">
 				<h3 class="govuk-heading-s">Statuses</h3>


### PR DESCRIPTION
## Describe your changes

- Override negative left margin with CSS class govuk-!-margin-left-0

## APPLICS-41 Navigation menu misaligned with the left-side of the screen

https://pins-ds.atlassian.net/browse/APPLICS-41

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
