### PR TITLE
fix(applications/api): unable to publish s51 advice without welsh fields (APPLICS-653)

### DIFF
--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -31,6 +31,7 @@ import {
 import BackOfficeAppError from '#utils/app-error.js';
 import { mapDateStringToUnixTimestamp } from '#utils/mapping/map-date-string-to-unix-timestamp.js';
 import logger from '#utils/logger.js';
+import { featureFlagClient } from '#utils/feature-flags.js';
 
 /**
  * @typedef {import('@pins/applications.api').Schema.Folder} Folder
@@ -242,10 +243,11 @@ export const getRedactionStatus = (/** @type {boolean} */ redactedStatus) => {
  */
 export const updateS51Advice = async ({ body, params }, response) => {
 	const adviceId = params.adviceId;
+	const caseIsWelsh = await isCaseWelsh(params.id);
 	const payload = body[''];
 
 	if (payload.publishedStatus === 'ready_to_publish') {
-		await checkCanPublish(adviceId);
+		await checkCanPublish(adviceId, caseIsWelsh);
 	}
 
 	if (payload.publishedStatus && payload.publishedStatus !== 'unpublished') {
@@ -267,16 +269,28 @@ export const updateS51Advice = async ({ body, params }, response) => {
 	response.send(updatedS51Advice);
 };
 
+const isCaseWelsh = async (caseId) => {
+	const caseData = await caseRepository.getById(caseId, { regions: true });
+
+	const regionsIncludeWelsh = caseData.ApplicationDetails?.regions?.some(
+		(item) => item.region.name === 'wales'
+	);
+	return (
+		regionsIncludeWelsh && (await featureFlagClient.isFeatureActive('applic-55-welsh-translation'))
+	);
+};
+
 /**
  * Updates the status and / or redaction status of an array of S51 Advice on a case.
  * There can be a status parameter, or a redacted parameter, or both
  *
  * @type {import('express').RequestHandler<{id: number}, any, any, any>}
  */
-export const updateManyS51Advices = async ({ body }, response) => {
+export const updateManyS51Advices = async ({ body, params }, response) => {
 	const { status: publishedStatus, redacted: isRedacted, items } = body[''];
 	const formattedResponseList = [];
 	const adviceIds = items.map((/** @type {{ id: number }} */ advice) => advice.id);
+	const caseIsWelsh = await isCaseWelsh(params.id);
 
 	let redactedStatus;
 
@@ -288,7 +302,7 @@ export const updateManyS51Advices = async ({ body }, response) => {
 
 	// special case - for Ready to Publish, need to check that required metadata is set on all the advice - else error
 	if (publishedStatus === 'ready_to_publish') {
-		const err = await verifyAllS51AdviceHasRequiredPropertiesForPublishing(adviceIds);
+		const err = await verifyAllS51AdviceHasRequiredPropertiesForPublishing(adviceIds, caseIsWelsh);
 		if (err) {
 			logger.info(`received error from verifyAllS51DocumentsAreVirusChecked: ${err}`);
 			throw new BackOfficeAppError('Enter missing information about the S51 advice', 400);

--- a/apps/api/src/server/applications/s51advice/s51-advice.service.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.service.js
@@ -225,10 +225,11 @@ export const unpublishS51 = async (id) => {
 };
 
 /**
- * @param {number} adviceId
+@param {number} adviceId
+@param {boolean} caseIsWelsh
  * */
-export const checkCanPublish = async (adviceId) => {
-	const err = await verifyAllS51AdviceHasRequiredPropertiesForPublishing([adviceId]);
+export const checkCanPublish = async (adviceId, caseIsWelsh) => {
+	const err = await verifyAllS51AdviceHasRequiredPropertiesForPublishing([adviceId], caseIsWelsh);
 	if (err) {
 		logger.info(`received error from verifyAllS51AdviceHasRequiredPropertiesForPublishing: ${err}`);
 		throw new BackOfficeAppError('Enter missing information about the S51 advice', 400);

--- a/apps/api/src/server/applications/s51advice/s51-advice.validators.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.validators.js
@@ -128,10 +128,17 @@ export const validateS51AdviceIsNotPublished = composeMiddleware(
  * Verifies if the given array of S51 Advice IDs have the correct required fields, so that they are ready to publish
  *
  * @param {number[]} s51AdviceIds
+ * @param {boolean} caseIsWelsh
  * @returns {Promise<Error | null>}
  */
-export const verifyAllS51AdviceHasRequiredPropertiesForPublishing = async (s51AdviceIds) => {
-	const publishableS51Advice = await s51AdviceRepository.getPublishableS51Advice(s51AdviceIds);
+export const verifyAllS51AdviceHasRequiredPropertiesForPublishing = async (
+	s51AdviceIds,
+	caseIsWelsh
+) => {
+	const publishableS51Advice = await s51AdviceRepository.getPublishableS51Advice(
+		s51AdviceIds,
+		caseIsWelsh
+	);
 
 	if (s51AdviceIds.length !== publishableS51Advice.length) {
 		const publishableIds = new Set(publishableS51Advice.map((pAdvice) => pAdvice.id));

--- a/apps/api/src/server/repositories/s51-advice.repository.js
+++ b/apps/api/src/server/repositories/s51-advice.repository.js
@@ -116,48 +116,54 @@ export const updateForCase = (caseId, s51AdviceDetails) => {
  * From a given list of S51 advice ids, retrieve the ones which are publishable
  *
  * @param {number[]} s51AdviceIds
+ * @param {boolean} caseIsWelsh
  * @returns {Promise<{id: number}[]>}
  */
-export const getPublishableS51Advice = (s51AdviceIds) => {
+export const getPublishableS51Advice = (s51AdviceIds, caseIsWelsh) => {
 	// most of the fields have a not null constraint in DB already, so dont need to check them
 	// need to check has title, and (either (enquirer || (firstName + lastName) or all))
+	const orQuery = [
+		{
+			title: ''
+		},
+		{
+			AND: [
+				{
+					enquirer: ''
+				},
+				{
+					OR: [
+						{
+							firstName: ''
+						},
+						{
+							lastName: ''
+						}
+					]
+				}
+			]
+		}
+	];
 	return databaseConnector.s51Advice.findMany({
 		where: {
 			id: {
 				in: s51AdviceIds
 			},
 			NOT: {
-				OR: [
-					{
-						title: ''
-					},
-					{
-						AND: [
+				OR: caseIsWelsh
+					? [
+							...orQuery,
 							{
-								enquirer: ''
+								titleWelsh: null
 							},
 							{
-								OR: [
-									{
-										firstName: ''
-									},
-									{
-										lastName: ''
-									}
-								]
+								adviceDetailsWelsh: null
+							},
+							{
+								enquiryDetailsWelsh: null
 							}
-						]
-					},
-					{
-						titleWelsh: null
-					},
-					{
-						adviceDetailsWelsh: null
-					},
-					{
-						enquiryDetailsWelsh: null
-					}
-				]
+					  ]
+					: orQuery
 			}
 		},
 		select: {


### PR DESCRIPTION
## Describe your changes

- When determining if an advice is publishable, only check the welsh fields have been populated if the case is welsh and the feature flag for welsh translation is on. 

Please note, the e2e regression tests has been run successfully locally with Welsh feature flag on and off.

## APPLICS-653 Unable to publish the S51 advice without welsh fields
https://pins-ds.atlassian.net/browse/APPLICS-653

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
