### PR TITLE
fix(applications/api): unable to publish ETTs when Welsh selected (APPLICS-663)

### DIFF
--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.validators.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.validators.js
@@ -4,13 +4,13 @@ import { param } from 'express-validator';
 import * as examinationTimetableTypesRepository from '#repositories/examination-timetable-types.repository.js';
 import * as examinationTimetableItemsRepository from '#repositories/examination-timetable-items.repository.js';
 import * as examinationTimetableRepository from '#repositories/examination-timetable.repository.js';
-import * as caseRepository from '#repositories/case.repository.js';
 import {
 	validateExistingApplication,
 	verifyNotTraining
 } from '../application/application.validators.js';
 import { customErrorValidationHandler, validationErrorHandler } from '#middleware/error-handler.js';
 import logger from '#utils/logger.js';
+import isCaseWelsh from '#utils/is-case-welsh.js';
 
 /**
  * Validate that an exam timetable item type exists
@@ -146,7 +146,7 @@ const generateExamTimetablePublishingErrors = (timetableItems) => {
 };
 
 /**
- * Validate that all examination timetable items have a welsh name
+ * Validate that all welsh case examination timetable items have a welsh name
  * @param {number} value
  * @throws {Error}
  * @returns {Promise<void>}
@@ -154,12 +154,7 @@ const generateExamTimetablePublishingErrors = (timetableItems) => {
  */
 
 export const validateExamTimetableWelshName = async (value) => {
-	const caseData = await caseRepository.getById(value, { regions: true });
-	if (!caseData) throw new Error(`Could not find examination a case with ID ${value}`);
-
-	const caseIsWelsh = Boolean(
-		caseData.ApplicationDetails?.regions?.find((item) => item.region.name === 'wales')
-	);
+	const caseIsWelsh = await isCaseWelsh(value);
 
 	if (!caseIsWelsh) return;
 

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -31,7 +31,7 @@ import {
 import BackOfficeAppError from '#utils/app-error.js';
 import { mapDateStringToUnixTimestamp } from '#utils/mapping/map-date-string-to-unix-timestamp.js';
 import logger from '#utils/logger.js';
-import { featureFlagClient } from '#utils/feature-flags.js';
+import isCaseWelsh from '#utils/is-case-welsh.js';
 
 /**
  * @typedef {import('@pins/applications.api').Schema.Folder} Folder
@@ -267,17 +267,6 @@ export const updateS51Advice = async ({ body, params }, response) => {
 	await broadcastNsipS51AdviceEvent(updatedS51Advice, EventType.Update);
 
 	response.send(updatedS51Advice);
-};
-
-const isCaseWelsh = async (caseId) => {
-	const caseData = await caseRepository.getById(caseId, { regions: true });
-
-	const regionsIncludeWelsh = caseData.ApplicationDetails?.regions?.some(
-		(item) => item.region.name === 'wales'
-	);
-	return (
-		regionsIncludeWelsh && (await featureFlagClient.isFeatureActive('applic-55-welsh-translation'))
-	);
 };
 
 /**

--- a/apps/api/src/server/utils/is-case-welsh.js
+++ b/apps/api/src/server/utils/is-case-welsh.js
@@ -1,0 +1,20 @@
+import * as caseRepository from '#repositories/case.repository.js';
+import { featureFlagClient } from '#utils/feature-flags.js';
+
+/**
+ * Is case welsh
+ *
+ * @param caseId
+ * @returns {Promise<false|*>}
+ */
+export default async function isCaseWelsh(caseId) {
+	const caseData = await caseRepository.getById(caseId, { regions: true });
+	if (!caseData) throw new Error(`Could not find examination a case with ID ${caseId}`);
+
+	const regionsIncludeWelsh = caseData.ApplicationDetails?.regions?.some(
+		(item) => item.region.name === 'wales'
+	);
+	return (
+		regionsIncludeWelsh && (await featureFlagClient.isFeatureActive('applic-55-welsh-translation'))
+	);
+}


### PR DESCRIPTION
## Describe your changes

When determining if an ETT is publishable, only check the Welsh fields have been populated if the case is Welsh and the feature flag for Welsh translation is on. 

- Move the solution to determine a Welsh case when publishing a S51 advice to a reusable utility function (IsCaseWelsh)
- Change both S51 advice and ETT publishing to use the same utility function IsCaseWelsh
- Run the api unit tests
- Run the e2e regression tests locally with Welsh feature flag on and off

## APPLICS-663 Unable to publish ETTs when Welsh selected
https://pins-ds.atlassian.net/browse/APPLICS-663

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
- [x] I have performed local e2e tests
