### PR TITLE
test(test/e2e): allow welsh spec to skip when feature flag is off (APPLICS-387)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/welsh.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/welsh.spec.js
@@ -27,27 +27,31 @@ describe('Enable and update Project Information with Welsh fields', () => {
 		let projectInfoNew = projectInformation();
 
 		before(() => {
-			cy.login(applicationsUsers.caseAdmin);
-			createCasePage.createCaseWithWelshAsRegion(projectInfo, true);
+			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
+				cy.login(applicationsUsers.caseAdmin);
+				createCasePage.createCaseWithWelshAsRegion(projectInfo, true);
+			}
 		});
 
 		it('As a user able to update the case information with welsh fields', () => {
-			cy.login(applicationsUsers.caseAdmin);
-			cy.visit('/');
-			const caseRef = Cypress.env('currentCreatedCase');
-			applicationsHomePage.searchFor(caseRef);
-			searchResultsPage.clickTopSearchResult();
-			validateProjectOverview(projectInfo, true);
-			casePage.clickLinkByText('Update project information');
-			casePage.showAllSections();
-			validateWelshProjectInformation(projectInfo, true);
-			updateProjectInformation(projectInfoNew);
-			validateProjectInformation(projectInfoNew, false, true);
-			casePage.clickLinkByText('Overview');
-			casePage.clickButtonByText('Preview and publish project');
-			validatePreviewAndPublishInfo(projectInfoNew);
-			casePage.clickButtonByText('Accept and publish project');
-			casePage.validatePublishBannerMessage('Project page successfully published');
+			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
+				cy.login(applicationsUsers.caseAdmin);
+				cy.visit('/');
+				const caseRef = Cypress.env('currentCreatedCase');
+				applicationsHomePage.searchFor(caseRef);
+				searchResultsPage.clickTopSearchResult();
+				validateProjectOverview(projectInfo, true);
+				casePage.clickLinkByText('Update project information');
+				casePage.showAllSections();
+				validateWelshProjectInformation(projectInfo, true);
+				updateProjectInformation(projectInfoNew);
+				validateProjectInformation(projectInfoNew, false, true);
+				casePage.clickLinkByText('Overview');
+				casePage.clickButtonByText('Preview and publish project');
+				validatePreviewAndPublishInfo(projectInfoNew);
+				casePage.clickButtonByText('Accept and publish project');
+				casePage.validatePublishBannerMessage('Project page successfully published');
+			}
 		});
 	});
 });

--- a/apps/e2e/cypress/page_objects/createCasePage.js
+++ b/apps/e2e/cypress/page_objects/createCasePage.js
@@ -96,12 +96,8 @@ export class CreateCasePage extends Page {
 		this.sections.geographicalInformation.fillEastingGridRef(projectInformation.gridRefEasting);
 		this.sections.geographicalInformation.fillNorthingGridRef(projectInformation.gridRefNorthing);
 		this.clickSaveAndContinue();
-		if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
-			cy.get(
-				'body > div:nth-child(4) > main:nth-child(2) > form:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(8) > input:nth-child(1)'
-			).click();
-			this.clickSaveAndContinue();
-		}
+		this.sections.regions.chooseRegions(['Wales']);
+		this.clickSaveAndContinue();
 		this.sections.zoomLevel.chooseZoomLevel(mandatoryOnly ? 'None' : projectInformation.zoomLevel);
 		this.clickSaveAndContinue();
 


### PR DESCRIPTION
## Describe your changes

- Moved feature flag test to surround entire Welsh test spec
- Simplify checking the Welsh region by reusing the chooseRegion function
- Ran e2e test locally with the flag switched on and off

## APPLICS-374 Allow Welsh spec to skip when feature flag is off
https://pins-ds.atlassian.net/browse/APPLICS-374

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
