### PR TITLE
feat(applications/web): s51 advice properties: validate welsh properties (APPLICS-475)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/s51Advice.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/s51Advice.spec.js
@@ -99,6 +99,22 @@ describe('Section 51 Advice', () => {
 			}
 		});
 
+		it('As a user able to prevent an S51 Advice being published without completed welsh fields', () => {
+			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
+				s51AdvicePage.selectRadioButtonByValue('Ready to publish');
+				s51AdvicePage.chooseCheckboxByIndex(1);
+				s51AdvicePage.clickButtonByText('Apply changes');
+				s51AdvicePage.validateErrorMessageIsInSummary(
+					'You must fill in all mandatory S51 Advice properties to publish S51 Advice'
+				);
+				s51AdvicePage.validateErrorMessage(
+					'You must fill in all mandatory S51 Advice properties to publish S51 Advice'
+				);
+				s51AdvicePage.clickLinkByText('View/edit advice');
+				s51AdvicePage.checkAdviceProperty('Status', 'Not checked');
+			}
+		});
+
 		it('As a user able to edit the title in welsh for an existing S51 Advice', () => {
 			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
 				const details = s51AdviceDetails();
@@ -146,6 +162,25 @@ describe('Section 51 Advice', () => {
 				s51AdvicePage.validateBannerMessage('Advice given in Welsh updated');
 			}
 		});
+
+		it('As a user able to publish a S51 Advice with completed welsh fields', () => {
+			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
+				const details = s51AdviceDetails();
+				s51AdvicePage.clickLinkByText('View/edit advice');
+				s51AdvicePage.clickLinkByText('S51 title in Welsh');
+				s51AdvicePage.fillTitleWelsh(details.titleWelsh, true);
+				s51AdvicePage.clickLinkByText('Enquiry details in Welsh');
+				s51AdvicePage.fillEnquiryDetailsWelsh(details.enquiryDetailsWelsh, true);
+				s51AdvicePage.clickLinkByText('Advice given in Welsh');
+				s51AdvicePage.fillAdviceDetailsWelsh(details.adviceDetailsWelsh, true);
+				s51AdvicePage.clickBackLink();
+				s51AdvicePage.selectRadioButtonByValue('Ready to publish');
+				s51AdvicePage.chooseCheckboxByIndex(1);
+				s51AdvicePage.clickButtonByText('Apply changes');
+				s51AdvicePage.clickLinkByText('View/edit advice');
+				s51AdvicePage.checkAdviceProperty('Status', 'Ready to publish');
+			}
+		});
 	});
 
 	describe('in a Welsh region', () => {
@@ -161,7 +196,7 @@ describe('Section 51 Advice', () => {
 			}
 		});
 
-		it('As a user able to create S51 Advice - Enquirer Full Details', () => {
+		it('As a user able to create and publish an S51 Advice', () => {
 			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
 				const details = s51AdviceDetails();
 				s51AdvicePage.completeS51Advice(

--- a/apps/e2e/cypress/page_objects/s51AdvicePage.js
+++ b/apps/e2e/cypress/page_objects/s51AdvicePage.js
@@ -29,6 +29,10 @@ export class S51AdvicePage extends Page {
 			const regEx = exact ? new RegExp(`^${question}$`, 'g') : new RegExp(question);
 			return cy.contains(this.selectors.tableCell, regEx).next();
 		},
+		answerListItem: (question, exact = false) => {
+			const regEx = exact ? new RegExp(`^${question}$`, 'g') : new RegExp(question);
+			return cy.contains(this.selectors.summaryListKey, regEx).next();
+		},
 		changeLink: (question) =>
 			cy.contains(this.selectors.tableCell, question, { matchCase: false }).nextUntil('a'),
 		changetitleLink: () =>
@@ -44,6 +48,14 @@ export class S51AdvicePage extends Page {
 	checkAnswer(question, answer, options) {
 		const { assertStrict = true, questionExactText = false } = options || {};
 		this.elements.answerCell(question, questionExactText).then(($elem) => {
+			const assertion = assertStrict ? 'equal' : 'include';
+			cy.wrap($elem.text().trim()).should(assertion, answer.trim());
+		});
+	}
+
+	checkAdviceProperty(question, answer, options) {
+		const { assertStrict = true, questionExactText = false } = options || {};
+		this.elements.answerListItem(question, questionExactText).then(($elem) => {
 			const assertion = assertStrict ? 'equal' : 'include';
 			cy.wrap($elem.text().trim()).should(assertion, answer.trim());
 		});

--- a/apps/web/src/server/applications/case/s51/applications-s51.router.js
+++ b/apps/web/src/server/applications/case/s51/applications-s51.router.js
@@ -7,7 +7,8 @@ import {
 	validateS51AdviceToChange,
 	validateS51AdviceActions,
 	validateS51AdviceToPublish,
-	validateS51UniqueTitle
+	validateS51UniqueTitle,
+	validateS51AdviceReadyToPublish
 } from './applications-s51.validators.js';
 
 const applicationsS51Router = createRouter({ mergeParams: true });
@@ -19,7 +20,12 @@ applicationsS51Router
 applicationsS51Router
 	.route('/change-status')
 	.post(
-		[validateS51AdviceToChange, validateS51AdviceActions, locals.registerFolder],
+		[
+			validateS51AdviceToChange,
+			validateS51AdviceActions,
+			validateS51AdviceReadyToPublish,
+			locals.registerFolder
+		],
 		asyncHandler(controller.updateApplicationsCaseS51ItemStatus)
 	);
 

--- a/apps/web/src/server/views/applications/case-s51/s51-table.njk
+++ b/apps/web/src/server/views/applications/case-s51/s51-table.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
-{% macro folderS51Table(items, pagination, caseId, folderId, isGeneralS51folder) %}
+{% macro folderS51Table(items, pagination, caseId, folderId, isGeneralS51folder, errors) %}
 
 	<div class="pins-files-list__info govuk-body">
 		<h3 class="govuk-heading-s">Select items to make changes to statuses</h3>
@@ -60,6 +60,7 @@
 
 
 				{% set displayDatePublished = 'Not published' %}
+				{% set editLinkId = 'edit-id-' + item.id %}
 				{% if item.datePublished and item.publishedStatus == 'published' %}
 					{% set displayDatePublished = item.datePublished|datestamp({format: 'dd MMM yyyy'}) %}
 				{% elif item.datePublished == NULL and item.publishedStatus == 'published' and item.dateUpdated %}
@@ -67,7 +68,10 @@
 				{% endif %}
 
 				<tr class="govuk-table__row">
-					<td class="govuk-table__cell">
+					<td class="govuk-table__cell {{ 'pins-files-list--error' if (errors[editLinkId]) }}">
+						{% if (errors[editLinkId]) %}
+						<div class="pins-files-list-border"></div>
+						{% endif %}
 						{{ govukCheckboxes({
 													name: "selectedFilesIds[]",
 													items: [
@@ -80,6 +84,11 @@
 												}) }}
 					</td>
 					<td class="govuk-table__cell">
+						{% if (errors[editLinkId]) %}
+						<p id="selectedFilesIds[]-error" class="govuk-error-message">
+							<span class="govuk-visually-hidden">Error:</span> {{ errors[editLinkId].msg }}
+						</p>
+						{% endif %}
 						<span class='font-weight--700'>
 							{{item.referenceNumber}} - {{item.title}}
 						</span>
@@ -99,7 +108,7 @@
 						{{ item.publishedStatus|statusName }}
 					</td>
 					<td class="govuk-table__cell">
-						<a href='{{'s51-item'|url({caseId: caseId, folderId: folderId, adviceId: item.id, step: 'properties'})}}' class='govuk-link'>View/edit advice</a>
+						<a href='{{'s51-item'|url({caseId: caseId, folderId: folderId, adviceId: item.id, step: 'properties'})}}' id='{{ editLinkId }}' class='govuk-link'>View/edit advice</a>
 					</td>
 				</tr>
 			{% endfor %}

--- a/apps/web/src/server/views/applications/components/folder/folder.njk
+++ b/apps/web/src/server/views/applications/components/folder/folder.njk
@@ -59,7 +59,7 @@
 							{{ folderActions(isS51folder) }}
 
 							{% if isS51folder %}
-								{{ folderS51Table(items, pagination, caseId, folderId, isGeneralS51folder) }}
+								{{ folderS51Table(items, pagination, caseId, folderId, isGeneralS51folder, errors) }}
 							{% else %}
 								{{ folderDocumentsTable(items, pagination, caseId, folderId) }}
 							{% endif %}

--- a/apps/web/src/styles/7-components/files-list.scss
+++ b/apps/web/src/styles/7-components/files-list.scss
@@ -114,6 +114,19 @@
 			display: block;
 			background: colors.govuk-colour('red');
 		}
+
+		.pins-files-list--error {
+			.pins-files-list-border {
+				border-left: 5px solid colors.govuk-colour('red');
+				display: block;
+				position: absolute;
+				top: 10px;
+				bottom: 10px;
+			}
+			.govuk-form-group {
+				padding-left: 15px;
+			}
+		}
 	}
 
 	&:not([class*="publish"]) {
@@ -152,9 +165,13 @@
 	}
 
 	.govuk-form-group {
-	  margin-bottom: 0;
+	   margin-bottom: 0;
 	}
 
+	.govuk-form-group--error {
+	  display: flex;
+	  border: none;
+	}
 
 	.govuk-link {
 	  margin-bottom: 1rem;
@@ -163,6 +180,10 @@
 
 	.file-info {
 	  margin: .5rem 0;
+	}
+
+	.govuk-error-message {
+	  font-size: inherit;
 	}
   }
 


### PR DESCRIPTION
## Describe your changes

- Add the validation of the Welsh properties in a s51 advice when marking ready to publish
- Added e2e tests to test the above

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-475 Welsh - S51 advice properties: validation of Welsh fields in S51 advice property page
https://pins-ds.atlassian.net/browse/APPLICS-475

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
