### PR TITLE
fix(packages/feature-flags): static flags don't require conxion string

### DIFF
--- a/packages/feature-flags/src/feature-flag-client.js
+++ b/packages/feature-flags/src/feature-flag-client.js
@@ -23,12 +23,5 @@ export function FeatureFlagClient(logger, connectionString) {
 	this.isFeatureActive = makeIsFeatureActive(logger, this.client);
 
 	/** @type {import('./list-flags.js').ListFlagsFn} */
-	this.listFlags = (() => {
-		if (!this.client) {
-			logger.debug('Cannot list flags because no Azure App Config client exists.');
-			return async () => ({});
-		}
-
-		return makeListFlags(logger, this.client);
-	})();
+	this.listFlags = makeListFlags(logger, this.client);
 }

--- a/packages/feature-flags/src/list-flags.js
+++ b/packages/feature-flags/src/list-flags.js
@@ -7,13 +7,20 @@ import staticFlags from './static-feature-flags.js';
 
 /**
  * @param {import('./feature-flag-client.js').Logger} logger
- * @param {import('@azure/app-configuration').AppConfigurationClient} client
+ * @param {import('@azure/app-configuration').AppConfigurationClient} [client]
  * @returns {ListFlagsFn}
  * */
 export const makeListFlags = (logger, client) => async () => {
 	if (process.env.STATIC_FEATURE_FLAGS_ENABLED === 'true') {
 		logger.debug('returning static feature flags (STATIC_FEATURE_FLAGS_ENABLED=true)');
 		return staticFlags;
+	}
+
+	if (!client) {
+		logger.debug(
+			'Cannot list flags because no Azure App Config client exists. Returning an empty object.'
+		);
+		return {};
 	}
 
 	const aacResult = await client.listConfigurationSettings();


### PR DESCRIPTION
## Describe your changes

There was a piece of logic causing {} to be returned when there is no connection string, even when trying to fetch the static flags for which a connection string isn't required.

This change keeps the check but only if requesting the real flags from Azure App Config.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
