### PR TITLE
fix(applications/web): document properties change from welsh functional changes (APPLICS-497)

### DIFF
--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
@@ -202,7 +202,7 @@ exports[`Edit applications documentation metadata Edit author POST /case/123/pro
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#author\\">You must enter who the document is from</a>
+                            <li><a href=\\"#author\\">Enter who the document is from</a>
                             </li>
                         </ul>
                     </div>
@@ -215,10 +215,10 @@ exports[`Edit applications documentation metadata Edit author POST /case/123/pro
             <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\">
                 <div class=\\"govuk-form-group govuk-form-group--error\\">
                     <h1 class=\\"govuk-label-wrapper\\"><label class=\\"govuk-label govuk-label--l\\" for=\\"author\\"> Who the document is from</label></h1>
-                    <p id=\\"author-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter who the
-                        document is from</p>
-                    <textarea class=\\"govuk-textarea govuk-textarea--error\\"
-                    id=\\"author\\" name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\"></textarea>
+                    <p id=\\"author-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter who the document
+                        is from</p>
+                    <textarea class=\\"govuk-textarea govuk-textarea--error\\" id=\\"author\\"
+                    name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\"></textarea>
                 </div>
                 <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
             </form>
@@ -236,7 +236,7 @@ exports[`Edit applications documentation metadata Edit author POST /case/123/pro
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#author\\">The value must be 150 characters or fewer</a>
+                            <li><a href=\\"#author\\">Who the document is from must be 150 characters or less</a>
                             </li>
                         </ul>
                     </div>
@@ -249,8 +249,8 @@ exports[`Edit applications documentation metadata Edit author POST /case/123/pro
             <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\">
                 <div class=\\"govuk-form-group govuk-form-group--error\\">
                     <h1 class=\\"govuk-label-wrapper\\"><label class=\\"govuk-label govuk-label--l\\" for=\\"author\\"> Who the document is from</label></h1>
-                    <p id=\\"author-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The value must be 150
-                        characters or fewer</p>
+                    <p id=\\"author-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Who the document is from
+                        must be 150 characters or less</p>
                     <textarea class=\\"govuk-textarea govuk-textarea--error\\"
                     id=\\"author\\" name=\\"author\\" rows=\\"5\\" aria-describedby=\\"author-error\\">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</textarea>
                 </div>

--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/documentation-metadata.test.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/documentation-metadata.test.js
@@ -331,7 +331,7 @@ describe('Edit applications documentation metadata', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('You must enter who the document is from');
+				expect(element.innerHTML).toContain('Enter who the document is from');
 			});
 
 			it('should return an error if value length > 100', async () => {
@@ -341,7 +341,9 @@ describe('Edit applications documentation metadata', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('The value must be 150 characters or fewer');
+				expect(element.innerHTML).toContain(
+					'Who the document is from must be 150 characters or less'
+				);
 			});
 
 			it('should redirect to document properties page if there is no error', async () => {

--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
@@ -1,5 +1,6 @@
 import { url } from '../../../lib/nunjucks-filters/url.js';
 import { updateDocumentMetaData } from './documentation-metadata.service.js';
+import { setSessionBanner } from '../../common/services/session.service.js';
 
 /** @typedef {import('@pins/express').ValidationErrors} ValidationErrors */
 /** @typedef {"name" | "description" | "descriptionWelsh" | "published-date" | "receipt-date"| "redaction" | "published-status" | "type"|"webfilter" | "webfilterWelsh" | "agent"| "author" | "authorWelsh" | "transcript"} MetaDataNames */
@@ -178,7 +179,7 @@ export async function viewDocumentationMetaData({ params }, response) {
  * @type {import('@pins/express').RenderHandler<{}, {}, Partial<Record<string, any>>, {}, RequestParams, ResponseLocals>}
  */
 export async function updateDocumentationMetaData(request, response) {
-	const { errors: validationErrors, params, body } = request;
+	const { errors: validationErrors, params, body, session } = request;
 	const { caseId, documentGuid } = response.locals;
 	const { metaDataName } = params;
 
@@ -223,6 +224,9 @@ export async function updateDocumentationMetaData(request, response) {
 			{ errors, layout }
 		);
 	}
+
+	setSessionBanner(session, `${layouts[metaDataName].label} updated`);
+
 	response.redirect('../properties');
 }
 

--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.validators.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.validators.js
@@ -73,18 +73,18 @@ export const validateDocumentationMetaAuthor = createValidator(
 	body('author')
 		.trim()
 		.isLength({ min: 1 })
-		.withMessage('You must enter who the document is from')
+		.withMessage('Enter who the document is from')
 		.isLength({ max: 150 })
-		.withMessage('The value must be 150 characters or fewer')
+		.withMessage('Who the document is from must be 150 characters or less')
 );
 
 export const validateDocumentationMetaAuthorWelsh = createValidator(
 	body('authorWelsh')
 		.trim()
 		.isLength({ min: 1 })
-		.withMessage('You must enter who the document is from in Welsh')
+		.withMessage('Enter who the document is from in Welsh')
 		.isLength({ max: 150 })
-		.withMessage('The value must be 150 characters or fewer')
+		.withMessage('Who the document is from in Welsh must be 150 characters or less')
 );
 
 export const validateDocumentationMetaFilter1 = createValidator(

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -5,7 +5,9 @@ import {
 	getSessionFilesNumberOnList,
 	setSessionFilesNumberOnList,
 	getSuccessBanner,
-	destroySuccessBanner
+	destroySuccessBanner,
+	getSessionBanner,
+	deleteSessionBanner
 } from '../../common/services/session.service.js';
 import { buildBreadcrumbItems } from '../applications-case.locals.js';
 import {
@@ -207,19 +209,24 @@ export async function viewApplicationsCaseDocumentationUnpublishSinglePage(reque
 /**
  * View the documentation properties page
  *
- * @type {import('@pins/express').RenderHandler<{documentationFile: DocumentationFile, documentVersions: DocumentVersion[], showSuccessBanner: boolean|undefined, caseIsWelsh: boolean}, {}>}
+ * @type {import('@pins/express').RenderHandler<{documentationFile: DocumentationFile, documentVersions: DocumentVersion[], updateBannerText: string|undefined, showSuccessBanner: boolean|undefined, caseIsWelsh: boolean}, {}>}
  */
 export async function viewApplicationsCaseDocumentationProperties({ session }, response) {
 	const { caseId, caseIsWelsh, documentGuid } = response.locals;
 
 	const documentationFile = await getCaseDocumentationFileInfo(caseId, documentGuid);
 	const documentVersions = await getCaseDocumentationFileVersions(documentGuid);
-	const showSuccessBanner = getSuccessBanner(session);
+
+	const updateBannerText = getSessionBanner(session);
+	const showSuccessBanner = !!updateBannerText || getSuccessBanner(session);
+
+	deleteSessionBanner(session);
 	destroySuccessBanner(session);
 
 	response.render(`applications/case-documentation/properties/documentation-properties`, {
 		documentationFile,
 		documentVersions,
+		updateBannerText,
 		showSuccessBanner,
 		caseIsWelsh
 	});

--- a/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/documentation-properties.njk
@@ -10,6 +10,8 @@
 {% set pageTitle = case.title %}
 {% set serviceName = 'Project documentation' %}
 
+{% set bannerText = updateBannerText if updateBannerText else 'New version uploaded' %}
+
 {% block beforeContent %}
 <aside>
     {{ govukBackLink({
@@ -27,9 +29,10 @@
 					classes: 'govuk-!-margin-top-0',
 					items: breadcrumbItems
 				}) }}
+
 				{% set html %}
 					<h3 class="govuk-notification-banner__heading">
-						New version uploaded
+						{{ bannerText }}
 					</h3>
 				{% endset %}
 


### PR DESCRIPTION
## Describe your changes

Implement the ability to change s51 advice properties Welsh fields.

- Corrected the error messages to match those in the ticket for both "Who from" and "Who from in Welsh" pages
- Added the success banner when document properties are successfully updated
- Fixed unit tests to test changing s51 advice properties Welsh fields

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-497 Welsh - Document properties: 'Change' From (Welsh) field - functional changes
https://pins-ds.atlassian.net/browse/APPLICS-497

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
