### PR TITLE
fix(functions): increase express body limit

### DIFF
--- a/apps/api/src/server/build-app.js
+++ b/apps/api/src/server/build-app.js
@@ -47,7 +47,7 @@ const buildApp = (
 
 	app.use(asyncHandler(authoriseRequest));
 
-	app.use('/migration', bodyParser.json({ limit: '30mb' }));
+	app.use('/migration', bodyParser.json({ limit: '100mb' }));
 	app.use(bodyParser.json());
 
 	app.use(compression());


### PR DESCRIPTION
## Describe your changes

Migration requests are failing because express body limits any requests over 30mb, I have increased this to 100mb - this resolves the issue with requests with a large amount of documents.  

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
