### PR TITLE
fix(functions): fix construct uri bug

### DIFF
--- a/apps/functions/applications-migration/common/back-office-api-client.js
+++ b/apps/functions/applications-migration/common/back-office-api-client.js
@@ -61,7 +61,7 @@ const constructAuthenticatedRequest = () => {
  * @param {Record<string, string>} params
  * @returns {string}
  */
-const constructUri = (path, params) => {
+const constructUri = (path, params = {}) => {
 	const reqParams = new URLSearchParams();
 	const scheme = config.apiHost?.match(/localhost/) ? 'http' : 'https';
 	Object.keys(params).forEach((key) => {


### PR DESCRIPTION
## Describe your changes

Fix small bug with `constructUri` function where `params` is not passed in

```
// no 2nd arg causes error
> constructUri('/migration/validate')
Uncaught TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at constructUri (REPL17:4:9)
```

## Issue ticket number and link

N/A

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
