### PR TITLE
feat(functions): add skipValidation flag to migrators

### DIFF
--- a/apps/api/src/server/migration/migration.controller.js
+++ b/apps/api/src/server/migration/migration.controller.js
@@ -14,13 +14,13 @@ export const postMigrateModel = async ({ body, params: { modelType } }, response
 
 	const { migrator, validator } = migrationMap;
 
-	for (const model of body) {
-		if (!validator(model)) {
+	for (const model of body.data) {
+		if (!body.skipValidation && !validator(model)) {
 			throw Error(`Model ${modelType} failed with errors ${JSON.stringify(validator.errors)}`);
 		}
 	}
 
-	await migrator(body);
+	await migrator(body.data);
 
 	response.sendStatus(200);
 };

--- a/apps/functions/applications-migration/common/migrators/exam-timetable-migration.js
+++ b/apps/functions/applications-migration/common/migrators/exam-timetable-migration.js
@@ -8,12 +8,13 @@ import { QueryTypes } from 'sequelize';
  *
  * @param {import('@azure/functions').Logger} log
  * @param {string[]} caseReferences
+ * @param {boolean} skipValidation
  */
-export async function migrateExamTimetables(log, caseReferences) {
+export async function migrateExamTimetables(log, caseReferences, skipValidation = false) {
 	log.info(`Migrating Timetables for ${caseReferences.length} Cases`);
 
 	for (const caseReference of caseReferences) {
-		await migrateExamTimetablesForCase(log, caseReference);
+		await migrateExamTimetablesForCase(log, caseReference, skipValidation);
 	}
 }
 
@@ -22,8 +23,9 @@ export async function migrateExamTimetables(log, caseReferences) {
  *
  * @param {import('@azure/functions').Logger} log
  * @param {string} caseReference
+ * @param {boolean} skipValidation
  */
-export async function migrateExamTimetablesForCase(log, caseReference) {
+export async function migrateExamTimetablesForCase(log, caseReference, skipValidation = false) {
 	try {
 		log.info(`Migrating Exam Timetable for case ${caseReference}`);
 
@@ -32,7 +34,10 @@ export async function migrateExamTimetablesForCase(log, caseReference) {
 		if (examTimetable) {
 			log.info(`Migrating Exam Timetable Items for case ${caseReference}`);
 
-			await makePostRequest(log, '/migration/nsip-exam-timetable', [examTimetable]);
+			await makePostRequest(log, '/migration/nsip-exam-timetable', {
+				data: [examTimetable],
+				skipValidation
+			});
 
 			log.info(`Successfully migrated Exam Timetable for case ${caseReference}`);
 		} else {

--- a/apps/functions/applications-migration/common/migrators/folder-migration.js
+++ b/apps/functions/applications-migration/common/migrators/folder-migration.js
@@ -22,4 +22,4 @@ export const migrateFoldersForCase = async (logger, caseReference) => {
 		logger.error(`Failed to migrate Folders for case ${caseReference}`, e?.response?.body, e);
 		throw e;
 	}
-}
+};

--- a/apps/functions/applications-migration/common/migrators/nsip-document-migration.js
+++ b/apps/functions/applications-migration/common/migrators/nsip-document-migration.js
@@ -6,20 +6,26 @@ import { makePostRequest } from '../back-office-api-client.js';
  * Handle an HTTP trigger/request to run the migration
  * @param {import('@azure/functions').Logger} log
  * @param {string[]} caseReferences
+ * @param {boolean} skipValidation
  */
-export const migrationNsipDocuments = async (log, caseReferences) => {
+export const migrationNsipDocuments = async (log, caseReferences, skipValidation = false) => {
 	log.info(`Migrating Documents for ${caseReferences.length} Cases`);
 
 	for (const caseReference of caseReferences) {
-		await migrationNsipDocumentsByReference(log, caseReference);
+		await migrationNsipDocumentsByReference(log, caseReference, skipValidation);
 	}
 };
 
 /**
  * @param {import('@azure/functions').Logger} log
  * @param {string} caseReference
+ * @param {boolean} skipValidation
  */
-export const migrationNsipDocumentsByReference = async (log, caseReference) => {
+export const migrationNsipDocumentsByReference = async (
+	log,
+	caseReference,
+	skipValidation = false
+) => {
 	try {
 		log.info(`Migrating NSIP Documents for case ${caseReference}`);
 
@@ -28,7 +34,7 @@ export const migrationNsipDocumentsByReference = async (log, caseReference) => {
 		if (documents.length > 0) {
 			log.info(`Migrating ${documents.length} NSIP Documents for case ${caseReference}`);
 
-			await makePostRequest(log, '/migration/nsip-document', documents);
+			await makePostRequest(log, '/migration/nsip-document', { data: documents, skipValidation });
 
 			log.info('Successfully migrated NSIP Document');
 		} else {

--- a/apps/functions/applications-migration/common/migrators/nsip-project-migration.js
+++ b/apps/functions/applications-migration/common/migrators/nsip-project-migration.js
@@ -7,12 +7,13 @@ import { makePostRequest } from '../back-office-api-client.js';
  *
  * @param {import('@azure/functions').Logger} log
  * @param {string[]} caseReferences
+ * @param {boolean} skipValidation
  */
-export const migrateNsipProjects = async (log, caseReferences) => {
+export const migrateNsipProjects = async (log, caseReferences, skipValidation = false) => {
 	log.info(`Migrating ${caseReferences.length} Cases`);
 
 	for (const caseReference of caseReferences) {
-		await migrateNsipProjectByReference(log, caseReference);
+		await migrateNsipProjectByReference(log, caseReference, false, skipValidation);
 	}
 };
 
@@ -22,8 +23,14 @@ export const migrateNsipProjects = async (log, caseReferences) => {
  * @param {import('@azure/functions').Logger} log
  * @param {string} caseReference
  * @param {boolean} overrideMigrationStatus
+ * @param {boolean} skipValidation
  */
-export async function migrateNsipProjectByReference(log, caseReference, overrideMigrationStatus) {
+export async function migrateNsipProjectByReference(
+	log,
+	caseReference,
+	overrideMigrationStatus,
+	skipValidation = false
+) {
 	try {
 		log.info(`Migrating NSIP Project for case ${caseReference}`);
 
@@ -32,7 +39,7 @@ export async function migrateNsipProjectByReference(log, caseReference, override
 		if (projects.length > 0) {
 			log.info(`Migrating ${projects.length} NSIP Projects for case ${caseReference}`);
 
-			await makePostRequest(log, '/migration/nsip-project', projects);
+			await makePostRequest(log, '/migration/nsip-project', { data: projects, skipValidation });
 
 			log.info('Successfully migrated NSIP Project');
 		} else {

--- a/apps/functions/applications-migration/common/migrators/nsip-representation-migration.js
+++ b/apps/functions/applications-migration/common/migrators/nsip-representation-migration.js
@@ -10,10 +10,11 @@ const query = `SELECT *
  *
  * @param {import('@azure/functions').Logger} logger
  * @param {string[]} caseReferences
+ * @param {boolean} skipValidation
  */
-export const migrateRepresentations = async (logger, caseReferences) => {
+export const migrateRepresentations = async (logger, caseReferences, skipValidation = false) => {
 	for (const caseReference of caseReferences) {
-		await migrationRepresentationsForCase(logger, caseReference);
+		await migrationRepresentationsForCase(logger, caseReference, skipValidation);
 	}
 };
 
@@ -22,8 +23,9 @@ export const migrateRepresentations = async (logger, caseReferences) => {
  *
  * @param {import('@azure/functions').Logger} log
  * @param {string} caseReference
+ * @param {boolean} skipValidation
  */
-export async function migrationRepresentationsForCase(log, caseReference) {
+export async function migrationRepresentationsForCase(log, caseReference, skipValidation = false) {
 	try {
 		log.info(`reading Representations with caseReference ${caseReference}`);
 
@@ -36,7 +38,10 @@ export async function migrationRepresentationsForCase(log, caseReference) {
 		);
 
 		if (representationEntities.length > 0) {
-			await makePostRequest(log, '/migration/nsip-representation', representationEntities);
+			await makePostRequest(log, '/migration/nsip-representation', {
+				data: representationEntities,
+				skipValidation
+			});
 		}
 	} catch (e) {
 		log.error(`Failed to migrate Representations for case ${caseReference}`, e?.response?.body, e);

--- a/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
+++ b/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
@@ -29,10 +29,11 @@ const s51AdviceProperties = [
  *
  * @param {import('@azure/functions').Logger} logger
  * @param {string[]} caseReferences
+ * @param {boolean} skipValidation
  */
-export const migrateS51Advice = async (logger, caseReferences) => {
+export const migrateS51Advice = async (logger, caseReferences, skipValidation = false) => {
 	for (const caseReference of caseReferences) {
-		await migrateS51AdviceForCase(logger, caseReference);
+		await migrateS51AdviceForCase(logger, caseReference, undefined, skipValidation);
 	}
 };
 
@@ -41,8 +42,15 @@ export const migrateS51Advice = async (logger, caseReferences) => {
  *
  * @param {import('@azure/functions').Logger} log
  * @param {string} caseReference
+ * @param {string} synapseQuery
+ * @param {boolean} skipValidation
  */
-export async function migrateS51AdviceForCase(log, caseReference, synapseQuery = query) {
+export async function migrateS51AdviceForCase(
+	log,
+	caseReference,
+	synapseQuery = query,
+	skipValidation = false
+) {
 	try {
 		log.info(`reading S51 Advice with caseReference ${caseReference}`);
 
@@ -53,7 +61,10 @@ export async function migrateS51AdviceForCase(log, caseReference, synapseQuery =
 		);
 
 		if (s51AdviceEntities.length > 0) {
-			await makePostRequest(log, '/migration/s51-advice', s51AdviceEntities);
+			await makePostRequest(log, '/migration/s51-advice', {
+				data: s51AdviceEntities,
+				skipValidation
+			});
 		}
 	} catch (e) {
 		log.error(`Failed to migrate S51 Advice for case ${caseReference}`, e?.response?.body, e);

--- a/apps/functions/applications-migration/common/migrators/service-user-migration.js
+++ b/apps/functions/applications-migration/common/migrators/service-user-migration.js
@@ -9,10 +9,11 @@ const serviceUserQuery =
  *
  * @param {import('@azure/functions').Logger} logger
  * @param {string[]} caseReferences
+ * @param {boolean} skipValidation
  */
-export const migrateServiceUsers = async (logger, caseReferences) => {
+export const migrateServiceUsers = async (logger, caseReferences, skipValidation = false) => {
 	for (const caseReference of caseReferences) {
-		await migrateServiceUsersForCase(logger, caseReference);
+		await migrateServiceUsersForCase(logger, caseReference, skipValidation);
 	}
 };
 
@@ -21,8 +22,9 @@ export const migrateServiceUsers = async (logger, caseReferences) => {
  *
  * @param {import('@azure/functions').Logger} log
  * @param {string} caseReference
+ * @param {boolean} skipValidation
  */
-export async function migrateServiceUsersForCase(log, caseReference) {
+export async function migrateServiceUsersForCase(log, caseReference, skipValidation = false) {
 	try {
 		log.info(`reading Service Users with caseReference ${caseReference}`);
 
@@ -31,7 +33,7 @@ export async function migrateServiceUsersForCase(log, caseReference) {
 		log.info(`found ${count} Service Users: ${JSON.stringify(serviceUsers.map((u) => u.id))}`);
 
 		if (serviceUsers.length > 0) {
-			await makePostRequest(log, '/migration/service-user', serviceUsers);
+			await makePostRequest(log, '/migration/service-user', { data: serviceUsers, skipValidation });
 		}
 	} catch (e) {
 		log.error(`Failed to migrate Service User for case ${caseReference}`, e?.response?.body, e);

--- a/apps/functions/applications-migration/exam-timetable-migration/index.js
+++ b/apps/functions/applications-migration/exam-timetable-migration/index.js
@@ -5,11 +5,11 @@ import { handleMigrationWithResponse } from '../common/handle-migration-with-res
  * @param {import('@azure/functions').Context} context
  * @param {import('@azure/functions').HttpRequest} req
  */
-export default async function (context, { body: { caseReferences } }) {
+export default async function (context, { body: { caseReferences, skipValidation } }) {
 	await handleMigrationWithResponse(
 		context,
 		caseReferences,
-		() => migrateExamTimetables(context.log, caseReferences),
+		() => migrateExamTimetables(context.log, caseReferences, skipValidation),
 		'exam timetable'
 	);
 }

--- a/apps/functions/applications-migration/nsip-document-migration/index.js
+++ b/apps/functions/applications-migration/nsip-document-migration/index.js
@@ -5,11 +5,11 @@ import { handleMigrationWithResponse } from '../common/handle-migration-with-res
  * @param {import('@azure/functions').Context} context
  * @param {import('@azure/functions').HttpRequest} req
  */
-export default async function (context, { body: { caseReferences } }) {
+export default async function (context, { body: { caseReferences, skipValidation } }) {
 	await handleMigrationWithResponse(
 		context,
 		caseReferences,
-		() => migrationNsipDocuments(context.log, caseReferences),
+		() => migrationNsipDocuments(context.log, caseReferences, skipValidation),
 		'document'
 	);
 }

--- a/apps/functions/applications-migration/nsip-project-migration/index.js
+++ b/apps/functions/applications-migration/nsip-project-migration/index.js
@@ -4,11 +4,11 @@ import { handleMigrationWithResponse } from '../common/handle-migration-with-res
  * @param {import('@azure/functions').Context} context
  * @param {import('@azure/functions').HttpRequest} req
  */
-export default async function (context, { body: { caseReferences } }) {
+export default async function (context, { body: { caseReferences, skipValidation } }) {
 	await handleMigrationWithResponse(
 		context,
 		caseReferences,
-		() => migrateNsipProjects(context.log, caseReferences),
+		() => migrateNsipProjects(context.log, caseReferences, skipValidation),
 		'project'
 	);
 }

--- a/apps/functions/applications-migration/nsip-representation-migration/index.js
+++ b/apps/functions/applications-migration/nsip-representation-migration/index.js
@@ -5,11 +5,11 @@ import { handleMigrationWithResponse } from '../common/handle-migration-with-res
  * @param {import('@azure/functions').Context} context
  * @param {import('@azure/functions').HttpRequest} req
  */
-export default async function (context, { body: { caseReferences } }) {
+export default async function (context, { body: { caseReferences, skipValidation } }) {
 	await handleMigrationWithResponse(
 		context,
 		caseReferences,
-		() => migrateRepresentations(context.log, caseReferences),
+		() => migrateRepresentations(context.log, caseReferences, skipValidation),
 		'representation'
 	);
 }

--- a/apps/functions/applications-migration/project-updates-migration/index.js
+++ b/apps/functions/applications-migration/project-updates-migration/index.js
@@ -5,11 +5,11 @@ import { handleMigrationWithResponse } from '../common/handle-migration-with-res
  * @param {import('@azure/functions').Context} context
  * @param {import('@azure/functions').HttpRequest} req
  */
-export default async function (context, { body: { caseReferences } }) {
+export default async function (context, { body: { caseReferences, skipValidation } }) {
 	await handleMigrationWithResponse(
 		context,
 		caseReferences,
-		() => migrateProjectUpdates(context.log, caseReferences),
+		() => migrateProjectUpdates(context.log, caseReferences, skipValidation),
 		'project update'
 	);
 }

--- a/apps/functions/applications-migration/s51-advice-migration/index.js
+++ b/apps/functions/applications-migration/s51-advice-migration/index.js
@@ -5,11 +5,11 @@ import { handleMigrationWithResponse } from '../common/handle-migration-with-res
  * @param {import('@azure/functions').Context} context
  * @param {import('@azure/functions').HttpRequest} req
  */
-export default async function (context, { body: { caseReferences } }) {
+export default async function (context, { body: { caseReferences, skipValidation } }) {
 	await handleMigrationWithResponse(
 		context,
 		caseReferences,
-		() => migrateS51Advice(context.log, caseReferences),
+		() => migrateS51Advice(context.log, caseReferences, skipValidation),
 		'S51 advice'
 	);
 }

--- a/apps/functions/applications-migration/service-user-migration/index.js
+++ b/apps/functions/applications-migration/service-user-migration/index.js
@@ -5,11 +5,11 @@ import { handleMigrationWithResponse } from '../common/handle-migration-with-res
  * @param {import('@azure/functions').Context} context
  * @param {import('@azure/functions').HttpRequest} req
  */
-export default async function (context, { body: { caseReferences } }) {
+export default async function (context, { body: { caseReferences, skipValidation } }) {
 	await handleMigrationWithResponse(
 		context,
 		caseReferences,
-		() => migrateServiceUsers(context.log, caseReferences),
+		() => migrateServiceUsers(context.log, caseReferences, skipValidation),
 		'service user'
 	);
 }


### PR DESCRIPTION
## Describe your changes

Adds `skipValidation` boolean flag to migrator functions. Skips the schema validation step performed by the API. For situations where the upstream data from ODW curated does not conform to the schema, but we wish to run the function anyway (perhaps if the failures in validation are inconsequential to migration)

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
