### PR TITLE
fix(applications/web): document description in welsh message is incorrect (APPLICS-521)

### DIFF
--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/__snapshots__/documentation-metadata.test.js.snap
@@ -294,7 +294,7 @@ exports[`Edit applications documentation metadata Edit description POST /case/12
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#description\\">You must enter a description of the document</a>
+                            <li><a href=\\"#description\\">Enter document description</a>
                             </li>
                         </ul>
                     </div>
@@ -309,10 +309,9 @@ exports[`Edit applications documentation metadata Edit description POST /case/12
                 <div class=\\"govuk-form-group govuk-form-group--error\\">
                     <label class=\\"govuk-label font-weight--700\\" for=\\"description\\">Description of the document</label>
                     <div id=\\"description-hint\\" class=\\"govuk-hint\\">There is a limit of 800 characters</div>
-                    <p id=\\"description-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter a description
-                        of the document</p>
-                    <input class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\"
-                    id=\\"description\\" name=\\"description\\" type=\\"text\\" value=\\"\\" aria-describedby=\\"description-hint\\"
+                    <p id=\\"description-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter document description</p>
+                    <input                     class=\\"govuk-input govuk-!-width-two-thirds govuk-input--error\\" id=\\"description\\"
+                    name=\\"description\\" type=\\"text\\" value=\\"\\" aria-describedby=\\"description-hint\\"
                     maxlength=\\"800\\">
                 </div>
                 <div class=\\"govuk-grid-row\\">
@@ -396,7 +395,7 @@ exports[`Edit applications documentation metadata Edit description in Welsh POST
                     <h2 class=\\"govuk-error-summary__title\\"> There is a problem</h2>
                     <div class=\\"govuk-error-summary__body\\">
                         <ul class=\\"govuk-list govuk-error-summary__list\\">
-                            <li><a href=\\"#descriptionWelsh\\">You must enter a description of the document in Welsh</a>
+                            <li><a href=\\"#descriptionWelsh\\">Enter document description in Welsh</a>
                             </li>
                         </ul>
                     </div>
@@ -412,10 +411,10 @@ exports[`Edit applications documentation metadata Edit description in Welsh POST
                 <div class=\\"govuk-inset-text\\">Ullamco laboris nisi ut aliquip ex ea commodo consequat</div>
                 <div class=\\"govuk-form-group govuk-form-group--error\\">
                     <label class=\\"govuk-label govuk-label--m\\" for=\\"descriptionWelsh\\">Document description in Welsh</label>
-                    <p id=\\"descriptionWelsh-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> You must enter a description
-                        of the document in Welsh</p>
-                    <textarea class=\\"govuk-textarea govuk-textarea--error\\"
-                    id=\\"descriptionWelsh\\" name=\\"descriptionWelsh\\" rows=\\"5\\" aria-describedby=\\"descriptionWelsh-error\\"></textarea>
+                    <p id=\\"descriptionWelsh-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter document description
+                        in Welsh</p>
+                    <textarea class=\\"govuk-textarea govuk-textarea--error\\" id=\\"descriptionWelsh\\"
+                    name=\\"descriptionWelsh\\" rows=\\"5\\" aria-describedby=\\"descriptionWelsh-error\\"></textarea>
                 </div>
                 <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">Save and return</button>
             </form>

--- a/apps/web/src/server/applications/case/documentation-metadata/__tests__/documentation-metadata.test.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/__tests__/documentation-metadata.test.js
@@ -108,7 +108,7 @@ describe('Edit applications documentation metadata', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('You must enter a description of the document');
+				expect(element.innerHTML).toContain('Enter document description');
 			});
 
 			it('should return an error if value length > 800', async () => {
@@ -149,9 +149,7 @@ describe('Edit applications documentation metadata', () => {
 				const element = parseHtml(response.text);
 
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain(
-					'You must enter a description of the document in Welsh'
-				);
+				expect(element.innerHTML).toContain('Enter document description in Welsh');
 			});
 
 			it('should return an error if value length > 800', async () => {

--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.validators.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.validators.js
@@ -55,7 +55,7 @@ export const validateDocumentationMetaDescription = createValidator(
 	body('description')
 		.trim()
 		.isLength({ min: 1 })
-		.withMessage('You must enter a description of the document')
+		.withMessage('Enter document description')
 		.isLength({ max: 800 })
 		.withMessage('Document description must be 800 characters or less')
 );
@@ -64,7 +64,7 @@ export const validateDocumentationMetaDescriptionWelsh = createValidator(
 	body('descriptionWelsh')
 		.trim()
 		.isLength({ min: 1 })
-		.withMessage('You must enter a description of the document in Welsh')
+		.withMessage('Enter document description in Welsh')
 		.isLength({ max: 800 })
 		.withMessage('Document description in Welsh must be 800 characters or less')
 );


### PR DESCRIPTION
## Describe your changes

The bug was fixed with the changes as described

- Corrected wording in validation text for Welsh

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-521 On document properties page - Error message for Document description in Welsh is not matching with AC
https://pins-ds.atlassian.net/browse/APPLICS-521

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
