### PR TITLE
feat(tooling): create remove training cases script (APPLICS-605)

### DIFF
--- a/apps/api/src/server/utils/prisma-middleware.js
+++ b/apps/api/src/server/utils/prisma-middleware.js
@@ -8,8 +8,12 @@
  */
 export async function modifyPrismaDocumentQueryMiddleware(parameters, next) {
 	if (parameters.model === 'Document' && parameters.action === 'delete') {
-		parameters.action = 'update';
-		parameters.args.data = { isDeleted: true };
+		if (parameters.args.isTraining) {
+			delete parameters.args.isTraining;
+		} else {
+			parameters.action = 'update';
+			parameters.args.data = { isDeleted: true };
+		}
 	}
 	if (process.env.NODE_ENV !== 'seeding' && parameters.model === 'Folder') {
 		if (parameters.action === 'delete') {

--- a/apps/api/src/server/utils/prisma-middleware.js
+++ b/apps/api/src/server/utils/prisma-middleware.js
@@ -8,25 +8,21 @@
  * @returns {Promise<(arg0: any) => any>} The result of the next middleware in the chain.
  */
 export async function modifyPrismaDocumentQueryMiddleware(parameters, next) {
-	if (parameters.model === 'Document' && parameters.action === 'delete') {
-		if (parameters.args.hardDelete) {
-			delete parameters.args.hardDelete;
-		} else {
-			parameters.action = 'update';
-			parameters.args.data = { isDeleted: true };
-		}
+	const { hardDelete = false } = parameters.args;
+	if (hardDelete) {
+		delete parameters.args.hardDelete;
+	}
+	if (parameters.model === 'Document' && parameters.action === 'delete' && !hardDelete) {
+		parameters.action = 'update';
+		parameters.args.data = { isDeleted: true };
 	}
 	if (process.env.NODE_ENV !== 'seeding' && parameters.model === 'Folder') {
-		if (parameters.action === 'delete') {
-			if (parameters.args.hardDelete) {
-				delete parameters.args.hardDelete;
-			} else {
-				parameters.action = 'update';
-				parameters.args = parameters.args || {};
-				parameters.args.data = { deletedAt: new Date() };
-			}
+		if (parameters.action === 'delete' && !hardDelete) {
+			parameters.action = 'update';
+			parameters.args = parameters.args || {};
+			parameters.args.data = { deletedAt: new Date() };
 		}
-		if (parameters.action === 'deleteMany') {
+		if (parameters.action === 'deleteMany' && !hardDelete) {
 			parameters.action = 'updateMany';
 			parameters.args = parameters.args || {};
 			parameters.args.data = { deletedAt: new Date() };

--- a/apps/api/src/server/utils/prisma-middleware.js
+++ b/apps/api/src/server/utils/prisma-middleware.js
@@ -18,9 +18,13 @@ export async function modifyPrismaDocumentQueryMiddleware(parameters, next) {
 	}
 	if (process.env.NODE_ENV !== 'seeding' && parameters.model === 'Folder') {
 		if (parameters.action === 'delete') {
-			parameters.action = 'update';
-			parameters.args = parameters.args || {};
-			parameters.args.data = { deletedAt: new Date() };
+			if (parameters.args.hardDelete) {
+				delete parameters.args.hardDelete;
+			} else {
+				parameters.action = 'update';
+				parameters.args = parameters.args || {};
+				parameters.args.data = { deletedAt: new Date() };
+			}
 		}
 		if (parameters.action === 'deleteMany') {
 			parameters.action = 'updateMany';

--- a/apps/api/src/server/utils/prisma-middleware.js
+++ b/apps/api/src/server/utils/prisma-middleware.js
@@ -1,6 +1,7 @@
 /**
  * A middleware function that modifies Prisma Client parameters for Document model.
- * When deleting a Document, it updates the `isDeleted` property instead of actually deleting the record.
+ * When deleting a Document, it updates the `isDeleted` property instead of actually deleting the record
+ * unless the `hardDelete` arg is included.
  *
  * @param {import('@prisma/client').Prisma.MiddlewareParams} parameters - The Prisma Client parameters object.
  * @param {(arg0: any) => any} next - The next middleware in the chain.
@@ -8,8 +9,8 @@
  */
 export async function modifyPrismaDocumentQueryMiddleware(parameters, next) {
 	if (parameters.model === 'Document' && parameters.action === 'delete') {
-		if (parameters.args.isTraining) {
-			delete parameters.args.isTraining;
+		if (parameters.args.hardDelete) {
+			delete parameters.args.hardDelete;
 		} else {
 			parameters.action = 'update';
 			parameters.args.data = { isDeleted: true };

--- a/azure-pipelines-remove-training-cases.yml
+++ b/azure-pipelines-remove-training-cases.yml
@@ -6,6 +6,7 @@ parameters:
       values:
           - Dev
           - Test
+          - Training
           - Prod
 
 pool: pins-odt-agent-pool
@@ -60,6 +61,9 @@ jobs:
                           environmentVariables:
                               DATABASE_URL: $(DATABASE_URL)
                               REMOVE_ALL_CASES: $(REMOVE_ALL_CASES)
+                              MAX_CASES_TO_DELETE: $(MAX_CASES_TO_DELETE)
+                              TRANSACTION_MAX_WAIT_IN_SECONDS: $(TRANSACTION_MAX_WAIT_IN_SECONDS)
+                              TRANSACTION_TIMEOUT_IN_SECONDS: $(TRANSACTION_TIMEOUT_IN_SECONDS)
                           script: npm run applications:remove-all-training-cases
                           workingDirectory: $(Build.Repository.LocalPath)/packages/scripts
       workspace:

--- a/azure-pipelines-remove-training-cases.yml
+++ b/azure-pipelines-remove-training-cases.yml
@@ -1,0 +1,58 @@
+parameters:
+    - name: environment
+      displayName: Environment
+      type: string
+      default: Dev
+      values:
+          - Dev
+          - Test
+          - Prod
+
+pool: pins-odt-agent-pool
+
+pr: none
+
+trigger: none
+
+resources:
+    repositories:
+        - repository: templates
+          type: github
+          endpoint: Planning-Inspectorate
+          name: Planning-Inspectorate/common-pipeline-templates
+          ref: refs/tags/release/3.16.1
+
+variables:
+    - template: variables/environments/${{ lower(parameters.environment )}}.yml@templates
+    - group: pipeline_secrets
+
+
+jobs:
+    - deployment: Remove_training_cases_from_DB
+      displayName: Remove training cases from ${{ parameters.environment }} Database
+      environment: ${{ parameters.environment }}
+      strategy:
+        runOnce:
+            deploy:
+                steps:
+                    - download: none
+                    - checkout: self
+                    - template: steps/node_script.yml@templates
+                      parameters:
+                          script: npm ci
+                    - template: steps/azure_auth.yml@templates
+                    - template: steps/azure_get_secrets.yml@templates
+                      parameters:
+                          secrets:
+                              - name: back-office-sql-server-connection-string
+                                variable: DATABASE_URL
+                    - template: steps/node_script.yml@templates
+                      parameters:
+                          environmentVariables:
+                              DATABASE_URL: $(DATABASE_URL)
+                              REMOVE_ALL_CASES: $(REMOVE_ALL_CASES)
+                          script: npm run applications:remove-all-training-cases
+                          workingDirectory: $(Build.Repository.LocalPath)/packages/scripts
+      workspace:
+        clean: all
+

--- a/azure-pipelines-remove-training-cases.yml
+++ b/azure-pipelines-remove-training-cases.yml
@@ -39,6 +39,7 @@ jobs:
                     - checkout: self
                     - template: steps/node_script.yml@templates
                       parameters:
+                          nodeVersion: 20
                           script: npm ci
                     - template: steps/azure_auth.yml@templates
                     - template: steps/azure_get_secrets.yml@templates
@@ -48,6 +49,14 @@ jobs:
                                 variable: DATABASE_URL
                     - template: steps/node_script.yml@templates
                       parameters:
+                          nodeVersion: 20
+                          environmentVariables:
+                              DATABASE_URL: $(DATABASE_URL)
+                          script: npm run prisma-generate
+                          workingDirectory: $(Build.Repository.LocalPath)/apps/api
+                    - template: steps/node_script.yml@templates
+                      parameters:
+                          nodeVersion: 20
                           environmentVariables:
                               DATABASE_URL: $(DATABASE_URL)
                               REMOVE_ALL_CASES: $(REMOVE_ALL_CASES)

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -11,7 +11,8 @@
 		"lint:js": "npx eslint .",
 		"lint:js:fix": "npx eslint . --fix",
 		"tscheck": "npx tsc -p jsconfig.json --maxNodeModuleJsDepth 0",
-		"applications:regenerate-api-keys": "node ./run/regenerate-api-keys-entry.js"
+		"applications:regenerate-api-keys": "node ./run/regenerate-api-keys-entry.js",
+		"applications:remove-all-training-cases": "node ./run/remove-all-training-cases-entry.js"
 	},
 	"dependencies": {
 		"@azure/identity": "*",

--- a/packages/scripts/run/remove-all-training-cases-entry.js
+++ b/packages/scripts/run/remove-all-training-cases-entry.js
@@ -1,6 +1,6 @@
-import { removeAllTrainingCase } from '../src/remove-training-cases.js';
+import { removeAllTrainingCases } from '../src/remove-training-cases.js';
 
-removeAllTrainingCase()
+removeAllTrainingCases()
 	.then(() => {
 		console.log('Successfully removed all training cases from backoffice-applications');
 	})

--- a/packages/scripts/run/remove-all-training-cases-entry.js
+++ b/packages/scripts/run/remove-all-training-cases-entry.js
@@ -1,0 +1,15 @@
+import { removeAllTrainingCase } from '../src/remove-training-cases.js';
+
+removeAllTrainingCase()
+	.then(() => {
+		console.log('Successfully removed all training cases from backoffice-applications');
+	})
+	.catch((error) => {
+		throw new Error(
+			`Error occurred while removing all training cases from backoffice-applications: ${JSON.stringify(
+				error,
+				null,
+				2
+			)}`
+		);
+	});

--- a/packages/scripts/src/remove-training-cases.js
+++ b/packages/scripts/src/remove-training-cases.js
@@ -190,7 +190,7 @@ const removeFoldersAndDocuments = async (tx, caseDetails) => {
 			console.log(`Removing folder: ${folderPath}`);
 		} else {
 			// Now safe to delete all folders for a case as all the dependencies have been deleted
-			tx.folder.deleteMany({ where: { caseId: caseDetails.caseId } });
+			await tx.folder.deleteMany({ where: { caseId } });
 		}
 	};
 
@@ -254,7 +254,13 @@ const removeCase = async (reference) => {
 				if (skippedDocs.length) {
 					console.log(`Skipped docs: ${JSON.stringify(skippedDocs, null, 2)}`);
 				}
-				await tx.case.delete({ where: { id: caseId } });
+				const skippedFolders = await tx.folder.findMany({ where: { caseId } });
+				if (skippedFolders.length) {
+					console.log(`Skipped folders: ${JSON.stringify(skippedFolders, null, 2)}`);
+				}
+				const result = await tx.case.delete({ where: { id: caseId } });
+
+				console.log(result);
 
 				console.log(reference + ' Removed');
 

--- a/packages/scripts/src/remove-training-cases.js
+++ b/packages/scripts/src/remove-training-cases.js
@@ -1,0 +1,317 @@
+// @ts-nocheck
+import {
+	getByRef as getCaseByRef,
+	getById as getCaseById
+} from '@pins/applications.api/src/server/repositories/case.repository.js';
+import { databaseConnector } from '@pins/applications.api/src/server/utils/database-connector.js';
+
+const isSimulatedTest = process.env.REMOVE_ALL_CASES?.toLowerCase() !== 'true';
+
+/**
+ * @typedef {import('@prisma/client')} PrismaClient
+ */
+
+/**
+ * @param {PrismaClient} tx
+ * @param {any} applicationDetails
+ * @returns {Promise<void>}
+ */
+const removeApplicationDetails = async (tx, applicationDetails) => {
+	if (applicationDetails?.id) {
+		await tx.regionsOnApplicationDetails.deleteMany({
+			where: { applicationDetailsId: applicationDetails.id }
+		});
+		await tx.applicationDetails.delete({ where: { id: applicationDetails.id } });
+	}
+};
+
+/**
+ * @param {import('@prisma/client')} tx
+ * @param caseId
+ * @returns {Promise<void>}
+ */
+const removeProjectUpdates = async (tx, caseId) => {
+	const projectUpdates = await tx.projectUpdate.findMany({
+		where: { caseId }
+	});
+	await Promise.all(
+		projectUpdates.map(async (projectUpdate) => {
+			const { id } = projectUpdate;
+			await tx.projectUpdateNotificationLog.deleteMany({ where: { projectUpdateId: id } });
+			await tx.projectUpdate.delete({ where: { id } });
+		})
+	);
+};
+
+/**
+ * @param {import('@prisma/client')} tx
+ * @param caseId
+ * @returns {Promise<void>}
+ */
+const removeRepresentations = async (tx, caseId) => {
+	const representations = await tx.representation.findMany({
+		where: { caseId }
+	});
+	await Promise.all(
+		representations.map(async (representation) => {
+			const { id } = representation;
+			await tx.representationAction.deleteMany({ where: { representationId: id } });
+			await tx.representation.delete({ where: { id } });
+		})
+	);
+};
+
+/**
+ * @param {import('@prisma/client')} tx
+ * @param caseId
+ * @returns {Promise<void>}
+ */
+const removeExaminationTimetables = async (tx, caseId) => {
+	const examinationTimetables = await tx.examinationTimetable.findMany({
+		where: { caseId }
+	});
+	await Promise.all(
+		examinationTimetables.map(async (examinationTimetable) => {
+			const { id } = examinationTimetable;
+			await tx.examinationTimetableItem.deleteMany({ where: { examinationTimetableId: id } });
+			await tx.examinationTimetable.delete({ where: { id } });
+		})
+	);
+};
+
+/**
+ * @param {PrismaClient} tx
+ * @param {any} serviceUser
+ * @returns {Promise<void>}
+ */
+const removeServiceUser = async (tx, serviceUser) => {
+	if (serviceUser?.id) {
+		const { address } = serviceUser;
+		if (address?.id) {
+			await tx.address.delete({ where: { id: address.id } });
+		}
+		await tx.serviceUser.delete({ where: { id: serviceUser.id } });
+	}
+};
+
+/**
+ *
+ * @param {PrismaClient} tx
+ * @param document
+ * @returns {Promise<void>}
+ */
+const removeDocument = async (tx, document) => {
+	const { guid } = document;
+
+	// TODO: Currently an issue with cyclic references, hence this hack to clear the latestVersionId
+	await tx.$queryRawUnsafe(`UPDATE Document SET latestVersionId = NULL WHERE guid = '${guid}';`);
+
+	await tx.documentActivityLog.deleteMany({
+		where: {
+			documentGuid: guid
+		}
+	});
+
+	// TODO: Currently an issue with cyclic references, hence this hack to clear the transcriptGuid
+	await tx.$queryRawUnsafe(
+		`UPDATE DocumentVersion SET transcriptGuid = NULL WHERE documentGuid = '${guid}';`
+	);
+
+	await tx.documentVersion.deleteMany({
+		where: {
+			documentGuid: guid
+		}
+	});
+
+	await tx.$queryRawUnsafe(`DELETE Document WHERE guid = '${guid}';`);
+};
+
+/**
+ *
+ * @param {PrismaClient} tx
+ * @param caseId
+ * @returns {Promise<void>}
+ */
+const removeS51Advices = async (tx, caseId) => {
+	const advices = await tx.s51Advice.findMany({
+		where: { caseId }
+	});
+	await Promise.all(
+		advices.map(async ({ id: adviceId }) =>
+			tx.s51AdviceDocument.deleteMany({ where: { adviceId } })
+		)
+	);
+	await tx.s51Advice.deleteMany({ where: { caseId } });
+};
+
+/**
+ *
+ * @param {PrismaClient} tx
+ * @param caseId
+ * @returns {Promise<void>}
+ */
+const removeFoldersAndDocuments = async (tx, caseId) => {
+	const folders = await tx.folder.findMany({
+		where: { caseId }
+	});
+	const documents = await tx.document.findMany({
+		where: { caseId }
+	});
+
+	const removeFoldersByParentId = async (folderId) => {
+		await Promise.all(
+			folders
+				.filter((folder) => folder.parentFolderId === folderId)
+				.map((folder) => removeFoldersByParentId(folder.id))
+		);
+		if (folderId) {
+			await Promise.all(
+				documents
+					.filter((document) => document.folderId === folderId)
+					.map((document) => removeDocument(tx, document))
+			);
+			await tx.folder.delete({ where: { id: folderId } });
+		}
+	};
+
+	await removeFoldersByParentId(null);
+};
+
+/**
+ *
+ * @param {PrismaClient} tx
+ * @param caseId
+ * @returns {Promise<void>}
+ */
+const removeOtherAssociatedRecords = async (tx, caseId) => {
+	await Promise.all([
+		tx.caseStatus.deleteMany({
+			where: { caseId }
+		}),
+		tx.casePublishedState.deleteMany({
+			where: { caseId }
+		}),
+		tx.gridReference.deleteMany({
+			where: { caseId }
+		}),
+		tx.projectTeam.deleteMany({
+			where: { caseId }
+		}),
+		tx.subscription.deleteMany({
+			where: { caseId }
+		})
+	]);
+};
+
+/**
+ * @param {string} reference
+ * @returns {Promise<void>}
+ */
+const removeCase = async (reference) => {
+	try {
+		await databaseConnector.$transaction(async (tx) => {
+			const { id: caseId } = (await getCaseByRef(reference)) || {};
+			if (!caseId) {
+				throw new Error('No such case ' + reference);
+			}
+			const caseDetails = await getCaseById(caseId, {
+				applicationDetails: true,
+				applicant: true
+			});
+
+			const { applicant, ApplicationDetails } = caseDetails;
+
+			await Promise.all([
+				removeApplicationDetails(tx, ApplicationDetails),
+				removeExaminationTimetables(tx, caseId),
+				removeRepresentations(tx, caseId),
+				removeProjectUpdates(tx, caseId),
+				removeS51Advices(tx, caseId),
+				removeOtherAssociatedRecords(tx, caseId)
+			]);
+
+			await Promise.all([
+				removeFoldersAndDocuments(tx, caseId),
+				removeServiceUser(tx, applicant),
+				removeS51Advices(tx, caseId)
+			]);
+
+			await tx.case.delete({ where: { id: caseId } });
+
+			console.log(reference + ' Removed');
+
+			if (isSimulatedTest) {
+				throw new Error('Simulated deletion test');
+			}
+		});
+	} catch (e) {
+		if (e.message !== 'Simulated deletion test') {
+			console.log(reference + ' Removal failed');
+			return e;
+		}
+	}
+};
+
+/**
+ * Remove cases and associated records that match the references supplied
+ *
+ * @param {string[]} references
+ * @returns {Promise<{successes,errors}>}
+ */
+export const removeCases = async (references) => {
+	const errors = [];
+	const successes = [];
+
+	if (isSimulatedTest) {
+		console.log('SIMULATED DELETION TEST, NO CASES WILL BE REMOVED\n');
+	}
+
+	for (const reference of references) {
+		const error = await removeCase(reference);
+		if (error) {
+			errors.push({ reference, error });
+		} else {
+			successes.push({ reference });
+		}
+	}
+
+	console.log('\n*************************************');
+	console.log(`Removed ${successes.length} case${successes.length === 1 ? '' : 's'}`);
+	successes.forEach(({ reference }) => console.log('- ' + reference));
+	if (errors.length > 0) {
+		console.log(`\nSkipped ${errors.length} cases due to errors:`);
+		errors.forEach(({ reference }) => console.log('- ' + reference));
+	}
+	console.log('*************************************\n');
+	if (errors.length > 0) {
+		throw errors;
+	}
+};
+
+/**
+ * Retrieves the references for all the training cases
+ *
+ * @param {string} startsWith
+ * @returns {Promise<string[]>}
+ */
+const getReferencesPrefixedWith = async (startsWith) => {
+	const cases = await databaseConnector.case.findMany({
+		where: {
+			reference: {
+				startsWith
+			}
+		}
+	});
+
+	return cases.map(({ reference }) => reference);
+};
+
+/**
+ * Remove all training cases and associated records
+ *
+ * @returns {Promise<void>}
+ */
+export const removeAllTrainingCase = async () => {
+	const references = await getReferencesPrefixedWith('TRAIN');
+	await removeCases(references);
+};

--- a/packages/scripts/src/remove-training-cases.js
+++ b/packages/scripts/src/remove-training-cases.js
@@ -330,6 +330,8 @@ export const removeCases = async (references) => {
 		console.log('SIMULATED DELETION TEST, NO CASES WILL BE REMOVED\n');
 	}
 
+	console.log(`Attempting to delete ${references.length} cases\n`);
+
 	for (const reference of references) {
 		const error = await removeCase(reference);
 		if (error) {

--- a/packages/scripts/src/remove-training-cases.js
+++ b/packages/scripts/src/remove-training-cases.js
@@ -188,9 +188,8 @@ const removeFoldersAndDocuments = async (tx, caseDetails) => {
 			}
 
 			console.log(`Removing folder: ${folderPath}`);
-		} else {
-			// Now safe to delete all folders for a case as all the dependencies have been deleted
-			await tx.folder.deleteMany({ where: { caseId } });
+
+			await tx.folder.delete({ where: { id: folderId } });
 		}
 	};
 

--- a/packages/scripts/src/remove-training-cases.js
+++ b/packages/scripts/src/remove-training-cases.js
@@ -250,17 +250,7 @@ const removeCase = async (reference) => {
 				await removeServiceUser(tx, applicant);
 				await removeS51Advices(tx, caseId);
 
-				const skippedDocs = await tx.document.findMany({ where: { caseId } });
-				if (skippedDocs.length) {
-					console.log(`Skipped docs: ${JSON.stringify(skippedDocs, null, 2)}`);
-				}
-				const skippedFolders = await tx.folder.findMany({ where: { caseId } });
-				if (skippedFolders.length) {
-					console.log(`Skipped folders: ${JSON.stringify(skippedFolders, null, 2)}`);
-				}
-				const result = await tx.case.delete({ where: { id: caseId } });
-
-				console.log(result);
+				await tx.case.delete({ where: { id: caseId } });
 
 				console.log(reference + ' Removed');
 

--- a/packages/scripts/src/remove-training-cases.js
+++ b/packages/scripts/src/remove-training-cases.js
@@ -229,7 +229,7 @@ const removeFoldersAndDocuments = async (tx, caseDetails) => {
 
 			console.log(`Removing folder: ${folderPath}`);
 
-			await tx.folder.delete({ where: { id: folderId } });
+			await tx.folder.delete({ where: { id: folderId }, hardDelete: true });
 		}
 	};
 


### PR DESCRIPTION
## Describe your changes

A new pipeline and script has been created to remove all training cases and associated records as described in the ticket APPLICS-605.  

Please note that without the environment variable REMOVE_ALL_CASES being set to 'true', the transaction for each case is aborted to prevent the removal from actually taking place. 

I have successfully run this locally on my own machine against my local DB with the env var set to true and not set to true.  When set to true, the training cases and all associated records are deleted successfully.

I have run this in the pipeline on DEV without REMOVE_ALL_CASES being set and each deletion is rolled back as each transaction is aborted by throwing a synthetic error as designed.

This has not yet been run in a pipeline without aborting the transactions.

## APPLICS-605 Remove Training cases from PROD
https://pins-ds.atlassian.net/browse/APPLICS-605

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
