### PR TITLE
fix(applications/web): date fields do not show entered data when in error (APPLICS-501)

### DIFF
--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
@@ -804,21 +804,21 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                                         <p id=\\"datePublished.day-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.day\\" name=\\"datePublished.day\\"
-                                        type=\\"text\\" value=\\"07\\" aria-describedby=\\"datePublished.day-error\\">
+                                        type=\\"text\\" aria-describedby=\\"datePublished.day-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.month\\">Month</label>
                                         <p id=\\"datePublished.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.month\\"
-                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"03\\" aria-describedby=\\"datePublished.month-error\\">
+                                        name=\\"datePublished.month\\" type=\\"text\\" aria-describedby=\\"datePublished.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.year\\">Year</label>
                                         <p id=\\"datePublished.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.year\\"
-                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"2023\\" aria-describedby=\\"datePublished.year-error\\">
+                                        name=\\"datePublished.year\\" type=\\"text\\" aria-describedby=\\"datePublished.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -871,21 +871,21 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                                         <p id=\\"datePublished.day-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.day\\" name=\\"datePublished.day\\"
-                                        type=\\"text\\" value=\\"07\\" aria-describedby=\\"datePublished.day-error\\">
+                                        type=\\"text\\" value=\\"01\\" aria-describedby=\\"datePublished.day-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.month\\">Month</label>
                                         <p id=\\"datePublished.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.month\\"
-                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"03\\" aria-describedby=\\"datePublished.month-error\\">
+                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"01\\" aria-describedby=\\"datePublished.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.year\\">Year</label>
                                         <p id=\\"datePublished.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.year\\"
-                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"2023\\" aria-describedby=\\"datePublished.year-error\\">
+                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"2100\\" aria-describedby=\\"datePublished.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -938,21 +938,21 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                                         <p id=\\"datePublished.day-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.day\\" name=\\"datePublished.day\\"
-                                        type=\\"text\\" value=\\"07\\" aria-describedby=\\"datePublished.day-error\\">
+                                        type=\\"text\\" value=\\"99\\" aria-describedby=\\"datePublished.day-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.month\\">Month</label>
                                         <p id=\\"datePublished.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.month\\"
-                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"03\\" aria-describedby=\\"datePublished.month-error\\">
+                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"01\\" aria-describedby=\\"datePublished.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.year\\">Year</label>
                                         <p id=\\"datePublished.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.year\\"
-                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"2023\\" aria-describedby=\\"datePublished.year-error\\">
+                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"2000\\" aria-describedby=\\"datePublished.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -1005,21 +1005,21 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                                         <p id=\\"datePublished.day-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.day\\" name=\\"datePublished.day\\"
-                                        type=\\"text\\" value=\\"07\\" aria-describedby=\\"datePublished.day-error\\">
+                                        type=\\"text\\" value=\\"01\\" aria-describedby=\\"datePublished.day-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.month\\">Month</label>
                                         <p id=\\"datePublished.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.month\\"
-                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"03\\" aria-describedby=\\"datePublished.month-error\\">
+                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"99\\" aria-describedby=\\"datePublished.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.year\\">Year</label>
                                         <p id=\\"datePublished.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.year\\"
-                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"2023\\" aria-describedby=\\"datePublished.year-error\\">
+                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"2000\\" aria-describedby=\\"datePublished.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -1072,21 +1072,21 @@ exports[`Edit applications documentation metadata Edit published date POST /case
                                         <p id=\\"datePublished.day-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.day\\" name=\\"datePublished.day\\"
-                                        type=\\"text\\" value=\\"07\\" aria-describedby=\\"datePublished.day-error\\">
+                                        type=\\"text\\" value=\\"01\\" aria-describedby=\\"datePublished.day-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.month\\">Month</label>
                                         <p id=\\"datePublished.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.month\\"
-                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"03\\" aria-describedby=\\"datePublished.month-error\\">
+                                        name=\\"datePublished.month\\" type=\\"text\\" value=\\"01\\" aria-describedby=\\"datePublished.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"datePublished.year\\">Year</label>
                                         <p id=\\"datePublished.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"datePublished.year\\"
-                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"2023\\" aria-describedby=\\"datePublished.year-error\\">
+                                        name=\\"datePublished.year\\" type=\\"text\\" value=\\"200\\" aria-describedby=\\"datePublished.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -1183,21 +1183,21 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                                         <p id=\\"dateCreated.day-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.day\\" name=\\"dateCreated.day\\"
-                                        type=\\"text\\" value=\\"01\\" aria-describedby=\\"dateCreated.day-error\\">
+                                        type=\\"text\\" aria-describedby=\\"dateCreated.day-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.month\\">Month</label>
                                         <p id=\\"dateCreated.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.month\\" name=\\"dateCreated.month\\"
-                                        type=\\"text\\" value=\\"12\\" aria-describedby=\\"dateCreated.month-error\\">
+                                        type=\\"text\\" aria-describedby=\\"dateCreated.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.year\\">Year</label>
                                         <p id=\\"dateCreated.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.year\\" name=\\"dateCreated.year\\"
-                                        type=\\"text\\" value=\\"2022\\" aria-describedby=\\"dateCreated.year-error\\">
+                                        type=\\"text\\" aria-describedby=\\"dateCreated.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -1257,14 +1257,14 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                                         <p id=\\"dateCreated.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.month\\" name=\\"dateCreated.month\\"
-                                        type=\\"text\\" value=\\"12\\" aria-describedby=\\"dateCreated.month-error\\">
+                                        type=\\"text\\" value=\\"01\\" aria-describedby=\\"dateCreated.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.year\\">Year</label>
                                         <p id=\\"dateCreated.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.year\\" name=\\"dateCreated.year\\"
-                                        type=\\"text\\" value=\\"2022\\" aria-describedby=\\"dateCreated.year-error\\">
+                                        type=\\"text\\" value=\\"2100\\" aria-describedby=\\"dateCreated.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -1317,21 +1317,21 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                                         <p id=\\"dateCreated.day-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.day\\" name=\\"dateCreated.day\\"
-                                        type=\\"text\\" value=\\"01\\" aria-describedby=\\"dateCreated.day-error\\">
+                                        type=\\"text\\" value=\\"99\\" aria-describedby=\\"dateCreated.day-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.month\\">Month</label>
                                         <p id=\\"dateCreated.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.month\\" name=\\"dateCreated.month\\"
-                                        type=\\"text\\" value=\\"12\\" aria-describedby=\\"dateCreated.month-error\\">
+                                        type=\\"text\\" value=\\"01\\" aria-describedby=\\"dateCreated.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.year\\">Year</label>
                                         <p id=\\"dateCreated.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.year\\" name=\\"dateCreated.year\\"
-                                        type=\\"text\\" value=\\"2022\\" aria-describedby=\\"dateCreated.year-error\\">
+                                        type=\\"text\\" value=\\"2000\\" aria-describedby=\\"dateCreated.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -1391,14 +1391,14 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                                         <p id=\\"dateCreated.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.month\\" name=\\"dateCreated.month\\"
-                                        type=\\"text\\" value=\\"12\\" aria-describedby=\\"dateCreated.month-error\\">
+                                        type=\\"text\\" value=\\"99\\" aria-describedby=\\"dateCreated.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.year\\">Year</label>
                                         <p id=\\"dateCreated.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.year\\" name=\\"dateCreated.year\\"
-                                        type=\\"text\\" value=\\"2022\\" aria-describedby=\\"dateCreated.year-error\\">
+                                        type=\\"text\\" value=\\"2000\\" aria-describedby=\\"dateCreated.year-error\\">
                                     </div>
                                 </div>
                             </div>
@@ -1458,14 +1458,14 @@ exports[`Edit applications documentation metadata Edit receipt date POST /case/1
                                         <p id=\\"dateCreated.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.month\\" name=\\"dateCreated.month\\"
-                                        type=\\"text\\" value=\\"12\\" aria-describedby=\\"dateCreated.month-error\\">
+                                        type=\\"text\\" value=\\"01\\" aria-describedby=\\"dateCreated.month-error\\">
                                     </div>
                                     <div class=\\"govuk-form-group govuk-form-group--error\\">
                                         <label class=\\"govuk-label govuk-hint\\" for=\\"dateCreated.year\\">Year</label>
                                         <p id=\\"dateCreated.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                         </p>
                                         <input class=\\"govuk-input govuk-input--error\\" id=\\"dateCreated.year\\" name=\\"dateCreated.year\\"
-                                        type=\\"text\\" value=\\"2022\\" aria-describedby=\\"dateCreated.year-error\\">
+                                        type=\\"text\\" value=\\"200\\" aria-describedby=\\"dateCreated.year-error\\">
                                     </div>
                                 </div>
                             </div>

--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
@@ -186,11 +186,16 @@ export async function updateDocumentationMetaData(request, response) {
 
 	if (metaDataName === 'published-date' || metaDataName === 'receipt-date') {
 		const fieldName = layouts[metaDataName].metaDataName;
-		const newValue = `${body[`${fieldName}.year`]}-${body[`${fieldName}.month`]}-${
-			body[`${fieldName}.day`]
-		}`;
 
-		newMetaData = { [fieldName]: new Date(newValue) };
+		const day = body[`${fieldName}.day`];
+		const month = body[`${fieldName}.month`];
+		const year = body[`${fieldName}.year`];
+
+		if (validationErrors && validationErrors[fieldName]) {
+			validationErrors[fieldName].value = { year, month, day };
+		} else {
+			newMetaData = { [fieldName]: new Date(`${year}-${month}-${day}`) };
+		}
 	}
 	// special case for documentType "No document type" - we need to send null to the api
 	if (metaDataName === 'type' && newMetaData.documentType === '') {

--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/__snapshots__/applications-timetable.test.js.snap
@@ -1836,21 +1836,21 @@ exports[`Create examination timetable page should display errors if start date a
                                     <p id=\\"startDate.day-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                     </p>
                                     <input class=\\"govuk-input govuk-input--error\\" id=\\"startDate.day\\" name=\\"startDate.day\\"
-                                    type=\\"text\\" value=\\"01\\" aria-describedby=\\"startDate.day-error\\">
+                                    type=\\"text\\" aria-describedby=\\"startDate.day-error\\">
                                 </div>
                                 <div class=\\"govuk-form-group govuk-form-group--error\\">
                                     <label class=\\"govuk-label govuk-hint\\" for=\\"startDate.month\\">Month</label>
                                     <p id=\\"startDate.month-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                     </p>
                                     <input class=\\"govuk-input govuk-input--error\\" id=\\"startDate.month\\" name=\\"startDate.month\\"
-                                    type=\\"text\\" value=\\"02\\" aria-describedby=\\"startDate.month-error\\">
+                                    type=\\"text\\" aria-describedby=\\"startDate.month-error\\">
                                 </div>
                                 <div class=\\"govuk-form-group govuk-form-group--error\\">
                                     <label class=\\"govuk-label govuk-hint\\" for=\\"startDate.year\\">Year</label>
                                     <p id=\\"startDate.year-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span>
                                     </p>
                                     <input class=\\"govuk-input govuk-input--error\\" id=\\"startDate.year\\" name=\\"startDate.year\\"
-                                    type=\\"text\\" value=\\"2001\\" aria-describedby=\\"startDate.year-error\\">
+                                    type=\\"text\\" aria-describedby=\\"startDate.year-error\\">
                                 </div>
                             </div>
                         </div>

--- a/apps/web/src/server/applications/case/key-dates/__tests__/__snapshots__/applications-key-dates.test.js.snap
+++ b/apps/web/src/server/applications/case/key-dates/__tests__/__snapshots__/applications-key-dates.test.js.snap
@@ -1371,17 +1371,17 @@ exports[`S51 Advice Key dates page Sections POST /case/123/key-dates/:sectionNam
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"datePINSFirstNotifiedOfProject.day\\">Day</label>
                             <input class=\\"govuk-input\\" id=\\"datePINSFirstNotifiedOfProject.day\\"
-                            name=\\"datePINSFirstNotifiedOfProject.day\\" type=\\"text\\" value=\\"20\\">
+                            name=\\"datePINSFirstNotifiedOfProject.day\\" type=\\"text\\" value=\\"01\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"datePINSFirstNotifiedOfProject.month\\">Month</label>
                             <input class=\\"govuk-input\\" id=\\"datePINSFirstNotifiedOfProject.month\\"
-                            name=\\"datePINSFirstNotifiedOfProject.month\\" type=\\"text\\" value=\\"08\\">
+                            name=\\"datePINSFirstNotifiedOfProject.month\\" type=\\"text\\" value=\\"02\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"datePINSFirstNotifiedOfProject.year\\">Year</label>
                             <input class=\\"govuk-input\\" id=\\"datePINSFirstNotifiedOfProject.year\\"
-                            name=\\"datePINSFirstNotifiedOfProject.year\\" type=\\"text\\" value=\\"2023\\">
+                            name=\\"datePINSFirstNotifiedOfProject.year\\" type=\\"text\\" value=\\"2000\\">
                         </div>
                     </div>
                 </div>
@@ -1611,17 +1611,17 @@ exports[`S51 Advice Key dates page Sections POST /case/123/key-dates/:sectionNam
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateOfDCOSubmission.day\\">Day</label>
                             <input class=\\"govuk-input\\" id=\\"dateOfDCOSubmission.day\\" name=\\"dateOfDCOSubmission.day\\"
-                            type=\\"text\\" value=\\"08\\">
+                            type=\\"text\\" value=\\"01\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateOfDCOSubmission.month\\">Month</label>
                             <input class=\\"govuk-input\\" id=\\"dateOfDCOSubmission.month\\"
-                            name=\\"dateOfDCOSubmission.month\\" type=\\"text\\" value=\\"04\\">
+                            name=\\"dateOfDCOSubmission.month\\" type=\\"text\\" value=\\"02\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateOfDCOSubmission.year\\">Year</label>
                             <input class=\\"govuk-input\\" id=\\"dateOfDCOSubmission.year\\" name=\\"dateOfDCOSubmission.year\\"
-                            type=\\"text\\" value=\\"2023\\">
+                            type=\\"text\\" value=\\"2000\\">
                         </div>
                     </div>
                 </div>
@@ -1742,17 +1742,17 @@ exports[`S51 Advice Key dates page Sections POST /case/123/key-dates/:sectionNam
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateOfRepresentationPeriodOpen.day\\">Day</label>
                             <input class=\\"govuk-input\\" id=\\"dateOfRepresentationPeriodOpen.day\\"
-                            name=\\"dateOfRepresentationPeriodOpen.day\\" type=\\"text\\" value=\\"22\\">
+                            name=\\"dateOfRepresentationPeriodOpen.day\\" type=\\"text\\" value=\\"01\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateOfRepresentationPeriodOpen.month\\">Month</label>
                             <input class=\\"govuk-input\\" id=\\"dateOfRepresentationPeriodOpen.month\\"
-                            name=\\"dateOfRepresentationPeriodOpen.month\\" type=\\"text\\" value=\\"09\\">
+                            name=\\"dateOfRepresentationPeriodOpen.month\\" type=\\"text\\" value=\\"02\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateOfRepresentationPeriodOpen.year\\">Year</label>
                             <input class=\\"govuk-input\\" id=\\"dateOfRepresentationPeriodOpen.year\\"
-                            name=\\"dateOfRepresentationPeriodOpen.year\\" type=\\"text\\" value=\\"2023\\">
+                            name=\\"dateOfRepresentationPeriodOpen.year\\" type=\\"text\\" value=\\"2000\\">
                         </div>
                     </div>
                 </div>
@@ -2058,17 +2058,17 @@ exports[`S51 Advice Key dates page Sections POST /case/123/key-dates/:sectionNam
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateSection58NoticeReceived.day\\">Day</label>
                             <input class=\\"govuk-input\\" id=\\"dateSection58NoticeReceived.day\\"
-                            name=\\"dateSection58NoticeReceived.day\\" type=\\"text\\" value=\\"26\\">
+                            name=\\"dateSection58NoticeReceived.day\\" type=\\"text\\" value=\\"01\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateSection58NoticeReceived.month\\">Month</label>
                             <input class=\\"govuk-input\\" id=\\"dateSection58NoticeReceived.month\\"
-                            name=\\"dateSection58NoticeReceived.month\\" type=\\"text\\" value=\\"10\\">
+                            name=\\"dateSection58NoticeReceived.month\\" type=\\"text\\" value=\\"02\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"dateSection58NoticeReceived.year\\">Year</label>
                             <input class=\\"govuk-input\\" id=\\"dateSection58NoticeReceived.year\\"
-                            name=\\"dateSection58NoticeReceived.year\\" type=\\"text\\" value=\\"2023\\">
+                            name=\\"dateSection58NoticeReceived.year\\" type=\\"text\\" value=\\"2000\\">
                         </div>
                     </div>
                 </div>
@@ -2241,17 +2241,17 @@ exports[`S51 Advice Key dates page Sections POST /case/123/key-dates/:sectionNam
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"deadlineForSubmissionOfRecommendation.day\\">Day</label>
                             <input class=\\"govuk-input\\" id=\\"deadlineForSubmissionOfRecommendation.day\\"
-                            name=\\"deadlineForSubmissionOfRecommendation.day\\" type=\\"text\\" value=\\"14\\">
+                            name=\\"deadlineForSubmissionOfRecommendation.day\\" type=\\"text\\" value=\\"01\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"deadlineForSubmissionOfRecommendation.month\\">Month</label>
                             <input class=\\"govuk-input\\" id=\\"deadlineForSubmissionOfRecommendation.month\\"
-                            name=\\"deadlineForSubmissionOfRecommendation.month\\" type=\\"text\\" value=\\"06\\">
+                            name=\\"deadlineForSubmissionOfRecommendation.month\\" type=\\"text\\" value=\\"02\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"deadlineForSubmissionOfRecommendation.year\\">Year</label>
                             <input class=\\"govuk-input\\" id=\\"deadlineForSubmissionOfRecommendation.year\\"
-                            name=\\"deadlineForSubmissionOfRecommendation.year\\" type=\\"text\\" value=\\"2023\\">
+                            name=\\"deadlineForSubmissionOfRecommendation.year\\" type=\\"text\\" value=\\"2000\\">
                         </div>
                     </div>
                 </div>
@@ -2343,17 +2343,17 @@ exports[`S51 Advice Key dates page Sections POST /case/123/key-dates/:sectionNam
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"deadlineForDecision.day\\">Day</label>
                             <input class=\\"govuk-input\\" id=\\"deadlineForDecision.day\\" name=\\"deadlineForDecision.day\\"
-                            type=\\"text\\" value=\\"21\\">
+                            type=\\"text\\" value=\\"01\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"deadlineForDecision.month\\">Month</label>
                             <input class=\\"govuk-input\\" id=\\"deadlineForDecision.month\\"
-                            name=\\"deadlineForDecision.month\\" type=\\"text\\" value=\\"08\\">
+                            name=\\"deadlineForDecision.month\\" type=\\"text\\" value=\\"02\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"deadlineForDecision.year\\">Year</label>
                             <input class=\\"govuk-input\\" id=\\"deadlineForDecision.year\\" name=\\"deadlineForDecision.year\\"
-                            type=\\"text\\" value=\\"2023\\">
+                            type=\\"text\\" value=\\"2000\\">
                         </div>
                     </div>
                 </div>
@@ -2445,17 +2445,17 @@ exports[`S51 Advice Key dates page Sections POST /case/123/key-dates/:sectionNam
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"jRPeriodEndDate.day\\">Day</label>
                             <input class=\\"govuk-input\\" id=\\"jRPeriodEndDate.day\\" name=\\"jRPeriodEndDate.day\\"
-                            type=\\"text\\" value=\\"15\\">
+                            type=\\"text\\" value=\\"01\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"jRPeriodEndDate.month\\">Month</label>
                             <input class=\\"govuk-input\\" id=\\"jRPeriodEndDate.month\\" name=\\"jRPeriodEndDate.month\\"
-                            type=\\"text\\" value=\\"06\\">
+                            type=\\"text\\" value=\\"02\\">
                         </div>
                         <div class=\\"govuk-form-group\\">
                             <label class=\\"govuk-label govuk-hint\\" for=\\"jRPeriodEndDate.year\\">Year</label>
                             <input class=\\"govuk-input\\" id=\\"jRPeriodEndDate.year\\" name=\\"jRPeriodEndDate.year\\"
-                            type=\\"text\\" value=\\"2023\\">
+                            type=\\"text\\" value=\\"2000\\">
                         </div>
                     </div>
                 </div>

--- a/apps/web/src/server/applications/case/s51/applications-s51.controller.js
+++ b/apps/web/src/server/applications/case/s51/applications-s51.controller.js
@@ -29,6 +29,7 @@ import {
 	mapS51AdviceToPage,
 	mapUpdateBodyToPayload
 } from './applications-s51.mapper.js';
+import addEnteredDateToValidationErrors from '../../../lib/add-entered-date-to-validation-errors.js';
 
 /** @typedef {import('./applications-s51.types.js').ApplicationsS51CreateBody} ApplicationsS51CreateBody */
 /** @typedef {import('./applications-s51.types.js').ApplicationsS51CreatePayload} ApplicationsS51CreatePayload */
@@ -201,7 +202,14 @@ export async function postApplicationsCaseEditS51Item(
 		}
 	}
 
+	if (validationErrors) {
+		// Make sure any date errors have the value populated with the entered data
+		// @ts-ignore
+		addEnteredDateToValidationErrors(validationErrors, values);
+	}
+
 	let apiErrors;
+
 	if (!titleErrors && !validationErrors) {
 		const { errors } = await updateS51Advice(caseId, Number(adviceId), payload);
 		apiErrors = errors;
@@ -263,9 +271,13 @@ export async function updateApplicationsCaseS51CreatePage(request, response) {
 	const { caseId, title } = response.locals;
 
 	let apiErrors;
-	if (params.step === 'title' && body.title) {
+
+	if (!validationErrors && params.step === 'title' && body.title) {
 		const { errors } = await checkS51NameIsUnique(Number(caseId), title);
 		apiErrors = errors;
+	} else if (validationErrors) {
+		// Make sure any date errors have the value populated with the entered data
+		addEnteredDateToValidationErrors(validationErrors, body);
 	}
 
 	if (validationErrors || apiErrors) {

--- a/apps/web/src/server/lib/__tests__/add-entered-date-to-validation-errors.test.js
+++ b/apps/web/src/server/lib/__tests__/add-entered-date-to-validation-errors.test.js
@@ -1,0 +1,32 @@
+import addEnteredDatesToValidationErrors from '../add-entered-date-to-validation-errors.js';
+
+describe('addEnteredDatesToValidationErrors', () => {
+	it('Should populate validation errors for dates with entered value', () => {
+		const enteredData = {
+			title: '1234',
+			'date.day': '01',
+			'date.month': '110',
+			'date.year': '24',
+			description: 'xxxxx'
+		};
+		const validationErrors = {
+			date: { msg: 'month is incorrect', value: undefined },
+			description: { msg: 'should not be xxxxx', value: 'xxxxx' }
+		};
+		addEnteredDatesToValidationErrors(validationErrors, enteredData);
+		expect(validationErrors).toEqual({
+			date: {
+				msg: 'month is incorrect',
+				value: {
+					day: '01',
+					month: '110',
+					year: '24'
+				}
+			},
+			description: {
+				msg: 'should not be xxxxx',
+				value: 'xxxxx'
+			}
+		});
+	});
+});

--- a/apps/web/src/server/lib/add-entered-date-to-validation-errors.js
+++ b/apps/web/src/server/lib/add-entered-date-to-validation-errors.js
@@ -1,0 +1,15 @@
+/**
+ * @param {Record<string, any>} validationErrors
+ * @param {Record<string, string>} data
+ */
+export default function addEnteredDatesToValidationErrors(validationErrors, data) {
+	Object.entries(validationErrors).forEach(([fieldName, error]) => {
+		if (Object.keys(data).includes(`${fieldName}.day`)) {
+			error.value = {
+				year: data[`${fieldName}.year`],
+				month: data[`${fieldName}.month`],
+				day: data[`${fieldName}.day`]
+			};
+		}
+	});
+}

--- a/apps/web/src/server/views/applications/components/inputs/date-input.component.njk
+++ b/apps/web/src/server/views/applications/components/inputs/date-input.component.njk
@@ -41,16 +41,21 @@
 				<div class="govuk-grid-row pins-date-form-group">
 
 					{% set fieldNameDay = [fieldName, '.day'] | join %}
-					{% set valueDay = values[fieldName] | datestamp({format: 'dd'})if values[fieldName] else
-						values[fieldNameDay] %}
-
 					{% set fieldNameMonth = [fieldName, '.month'] | join %}
-					{% set valueMonth = values[fieldName] | datestamp({format: 'MM'})if values[fieldName] else
-						values[fieldNameMonth] %}
-
 					{% set fieldNameYear = [fieldName, '.year'] | join %}
-					{% set valueYear = values[fieldName] | datestamp({format: 'yyyy'})if values[fieldName] else
-						values[fieldNameYear] %}
+
+					{% if errors[fieldName] %}
+						{% set valueDay = errors[fieldName].value.day %}
+						{% set valueMonth = errors[fieldName].value.month %}
+						{% set valueYear = errors[fieldName].value.year %}
+					{% else %}
+						{% set valueDay = values[fieldName] | datestamp({format: 'dd'})if values[fieldName] else
+							values[fieldNameDay] %}
+						{% set valueMonth = values[fieldName] | datestamp({format: 'MM'})if values[fieldName] else
+							values[fieldNameMonth] %}
+						{% set valueYear = values[fieldName] | datestamp({format: 'yyyy'})if values[fieldName] else
+							values[fieldNameYear] %}
+					{% endif %}
 
 					{{ govukInput({
 						label: {


### PR DESCRIPTION
## Describe your changes

The date validators do not return the entered date in the value field for the error, so this is done within the controller where required.

- Update nunjucks date-input.component.njk to display entered dates when in error
- Updated controllers for documentation, key dates, and s51 advice to include the entered date in the validation errors
- Fixed web unit test snapshots to test the above

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-501 Date fields do not show entered data when in error
https://pins-ds.atlassian.net/browse/APPLICS-501

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
