### PR TITLE
fix(applications/web): s51 advice unable to update enquiry details (APPLICS-518)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/s51Advice.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/s51Advice.spec.js
@@ -77,6 +77,24 @@ describe('Section 51 Advice', () => {
 		});
 	});
 
+	describe('updating English fields', () => {
+		beforeEach(() => {
+			cy.login(applicationsUsers.caseAdmin);
+			cy.visit('/');
+			applicationsHomePage.searchFor(Cypress.env('currentCreatedCase'));
+			searchResultsPage.clickTopSearchResult();
+			s51AdvicePage.clickLinkByText(texts.projectDocumentationLinkText);
+			s51AdvicePage.clickLinkByText(texts.s51AdviceLinkText);
+		});
+
+		it('As a user able to update the enquiry details', () => {
+			s51AdvicePage.clickLinkByText('View/edit advice');
+			s51AdvicePage.clickLinkByText('Enquiry details');
+			s51AdvicePage.fillEnquiryDetail('enquiry details updated');
+			s51AdvicePage.validateBannerMessage('Enquiry details updated');
+		});
+	});
+
 	describe('updating region to be Wales', () => {
 		beforeEach(() => {
 			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {

--- a/apps/e2e/cypress/page_objects/s51AdvicePage.js
+++ b/apps/e2e/cypress/page_objects/s51AdvicePage.js
@@ -83,6 +83,11 @@ export class S51AdvicePage extends Page {
 		this.clickContinue();
 	}
 
+	fillEnquiryDetail(enquiryDetails) {
+		this.elements.enquiryDetailsInput().clear().type(enquiryDetails);
+		this.clickSaveAndReturn();
+	}
+
 	fillEnquiryDetails(opts) {
 		this.elements.enquiryDayInput().type(opts.day);
 		this.elements.enquiryMonthInput().type(opts.month);
@@ -90,6 +95,7 @@ export class S51AdvicePage extends Page {
 		this.elements.enquiryDetailsInput().type(opts.enquiryDetails);
 		this.clickContinue();
 	}
+
 	fillEnquiryDetailsWelsh(enquiryDetailsWelsh, isEdit) {
 		this.elements.enquiryDetailsWelshInput().clear().type(enquiryDetailsWelsh);
 		this.clickSaveAndReturn();
@@ -98,6 +104,11 @@ export class S51AdvicePage extends Page {
 	fillAdviserDetails(adviserName) {
 		this.elements.adviserInput().type(adviserName);
 		this.clickContinue();
+	}
+
+	fillAdviceDetail(adviceDetails) {
+		this.elements.adviceDetailsInput().clear().type(adviceDetails);
+		this.clickSaveAndReturn();
 	}
 
 	fillAdviceDetails(opts) {

--- a/apps/web/src/server/applications/case/s51/applications-s51.controller.js
+++ b/apps/web/src/server/applications/case/s51/applications-s51.controller.js
@@ -51,6 +51,7 @@ const s51Steps = {
 	enquirer: { name: 'Enquirer', nextPage: 'method' },
 	method: { name: 'Enquiry method', nextPage: 'enquiry-details' },
 	'enquiry-date': { name: 'Enquiry date' },
+	'enquiry-detail': { name: 'Enquiry details' },
 	'enquiry-details': {
 		name: 'Enquiry details',
 		nextPage: 'person'
@@ -60,6 +61,7 @@ const s51Steps = {
 	},
 	person: { name: 'Advice given by', nextPage: 'advice-details' },
 	'advice-date': { name: 'Date advice given' },
+	'advice-detail': { name: 'Advice given' },
 	'advice-details': {
 		name: 'Advice given',
 		nextPage: 'check-your-answers'


### PR DESCRIPTION
## Describe your changes

The bug was fixed with the changes as described

- Added missing step config for both Enquiry detail and Advice detail
- Added a new e2e test

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-518 On S51 advice properties page - Unable to update the existing data for enquiry details 
https://pins-ds.atlassian.net/browse/APPLICS-518

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
