### PR TITLE
fix(api): bach DB updates for  Reps to avoid Prisma limit

### DIFF
--- a/apps/api/src/server/applications/application/representations/publish/publish.service.js
+++ b/apps/api/src/server/applications/application/representations/publish/publish.service.js
@@ -1,6 +1,6 @@
 import * as representationsRepository from '#repositories/representation.repository.js';
 import { EventType } from '@pins/event-client';
-import { setRepresentationsAsPublished } from '#repositories/representation.repository.js';
+import { setRepresentationsAsPublishedBatch } from '#repositories/representation.repository.js';
 import { broadcastNsipRepresentationPublishEventBatch } from '#infrastructure/event-broadcasters.js';
 
 /**
@@ -17,7 +17,7 @@ export const publishCaseRepresentations = async (caseId, representationIds, acti
 	if (representations.length > 0) {
 		await broadcastNsipRepresentationPublishEventBatch(representations, EventType.Publish, caseId);
 
-		await setRepresentationsAsPublished(representations, actionBy);
+		await setRepresentationsAsPublishedBatch(representations, actionBy);
 	}
 
 	return representations;

--- a/apps/api/src/server/repositories/representation.repository.js
+++ b/apps/api/src/server/repositories/representation.repository.js
@@ -619,6 +619,22 @@ export const setRepresentationsAsPublished = async (representations, actionBy) =
 };
 
 /**
+ * Sets representations as 'published' in batches
+ * This is required as there is a limit in prisma for the amount of parameters to update in one go
+ * @param {Prisma.RepresentationSelect[]} representations
+ * @param {string} actionBy User performing publish action
+ * @returns {Promise<void>}
+ */
+export const setRepresentationsAsPublishedBatch = async (representations, actionBy) => {
+	const batchSize = 1000;
+	for (let i = 0; i < representations.length; i += batchSize) {
+		const batch = representations.slice(i, i + batchSize);
+		await setRepresentationsAsPublished(batch, actionBy);
+		console.info(`updated representations from range ${i} - ${i + batch.length}`);
+	}
+};
+
+/**
  *
  * @param {number} caseId
  * @param {number} skip


### PR DESCRIPTION
## Describe your changes

Fix to batch DB updates in batches of 1000 for representation updates.  This was causing failures on publishing over 2000 representations.
Unit test has was not originally done for the repository function setRepresentationsAsPublished.  Not added here as it would require a refactor and large amount of mocks of prisma representation object.

Batching has been tested locally and will be tested and validated in dev against case BC0110001 with 5000 reps.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/APPLICS-270

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
