### PR TITLE
fix(applications/web): remove spaces from 25 and 50 links (APPLICS-34)

### DIFF
--- a/apps/web/src/server/applications/case/project-updates/__tests__/__snapshots__/project-updates.test.js.snap
+++ b/apps/web/src/server/applications/case/project-updates/__tests__/__snapshots__/project-updates.test.js.snap
@@ -29,11 +29,11 @@ exports[`project-updates GET /applications-service/:caseId/project-updates shoul
                     </div>
                     <div class=\\"govuk-grid-column-one-half text-align--right\\">
                         <p><span class=\\"govuk-!-margin-right-2\\"><strong>Results per page</strong></span>
-                            <span                             class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span> 25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
-                                </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span> 50
+                            <span                             class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span>25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
+                                </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span>50
                                 <span                                 class=\\"govuk-visually-hidden\\">results per page</span>
                                     </a>
-                                    </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span> 100
+                                    </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span>100
                                     <span                                     class=\\"govuk-visually-hidden\\">results per page</span>
                                         </a>
                                         </span>
@@ -412,11 +412,11 @@ exports[`project-updates POST /applications-service/:caseId/project-updates/:pro
                     </div>
                     <div class=\\"govuk-grid-column-one-half text-align--right\\">
                         <p><span class=\\"govuk-!-margin-right-2\\"><strong>Results per page</strong></span>
-                            <span                             class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span> 25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
-                                </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span> 50
+                            <span                             class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span>25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
+                                </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span>50
                                 <span                                 class=\\"govuk-visually-hidden\\">results per page</span>
                                     </a>
-                                    </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span> 100
+                                    </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span>100
                                     <span                                     class=\\"govuk-visually-hidden\\">results per page</span>
                                         </a>
                                         </span>
@@ -515,11 +515,11 @@ exports[`project-updates POST /applications-service/:caseId/project-updates/:pro
                     </div>
                     <div class=\\"govuk-grid-column-one-half text-align--right\\">
                         <p><span class=\\"govuk-!-margin-right-2\\"><strong>Results per page</strong></span>
-                            <span                             class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span> 25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
-                                </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span> 50
+                            <span                             class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span>25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
+                                </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span>50
                                 <span                                 class=\\"govuk-visually-hidden\\">results per page</span>
                                     </a>
-                                    </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span> 100
+                                    </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span>100
                                     <span                                     class=\\"govuk-visually-hidden\\">results per page</span>
                                         </a>
                                         </span>
@@ -618,11 +618,11 @@ exports[`project-updates POST /applications-service/:caseId/project-updates/:pro
                     </div>
                     <div class=\\"govuk-grid-column-one-half text-align--right\\">
                         <p><span class=\\"govuk-!-margin-right-2\\"><strong>Results per page</strong></span>
-                            <span                             class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span> 25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
-                                </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span> 50
+                            <span                             class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span>25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
+                                </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span>50
                                 <span                                 class=\\"govuk-visually-hidden\\">results per page</span>
                                     </a>
-                                    </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span> 100
+                                    </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"/applications-service/case/1/project-updates?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span>100
                                     <span                                     class=\\"govuk-visually-hidden\\">results per page</span>
                                         </a>
                                         </span>

--- a/apps/web/src/server/applications/case/representations/__tests__/__snapshots__/applications-representaions.test.js.snap
+++ b/apps/web/src/server/applications/case/representations/__tests__/__snapshots__/applications-representaions.test.js.snap
@@ -135,11 +135,11 @@ exports[`applications representations GET /applications-service/:caseId/relevant
             </div>
             <div class=\\"govuk-grid-column-one-half text-align--right\\">
                 <p><span class=\\"govuk-!-margin-right-2\\"><strong>Results per page</strong></span>
-                    <span                     class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span> 25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
-                        </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span> 50
+                    <span                     class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span>25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
+                        </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span>50
                         <span                         class=\\"govuk-visually-hidden\\">results per page</span>
                             </a>
-                            </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span> 100
+                            </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span>100
                             <span                             class=\\"govuk-visually-hidden\\">results per page</span>
                                 </a>
                                 </span>
@@ -327,11 +327,11 @@ exports[`applications representations GET /applications-service/:id/relevant-rep
             </div>
             <div class=\\"govuk-grid-column-one-half text-align--right\\">
                 <p><span class=\\"govuk-!-margin-right-2\\"><strong>Results per page</strong></span>
-                    <span                     class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?searchTerm=mock-search-term&amp;page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span> 25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
-                        </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?searchTerm=mock-search-term&amp;page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span> 50
+                    <span                     class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?searchTerm=mock-search-term&amp;page=1&amp;pageSize=25\\"><span class=\\"govuk-visually-hidden\\">View </span>25<span class=\\"govuk-visually-hidden\\"> results per page</span></a>
+                        </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?searchTerm=mock-search-term&amp;page=1&amp;pageSize=50\\"><span class=\\"govuk-visually-hidden\\">View </span>50
                         <span                         class=\\"govuk-visually-hidden\\">results per page</span>
                             </a>
-                            </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?searchTerm=mock-search-term&amp;page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span> 100
+                            </span><span class=\\"govuk-!-margin-left-1\\">|</span><span class=\\"govuk-!-margin-left-1\\"><a class=\\"govuk-link\\" href=\\"relevant-representations?searchTerm=mock-search-term&amp;page=1&amp;pageSize=100\\"><span class=\\"govuk-visually-hidden\\">View </span>100
                             <span                             class=\\"govuk-visually-hidden\\">results per page</span>
                                 </a>
                                 </span>

--- a/apps/web/src/server/views/applications/components/pagination/results-per-page.component.njk
+++ b/apps/web/src/server/views/applications/components/pagination/results-per-page.component.njk
@@ -48,10 +48,6 @@
 		<input type="hidden" name="pageSize" value="{{ size }}">
 		{{ size }}
 	{% else %}
-		<a class="govuk-link" href="{{ link }}">
-			<span class="govuk-visually-hidden">View </span>
-			{{ size }}
-			<span class="govuk-visually-hidden"> results per page</span>
-		</a>
+		<a class="govuk-link" href="{{ link }}"><span class="govuk-visually-hidden">View </span>{{ size }}<span class="govuk-visually-hidden"> results per page</span></a>
 	{% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Describe your changes

- Remove the unnecessary whitespace within the filter links

## APPLICS-34 Relevant Representations: Results per page filter

https://pins-ds.atlassian.net/browse/APPLICS-34

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
