### PR TITLE
feat(applications/web): entered data should be displayed when property is in error (APPLICS-474)

### DIFF
--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
@@ -55,7 +55,7 @@ exports[`Edit applications documentation metadata Edit Welsh webfilter (filter1W
                     <p id=\\"filter1Welsh-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter a webfilter
                         in Welsh</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"filter1Welsh\\" name=\\"filter1Welsh\\" type=\\"text\\" value=\\"Ut\\" aria-describedby=\\"filter1Welsh-hint\\"
+                    id=\\"filter1Welsh\\" name=\\"filter1Welsh\\" type=\\"text\\" value=\\"\\" aria-describedby=\\"filter1Welsh-hint\\"
                     maxlength=\\"100\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
@@ -98,8 +98,8 @@ exports[`Edit applications documentation metadata Edit Welsh webfilter (filter1W
                     <p id=\\"filter1Welsh-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The webfilter must be
                         100 characters or fewer</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"filter1Welsh\\" name=\\"filter1Welsh\\" type=\\"text\\" value=\\"Ut\\" aria-describedby=\\"filter1Welsh-hint\\"
-                    maxlength=\\"100\\">
+                    id=\\"filter1Welsh\\" name=\\"filter1Welsh\\" type=\\"text\\" value=\\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\"
+                    aria-describedby=\\"filter1Welsh-hint\\" maxlength=\\"100\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
                     <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -163,7 +163,7 @@ exports[`Edit applications documentation metadata Edit agent (representative) PO
                     <p id=\\"representative-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The agent name be 150
                         characters or fewer</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"representative\\" name=\\"representative\\" type=\\"text\\" value=\\"Ullamco Aliqua\\"
+                    id=\\"representative\\" name=\\"representative\\" type=\\"text\\" value=\\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\"
                     aria-describedby=\\"representative-hint\\" maxlength=\\"150\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
@@ -218,7 +218,7 @@ exports[`Edit applications documentation metadata Edit author POST /case/123/pro
                     <p id=\\"author-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter who the
                         document is from</p>
                     <textarea class=\\"govuk-textarea govuk-textarea--error\\"
-                    id=\\"author\\" name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\">Tempor incididunt</textarea>
+                    id=\\"author\\" name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\"></textarea>
                 </div>
                 <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
             </form>
@@ -252,7 +252,7 @@ exports[`Edit applications documentation metadata Edit author POST /case/123/pro
                     <p id=\\"author-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The value must be 150
                         characters or fewer</p>
                     <textarea class=\\"govuk-textarea govuk-textarea--error\\"
-                    id=\\"author\\" name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\">Tempor incididunt</textarea>
+                    id=\\"author\\" name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</textarea>
                 </div>
                 <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
             </form>
@@ -312,8 +312,8 @@ exports[`Edit applications documentation metadata Edit description POST /case/12
                     <p id=\\"description-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter a description
                         of the document</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"description\\" name=\\"description\\" type=\\"text\\" value=\\"Ullamco laboris nisi ut aliquip ex ea commodo consequat\\"
-                    aria-describedby=\\"description-hint\\" maxlength=\\"800\\">
+                    id=\\"description\\" name=\\"description\\" type=\\"text\\" value=\\"\\" aria-describedby=\\"description-hint\\"
+                    maxlength=\\"800\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
                     <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -353,7 +353,7 @@ exports[`Edit applications documentation metadata Edit description POST /case/12
                     <p id=\\"description-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The description must
                         be 800 characters or fewer</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"description\\" name=\\"description\\" type=\\"text\\" value=\\"Ullamco laboris nisi ut aliquip ex ea commodo consequat\\"
+                    id=\\"description\\" name=\\"description\\" type=\\"text\\" value=\\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\"
                     aria-describedby=\\"description-hint\\" maxlength=\\"800\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
@@ -452,7 +452,7 @@ exports[`Edit applications documentation metadata Edit description in Welsh POST
                     <p id=\\"descriptionWelsh-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The description must
                         be 800 characters or fewer</p>
                     <textarea class=\\"govuk-textarea govuk-textarea--error\\"
-                    id=\\"descriptionWelsh\\" name=\\"descriptionWelsh\\" rows=\\"5\\" aria-describedby=\\"descriptionWelsh-error\\"></textarea>
+                    id=\\"descriptionWelsh\\" name=\\"descriptionWelsh\\" rows=\\"5\\" aria-describedby=\\"descriptionWelsh-error\\">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</textarea>
                 </div>
                 <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
             </form>
@@ -573,8 +573,8 @@ exports[`Edit applications documentation metadata Edit name POST /case/123/proje
                     <p id=\\"fileName-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter a file
                         name</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"fileName\\" name=\\"fileName\\" type=\\"text\\" value=\\"12 Ullamco laboris nisi ut\\"
-                    aria-describedby=\\"fileName-hint\\" maxlength=\\"255\\">
+                    id=\\"fileName\\" name=\\"fileName\\" type=\\"text\\" value=\\"\\" aria-describedby=\\"fileName-hint\\"
+                    maxlength=\\"255\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
                     <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -614,7 +614,7 @@ exports[`Edit applications documentation metadata Edit name POST /case/123/proje
                     <p id=\\"fileName-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The name must be 255
                         characters or fewer</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"fileName\\" name=\\"fileName\\" type=\\"text\\" value=\\"12 Ullamco laboris nisi ut\\"
+                    id=\\"fileName\\" name=\\"fileName\\" type=\\"text\\" value=\\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\"
                     aria-describedby=\\"fileName-hint\\" maxlength=\\"255\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
@@ -1612,7 +1612,7 @@ exports[`Edit applications documentation metadata Edit webfilter (filter1) POST 
                     <div id=\\"filter1-hint\\" class=\\"govuk-hint\\">There is a limit of 100 characters</div>
                     <p id=\\"filter1-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter a webfilter</p>
                     <input                     class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\" id=\\"filter1\\"
-                    name=\\"filter1\\" type=\\"text\\" value=\\"Ut\\" aria-describedby=\\"filter1-hint\\" maxlength=\\"100\\">
+                    name=\\"filter1\\" type=\\"text\\" value=\\"\\" aria-describedby=\\"filter1-hint\\" maxlength=\\"100\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
                     <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
@@ -1652,8 +1652,8 @@ exports[`Edit applications documentation metadata Edit webfilter (filter1) POST 
                     <p id=\\"filter1-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The webfilter must be
                         100 characters or fewer</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"filter1\\" name=\\"filter1\\" type=\\"text\\" value=\\"Ut\\" aria-describedby=\\"filter1-hint\\"
-                    maxlength=\\"100\\">
+                    id=\\"filter1\\" name=\\"filter1\\" type=\\"text\\" value=\\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\"
+                    aria-describedby=\\"filter1-hint\\" maxlength=\\"100\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
                     <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">

--- a/apps/web/src/server/views/applications/case-documentation/documentation-edit-textarea.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-edit-textarea.njk
@@ -3,7 +3,7 @@
 
 {% block formContent %}
 	{{ textareaFormComponent({
-		value: documentMetaData[layout.metaDataName],
+		value: errors[layout.metaDataName].value if errors[layout.metaDataName] else documentMetaData[layout.metaDataName],
 		name: layout.metaDataName,
 		label: layout.label,
 		englishValue: documentMetaData[layout.metaDataEnglishName] if documentMetaData[layout.metaDataEnglishName] else null,

--- a/apps/web/src/server/views/applications/case-documentation/edit/max-length-input.njk
+++ b/apps/web/src/server/views/applications/case-documentation/edit/max-length-input.njk
@@ -1,5 +1,8 @@
 {% macro maxLengthInput(layout, value, errors) %}
 	{% set error = errors[layout.metaDataName] %}
+	{% if error %}
+		{% set value=error.value %}
+	{% endif %}
 
     <div class="govuk-form-group {{ "govuk-form-group--error" if error else "" }}">
 
@@ -11,7 +14,7 @@
             {{ layout.hint }}
         </div>
 
-        {% if errors[layout.metaDataName] %}
+        {% if error %}
             <p id="{{layout.metaDataName}}-error" class="govuk-error-message">
                 <span class="govuk-visually-hidden">Error:</span>
                 {{ (error | errorMessage).text }}


### PR DESCRIPTION
## Describe your changes

- Update nunjucks templates to display entered data if in error
- Fixed web unit test snapshots to test the above

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-474 Who the document is from in Welsh is allowing more than 150 characters
https://pins-ds.atlassian.net/browse/APPLICS-474

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
