### PR TITLE
fix(test/e2e): make examination timetable e2e tests more stable

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/examTimetable.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/examTimetable.spec.js
@@ -120,6 +120,15 @@ describe('Examination Timetable', () => {
 		createCasePage.createCase(projectInfo);
 	});
 
+	beforeEach(() => {
+		cy.visit('/');
+		const caseRef = Cypress.env('currentCreatedCase');
+		applicationsHomePage.searchFor(caseRef);
+		searchResultsPage.clickTopSearchResult();
+		examTimetablePage.clickLinkByText('Examination timetable');
+		examTimetablePage.deleteAllExaminationTimetableItems();
+	});
+
 	it('As a user able to create timetable item - only start dates (StartTime Mandatory Template)', () => {
 		cy.login(applicationsUsers.caseAdmin);
 		cy.visit('/');

--- a/apps/e2e/cypress/e2e/back-office-applications/welsh.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/welsh.spec.js
@@ -196,10 +196,6 @@ describe('Update project information to add a Welsh region', () => {
 
 describe('Display and edit welsh fields in Examination Timetable', () => {
 	context('As a user', () => {
-		function openAccordion(text) {
-			cy.contains(text).find('.govuk-accordion__section-toggle-text').scrollIntoView().click();
-		}
-
 		function validateBannerMessage(bannerText) {
 			cy.get('.govuk-notification-banner__content')
 				.invoke('text')
@@ -218,13 +214,24 @@ describe('Display and edit welsh fields in Examination Timetable', () => {
 			}
 		});
 
-		it('Welsh fields are present on the examination timetable item', () => {
+		beforeEach(() => {
 			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
 				cy.visit('/');
 				const caseRef = Cypress.env('currentCreatedCase');
 				applicationsHomePage.searchFor(caseRef);
 				searchResultsPage.clickTopSearchResult();
 				updateProjectRegions(['Wales']);
+				examTimetablePage.clickLinkByText('Examination timetable');
+				examTimetablePage.deleteAllExaminationTimetableItems();
+			}
+		});
+
+		it('Welsh fields are present on the examination timetable item', () => {
+			if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
+				cy.visit('/');
+				const caseRef = Cypress.env('currentCreatedCase');
+				applicationsHomePage.searchFor(caseRef);
+				searchResultsPage.clickTopSearchResult();
 				examTimetablePage.clickLinkByText('Examination timetable');
 				examTimetablePage.clickButtonByText('Create timetable item');
 				const options = timetableItem();
@@ -234,7 +241,7 @@ describe('Display and edit welsh fields in Examination Timetable', () => {
 				examTimetablePage.clickButtonByText('Continue');
 				examTimetablePage.clickButtonByText('Save item');
 				examTimetablePage.clickLinkByText('Go back to examination timetable');
-				cy.get('.govuk-accordion__section-button').click();
+				examTimetablePage.openExaminationTimetableItemAccordion(options.itemName);
 				examTimetablePage.checkAnswer('Item name in Welsh', '');
 				examTimetablePage.checkAnswer('Item description in Welsh', '');
 			}
@@ -246,7 +253,6 @@ describe('Display and edit welsh fields in Examination Timetable', () => {
 				const caseRef = Cypress.env('currentCreatedCase');
 				applicationsHomePage.searchFor(caseRef);
 				searchResultsPage.clickTopSearchResult();
-				updateProjectRegions(['Wales']);
 				examTimetablePage.clickLinkByText('Examination timetable');
 				examTimetablePage.clickButtonByText('Create timetable item');
 				const options = timetableItem();
@@ -257,7 +263,7 @@ describe('Display and edit welsh fields in Examination Timetable', () => {
 				examTimetablePage.clickButtonByText('Save item');
 				examTimetablePage.clickLinkByText('Go back to examination timetable');
 
-				openAccordion(Cypress.env('currentCreatedItem'));
+				examTimetablePage.openExaminationTimetableItemAccordion(options.itemName);
 				examTimetablePage.clickChangeLink('Item name in Welsh');
 				examTimetablePage.clickSaveAndReturn();
 				examTimetablePage.validateErrorMessage('Enter item name in Welsh');
@@ -278,7 +284,6 @@ describe('Display and edit welsh fields in Examination Timetable', () => {
 				const caseRef = Cypress.env('currentCreatedCase');
 				applicationsHomePage.searchFor(caseRef);
 				searchResultsPage.clickTopSearchResult();
-				updateProjectRegions(['Wales']);
 				examTimetablePage.clickLinkByText('Examination timetable');
 				examTimetablePage.clickButtonByText('Create timetable item');
 				examTimetablePage.selectTimetableItem('Deadline');
@@ -317,8 +322,7 @@ describe('Display and edit welsh fields in Examination Timetable', () => {
 				const caseRef = Cypress.env('currentCreatedCase');
 				applicationsHomePage.searchFor(caseRef);
 				searchResultsPage.clickTopSearchResult();
-				updateProjectRegions(['Wales']);
-				cy.contains('a', 'Examination timetable').click();
+				examTimetablePage.clickLinkByText('Examination timetable');
 				examTimetablePage.clickButtonByText('Create timetable item');
 				const options = timetableItem();
 				examTimetablePage.selectTimetableItem('Deadline');
@@ -342,8 +346,7 @@ describe('Display and edit welsh fields in Examination Timetable', () => {
 				const caseRef = Cypress.env('currentCreatedCase');
 				applicationsHomePage.searchFor(caseRef);
 				searchResultsPage.clickTopSearchResult();
-				updateProjectRegions(['Wales']);
-				cy.contains('a', 'Examination timetable').click();
+				examTimetablePage.clickLinkByText('Examination timetable');
 				examTimetablePage.clickButtonByText('Create timetable item');
 				const options = timetableItem();
 				examTimetablePage.selectTimetableItem('Deadline');
@@ -353,7 +356,7 @@ describe('Display and edit welsh fields in Examination Timetable', () => {
 				examTimetablePage.clickButtonByText('Save item');
 				examTimetablePage.clickLinkByText('Go back to examination timetable');
 
-				openAccordion(Cypress.env('currentCreatedItem'));
+				examTimetablePage.openExaminationTimetableItemAccordion(options.itemName);
 				examTimetablePage.clickChangeLink('Item name in Welsh');
 				examTimetablePage.fillInput('Valid welsh name');
 				examTimetablePage.clickSaveAndReturn();

--- a/apps/e2e/cypress/page_objects/basePage.js
+++ b/apps/e2e/cypress/page_objects/basePage.js
@@ -173,8 +173,8 @@ export class Page {
 		this.clickButtonByText('Save And Return');
 	}
 
-	clickLinkByText(linkText) {
-		this.basePageElements.linkByText(linkText).scrollIntoView().click();
+	clickLinkByText(linkText, options) {
+		this.basePageElements.linkByText(linkText).scrollIntoView().click(options);
 	}
 
 	clickTabByText(tabText) {

--- a/apps/e2e/cypress/page_objects/examinationTimetablePage.js
+++ b/apps/e2e/cypress/page_objects/examinationTimetablePage.js
@@ -78,14 +78,16 @@ export class ExaminationTimetablePage extends Page {
 
 	toggleExaminationTimetableItem(itemName, hide = true) {
 		const actionText = hide ? 'Hide' : 'Show';
-		cy.contains(itemName).within(() => {
-			cy.get(this.selectors.accordionToggleText).then(($elem) => {
-				const text = $elem.text().trim();
-				if (text === actionText) {
-					cy.wrap($elem).click();
-				}
-			});
-		});
+		cy.get('.timetable-table').within(() =>
+			cy.contains(itemName).within(() => {
+				cy.get(this.selectors.accordionToggleText).then(($elem) => {
+					const text = $elem.text().trim();
+					if (text === actionText) {
+						cy.wrap($elem).click();
+					}
+				});
+			})
+		);
 	}
 
 	hideAllItems() {
@@ -95,11 +97,12 @@ export class ExaminationTimetablePage extends Page {
 			}
 		});
 	}
-	deleteExaminationTimetableItem() {
-		cy.get(1000);
-		cy.get('#accordion-examination-content-1 > a').click();
-		cy.get('#main-content > div > div > form > button').click();
+
+	openExaminationTimetableItemAccordion(itemName) {
+		this.hideAllItems();
+		this.toggleExaminationTimetableItem(itemName, false);
 	}
+
 	verifyPublishAndUnpublishExamtimetable() {
 		cy.get('.govuk-button').contains('Preview and publish').click();
 		cy.get('.govuk-button').click();
@@ -109,6 +112,22 @@ export class ExaminationTimetablePage extends Page {
 		cy.get('.govuk-button').click();
 		cy.get('.govuk-panel__title').contains('Timetable item successfully unpublished');
 		cy.get('div.govuk-body > a:nth-child(2)').click();
+	}
+
+	deleteAllExaminationTimetableItems() {
+		cy.get('body').then(($body) => {
+			const exists = $body.find(this.selectors.accordionToggleText).length > 0;
+			if (exists) {
+				this.hideAllItems();
+				cy.get(this.selectors.accordionToggleText).each(($elem) => {
+					if ($elem.text() === 'Show') {
+						cy.wrap($elem).click();
+						this.clickLinkByText('Delete timetable item', { force: true });
+						this.clickButtonByText('Delete timetable item');
+					}
+				});
+			}
+		});
 	}
 
 	clickChangeLink(question) {


### PR DESCRIPTION
## Describe your changes

This PR:
- deletes all the examination timetable items prior to running each test so that the items created in previous tests do not affect the results of the following tests.
- tidies up some of the functions within the tests.

## APPLICS-556 Able to publish the examination timetable without welsh data
https://pins-ds.atlassian.net/browse/APPLICS-556

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
