### PR TITLE
fix(web): send publish representations in batches

### DIFF
--- a/apps/web/src/server/applications/case/representations/__fixtures__/publishable-representations.fixture.js
+++ b/apps/web/src/server/applications/case/representations/__fixtures__/publishable-representations.fixture.js
@@ -34,3 +34,30 @@ export const publishableRepresentationsFixture = {
 		}
 	]
 };
+
+/**
+ * Used to generate large number of representation items
+ *
+ * @param {any} fixture
+ * @param {number} count
+ * @return {any}
+ */
+export function generateAdditionalItems(fixture, count) {
+	const baseItems = fixture.items;
+	const newItems = [...baseItems];
+
+	let currentId = baseItems.length + 1;
+
+	for (let i = 0; i < count; i++) {
+		const baseItem = baseItems[i % baseItems.length];
+		const newItem = { ...baseItem, id: currentId };
+		newItems.push(newItem);
+		currentId++;
+	}
+
+	return {
+		...fixture,
+		itemCount: newItems.length,
+		items: newItems
+	};
+}

--- a/apps/web/src/server/applications/case/representations/utils/publish-representations.js
+++ b/apps/web/src/server/applications/case/representations/utils/publish-representations.js
@@ -28,7 +28,8 @@ export const getPublishRepresentationsPayload = (session, representationIds) => 
 export const getNumberOfRepresentationsPublished = ({ publishedRepIds }) => {
 	const numberOfRepresentationsPublished = publishedRepIds.length;
 
-	if (!numberOfRepresentationsPublished) throw new Error('No representations were published');
+	if (!numberOfRepresentationsPublished)
+		throw new Error('No representations in batch were published');
 
 	return numberOfRepresentationsPublished;
 };


### PR DESCRIPTION
## Describe your changes

Changes for BOAS web to publish representations in batches.  This is due to the slow publishing of over 1500 reps which causes the front end to timeout.
This will be rare but we need to handle the odd occasion when a large number of reps will be published.

Error handling for a publish error on a particular batch causes an exception and redirect to error page (as before).
This process is idempotent so the expectation is for user to retry.

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/APPLICS-270

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
