### PR TITLE
chore(applications): default message schema to pins-data-model fallback to back-office (APPLICS-117)

### DIFF
--- a/apps/api/src/message-schemas/commands/new-deadline-submission.d.ts
+++ b/apps/api/src/message-schemas/commands/new-deadline-submission.d.ts
@@ -1,0 +1,13 @@
+export interface DeadlineSubmission {
+	name: string;
+	email: string;
+	interestedParty?: boolean;
+	interestedPartyReference?: string;
+	deadline: string;
+	submissionType: string;
+	sensitiveData?: boolean;
+	lateSubmission?: boolean;
+	submissionId?: string;
+	blobGuid: string;
+	documentName: string;
+}

--- a/apps/api/src/message-schemas/commands/register-nsip-subscription.d.ts
+++ b/apps/api/src/message-schemas/commands/register-nsip-subscription.d.ts
@@ -1,0 +1,9 @@
+import { Schemas } from 'pins-data-model';
+
+/**
+ * register-nsip-subscription schema for use in code
+ */
+export interface RegisterNSIPSubscription {
+	nsipSubscription: Schemas.NsipSubscription;
+	subscriptionTypes: Pick<Schemas.NsipSubscription, 'subscriptionType'>[];
+}

--- a/apps/api/src/message-schemas/commands/register-representation.d.ts
+++ b/apps/api/src/message-schemas/commands/register-representation.d.ts
@@ -1,0 +1,11 @@
+export interface RegisterRepresentation {
+	referenceId: string;
+	caseReference: string;
+	representationType?: string;
+	originalRepresentation: string;
+	representationFrom: string;
+	registerFor: string;
+	represented: object;
+	representative: object;
+	dateReceived?: string;
+}

--- a/apps/functions/applications-command-handlers/deadline-submission-command/index.js
+++ b/apps/functions/applications-command-handlers/deadline-submission-command/index.js
@@ -3,12 +3,17 @@ import api from './back-office-api-client.js';
 import blob from './blob-client.js';
 import events from './event-client.js';
 
+/**
+ * @typedef {import('@pins/applications.api/src/message-schemas/commands/new-deadline-submission').DeadlineSubmission} PrevDeadlineSubmission
+ * @typedef {import('pins-data-model').Schemas.NewDeadlineSubmission} NewDeadlineSubmission
+ */
+
 const { submissionsContainer } = config;
 
 /**
  *
  * @param {import('@azure/functions').Context} context
- * @param {import('pins-data-model').Schemas.DeadlineSubmission} msg
+ * @param {NewDeadlineSubmission | PrevDeadlineSubmission} msg
  * @returns {Promise<string | null>}
  */
 async function run(context, msg) {
@@ -74,7 +79,7 @@ async function run(context, msg) {
 /**
  *
  * @param {import('@azure/functions').Context} context
- * @param {import('pins-data-model').Schemas.DeadlineSubmission} msg
+ * @param {NewDeadlineSubmission | PrevDeadlineSubmission} msg
  */
 export default async function (context, msg) {
 	context.log('Handle new deadline submission', msg);

--- a/apps/functions/applications-command-handlers/handle-subscription-command/logging-utils.js
+++ b/apps/functions/applications-command-handlers/handle-subscription-command/logging-utils.js
@@ -1,11 +1,12 @@
 /**
+ * @typedef {import('@pins/applications.api/src/message-schemas/commands/register-nsip-subscription').RegisterNSIPSubscription} PrevRegisterNSIPSubscription
  * @typedef {import('pins-data-model').Schemas.RegisterNSIPSubscription} RegisterNSIPSubscription
  */
 
 /**
  *
- * @param {RegisterNSIPSubscription} msg
- * @returns {RegisterNSIPSubscription}
+ * @param {RegisterNSIPSubscription | PrevRegisterNSIPSubscription} msg
+ * @returns {RegisterNSIPSubscription | PrevRegisterNSIPSubscription}
  */
 export const redactEmailForLogs = (msg) => {
 	if (msg?.nsipSubscription?.emailAddress) {

--- a/apps/functions/applications-command-handlers/register-representation-command/index.js
+++ b/apps/functions/applications-command-handlers/register-representation-command/index.js
@@ -1,6 +1,11 @@
 import api from './back-office-api-client.js';
 import { isEmpty, pick } from 'lodash-es';
 
+/**
+ * @typedef {import('@pins/applications.api/src/message-schemas/commands/register-subscription').RegisterRepresentation} PrevRegisterRepresentation
+ * @typedef {import('pins-data-model').Schemas.RegisterRepresentation} RegisterRepresentation
+ */
+
 const mapContactDetails = (entity) => {
 	if (isEmpty(entity)) return {};
 
@@ -34,7 +39,7 @@ const mapContactDetails = (entity) => {
 /**
  *
  * @param {import('@azure/functions').Context} context
- * @param {import('pins-data-model').Schemas.RegisterRepresentation} msg
+ * @param {RegisterRepresentation | PrevRegisterRepresentation} msg
  */
 export default async function (context, msg) {
 	context.log('Handle register-representation event');


### PR DESCRIPTION
## Describe your changes

- Allow message schema reference to use pins-model-data and fallback to previous local schema
- Restore removed message schema files

## APPLICS-117 TechDebt - Refactor message schema commands to use data-model repo instead of local
https://pins-ds.atlassian.net/browse/APPLICS-117

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
