### PR TITLE
fix(applications/web): project location details not retained (APPLICS-427)

### DIFF
--- a/apps/web/src/server/applications/common/components/form/form-case.component.js
+++ b/apps/web/src/server/applications/common/components/form/form-case.component.js
@@ -214,8 +214,10 @@ export async function caseGeographicalInformationDataUpdate(
 			body['geographicalInformation.gridReference.northing']
 	};
 
-	const { errors: apiErrors, id: updatedCaseId } = await updateCase(caseId, payload);
-	const properties = { errors: validationErrors || apiErrors, values };
+	const { errors, id: updatedCaseId } = validationErrors
+		? { errors: validationErrors, id: caseId }
+		: await updateCase(caseId, payload);
+	const properties = { errors, values };
 
 	return { properties, updatedCaseId };
 }


### PR DESCRIPTION
## Describe your changes

The bug was fixed with the changes as described

- Prevent update when validation fails

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-427 Project Location details not retained
https://pins-ds.atlassian.net/browse/APPLICS-427

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
