### PR TITLE
fix(applications/web): static text is not required for project name in welsh field (APPLICS-567)

### DIFF
--- a/apps/web/src/server/applications/case/edit/case/__tests__/__snapshots__/applications-edit-case.test.js.snap
+++ b/apps/web/src/server/applications/case/edit/case/__tests__/__snapshots__/applications-edit-case.test.js.snap
@@ -90,9 +90,8 @@ exports[`applications edit Name GET /edit/name When status is Non-draft: should 
     <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-3\\"> Project name</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <div class=\\"govuk-form-group\\">
-            <div id=\\"title-hint\\" class=\\"govuk-hint\\"></div>
-            <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\" id=\\"title\\"
-            name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-hint\\">Title CASE/04</textarea>
+            <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\" id=\\"title\\" name=\\"title\\"
+            rows=\\"5\\">Title CASE/04</textarea>
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group govuk-grid-column-one-half\\">
@@ -108,9 +107,8 @@ exports[`applications edit Name GET /edit/name should render form 1`] = `
     <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-3\\"> Project name</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <div class=\\"govuk-form-group\\">
-            <div id=\\"title-hint\\" class=\\"govuk-hint\\"></div>
-            <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\" id=\\"title\\"
-            name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-hint\\">Title CASE/04</textarea>
+            <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\" id=\\"title\\" name=\\"title\\"
+            rows=\\"5\\">Title CASE/04</textarea>
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group govuk-grid-column-one-half\\">
@@ -129,9 +127,8 @@ exports[`applications edit Name GET edit/name-welsh When feature flag is active 
         <div class=\\"govuk-inset-text govuk-!-margin-top-4\\">Title CASE/08</div>
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"titleWelsh\\">Project name in Welsh</label>
-            <div id=\\"titleWelsh-hint\\" class=\\"govuk-hint\\">for example, Bridge over a very long canyon</div>
             <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\"
-            id=\\"titleWelsh\\" name=\\"titleWelsh\\" rows=\\"5\\" aria-describedby=\\"titleWelsh-hint\\"></textarea>
+            id=\\"titleWelsh\\" name=\\"titleWelsh\\" rows=\\"5\\"></textarea>
         </div>
         <div class=\\"govuk-grid-row\\">
             <div class=\\"govuk-button-group govuk-grid-column-one-half\\">

--- a/apps/web/src/server/applications/create-new-case/case/__tests__/__snapshots__/applications-create-case.test.js.snap
+++ b/apps/web/src/server/applications/create-new-case/case/__tests__/__snapshots__/applications-create-case.test.js.snap
@@ -286,9 +286,8 @@ exports[`applications create Name and description GET /create-new-case should re
     <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-3\\"> Enter name and description</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <div class=\\"govuk-form-group\\">
-            <div id=\\"title-hint\\" class=\\"govuk-hint\\"></div>
-            <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\" id=\\"title\\"
-            name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-hint\\"></textarea>
+            <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\" id=\\"title\\" name=\\"title\\"
+            rows=\\"5\\"></textarea>
         </div>
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"description\\">Description of the project</label>
@@ -324,9 +323,8 @@ exports[`applications create Name and description GET /create-new-case/1 should 
     <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-3\\"> Enter name and description</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <div class=\\"govuk-form-group\\">
-            <div id=\\"title-hint\\" class=\\"govuk-hint\\"></div>
-            <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\" id=\\"title\\"
-            name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-hint\\">Title CASE/01</textarea>
+            <textarea class=\\"govuk-textarea govuk-!-width-two-thirds\\" id=\\"title\\" name=\\"title\\"
+            rows=\\"5\\">Title CASE/01</textarea>
         </div>
         <div class=\\"govuk-form-group\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"description\\">Description of the project</label>
@@ -368,11 +366,10 @@ exports[`applications create Name and description POST /create-new-case/:id Api-
     <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-3\\"> Enter name and description</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <div class=\\"govuk-form-group govuk-form-group--error\\">
-            <div id=\\"title-hint\\" class=\\"govuk-hint\\"></div>
             <p id=\\"title-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Some error message from
                 API</p>
             <textarea class=\\"govuk-textarea govuk-textarea--error govuk-!-width-two-thirds\\"
-            id=\\"title\\" name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-hint title-error\\">A title</textarea>
+            id=\\"title\\" name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-error\\">A title</textarea>
         </div>
         <div class=\\"govuk-form-group govuk-form-group--error\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"description\\">Description of the project</label>
@@ -413,11 +410,10 @@ exports[`applications create Name and description POST /create-new-case/:id Api-
     <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-3\\"> Enter name and description</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <div class=\\"govuk-form-group govuk-form-group--error\\">
-            <div id=\\"title-hint\\" class=\\"govuk-hint\\"></div>
             <p id=\\"title-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Some error message from
                 API</p>
             <textarea class=\\"govuk-textarea govuk-textarea--error govuk-!-width-two-thirds\\"
-            id=\\"title\\" name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-hint title-error\\">A title</textarea>
+            id=\\"title\\" name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-error\\">A title</textarea>
         </div>
         <div class=\\"govuk-form-group govuk-form-group--error\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"description\\">Description of the project</label>
@@ -458,10 +454,9 @@ exports[`applications create Name and description POST /create-new-case/:id Web-
     <h1 class=\\"govuk-heading-l govuk-!-margin-bottom-3\\"> Enter name and description</h1>
     <form method=\\"post\\" action=\\"\\" novalidate=\\"novalidate\\" class=\\"pins-applications-create\\">
         <div class=\\"govuk-form-group govuk-form-group--error\\">
-            <div id=\\"title-hint\\" class=\\"govuk-hint\\"></div>
             <p id=\\"title-error\\" class=\\"govuk-error-message\\"><span class=\\"govuk-visually-hidden\\">Error:</span> Enter project name</p>
             <textarea             class=\\"govuk-textarea govuk-textarea--error govuk-!-width-two-thirds\\" id=\\"title\\"
-            name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-hint title-error\\"></textarea>
+            name=\\"title\\" rows=\\"5\\" aria-describedby=\\"title-error\\"></textarea>
         </div>
         <div class=\\"govuk-form-group govuk-form-group--error\\">
             <label class=\\"govuk-label font-weight--700\\" for=\\"description\\">Description of the project</label>

--- a/apps/web/src/server/views/applications/components/case-form/case/title.njk
+++ b/apps/web/src/server/views/applications/components/case-form/case/title.njk
@@ -5,7 +5,6 @@
 	{% if name == 'titleWelsh' and values['title'] != null %}
 
     {% set labelText = 'Project name in Welsh' if name == 'titleWelsh' else 'Project name' %}
-    {% set hintText = "for example, Bridge over a very long canyon" %}
 
 		<p class='govuk-body govuk-!-margin-bottom-0'>Project name in English:</p>
 
@@ -24,9 +23,6 @@
 		name: name,
 		classes: "govuk-!-width-two-thirds",
 		value: values[name],
-		errorMessage: errors[name] | errorMessage,
-		hint: {
-			text: hintText
-		}
+		errorMessage: errors[name] | errorMessage
 	}) }}
 {% endmacro %}


### PR DESCRIPTION
## Describe your changes

The bug was fixed with the changes as described

- Remove hint from nunjucks template

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-567 On overview page - Static text is not required for Project name in Welsh field
https://pins-ds.atlassian.net/browse/APPLICS-567

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
