### PR TITLE
fix(functions): workarounds for curated layer issues

### DIFF
--- a/apps/functions/applications-migration/common/migrators/nsip-project-migration.js
+++ b/apps/functions/applications-migration/common/migrators/nsip-project-migration.js
@@ -67,10 +67,27 @@ export const getNsipProjects = async (log, caseReference, overrideMigrationStatu
 		nsipAdministrationOfficerIds: valueToArray(project.nsipAdministrationOfficerIds),
 		inspectorIds: valueToArray(project.inspectorIds),
 		migrationStatus: overrideMigrationStatus ? true : Boolean(project.migrationStatus),
-		regions: valueToArray(project.regions),
-		projectType: mapProjectType(project.projectType)
+		regions: mapRegions(valueToArray(project.regions)),
+		projectType: mapProjectType(project.projectType),
+
+		// TODO: remove fields manually mapped below once ODW-1329 resolved
+		// ensures required fields are present and corrects casing inconsistencies whilst curated layer is incorrect
+		welshLanguage: project.welshLanguage || project.WelshLanguage || null,
+		secretaryOfState: project.secretaryOfState || project.SecretaryOfState || null,
+		projectNameWelsh: project.projectNameWelsh || null,
+		projectLocationWelsh: project.projectLocationWelsh || null,
+		projectDescriptionWelsh: project.projectDescriptionWelsh || null,
+		examTimetablePublishStatus: project.examTimetablePublishStatus || null,
+		confirmedDateOfDecision: project.confirmedDateOfDecision || null
 	}));
 };
+
+/**
+ * temporary workaround to mitigate formatting issue ODW-1329
+ * replaces whitespaces with underscores
+ * TODO: remove once ODW-1329 resolved
+ */
+const mapRegions = (regions) => regions.map((region) => region.replaceAll(' ', '_'));
 
 /**
  * temporary workaround to fix casing issue


### PR DESCRIPTION
## Describe your changes

Workarounds for blocking issues currently present in the ODW curated layer. These can be removed once [ODW-1329](https://pins-ds.atlassian.net/browse/ODW-1329) is resolved.

Fixes for:
- `secretaryOfState` and `welshLanguage` being in incorrect case
- missing fields `projectNameWelsh`, `projectLocationWelsh`, `projectDescriptionWelsh`, `examTimetablePublishStatus`, `confirmedDateOfDecision`
- regions using space rather than underscore

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[ODW-1329]: https://pins-ds.atlassian.net/browse/ODW-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ