### PR TITLE
fix(functions): install pins-data-model in applications-command-hanlders

### DIFF
--- a/apps/functions/applications-command-handlers/package.json
+++ b/apps/functions/applications-command-handlers/package.json
@@ -11,6 +11,7 @@
     "@pins/event-client": "*",
     "@pins/platform": "*",
     "@pins/blob-storage-client": "*",
+    "pins-data-model": "*",
     "dotenv": "*",
     "got": "*",
     "joi": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -337,7 +337,8 @@
 				"dotenv": "*",
 				"got": "*",
 				"joi": "*",
-				"lodash-es": "*"
+				"lodash-es": "*",
+				"pins-data-model": "*"
 			},
 			"devDependencies": {
 				"cross-env": "*",


### PR DESCRIPTION
## Describe your changes

Install pins-data-model in applications-command-hanlders. This was causing the `handle-subscription-command` function to fail.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
