### PR TITLE
feat(applications/web): preview content type retrieved from db 

### DIFF
--- a/apps/web/src/server/app/components/file-downloader.component.js
+++ b/apps/web/src/server/app/components/file-downloader.component.js
@@ -21,8 +21,13 @@ const getDocumentsDownload = async ({ params, session }, response) => {
 
 	const accessToken = await getActiveDirectoryAccessToken(session);
 
-	const { privateBlobContainer, privateBlobPath, fileName, originalFilename } =
-		await getCaseDocumentationVersionFileInfo(caseId, fileGuid, version);
+	const {
+		privateBlobContainer,
+		privateBlobPath,
+		fileName,
+		originalFilename,
+		mime: contentType
+	} = await getCaseDocumentationVersionFileInfo(caseId, fileGuid, version);
 
 	// perform simulated download if auth disabled
 	if (accessToken?.token === 'AUTH_DISABLED') {
@@ -44,8 +49,8 @@ const getDocumentsDownload = async ({ params, session }, response) => {
 		return response.status(404);
 	}
 
-	if (preview && blobProperties?.contentType) {
-		response.setHeader('content-type', blobProperties.contentType);
+	if (preview && contentType) {
+		response.setHeader('content-type', contentType);
 	} else {
 		const downloadFileName = buildFileName({ fileName, originalFilename });
 		response.setHeader('content-disposition', `attachment; filename=${downloadFileName}`);


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-406

contentType for preview route is not retrieved from DB instead of blob storage metadata. This is because migrated cases from Aimi tool will not have the correct blob content type metadata.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
