### PR TITLE
fix(applications/web): project location in welsh content changes (APPLICS-499)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/createCase.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/createCase.spec.js
@@ -12,7 +12,6 @@ const projectInfo = projectInformation();
 const { applications: applicationsUsers } = users;
 
 describe('Create A Case', () => {
-
 	context('As a User', () => {
 		it('Should successfully create a case as a user', () => {
 			cy.login(applicationsUsers.caseAdmin);
@@ -49,7 +48,7 @@ describe('Create A Case', () => {
 
 			createCasePage.clickSaveAndContinue();
 			createCasePage.validateErrorMessageCountOnPage(3);
-			createCasePage.validateErrorMessage('Enter the project location');
+			createCasePage.validateErrorMessage('Enter project location');
 			createCasePage.validateErrorMessage('Enter the Grid reference Easting');
 			createCasePage.validateErrorMessage('Enter the Grid reference Northing');
 			createCasePage.sections.geographicalInformation.fillLocation(projectInfo.projectLocation);
@@ -76,5 +75,4 @@ describe('Create A Case', () => {
 			createCasePage.sections.caseCreated.validateCaseCreated();
 		});
 	});
-
 });

--- a/apps/e2e/cypress/e2e/back-office-applications/welsh.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/welsh.spec.js
@@ -55,13 +55,9 @@ function validateErrorMessageForProjectdesc() {
 }
 function validateErrorMessageForProjectlocation() {
 	casePage.clickChangeLink('Project location in Welsh');
-	cy.get(
-		'body > div:nth-child(4) > main:nth-child(2) > form:nth-child(2) > div:nth-child(3) > textarea'
-	).clear();
+	casePage.clearTextArea();
 	casePage.clickButtonByText('Save changes');
-	cy.get('#main-content > div > div > div > div > div > ul > li > a').contains(
-		'Enter the project location in Welsh'
-	);
+	casePage.validateErrorMessage('Enter project location in Welsh');
 }
 
 describe('Enable and update Project Information with Welsh fields', () => {
@@ -174,7 +170,7 @@ describe('Update project information to add a Welsh region', () => {
 				casePage.validateErrorMessageCountInSummary(3);
 				casePage.validateErrorMessageIsInSummary('Enter the name of the project in Welsh');
 				casePage.validateErrorMessageIsInSummary('Enter the description of the project in Welsh');
-				casePage.validateErrorMessageIsInSummary('Enter the project location in Welsh');
+				casePage.validateErrorMessageIsInSummary('Enter project location in Welsh');
 			}
 		});
 

--- a/apps/e2e/cypress/page_objects/basePage.js
+++ b/apps/e2e/cypress/page_objects/basePage.js
@@ -189,11 +189,15 @@ export class Page {
 		this.basePageElements.selectElem().select(optionNumber);
 	}
 
+	clearTextArea(index = 0) {
+		this.basePageElements.textArea().eq(index).clear();
+	}
+
 	fillInput(text, index = 0) {
 		this.basePageElements.input().eq(index).clear().type(text);
 	}
 
-	fillTextArea(text, index = 0) {
+	fillTextArea(text = '', index = 0) {
 		this.basePageElements.textArea().eq(index).clear().type(text);
 	}
 

--- a/apps/web/src/server/applications/applications.types.d.ts
+++ b/apps/web/src/server/applications/applications.types.d.ts
@@ -20,6 +20,11 @@ export type FormCaseLayout = {
 	pageTitle: string;
 	components: string[];
 	isEdit?: boolean;
+	label?: string;
+	englishLabel?: string;
+	name?: string;
+	englishName?: string;
+	template?: string;
 	backLink?: string;
 };
 

--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
@@ -27,7 +27,6 @@ const layouts = {
 	},
 	descriptionWelsh: {
 		label: 'Document description in Welsh',
-		hint: 'There is a limit of 800 characters',
 		pageTitle: 'Document description in Welsh',
 		englishLabel: 'Document description in English',
 		metaDataEnglishName: 'description',
@@ -66,7 +65,6 @@ const layouts = {
 	},
 	authorWelsh: {
 		label: 'Who the document is from in Welsh',
-		hint: 'There is a limit of 150 characters',
 		englishLabel: 'Who the document is from in English',
 		pageTitle: 'Who the document is from in Welsh',
 		metaDataName: 'authorWelsh',

--- a/apps/web/src/server/applications/case/edit/case/__tests__/__snapshots__/applications-edit-case.test.js.snap
+++ b/apps/web/src/server/applications/case/edit/case/__tests__/__snapshots__/applications-edit-case.test.js.snap
@@ -150,43 +150,40 @@ exports[`applications edit Name GET edit/name-welsh When feature flag is active 
 
 exports[`applications edit Name Project location GET /edit/:caseId/project-location should display resumed data if the API returns something 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h1 class=\\"govuk-heading-l\\"> Enter project location</h1>
-    <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
-        <div class=\\"govuk-form-group\\">
-            <div id=\\"geographicalInformation.locationDescription-hint\\" class=\\"govuk-hint govuk-!-width-three-quarters\\">for example, approximately 8km off the coast of Kent, in areas surrounding
-                Thanet Offshore Wind Farm</div>
-            <textarea class=\\"govuk-textarea govuk-!-width-three-quarters\\"
-            id=\\"geographicalInformation.locationDescription\\" name=\\"geographicalInformation.locationDescription\\"
-            rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescription-hint\\">London</textarea>
-        </div>
-        <div class=\\"govuk-grid-row\\">
-            <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
+    <div class=\\"govuk-grid-row\\">
+        <div class=\\"govuk-grid-column-two-thirds-from-desktop\\">
+            <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\">
+                <div class=\\"govuk-form-group\\">
+                    <h1 class=\\"govuk-label-wrapper\\"><label class=\\"govuk-label govuk-label--l\\" for=\\"geographicalInformation.locationDescription\\"> Project location</label></h1>
+                    <div id=\\"geographicalInformation.locationDescription-hint\\" class=\\"govuk-hint\\">for example, approximately 8km off the coast of Kent, in areas surrounding
+                        Thanet Offshore Wind Farm</div>
+                    <textarea class=\\"govuk-textarea\\" id=\\"geographicalInformation.locationDescription\\"
+                    name=\\"geographicalInformation.locationDescription\\" rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescription-hint\\">London</textarea>
+                </div>
                 <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save changes</button>
-            </div>
+            </form>
         </div>
-    </form>
+    </div>
 </main>"
 `;
 
 exports[`applications edit Name Project location GET edit/:caseId/project-location-welsh When feature flag is active should render page with english inset 1`] = `
 "<main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
-    <h1 class=\\"govuk-heading-l\\"> Project location in Welsh</h1>
-    <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
-        <p class='govuk-body govuk-!-margin-bottom-0'>Project location in English:</p>
-        <div class=\\"govuk-inset-text govuk-!-margin-top-4\\">London</div>
-        <div class=\\"govuk-form-group\\">
-            <div id=\\"geographicalInformation.locationDescriptionWelsh-hint\\" class=\\"govuk-hint govuk-!-width-three-quarters\\">for example, approximately 8km off the coast of Kent, in areas surrounding
-                Thanet Offshore Wind Farm</div>
-            <textarea class=\\"govuk-textarea govuk-!-width-three-quarters\\"
-            id=\\"geographicalInformation.locationDescriptionWelsh\\" name=\\"geographicalInformation.locationDescriptionWelsh\\"
-            rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescriptionWelsh-hint\\"></textarea>
-        </div>
-        <div class=\\"govuk-grid-row\\">
-            <div class=\\"govuk-button-group pins-button-group govuk-grid-column-one-half\\">
+    <div class=\\"govuk-grid-row\\">
+        <div class=\\"govuk-grid-column-two-thirds-from-desktop\\">
+            <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\">
+                <h1 class=\\"govuk-heading-l\\"> Project location in Welsh</h1>
+                <p class='govuk-body govuk-!-margin-bottom-0'>Project location in English:</p>
+                <div class=\\"govuk-inset-text\\">London</div>
+                <div class=\\"govuk-form-group\\">
+                    <label class=\\"govuk-label govuk-label--m\\" for=\\"geographicalInformation.locationDescriptionWelsh\\">Project location in Welsh</label>
+                    <textarea class=\\"govuk-textarea\\" id=\\"geographicalInformation.locationDescriptionWelsh\\"
+                    name=\\"geographicalInformation.locationDescriptionWelsh\\" rows=\\"5\\"></textarea>
+                </div>
                 <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save changes</button>
-            </div>
+            </form>
         </div>
-    </form>
+    </div>
 </main>"
 `;
 

--- a/apps/web/src/server/applications/case/edit/case/applications-edit-case.controller.js
+++ b/apps/web/src/server/applications/case/edit/case/applications-edit-case.controller.js
@@ -56,12 +56,21 @@ const teamEmailLayout = {
 const caseLocationLayout = {
 	pageTitle: 'Enter project location',
 	components: ['project-location'],
+	label: 'Project location',
+	name: 'geographicalInformation.locationDescription',
+	hint: 'for example, approximately 8km off the coast of Kent, in areas surrounding Thanet Offshore Wind Farm',
+	template: 'case-edit-textarea.njk',
 	isEdit: true
 };
 
 const caseLocationWelshLayout = {
 	pageTitle: 'Project location in Welsh',
 	components: ['project-location-welsh'],
+	label: 'Project location in Welsh',
+	englishLabel: 'Project location in English',
+	name: 'geographicalInformation.locationDescriptionWelsh',
+	englishName: 'geographicalInformation.locationDescription',
+	template: 'case-edit-textarea.njk',
 	isEdit: true
 };
 
@@ -124,10 +133,24 @@ const fullFieldNames = {
 export async function viewApplicationsEditCaseDescription(request, response) {
 	const properties = caseNameAndDescriptionData(request, response.locals);
 
-	response.render('applications/components/case-form/case-form-layout', {
+	response.render(resolveTemplate(descriptionLayout), {
 		...properties,
 		layout: descriptionLayout
 	});
+}
+
+/**
+ * Resolves the expected template to render
+ *
+ * @param {import('../../../applications.types.js').FormCaseLayout} layout
+ * @returns {string}
+ */
+function resolveTemplate(layout) {
+	const { template } = layout || {};
+	if (template) {
+		return `applications/case/case-form/${template}`;
+	}
+	return `applications/components/case-form/case-form-layout`;
 }
 
 /**
@@ -144,7 +167,7 @@ export async function viewApplicationsEditCaseDescriptionWelsh(request, response
 
 	const properties = caseNameAndDescriptionData(request, response.locals);
 
-	response.render('applications/components/case-form/case-form-layout', {
+	response.render(resolveTemplate(welshDescriptionLayout), {
 		...properties,
 		layout: welshDescriptionLayout
 	});
@@ -158,7 +181,7 @@ export async function viewApplicationsEditCaseDescriptionWelsh(request, response
 export async function viewApplicationsEditCaseName(request, response) {
 	const properties = caseNameAndDescriptionData(request, response.locals);
 
-	response.render('applications/components/case-form/case-form-layout', {
+	response.render(resolveTemplate(nameLayout), {
 		...properties,
 		layout: nameLayout
 	});
@@ -178,7 +201,7 @@ export async function viewApplicationsEditCaseNameWelsh(request, response) {
 
 	const properties = caseNameAndDescriptionData(request, response.locals);
 
-	response.render('applications/components/case-form/case-form-layout', {
+	response.render(resolveTemplate(welshNameLayout), {
 		...properties,
 		layout: welshNameLayout
 	});
@@ -228,7 +251,7 @@ export async function updateApplicationsEditCaseNameAndDescription(request, resp
 export async function viewApplicationsEditCaseTeamEmail(request, response) {
 	const properties = caseTeamEmailData(request, response.locals);
 
-	return response.render('applications/components/case-form/case-form-layout', {
+	return response.render(resolveTemplate(teamEmailLayout), {
 		...properties,
 		layout: teamEmailLayout
 	});
@@ -265,7 +288,7 @@ export async function updateApplicationsEditCaseTeamEmail(request, response) {
 export async function viewApplicationsEditCaseStage(request, response) {
 	const properties = await caseStageData(request, response.locals);
 
-	return response.render('applications/components/case-form/case-form-layout', {
+	return response.render(resolveTemplate(stageLayout), {
 		...properties,
 		layout: stageLayout
 	});
@@ -303,7 +326,7 @@ export async function updateApplicationsEditCaseStage(request, response) {
 export async function viewApplicationsCreateCaseLocation(request, response) {
 	const properties = await caseGeographicalInformationData(request, response.locals);
 
-	response.render('applications/components/case-form/case-form-layout', {
+	response.render(resolveTemplate(caseLocationLayout), {
 		...properties,
 		layout: caseLocationLayout
 	});
@@ -323,7 +346,7 @@ export async function viewApplicationsCreateCaseLocationWelsh(request, response)
 
 	const properties = await caseGeographicalInformationData(request, response.locals);
 
-	response.render('applications/components/case-form/case-form-layout', {
+	response.render(resolveTemplate(caseLocationWelshLayout), {
 		...properties,
 		layout: caseLocationWelshLayout
 	});
@@ -339,7 +362,7 @@ export async function viewApplicationsCreateCaseLocationWelsh(request, response)
 export async function viewApplicationsCreateCaseGridReferences(request, response) {
 	const properties = await caseGeographicalInformationData(request, response.locals);
 
-	response.render('applications/components/case-form/case-form-layout', {
+	response.render(resolveTemplate(gridReferencesLayout), {
 		...properties,
 		layout: gridReferencesLayout
 	});
@@ -364,12 +387,25 @@ export async function updateApplicationsEditCaseGeographicalInformation(request,
 		'geographicalInformation.gridReference.northing'
 	]);
 
-	const isCaseLocationPage = [
-		'geographicalInformation.locationDescription',
-		'geographicalInformation.locationDescriptionWelsh'
-	].includes(updatedField);
+	let layout;
 
-	const layout = isCaseLocationPage ? caseLocationLayout : gridReferencesLayout;
+	switch (updatedField) {
+		case 'geographicalInformation.locationDescription':
+			layout = caseLocationLayout;
+			break;
+		case 'geographicalInformation.locationDescriptionWelsh': {
+			layout = caseLocationWelshLayout;
+			// Include english equivalent if entered
+			const { locationDescription } = response.locals.currentCase?.geographicalInformation || {};
+			if (locationDescription) {
+				properties.values['geographicalInformation.locationDescription'] = locationDescription;
+			}
+			break;
+		}
+		default:
+			layout = gridReferencesLayout;
+			break;
+	}
 
 	if (properties.errors || !updatedCaseId) {
 		return handleErrors(properties, layout, response);
@@ -394,7 +430,7 @@ export async function updateApplicationsEditCaseGeographicalInformation(request,
 export async function viewApplicationsEditCaseRegions(request, response) {
 	const properties = await caseRegionsData(request, response.locals);
 
-	return response.render('applications/components/case-form/case-form-layout', {
+	return response.render(resolveTemplate(regionsLayout), {
 		...properties,
 		layout: regionsLayout
 	});
@@ -435,7 +471,7 @@ export async function updateApplicationsEditCaseRegions(request, response) {
 export async function viewApplicationsEditCaseZoomLevel(request, response) {
 	const properties = await caseZoomLevelData(request, response.locals);
 
-	return response.render('applications/components/case-form/case-form-layout', {
+	return response.render(resolveTemplate(zoomLevelLayout), {
 		...properties,
 		layout: zoomLevelLayout
 	});

--- a/apps/web/src/server/applications/case/edit/case/applications-edit-case.router.js
+++ b/apps/web/src/server/applications/case/edit/case/applications-edit-case.router.js
@@ -77,6 +77,7 @@ applicationsEditCaseRouter
 	)
 	.post(
 		validators.validateApplicationsCreateCaseLocationWelsh,
+		registerCaseWithQuery(['geographicalInformation']),
 		asyncHandler(controller.updateApplicationsEditCaseGeographicalInformation)
 	);
 

--- a/apps/web/src/server/applications/common/components/error-handler/error-handler.component.js
+++ b/apps/web/src/server/applications/common/components/error-handler/error-handler.component.js
@@ -9,7 +9,11 @@
  * @returns {*}
  */
 export const handleErrors = (properties, layout, response) => {
-	return response.render('applications/components/case-form/case-form-layout', {
+	const { template } = layout || {};
+	const fullTemplate = template
+		? `applications/case/case-form/${template}`
+		: `applications/components/case-form/case-form-layout`;
+	return response.render(fullTemplate, {
 		...properties,
 		layout
 	});

--- a/apps/web/src/server/applications/create-new-case/applications-create.service.js
+++ b/apps/web/src/server/applications/create-new-case/applications-create.service.js
@@ -38,9 +38,9 @@ export const getErrorMessageCaseCreate = (fieldName, existingError = null) => {
 		case 'gridReferenceNorthing':
 			return 'Enter the Grid reference Northing';
 		case 'projectLocation':
-			return 'Enter the project location';
+			return 'Enter project location';
 		case 'projectLocationWelsh':
-			return 'Enter the project location in Welsh';
+			return 'Enter project location in Welsh';
 		case 'regions':
 			return 'Choose at least one region';
 		case 'sector':

--- a/apps/web/src/server/applications/create-new-case/case/__tests__/__snapshots__/applications-create-case.test.js.snap
+++ b/apps/web/src/server/applications/create-new-case/case/__tests__/__snapshots__/applications-create-case.test.js.snap
@@ -160,7 +160,7 @@ exports[`applications create Geographical Information POST /create-new-case/:cas
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#geographicalInformation.locationDescription\\">Enter the project location</a>
+                            <li><a href=\\"#geographicalInformation.locationDescription\\">Enter project location</a>
                             </li>
                             <li><a href=\\"#geographicalInformation.gridReference.easting\\">Enter 6 digits for the Grid reference Easting</a>
                             </li>
@@ -180,7 +180,7 @@ exports[`applications create Geographical Information POST /create-new-case/:cas
             class=\\"govuk-hint govuk-!-width-three-quarters\\">for example, approximately 8km off the coast of Kent, in areas surrounding
                 Thanet Offshore Wind Farm</div>
             <p id=\\"geographicalInformation.locationDescription-error\\"
-            class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter the project location</p>
+            class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter project location</p>
             <textarea             class=\\"govuk-textarea govuk-textarea--error govuk-!-width-three-quarters\\"
             id=\\"geographicalInformation.locationDescription\\" name=\\"geographicalInformation.locationDescription\\"
             rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescription-hint geographicalInformation.locationDescription-error\\"></textarea>
@@ -225,7 +225,7 @@ exports[`applications create Geographical Information POST /create-new-case/:cas
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#geographicalInformation.locationDescription\\">Enter the project location</a>
+                            <li><a href=\\"#geographicalInformation.locationDescription\\">Enter project location</a>
                             </li>
                             <li><a href=\\"#geographicalInformation.gridReference.easting\\">Enter the Grid reference Easting</a>
                             </li>
@@ -245,7 +245,7 @@ exports[`applications create Geographical Information POST /create-new-case/:cas
             class=\\"govuk-hint govuk-!-width-three-quarters\\">for example, approximately 8km off the coast of Kent, in areas surrounding
                 Thanet Offshore Wind Farm</div>
             <p id=\\"geographicalInformation.locationDescription-error\\"
-            class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter the project location</p>
+            class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter project location</p>
             <textarea             class=\\"govuk-textarea govuk-textarea--error govuk-!-width-three-quarters\\"
             id=\\"geographicalInformation.locationDescription\\" name=\\"geographicalInformation.locationDescription\\"
             rows=\\"5\\" aria-describedby=\\"geographicalInformation.locationDescription-hint geographicalInformation.locationDescription-error\\"></textarea>

--- a/apps/web/src/server/applications/create-new-case/case/applications-create-case.validators.js
+++ b/apps/web/src/server/applications/create-new-case/case/applications-create-case.validators.js
@@ -61,7 +61,7 @@ export const validateApplicationsCreateCaseLocation = createValidator(
 		.isLength({ min: 1 })
 		.withMessage(getErrorMessageCaseCreate('projectLocation'))
 		.isLength({ max: 500 })
-		.withMessage('The project location must be 500 characters or fewer')
+		.withMessage('Project location must be 500 characters or less')
 );
 
 export const validateApplicationsCreateCaseLocationWelsh = createValidator(
@@ -70,7 +70,7 @@ export const validateApplicationsCreateCaseLocationWelsh = createValidator(
 		.isLength({ min: 1 })
 		.withMessage(getErrorMessageCaseCreate('projectLocationWelsh'))
 		.isLength({ max: 500 })
-		.withMessage('The project location must be 500 characters or fewer')
+		.withMessage('Project location in Welsh must be 500 characters or less')
 );
 
 export const validateApplicationsCreateCaseEasting = createValidator(

--- a/apps/web/src/server/applications/create-new-case/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
+++ b/apps/web/src/server/applications/create-new-case/check-your-answers/__tests__/__snapshots__/applications-create-check-your-answers.test.js.snap
@@ -189,7 +189,7 @@ exports[`applications create: check your answers Check your answers POST /check-
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#projectLocation\\">Enter the project location</a>
+                            <li><a href=\\"#projectLocation\\">Enter project location</a>
                             </li>
                             <li><a href=\\"#subSector\\">Choose the subsector of the project</a>
                             </li>

--- a/apps/web/src/server/applications/create-new-case/check-your-answers/__tests__/applications-create-check-your-answers.test.js
+++ b/apps/web/src/server/applications/create-new-case/check-your-answers/__tests__/applications-create-check-your-answers.test.js
@@ -84,7 +84,7 @@ describe('applications create: check your answers', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('Enter the project location');
+				expect(element.innerHTML).toContain('Enter project location');
 				expect(element.innerHTML).toContain('Choose the subsector of the project');
 				expect(element.innerHTML).toContain('Choose the sector of the project');
 				expect(element.innerHTML).toContain('Choose at least one region');

--- a/apps/web/src/server/views/applications/case/case-form/case-edit-textarea.njk
+++ b/apps/web/src/server/views/applications/case/case-form/case-edit-textarea.njk
@@ -1,0 +1,15 @@
+{% extends "../layouts/case-property.layout.njk" %}
+{% from "../../components/textarea-form-component.njk" import textareaFormComponent %}
+
+{% block formContent %}
+	{{ textareaFormComponent({
+		value: errors[layout.name].value if errors[layout.name] else values[layout.name],
+		name: layout.name,
+		label: layout.label,
+		hint: layout.hint,
+		englishValue: values[layout.englishName] if values[layout.englishName] else null,
+		englishLabel: layout.englishLabel,
+		errorMessage: errors[layout.name]
+	}) }}
+{% endblock %}
+

--- a/apps/web/src/server/views/applications/case/layouts/applications-case-layout.njk
+++ b/apps/web/src/server/views/applications/case/layouts/applications-case-layout.njk
@@ -21,6 +21,7 @@
 
 {% block pageHeading %}
 	<div class="top-errors-hook" role="alert"></div>
+	{% block pageSuccessBanner %}{% endblock %}
 	{% if not isGeneralS51folder %}
 		<div class="govuk-grid-row govuk-!-padding-top-9 govuk-!-padding-bottom-2 govuk-!-margin-left-0 govuk-!-margin-bottom-7 pins-masthead-summary">
 			<div class="govuk-grid-column-full">

--- a/apps/web/src/server/views/applications/case/layouts/case-property.layout.njk
+++ b/apps/web/src/server/views/applications/case/layouts/case-property.layout.njk
@@ -1,0 +1,27 @@
+{% extends "../../layouts/applications.layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block pageHeading %}{% endblock %}
+
+{% block beforeContent %}
+	{% set breadcrumbBackLink = 'dashboard'|url if layout.backLink == 'dashboard' else 'case-create'|url({caseId:caseId, step: layout.backLink}) %}
+	{% set computedBackLink = backPath if backPath else breadcrumbBackLink %}
+	{{ govukBackLink({
+		classes: 'govuk-!-margin-top-3',
+		text: "Back",
+		href: 'case-create'|url({caseId:caseId, step:'check-your-answers'}) if layout.isEdit and isDraft else computedBackLink
+	}) }}
+{% endblock %}
+
+{% block pageContent %}
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-two-thirds-from-desktop">
+			<form method="post" action="" novalidate="novalidate">
+				{% block formContent %}{% endblock %}
+				{% block formSubmitButton %}
+					{{ govukButton({ text: 'Save changes' }) }}
+				{% endblock %}
+			</form>
+		</div>
+	</div>
+{% endblock %}

--- a/apps/web/src/server/views/applications/case/overview.njk
+++ b/apps/web/src/server/views/applications/case/overview.njk
@@ -7,11 +7,13 @@
 
 {% set serviceName = 'Overview'%}
 
-{% block sectionContent %}
-  {% if banner %}
-    {{ govukNotificationBanner({ type: 'success', html: '<strong>' + banner + '</strong>' }) }}
-  {% endif %}
+{% block pageSuccessBanner %}
+	{% if banner %}
+		{{ govukNotificationBanner({ type: 'success', html: '<strong>' + banner + '</strong>' }) }}
+	{% endif %}
+{% endblock %}
 
+{% block sectionContent %}
 	<h2 class="govuk-heading-m">{{serviceName}}</h2>
 	<div class="govuk-!-margin-top-6">
 		<form method="post">

--- a/apps/web/src/server/views/applications/components/textarea-form-component.njk
+++ b/apps/web/src/server/views/applications/components/textarea-form-component.njk
@@ -24,6 +24,7 @@
 						classes: "govuk-label--l" if options.englishValue == null else "govuk-label--m",
 						isPageHeading: true if options.englishValue == null
 					},
+					hint: { text: options.hint } if options.hint,
 					errorMessage: options.errorMessage | errorMessage,
 					value: options.value
 				}) }}


### PR DESCRIPTION
## Describe your changes

Implement the content and template structure changes requested in the ticket.

- Corrected the error messages to match those in the ticket for both "Project location" and "Project location in Welsh" pages
- Created a new layout and template to accommodate the design changes and reuse the textarea component
- Extended the config for layouts to include english and welsh field names and template reference
- Moved the success banner when properties are successfully updated to match the figma design
- Fixed unit tests and snap shots to match new changes

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-499 Welsh - Overview page: Project location (Welsh) 'Change' page - Content changes
https://pins-ds.atlassian.net/browse/APPLICS-499

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
