### PR TITLE
feat(applications/web): project update links contain corrupt ampersands (APPLICS-604)

### DIFF
--- a/apps/web/src/server/applications/case/project-updates/__tests__/project-updates.mapper.test.js
+++ b/apps/web/src/server/applications/case/project-updates/__tests__/project-updates.mapper.test.js
@@ -39,4 +39,38 @@ describe('project-updates.mapper', () => {
 			emailSubscribers: false
 		});
 	});
+
+	it('decodes encoded text correctly', () => {
+		expect(
+			bodyToUpdateRequest({
+				backOfficeProjectUpdateContent:
+					'%3Cp%3EHere%20is%20a%20%3Ca%20href=%22https://test.com/cheese%20and%20ham%201.pdf%22%3Elink%3C/a%3E%20to%20decode%3C/p%3E',
+				backOfficeProjectUpdateContentWelsh:
+					'%3Cp%3EHere%20is%20a%20Welsh%20%3Ca%20href=%22http://test.com/cheese%20and%20ham%20in%20Welsh%201.pdf%22%3Elink%3C/a%3E%20to%20decode%3C/p%3E',
+				emailSubscribers: 'false'
+			})
+		).toEqual({
+			htmlContent:
+				'<p>Here is a <a href="https://test.com/cheese and ham 1.pdf">link</a> to decode</p>',
+			htmlContentWelsh:
+				'<p>Here is a Welsh <a href="http://test.com/cheese and ham in Welsh 1.pdf">link</a> to decode</p>',
+			emailSubscribers: false
+		});
+	});
+
+	it('cleans up ampersands corrupted by the rich text editor', () => {
+		expect(
+			bodyToUpdateRequest({
+				backOfficeProjectUpdateContent:
+					'<a href="https://test.com/cheese &amp;amp; ham 1.pdf">link</a>',
+				backOfficeProjectUpdateContentWelsh:
+					'<a href="http://test.com/cheese &amp;amp; ham in Welsh 1.pdf">link</a>',
+				emailSubscribers: 'false'
+			})
+		).toEqual({
+			htmlContent: '<a href="https://test.com/cheese &amp; ham 1.pdf">link</a>',
+			htmlContentWelsh: '<a href="http://test.com/cheese &amp; ham in Welsh 1.pdf">link</a>',
+			emailSubscribers: false
+		});
+	});
 });

--- a/apps/web/src/server/applications/case/project-updates/project-updates.mapper.js
+++ b/apps/web/src/server/applications/case/project-updates/project-updates.mapper.js
@@ -23,6 +23,7 @@ function mapContent(content) {
 		.replaceAll('</em>', '')
 		.replaceAll('<br>', '<br />')
 		.replaceAll('<p><br /></p>', '<br />')
+		.replaceAll('&amp;amp;', '&amp;')
 		.replaceAll('&nbsp;', ' '); // these are sometimes included when copy+pasting in an update
 }
 


### PR DESCRIPTION
## Describe your changes

Fix project updates mapper to handle corrupt ampersands created through the rich editor

## APPLICS-604 Live bug: Project update links containing ampersands return page not found
https://pins-ds.atlassian.net/browse/APPLICS-604

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
