### PR TITLE
Feature/applics 648 delete bespoke folders

### DIFF
--- a/apps/api/src/database/migrations/20240723133812_soft_delete_custom_folders/migration.sql
+++ b/apps/api/src/database/migrations/20240723133812_soft_delete_custom_folders/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[caseId,displayNameEn,parentFolderId,deletedAt]` on the table `Folder` will be added. If there are existing duplicate values, this will fail.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- DropIndex
+ALTER TABLE [dbo].[Folder] DROP CONSTRAINT [Folder_caseId_displayNameEn_parentFolderId_key];
+
+-- AlterTable
+ALTER TABLE [dbo].[Folder] ADD [deletedAt] DATETIME2;
+
+-- CreateIndex
+ALTER TABLE [dbo].[Folder] ADD CONSTRAINT [Folder_caseId_displayNameEn_parentFolderId_deletedAt_key] UNIQUE NONCLUSTERED ([caseId], [displayNameEn], [parentFolderId], [deletedAt]);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/database/schema.prisma
+++ b/apps/api/src/database/schema.prisma
@@ -244,6 +244,7 @@ model Folder {
   parentFolderId           Int?
   caseId                   Int?
   isCustom                 Boolean                    @default(false)
+  deletedAt                DateTime?
   document                 Document[]
   case                     Case?                      @relation(fields: [caseId], references: [id])
   parentFolder             Folder?                    @relation("FolderTree", fields: [parentFolderId], references: [id], onDelete: NoAction, onUpdate: NoAction)
@@ -251,7 +252,7 @@ model Folder {
   stage                    String?
   ExaminationTimetableItem ExaminationTimetableItem[]
 
-  @@unique([caseId, displayNameEn, parentFolderId])
+  @@unique([caseId, displayNameEn, parentFolderId, deletedAt])
 }
 
 /// Document model

--- a/apps/api/src/database/seed/seed-development.js
+++ b/apps/api/src/database/seed/seed-development.js
@@ -11,6 +11,7 @@ import { deleteAllRecords } from './seed-clear.js';
  * @returns {Promise<void>}
  */
 const seedDevelopment = async () => {
+	process.env.NODE_ENV = 'seeding';
 	try {
 		await deleteAllRecords(databaseConnector);
 		await seedStaticData(databaseConnector);

--- a/apps/api/src/server/applications/application/file-folders/folders.routes.js
+++ b/apps/api/src/server/applications/application/file-folders/folders.routes.js
@@ -3,6 +3,7 @@ import { asyncHandler } from '@pins/express';
 import { validateApplicationId } from '../application.validators.js';
 import {
 	createFolder,
+	deleteFolder,
 	getDocuments,
 	getFolderPathList,
 	getListOfFolders,
@@ -234,9 +235,9 @@ router.post(
 		}
 		#swagger.parameters['body'] = {
             in: 'body',
-			description: 'Create document parameters',
+			description: 'Create folder parameters',
 			required: true,
-      schema: { $ref: '#/definitions/CreateFolderRequestBody' }
+      		schema: { $ref: '#/definitions/CreateFolderRequestBody' }
 		}
 		#swagger.parameters['x-service-name'] = {
 			in: 'header',
@@ -304,6 +305,46 @@ router.patch(
 	validateApplicationId,
 	validateFolderId,
 	asyncHandler(updateFolder)
+);
+
+router.delete(
+	'/:id/folders/:folderId',
+	/*
+		#swagger.tags = ['Applications']
+		#swagger.path = '/applications/{id}/folders/{folderId}'
+		#swagger.description = 'Deletes a folder as long as it is empty'
+		#swagger.parameters['id'] = {
+			in: 'path',
+			description: 'Application ID',
+			required: true,
+			type: 'integer'
+		}
+		#swagger.parameters['folderId'] = {
+			in: 'path',
+			description: 'Folder ID to delete',
+			required: true,
+			type: 'integer'
+		}
+		#swagger.parameters['x-service-name'] = {
+			in: 'header',
+			type: 'string',
+			description: 'Service name header',
+			default: 'swagger'
+		}
+		#swagger.parameters['x-api-key'] = {
+			in: 'header',
+			type: 'string',
+			description: 'API key header',
+			default: '123'
+		}
+		#swagger.responses[200] = {
+            description: 'The newly deleted folder',
+            schema: { id: 1, displayNameEn: 'Example', displayOrder: 1100 }
+        }
+	*/
+	validateApplicationId,
+	validateFolderId,
+	asyncHandler(deleteFolder)
 );
 
 export { router as fileFoldersRoutes };

--- a/apps/api/src/server/applications/application/file-folders/folders.service.js
+++ b/apps/api/src/server/applications/application/file-folders/folders.service.js
@@ -121,7 +121,8 @@ export const getDocumentsInFolder = async (folderId, pageNumber = 1, pageSize = 
  */
 export const getChildFolders = async (folderId, folderList = []) => {
 	const currentLevelFolderList = await folderRepository.getFoldersByParentId(folderId, {
-		select: { id: true, parentFolderId: true }
+		select: { id: true, parentFolderId: true },
+		where: { parentFolderId: folderId, isCustom: true }
 	});
 	folderList.push(...currentLevelFolderList);
 
@@ -170,6 +171,16 @@ export const updateFolder = async (id, { name }) => {
 	}
 
 	return mapSingleFolderDetails(folder);
+};
+
+/**
+ *
+ * @param {number} folderId
+ * @returns {Promise<boolean | undefined>}
+ */
+export const checkIfFolderIsCustom = async (folderId) => {
+	const folder = await folderRepository.getById(folderId);
+	return folder?.isCustom;
 };
 
 /**

--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -272,18 +272,17 @@ export const deleteDocument = (documentGuid) => {
 
 /**
  *
- * @param {{folderId: number, skipValue: number, pageSize: number, documentVersion?: number}} folderId
+ * @param {number} folderId
+ * @param {import('@prisma/client').Prisma.DocumentFindManyArgs} [options={}]
  * @returns {import('@prisma/client').PrismaPromise<Document[]>}
  */
-export const getDocumentsInFolder = ({ folderId, skipValue, pageSize }) => {
+export const getDocumentsInFolder = (folderId, options = {}) => {
 	return databaseConnector.document.findMany({
 		include: {
 			documentVersion: true,
 			latestDocumentVersion: true,
 			folder: true
 		},
-		skip: skipValue,
-		take: pageSize,
 		orderBy: [
 			{
 				createdAt: 'desc'
@@ -292,8 +291,24 @@ export const getDocumentsInFolder = ({ folderId, skipValue, pageSize }) => {
 		where: {
 			folderId,
 			isDeleted: false
+		},
+		...options
+	});
+};
+
+/**
+ *
+ * @param {number} folderId
+ * @returns {Promise<boolean>}
+ */
+export const doesDocumentsExistInFolder = async (folderId) => {
+	const count = await databaseConnector.document.count({
+		where: {
+			folderId,
+			isDeleted: false
 		}
 	});
+	return count > 0;
 };
 
 /**

--- a/apps/api/src/server/repositories/folder.repository.js
+++ b/apps/api/src/server/repositories/folder.repository.js
@@ -129,6 +129,19 @@ export const getFolderByNameAndCaseId = (caseId, folderName, parentFolderId) =>
 	});
 
 /**
+ * @param {number} parentFolderId
+ * @param {object | null} options
+ */
+export const getFoldersByParentId = (parentFolderId, options = null) => {
+	return databaseConnector.folder.findMany({
+		where: {
+			parentFolderId
+		},
+		...options
+	});
+};
+
+/**
  * @param {Object} folder
  * @param {string} folder.displayNameEn
  * @param {number} folder.caseId

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -2727,6 +2727,65 @@
 						}
 					}
 				}
+			},
+			"delete": {
+				"tags": ["Applications"],
+				"description": "Deletes a folder as long as it is empty",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					},
+					{
+						"name": "folderId",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Folder ID to delete"
+					},
+					{
+						"name": "x-service-name",
+						"in": "header",
+						"type": "string",
+						"description": "Service name header",
+						"default": "swagger"
+					},
+					{
+						"name": "x-api-key",
+						"in": "header",
+						"type": "string",
+						"description": "API key header",
+						"default": "123"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "The newly deleted folder",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"id": {
+									"type": "number",
+									"example": 1
+								},
+								"displayNameEn": {
+									"type": "string",
+									"example": "Example"
+								},
+								"displayOrder": {
+									"type": "number",
+									"example": 1100
+								}
+							},
+							"xml": {
+								"name": "main"
+							}
+						}
+					}
+				}
 			}
 		},
 		"/applications/{id}/folders/{folderId}/parent-folders": {
@@ -2861,7 +2920,7 @@
 					{
 						"name": "body",
 						"in": "body",
-						"description": "Create document parameters",
+						"description": "Create folder parameters",
 						"required": true,
 						"schema": {
 							"$ref": "#/definitions/CreateFolderRequestBody"

--- a/apps/api/src/server/utils/prisma-middleware.js
+++ b/apps/api/src/server/utils/prisma-middleware.js
@@ -11,6 +11,28 @@ export async function modifyPrismaDocumentQueryMiddleware(parameters, next) {
 		parameters.action = 'update';
 		parameters.args.data = { isDeleted: true };
 	}
+	if (process.env.NODE_ENV !== 'seeding' && parameters.model === 'Folder') {
+		if (parameters.action === 'delete') {
+			parameters.action = 'update';
+			parameters.args = parameters.args || {};
+			parameters.args.data = { deletedAt: new Date() };
+		}
+		if (parameters.action === 'deleteMany') {
+			parameters.action = 'updateMany';
+			parameters.args = parameters.args || {};
+			parameters.args.data = { deletedAt: new Date() };
+		}
+		if (
+			(parameters.action.startsWith('find') || parameters.action === 'count') &&
+			!parameters.args.includeDeleted
+		) {
+			parameters.args = parameters.args || {};
+			parameters.args.where = {
+				...parameters.args.where,
+				deletedAt: { equals: null }
+			};
+		}
+	}
 
 	return next(parameters);
 }


### PR DESCRIPTION
## Describe your changes

Implement API functionality for deleting custom_folders.
This required introducing soft-delete for folders due to foreign key constraints against Documents when hard-deleting folders, so I've added a `deletedAt` property to the Folders schema. It's a date rather than a boolean due to the requirement of being able to recreate a folder with the same name after the initial one is deleted.

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
