### PR TITLE
fix(web/applications): correct error when document description too long

### DIFF
--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
@@ -335,7 +335,7 @@ exports[`Edit applications documentation metadata Edit description POST /case/12
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#description\\">The description must be 800 characters or fewer</a>
+                            <li><a href=\\"#description\\">Document description must be 800 characters or less</a>
                             </li>
                         </ul>
                     </div>
@@ -350,8 +350,8 @@ exports[`Edit applications documentation metadata Edit description POST /case/12
                 <div class=\\"govuk-form-group govuk-form-group--error\\">
                     <label class=\\"govuk-label font-weight--700\\" for=\\"description\\">Description of the document</label>
                     <div id=\\"description-hint\\" class=\\"govuk-hint\\">There is a limit of 800 characters</div>
-                    <p id=\\"description-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The description must
-                        be 800 characters or fewer</p>
+                    <p id=\\"description-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Document description
+                        must be 800 characters or less</p>
                     <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
                     id=\\"description\\" name=\\"description\\" type=\\"text\\" value=\\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\"
                     aria-describedby=\\"description-hint\\" maxlength=\\"800\\">
@@ -433,7 +433,7 @@ exports[`Edit applications documentation metadata Edit description in Welsh POST
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#descriptionWelsh\\">The description must be 800 characters or fewer</a>
+                            <li><a href=\\"#descriptionWelsh\\">Document description in Welsh must be 800 characters or less</a>
                             </li>
                         </ul>
                     </div>
@@ -449,8 +449,8 @@ exports[`Edit applications documentation metadata Edit description in Welsh POST
                 <div class=\\"govuk-inset-text\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</div>
                 <div class=\\"govuk-form-group govuk-form-group--error\\">
                     <label class=\\"govuk-label govuk-label--m\\" for=\\"descriptionWelsh\\">Document description in Welsh</label>
-                    <p id=\\"descriptionWelsh-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> The description must
-                        be 800 characters or fewer</p>
+                    <p id=\\"descriptionWelsh-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Document description
+                        in Welsh must be 800 characters or less</p>
                     <textarea class=\\"govuk-textarea govuk-textarea--error\\"
                     id=\\"descriptionWelsh\\" name=\\"descriptionWelsh\\" rows=\\"5\\" aria-describedby=\\"descriptionWelsh-error\\">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</textarea>
                 </div>

--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/documentation-metadata.test.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/documentation-metadata.test.js
@@ -161,7 +161,9 @@ describe('Edit applications documentation metadata', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('The description must be 800 characters or fewer');
+				expect(element.innerHTML).toContain(
+					'Document description in Welsh must be 800 characters or less'
+				);
 			});
 
 			it('should redirect to document properties page if there is no error', async () => {

--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.validators.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.validators.js
@@ -57,7 +57,7 @@ export const validateDocumentationMetaDescription = createValidator(
 		.isLength({ min: 1 })
 		.withMessage('You must enter a description of the document')
 		.isLength({ max: 800 })
-		.withMessage('The description must be 800 characters or fewer')
+		.withMessage('Document description must be 800 characters or less')
 );
 
 export const validateDocumentationMetaDescriptionWelsh = createValidator(
@@ -66,7 +66,7 @@ export const validateDocumentationMetaDescriptionWelsh = createValidator(
 		.isLength({ min: 1 })
 		.withMessage('You must enter a description of the document in Welsh')
 		.isLength({ max: 800 })
-		.withMessage('The description must be 800 characters or fewer')
+		.withMessage('Document description in Welsh must be 800 characters or less')
 );
 
 export const validateDocumentationMetaAuthor = createValidator(


### PR DESCRIPTION
## Describe your changes

Correct the error shown to the user when the description entered is more than 800 characters.

## Issue ticket number and link

[APPLICS-520](https://pins-ds.atlassian.net.mcas.ms/browse/APPLICS-520?McasTsid=20596&McasCtx=4)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-520]: https://pins-ds.atlassian.net/browse/APPLICS-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ