### PR TITLE
fix(applications/api): folder migration map typo

### DIFF
--- a/apps/api/src/server/migration/migrators/folder/folder.js
+++ b/apps/api/src/server/migration/migrators/folder/folder.js
@@ -16,7 +16,7 @@ import logger from '#utils/logger.js';
  * Project management > Internal ExA meetings
  * Pre-application > Draft documents > SOCC
  * Pre-application > Events / meetings > Outreach
- * Pre-application > Developer's consulation > Statutory > PEIR
+ * Pre-application > Developer's consultation > Statutory > PEIR
  * Pre-application > Correspondence > External
  * Pre-application > Correspondence > Internal
  * Acceptance > Correspondence > 01 - Internal
@@ -868,15 +868,15 @@ export const folderMapping = {
 		'Pre-application > Correspondence > External',
 	'05 - Pre-App > 06 - Meetings': 'Pre-application > Events / meetings',
 	'05 - Pre-App > 06 - Meetings > 01 - Outreach': 'Pre-application > Events / meetings > Outreach',
-	'05 - Pre-App > 07 - Developers Consultation': "Pre-application > Developer's consulation",
+	'05 - Pre-App > 07 - Developers Consultation': "Pre-application > Developer's consultation",
 	'05 - Pre-App > 07 - Developers Consultation > 01 - Statutory':
-		"Pre-application > Developer's consulation > Statutory",
+		"Pre-application > Developer's consultation > Statutory",
 	'05 - Pre-App > 07 - Developers Consultation > 01 - Statutory > 01 - PEIR':
-		"Pre-application > Developer's consulation > Statutory > PEIR",
+		"Pre-application > Developer's consultation > Statutory > PEIR",
 	'05 - Pre-App > 07 - Developers Consultation > 02 - Non-Statutory':
-		"Pre-application > Developer's consulation > Non-statutory",
+		"Pre-application > Developer's consultation > Non-statutory",
 	'05 - Pre-App > 07 - Developers Consultation > 03 - Consultation Feedback':
-		"Pre-application > Developer's consulation > Consultation feedback",
+		"Pre-application > Developer's consultation > Consultation feedback",
 
 	'06 - Post-Submission Correspondence > 01 - Acceptance': 'Acceptance > Correspondence',
 	'06 - Post-Submission Correspondence > 01 - Acceptance > 01 - Internal':


### PR DESCRIPTION
## Describe your changes

Folder migration for `EN010007` was failing as `consultation` was spelt incorrectly on the folder map. 

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
