### PR TITLE
fix(applications/api): folder migration creation

### DIFF
--- a/apps/api/src/server/build-app.js
+++ b/apps/api/src/server/build-app.js
@@ -47,7 +47,7 @@ const buildApp = (
 
 	app.use(asyncHandler(authoriseRequest));
 
-	app.use('/migration', bodyParser.json({ limit: '30mb' }));
+	app.use('/migration', bodyParser.json({ limit: '100mb' }));
 	app.use(bodyParser.json());
 
 	app.use(compression());

--- a/apps/api/src/server/migration/migrators/folder-migrator.js
+++ b/apps/api/src/server/migration/migrators/folder-migrator.js
@@ -13,9 +13,15 @@ export const migrateFolders = async (log, caseReference) => {
 	if (!caseId) throw Error(`Case does not exist for caseReference ${caseReference}`);
 
 	const existingFolders = await folderRepository.getAllByCaseId(caseId);
-	if (existingFolders.length > 0) {
-		log.warn(`Skipping as folders already exist for case ${caseReference}`);
-	} else {
-		await Promise.all(folderRepository.createFolders(caseId, defaultCaseFoldersForMigration));
-	}
+	const foldersToCreate = await removeAlreadyExistingFolders(existingFolders);
+	await Promise.all(folderRepository.createFolders(caseId, foldersToCreate));
+};
+
+const removeAlreadyExistingFolders = async (existingFolders) => {
+	return defaultCaseFoldersForMigration.filter(
+		(mandatoryFolder) =>
+			!existingFolders.some(
+				(existingFolder) => existingFolder.displayNameEn === mandatoryFolder.displayNameEn
+			)
+	);
 };

--- a/apps/api/src/server/migration/migrators/folder-migrator.js
+++ b/apps/api/src/server/migration/migrators/folder-migrator.js
@@ -13,15 +13,11 @@ export const migrateFolders = async (log, caseReference) => {
 	if (!caseId) throw Error(`Case does not exist for caseReference ${caseReference}`);
 
 	const existingFolders = await folderRepository.getAllByCaseId(caseId);
-	const foldersToCreate = await removeAlreadyExistingFolders(existingFolders);
+	const foldersToCreate = filterOutExistingFolders(existingFolders);
 	await Promise.all(folderRepository.createFolders(caseId, foldersToCreate));
 };
 
-const removeAlreadyExistingFolders = async (existingFolders) => {
-	return defaultCaseFoldersForMigration.filter(
-		(mandatoryFolder) =>
-			!existingFolders.some(
-				(existingFolder) => existingFolder.displayNameEn === mandatoryFolder.displayNameEn
-			)
+const filterOutExistingFolders = (existingFolders) =>
+	defaultCaseFoldersForMigration.filter(
+		(folder) => !existingFolders.some((existingFolder) => existingFolder.name === folder.name)
 	);
-};


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-379

Folder migration was skipping if a case had existing folders which meant even if 1 folder was created, the rest would get skipped. This behaviour would cause document migration to fail as not all folders were created from folder migration. This PR adds a step to firstly check what folders are still not created and then only creates those.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
