### PR TITLE
fix(applications/web): extra commas within s51 advice page (APPLICS-263)

### DIFF
--- a/apps/web/src/server/views/applications/case-s51/s51-table.njk
+++ b/apps/web/src/server/views/applications/case-s51/s51-table.njk
@@ -61,9 +61,9 @@
 
 				{% set displayDatePublished = 'Not published' %}
 				{% if item.datePublished and item.publishedStatus == 'published' %}
-					{% set displayDatePublished = item.datePublished|datestamp({format: 'dd MMM yyyy'}) %},
+					{% set displayDatePublished = item.datePublished|datestamp({format: 'dd MMM yyyy'}) %}
 				{% elif item.datePublished == NULL and item.publishedStatus == 'published' and item.dateUpdated %}
-					{% set displayDatePublished = item.dateUpdated|datestamp({format: 'dd MMM yyyy'}) %},
+					{% set displayDatePublished = item.dateUpdated|datestamp({format: 'dd MMM yyyy'}) %}
 				{% endif %}
 
 				<tr class="govuk-table__row">


### PR DESCRIPTION
## Describe your changes

- Remove the unnecessary commas within the template

## APPLICS-263 Extra commas within S51 Advice page
https://pins-ds.atlassian.net/browse/APPLICS-263

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
