### PR TITLE
fix(packages/feature-flags): catch errors when calling Azure App Config

### DIFF
--- a/packages/feature-flags/src/is-feature-active.js
+++ b/packages/feature-flags/src/is-feature-active.js
@@ -34,7 +34,7 @@ export const makeIsFeatureActive = (logger, client) => {
 				});
 			} catch (err) {
 				logger.error(err);
-				throw err;
+				return null;
 			}
 		})();
 


### PR DESCRIPTION
We want the app to continue working (and assume false for feature flags) if Azure App Config can't be reached for whatever reason.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
