### PR TITLE
fix(applications/web): only display welsh fields in publish preview when welsh region (APPLICS-412)

### DIFF
--- a/apps/web/src/server/applications/case/__tests__/__snapshots__/applications-case.test.js.snap
+++ b/apps/web/src/server/applications/case/__tests__/__snapshots__/applications-case.test.js.snap
@@ -25,10 +25,6 @@ exports[`Applications case pages Preview and publish page GET /case/123/preview-
                                 <td class=\\"govuk-table__cell\\">Title CASE/04</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <th scope=\\"row\\" class=\\"govuk-table__header\\">Project name in Welsh</th>
-                                <td class=\\"govuk-table__cell\\"></td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
                                 <th scope=\\"row\\" class=\\"govuk-table__header\\">Sector</th>
                                 <td class=\\"govuk-table__cell\\">Transport EN</td>
                             </tr>
@@ -47,20 +43,12 @@ exports[`Applications case pages Preview and publish page GET /case/123/preview-
                                     ullamco laboris nisi ut aliquip ex ea commodo consequat</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <th scope=\\"row\\" class=\\"govuk-table__header\\">Project description in Welsh</th>
-                                <td class=\\"govuk-table__cell\\"></td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
                                 <th scope=\\"row\\" class=\\"govuk-table__header\\">Project email address</th>
                                 <td class=\\"govuk-table__cell\\">some@ema.il</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
                                 <th scope=\\"row\\" class=\\"govuk-table__header\\">Project location</th>
                                 <td class=\\"govuk-table__cell\\">London</td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
-                                <th scope=\\"row\\" class=\\"govuk-table__header\\">Project location in Welsh</th>
-                                <td class=\\"govuk-table__cell\\"></td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
                                 <th scope=\\"row\\" class=\\"govuk-table__header\\">Grid references</th>
@@ -229,10 +217,6 @@ exports[`Applications case pages Preview and publish page GET /case/123/preview-
                                 <td class=\\"govuk-table__cell\\">Title CASE/04</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <th scope=\\"row\\" class=\\"govuk-table__header\\">Project name in Welsh</th>
-                                <td class=\\"govuk-table__cell\\"></td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
                                 <th scope=\\"row\\" class=\\"govuk-table__header\\">Sector</th>
                                 <td class=\\"govuk-table__cell\\">Transport EN</td>
                             </tr>
@@ -251,20 +235,12 @@ exports[`Applications case pages Preview and publish page GET /case/123/preview-
                                     ullamco laboris nisi ut aliquip ex ea commodo consequat</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
-                                <th scope=\\"row\\" class=\\"govuk-table__header\\">Project description in Welsh</th>
-                                <td class=\\"govuk-table__cell\\"></td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
                                 <th scope=\\"row\\" class=\\"govuk-table__header\\">Project email address</th>
                                 <td class=\\"govuk-table__cell\\">some@ema.il</td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
                                 <th scope=\\"row\\" class=\\"govuk-table__header\\">Project location</th>
                                 <td class=\\"govuk-table__cell\\">London</td>
-                            </tr>
-                            <tr class=\\"govuk-table__row\\">
-                                <th scope=\\"row\\" class=\\"govuk-table__header\\">Project location in Welsh</th>
-                                <td class=\\"govuk-table__cell\\"></td>
                             </tr>
                             <tr class=\\"govuk-table__row\\">
                                 <th scope=\\"row\\" class=\\"govuk-table__header\\">Grid references</th>

--- a/apps/web/src/server/applications/case/applications-case.controller.js
+++ b/apps/web/src/server/applications/case/applications-case.controller.js
@@ -6,7 +6,6 @@ import {
 	getProjectTeam,
 	getManyProjectTeamMembersInfo
 } from '../common/services/project-team.service.js';
-import { featureFlagClient } from '../../../common/feature-flags.js';
 
 /** @typedef {import('../applications.types').Case} Case */
 /** @typedef {import('@pins/express').ValidationErrors} ValidationErrors */
@@ -98,26 +97,12 @@ export async function viewApplicationsCaseOverview(request, response) {
 		nsipOfficers
 	};
 
-	/** @type {boolean} */
-	const caseIsWelsh = await (async () => {
-		if (!featureFlagClient.isFeatureActive('applic-55-welsh-translation')) {
-			return false;
-		}
-
-		return Boolean(
-			response.locals.case?.geographicalInformation?.regions?.find(
-				(/** @type {{name: string}} */ r) => r.name === 'wales'
-			)
-		);
-	})();
-
 	const banner = getSessionBanner(request.session);
 	deleteSessionBanner(request.session);
 
 	response.render(`applications/case/overview`, {
 		errors: request.errors,
 		selectedPageType: 'overview',
-		caseIsWelsh,
 		keyMembers,
 		banner
 	});

--- a/apps/web/src/server/applications/case/applications-case.locals.js
+++ b/apps/web/src/server/applications/case/applications-case.locals.js
@@ -5,6 +5,7 @@ import {
 	getCaseDocumentationFolderPath,
 	getCaseFolder
 } from './documentation/applications-documentation.service.js';
+import { featureFlagClient } from '../../../common/feature-flags.js';
 
 /**
  * @typedef {object} ApplicationCaseLocals
@@ -32,6 +33,11 @@ export const registerCase = async (request, response, next) => {
 
 	try {
 		response.locals.case = await getCase(response.locals.caseId);
+		response.locals.caseIsWelsh =
+			(await featureFlagClient.isFeatureActive('applic-55-welsh-translation')) &&
+			response.locals.case?.geographicalInformation?.regions?.some(
+				(/** @type {{name: string}} */ r) => r.name === 'wales'
+			);
 	} catch (/** @type {*} */ error) {
 		return response.render(`app/${error.message === '404' ? 404 : 500}.njk`, { error });
 	}

--- a/apps/web/src/server/applications/case/applications-case.router.js
+++ b/apps/web/src/server/applications/case/applications-case.router.js
@@ -57,7 +57,6 @@ applicationsCaseSummaryRouter
 		)
 	)
 	.post(
-		[locals.registerCase],
 		[validators.validateApplicationsCreateCaseNameWelsh],
 		[validators.validateApplicationsCreateCaseDescriptionWelsh],
 		[validators.validateApplicationsCreateCaseLocationWelsh],

--- a/apps/web/src/server/views/applications/case/components/case-info-table-preview.component.njk
+++ b/apps/web/src/server/views/applications/case/components/case-info-table-preview.component.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "./case-edit-link.component.njk" import caseEditLink %}
 
-{% macro caseInfoTablePreview(case) %}
+{% macro caseInfoTablePreview(case, caseIsWelsh) %}
 
 	{% set regionNames = [] %}
 	{% for item in case.geographicalInformation.regions %}
@@ -31,15 +31,15 @@
 	{% set items = [
 		{ label: 'Case reference number', text: case.reference },
 		{ label: 'Project name', text: case.title },
-		{ label: 'Project name in Welsh' , text: case.titleWelsh, omitted: not 'applic-55-welsh-translation' | isFeatureActive },
+		{ label: 'Project name in Welsh' , text: case.titleWelsh, omitted: not caseIsWelsh },
 		{ label: 'Sector', text: case.sector.displayNameEn },
 		{ label: 'Subsector', text: case.subSector.displayNameEn },
 		{ label: 'Case stage', text: case.status },
 		{ label: 'Project description', html: case.description },
-		{ label: 'Project description in Welsh', html: case.descriptionWelsh, omitted: not ('applic-55-welsh-translation' | isFeatureActive) },
+		{ label: 'Project description in Welsh', html: case.descriptionWelsh, omitted: not caseIsWelsh },
 		{ label: 'Project email address', html: case.caseEmail },
 		{ label: 'Project location', html: case.geographicalInformation.locationDescription },
-		{ label: 'Project location in Welsh', html: case.geographicalInformation.locationDescriptionWelsh, omitted: not ('applic-55-welsh-translation' | isFeatureActive) },
+		{ label: 'Project location in Welsh', html: case.geographicalInformation.locationDescriptionWelsh, omitted: not caseIsWelsh },
 		{ label: 'Grid references', html: gridReferences },
 		{ label: 'Regions' if ('applic-55-welsh-translation' | isFeatureActive) else 'Region(s)', html: regionNames },
 		{ label: 'Map zoom level' , text: case.geographicalInformation.mapZoomLevel.displayNameEn }

--- a/apps/web/src/server/views/applications/case/preview-and-publish.njk
+++ b/apps/web/src/server/views/applications/case/preview-and-publish.njk
@@ -36,7 +36,7 @@
 					<a href='{{overviewLink}}' class='govuk-link govuk-heading-s govuk-!-margin-bottom-0'>Edit</a>
 				</div>
 				<div>
-					{{ caseInfoTablePreview(case) }}
+					{{ caseInfoTablePreview(case, caseIsWelsh) }}
 				</div>
 			</div>
 


### PR DESCRIPTION
## Describe your changes

- Set caseIsWelsh flag in the case locals middleware so that it is available when required in other templates
- Include the Welsh fields in the Preview and Publish page only if Wales is included as a region
- Updated unit test snapshots

## APPLICS-412 Welsh - Overview page: View additional fields
https://pins-ds.atlassian.net/browse/APPLICS-412

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
