### PR TITLE
fix(functions): workaround for s51 caseid validation error

### DIFF
--- a/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
+++ b/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
@@ -83,6 +83,7 @@ export const getNsipS51Advice = async (log, caseReference, synapseQuery = query)
 		}
 		return {
 			...pick(row, s51AdviceProperties),
+			caseId: Number(row.caseId), // TODO: remove after ODW-1307 is completed
 			status: mapStatus(row.status),
 			attachmentIds: row.attachmentIds ? row.attachmentIds?.split(',') : []
 		};


### PR DESCRIPTION
## Describe your changes

ODW issue with `caseId` in `nsip_s51_advice` table causes schema validation to fail (should be number, is a string). This PR adds a workaround until it is fixed, which is being tracked ODW-1307

## Issue ticket number and link

N/A

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
