### PR TITLE
feat(applications/web): who document is for in welsh should match figma (APPLICS-473)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/documentProperties.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/documentProperties.spec.js
@@ -61,7 +61,7 @@ describe('Document Properties', () => {
 		fileUploadPage.clickLinkByText('View/Edit properties');
 		documentPropertiesPage.updateDocumentProperty('File name', fileName());
 		documentPropertiesPage.updateDocumentProperty('Description', description());
-		documentPropertiesPage.updateDocumentProperty('Who the document is from', from());
+		documentPropertiesPage.updateDocumentProperty('Who the document is from', from(), 'textarea');
 		documentPropertiesPage.updateDocumentProperty('Agent (optional)', agent());
 		documentPropertiesPage.updateDocumentProperty('Webfilter', webfilter());
 		documentPropertiesPage.updateDocumentType('No document type');

--- a/apps/e2e/cypress/e2e/back-office-applications/documentPropertiesWelsh.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/documentPropertiesWelsh.spec.js
@@ -64,10 +64,15 @@ describe('Document Properties including welsh fields', () => {
 			documentPropertiesPage.updateDocumentProperty('File name', fileName());
 			documentPropertiesPage.updateDocumentProperty('Description', description());
 			documentPropertiesPage.updateDocumentProperty('Description in Welsh', descriptionforWelsh());
-			documentPropertiesPage.updateDocumentProperty('Who the document is from', documentFrom());
+			documentPropertiesPage.updateDocumentProperty(
+				'Who the document is from',
+				documentFrom(),
+				'textarea'
+			);
 			documentPropertiesPage.updateDocumentProperty(
 				'Who the document is from in Welsh',
-				documentFromWelsh()
+				documentFromWelsh(),
+				'textarea'
 			);
 			documentPropertiesPage.updateDocumentProperty('Agent (optional)', agent());
 			documentPropertiesPage.updateDocumentProperty('Webfilter', webfilter());

--- a/apps/e2e/cypress/page_objects/documentPropertiesPage.js
+++ b/apps/e2e/cypress/page_objects/documentPropertiesPage.js
@@ -37,11 +37,16 @@ export class DocumentPropertiesPage extends Page {
 	/**
 	 * @param {string} property - Label text of the property. i.e `File name`
 	 * @param {string} newValue - this is the new value for this property
+	 * @param {string} type - this is the type of control in the page
 	 * @returns {void}
 	 */
-	updateDocumentProperty(property, newValue) {
+	updateDocumentProperty(property, newValue, type = 'input') {
 		this.elements.changeLink(property).click();
-		this.fillInput(newValue);
+		if (type === 'textarea') {
+			this.fillTextArea(newValue);
+		} else {
+			this.fillInput(newValue);
+		}
 		this.#save();
 		this.elements.propertyValue(property).then((elem) => {
 			expect(elem.text().trim()).to.eq(newValue);
@@ -112,8 +117,8 @@ export class DocumentPropertiesPage extends Page {
 		this.updateDocumentProperty('File name', this.fileName());
 		this.updateDocumentProperty('Description', this.description());
 		this.updateDocumentProperty('Description in Welsh', this.descriptionWelsh());
-		this.updateDocumentProperty('Who the document is from', this.from());
-		this.updateDocumentProperty('Who the document is from in Welsh', this.fromWelsh());
+		this.updateDocumentProperty('Who the document is from', this.from(), 'textarea');
+		this.updateDocumentProperty('Who the document is from in Welsh', this.fromWelsh(), 'textarea');
 		this.updateDocumentProperty('Agent (optional)', this.agent());
 		this.updateDocumentProperty('Webfilter', this.webfilter());
 		this.updateDocumentProperty('Webfilter in Welsh', this.webfilterWelsh());

--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
@@ -180,21 +180,13 @@ exports[`Edit applications documentation metadata Edit agent (representative) PO
 exports[`Edit applications documentation metadata Edit author GET /case/123/project-documentation/18/document/456/edit/author should render the page with values 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
     <div class=\\"govuk-grid-row\\">
-        <div class=\\"govuk-grid-column-two-thirds\\">
-            <h1 class=\\"govuk-heading-l\\"> Enter who the document is from</h1>
-            <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
-                <div class=\\"govuk-form-group \\">
-                    <label class=\\"govuk-label font-weight--700\\" for=\\"author\\">Document from</label>
-                    <div id=\\"author-hint\\" class=\\"govuk-hint\\">There is a limit of 150 characters</div>
-                    <input class=\\"govuk-input govuk-!-width-two-thirds  \\"
-                    id=\\"author\\" name=\\"author\\" type=\\"text\\" value=\\"Tempor incididunt\\" aria-describedby=\\"author-hint\\"
-                    maxlength=\\"150\\">
+        <div class=\\"govuk-grid-column-two-thirds-from-desktop\\">
+            <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\">
+                <div class=\\"govuk-form-group\\">
+                    <h1 class=\\"govuk-label-wrapper\\"><label class=\\"govuk-label govuk-label--l\\" for=\\"author\\"> Who the document is from</label></h1>
+                    <textarea class=\\"govuk-textarea\\" id=\\"author\\" name=\\"author\\" rows=\\"5\\">Tempor incididunt</textarea>
                 </div>
-                <div class=\\"govuk-grid-row\\">
-                    <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
-                        <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
-                    </div>
-                </div>
+                <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
             </form>
         </div>
     </div>
@@ -219,23 +211,16 @@ exports[`Edit applications documentation metadata Edit author POST /case/123/pro
         </div>
     </div>
     <div class=\\"govuk-grid-row\\">
-        <div class=\\"govuk-grid-column-two-thirds\\">
-            <h1 class=\\"govuk-heading-l\\"> Enter who the document is from</h1>
-            <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
+        <div class=\\"govuk-grid-column-two-thirds-from-desktop\\">
+            <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\">
                 <div class=\\"govuk-form-group govuk-form-group--error\\">
-                    <label class=\\"govuk-label font-weight--700\\" for=\\"author\\">Document from</label>
-                    <div id=\\"author-hint\\" class=\\"govuk-hint\\">There is a limit of 150 characters</div>
+                    <h1 class=\\"govuk-label-wrapper\\"><label class=\\"govuk-label govuk-label--l\\" for=\\"author\\"> Who the document is from</label></h1>
                     <p id=\\"author-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter who the
                         document is from</p>
-                    <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"author\\" name=\\"author\\" type=\\"text\\" value=\\"Tempor incididunt\\" aria-describedby=\\"author-hint\\"
-                    maxlength=\\"150\\">
+                    <textarea class=\\"govuk-textarea govuk-textarea--error\\"
+                    id=\\"author\\" name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\">Tempor incididunt</textarea>
                 </div>
-                <div class=\\"govuk-grid-row\\">
-                    <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
-                        <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
-                    </div>
-                </div>
+                <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
             </form>
         </div>
     </div>
@@ -260,23 +245,16 @@ exports[`Edit applications documentation metadata Edit author POST /case/123/pro
         </div>
     </div>
     <div class=\\"govuk-grid-row\\">
-        <div class=\\"govuk-grid-column-two-thirds\\">
-            <h1 class=\\"govuk-heading-l\\"> Enter who the document is from</h1>
-            <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
+        <div class=\\"govuk-grid-column-two-thirds-from-desktop\\">
+            <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\">
                 <div class=\\"govuk-form-group govuk-form-group--error\\">
-                    <label class=\\"govuk-label font-weight--700\\" for=\\"author\\">Document from</label>
-                    <div id=\\"author-hint\\" class=\\"govuk-hint\\">There is a limit of 150 characters</div>
+                    <h1 class=\\"govuk-label-wrapper\\"><label class=\\"govuk-label govuk-label--l\\" for=\\"author\\"> Who the document is from</label></h1>
                     <p id=\\"author-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The value must be 150
                         characters or fewer</p>
-                    <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"author\\" name=\\"author\\" type=\\"text\\" value=\\"Tempor incididunt\\" aria-describedby=\\"author-hint\\"
-                    maxlength=\\"150\\">
+                    <textarea class=\\"govuk-textarea govuk-textarea--error\\"
+                    id=\\"author\\" name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\">Tempor incididunt</textarea>
                 </div>
-                <div class=\\"govuk-grid-row\\">
-                    <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
-                        <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
-                    </div>
-                </div>
+                <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
             </form>
         </div>
     </div>

--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/documentation-metadata.test.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/documentation-metadata.test.js
@@ -277,7 +277,7 @@ describe('Edit applications documentation metadata', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('Enter who the document is from');
+				expect(element.innerHTML).toContain('Who the document is from');
 				expect(element.innerHTML).toContain(fixturePublishedDocumentationFile.author);
 			});
 		});
@@ -298,7 +298,7 @@ describe('Edit applications documentation metadata', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('There is a limit of 150 characters');
+				expect(element.innerHTML).toContain('The value must be 150 characters or fewer');
 			});
 
 			it('should redirect to document properties page if there is no error', async () => {

--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.validators.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.validators.js
@@ -24,6 +24,7 @@ export const validatorsDispatcher = async (request, response, next) => {
 		webfilterWelsh: validateDocumentationMetaFilter1Welsh,
 		agent: validateDocumentationMetaRepresentative,
 		author: validateDocumentationMetaAuthor,
+		authorWelsh: validateDocumentationMetaAuthorWelsh,
 		redaction: validateDocumentationMetaRedacted,
 		'receipt-date': validateDocumentationMetaDateCreated,
 		'published-date': validateDocumentationMetaDatePublished
@@ -63,6 +64,15 @@ export const validateDocumentationMetaAuthor = createValidator(
 		.trim()
 		.isLength({ min: 1 })
 		.withMessage('You must enter who the document is from')
+		.isLength({ max: 150 })
+		.withMessage('The value must be 150 characters or fewer')
+);
+
+export const validateDocumentationMetaAuthorWelsh = createValidator(
+	body('authorWelsh')
+		.trim()
+		.isLength({ min: 1 })
+		.withMessage('You must enter who the document is from in Welsh')
 		.isLength({ max: 150 })
 		.withMessage('The value must be 150 characters or fewer')
 );

--- a/apps/web/src/server/views/applications/case-documentation/documentation-edit-textarea.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-edit-textarea.njk
@@ -1,0 +1,14 @@
+{% extends "../layouts/document-edit-property.layout.njk" %}
+{% from "../components/textarea-form-component.njk" import textareaFormComponent %}
+
+{% block formContent %}
+	{{ textareaFormComponent({
+		value: documentMetaData[layout.metaDataName],
+		name: layout.metaDataName,
+		label: layout.label,
+		englishValue: documentMetaData[layout.metaDataEnglishName] if documentMetaData[layout.metaDataEnglishName] else null,
+		englishLabel: layout.englishLabel,
+		errorMessage: errors[layout.metaDataName]
+	}) }}
+{% endblock %}
+

--- a/apps/web/src/server/views/applications/layouts/document-edit-property.layout.njk
+++ b/apps/web/src/server/views/applications/layouts/document-edit-property.layout.njk
@@ -1,0 +1,24 @@
+{% extends "./applications.layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block pageHeading %}{% endblock %}
+
+{% block beforeContent %}
+	{{ govukBackLink({
+		text: "Back",
+		href: layout.backLink
+	}) }}
+{% endblock %}
+
+{% block pageContent %}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-two-thirds-from-desktop">
+			<form method="post" action="" novalidate="novalidate">
+				{% block formContent %}{% endblock %}
+				{% block formSubmitButton %}
+					{{ govukButton({ text: 'Save and return' }) }}
+				{% endblock %}
+			</form>
+		</div>
+	</div>
+{% endblock %}


### PR DESCRIPTION
## Describe your changes

- Add new nunjucks templates to match figma designs
- Add config to use new nunjucks template
- Fixed web unit tests to test the above
- Fixed e2e tests to test the above

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-473 Sub title for Who the document is from in Welsh is not matching with figma designs
https://pins-ds.atlassian.net/browse/APPLICS-473

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
