### PR TITLE
feat(functions): change blob contentType on publish document

### DIFF
--- a/apps/functions/applications-background-jobs/publish-document/__tests__/publish-document.test.js
+++ b/apps/functions/applications-background-jobs/publish-document/__tests__/publish-document.test.js
@@ -45,7 +45,8 @@ describe('Publishing document', () => {
 		documentReference: `${TEST_CASE_REFERENCE}-001`,
 		filename: TEST_BLOB_FILE_NAME,
 		originalFilename: `${TEST_BLOB_FILE_NAME}.jpeg`,
-		documentURI: `https://${TEST_BLOB_ACCOUNT}.blob.core.windows.net/${TEST_BLOB_SOURCE_CONTAINER}/application/${TEST_CASE_REFERENCE}/${TEST_BLOB_GUID}/${TEST_BLOB_VERSION}`
+		documentURI: `https://${TEST_BLOB_ACCOUNT}.blob.core.windows.net/${TEST_BLOB_SOURCE_CONTAINER}/application/${TEST_CASE_REFERENCE}/${TEST_BLOB_GUID}/${TEST_BLOB_VERSION}`,
+		mime: 'image/jpeg'
 	};
 	const baseTestCaseProperties = {
 		blobName: `application/${TEST_CASE_REFERENCE}/${TEST_BLOB_GUID}/${TEST_BLOB_VERSION}`,
@@ -139,7 +140,8 @@ describe('Publishing document', () => {
 			expect(mockCopyFile).toHaveBeenCalledWith({
 				sourceUrl: document.documentURI,
 				destinationContainerName: TEST_BLOB_PUBLISH_CONTAINER,
-				destinationBlobName: expectedDestinationName
+				destinationBlobName: expectedDestinationName,
+				newContentType: baseDocumentProperties.mime
 			});
 			expect(mockGotPost).toHaveBeenCalledTimes(1);
 			expect(mockGotPost).toHaveBeenCalledWith(

--- a/apps/functions/applications-background-jobs/publish-document/index.js
+++ b/apps/functions/applications-background-jobs/publish-document/index.js
@@ -14,7 +14,7 @@ import { blobClient } from '../common/blob-client.js';
  */
 export const index = async (
 	context,
-	{ caseId, documentId, version, documentURI, documentReference, filename, originalFilename }
+	{ caseId, documentId, version, documentURI, documentReference, filename, originalFilename, mime }
 ) => {
 	context.log(`Publishing document ID ${documentId} at URI ${documentURI}`);
 
@@ -28,7 +28,8 @@ export const index = async (
 		!documentURI ||
 		!filename ||
 		!originalFilename ||
-		!documentReference
+		!documentReference ||
+		!mime
 	) {
 		throw Error('One or more required properties are missing.');
 	}
@@ -56,7 +57,8 @@ export const index = async (
 	await blobClient.copyFileFromUrl({
 		sourceUrl: documentURI,
 		destinationContainerName: config.BLOB_PUBLISH_CONTAINER,
-		destinationBlobName: publishFileName
+		destinationBlobName: publishFileName,
+		newContentType: mime
 	});
 
 	const requestUri = `https://${config.API_HOST}/applications/${caseId}/documents/${documentId}/version/${version}/mark-as-published`;

--- a/packages/blob-storage-client/src/blob-storage-client.js
+++ b/packages/blob-storage-client/src/blob-storage-client.js
@@ -171,15 +171,26 @@ export class BlobStorageClient {
 
 	/**
 	 *
-	 * @param {{sourceUrl: string, destinationContainerName: string, destinationBlobName: string}} blobStorageHost
+	 * @param {{sourceUrl: string, destinationContainerName: string, destinationBlobName: string, newContentType?: string}} blobStorageHost
 	 * @returns {Promise<import('@azure/storage-blob').CopyStatusType | undefined>}
 	 */
-	copyFileFromUrl = async ({ sourceUrl, destinationContainerName, destinationBlobName }) => {
+	copyFileFromUrl = async ({
+		sourceUrl,
+		destinationContainerName,
+		destinationBlobName,
+		newContentType
+	}) => {
 		const destinationBlob = this.#getBlockBlobClient(destinationContainerName, destinationBlobName);
 
 		const copyJob = await destinationBlob.beginCopyFromURL(sourceUrl);
 
 		const result = await copyJob.pollUntilDone();
+
+		if (result.copyStatus === 'success' && newContentType) {
+			await destinationBlob.setHTTPHeaders({
+				blobContentType: newContentType
+			});
+		}
 
 		return result.copyStatus;
 	};

--- a/packages/blob-storage-client/src/blob-storage-client.js
+++ b/packages/blob-storage-client/src/blob-storage-client.js
@@ -190,6 +190,7 @@ export class BlobStorageClient {
 			await destinationBlob.setHTTPHeaders({
 				blobContentType: newContentType
 			});
+			console.log(`Updated content type for ${destinationBlobName} to ${newContentType}`);
 		}
 
 		return result.copyStatus;


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-405

Blob content type is incorrect for migrated cases, this change retrieves the correct blob content type from the message in publish function and sets the new blob content type. This is done after copying because the source container blobs have a legal hold and therefore cannot be changed, but the destination container allows blobs to be updated.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
