### PR TITLE
fix(applications/web): success banner missing text when updating document status (APPLICS-522)

### DIFF
--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
@@ -90,6 +90,7 @@ const layouts = {
 			{ value: 'not_redacted', text: 'Unredacted' }
 		],
 		pageTitle: 'Select the redaction status',
+		label: 'Redaction',
 		metaDataName: 'redactedStatus'
 	},
 	'published-status': {
@@ -100,6 +101,7 @@ const layouts = {
 			{ value: 'do_not_publish', text: 'Do not publish' }
 		],
 		pageTitle: 'Select the document status',
+		label: 'Status',
 		metaDataName: 'publishedStatus'
 	},
 	transcript: {


### PR DESCRIPTION
## Describe your changes

The bug was fixed with the changes as described

- Add labels for status and redaction.  Note that the labels form part of the success banner

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-522 Documents: Success banner missing text when updating document status
https://pins-ds.atlassian.net/browse/APPLICS-522

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
