### PR TITLE
fix(functions): allow migrate-case function to continue if folders exist

### DIFF
--- a/apps/api/src/server/migration/migrators/folder-migrator.js
+++ b/apps/api/src/server/migration/migrators/folder-migrator.js
@@ -13,8 +13,9 @@ export const migrateFolders = async (log, caseReference) => {
 	if (!caseId) throw Error(`Case does not exist for caseReference ${caseReference}`);
 
 	const existingFolders = await folderRepository.getAllByCaseId(caseId);
-	if (existingFolders.length > 0)
-		throw Error(`Default Folders already created for case ${caseReference}`);
-
-	await Promise.all(folderRepository.createFolders(caseId, defaultCaseFoldersForMigration));
+	if (existingFolders.length > 0) {
+		log.warn(`Skipping as folders already exist for case ${caseReference}`);
+	} else {
+		await Promise.all(folderRepository.createFolders(caseId, defaultCaseFoldersForMigration));
+	}
 };


### PR DESCRIPTION
## Describe your changes

Amends `folder` migrator function so an error is logged rather than thrown, if the case already has folders

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
