### PR TITLE
fix(tooling): fix hard delete bug (APPLICS-605)

### DIFF
--- a/apps/api/src/server/utils/prisma-middleware.js
+++ b/apps/api/src/server/utils/prisma-middleware.js
@@ -8,7 +8,7 @@
  * @returns {Promise<(arg0: any) => any>} The result of the next middleware in the chain.
  */
 export async function modifyPrismaDocumentQueryMiddleware(parameters, next) {
-	const { hardDelete = false } = parameters.args;
+	const { hardDelete = false } = parameters?.args || {};
 	if (hardDelete) {
 		delete parameters.args.hardDelete;
 	}


### PR DESCRIPTION
## Describe your changes

Fix a bug within the Prisma middleware to not assume that the args exist when checking for the hardDelete option

## APPLICS-605 Remove Training cases from PROD
https://pins-ds.atlassian.net/browse/APPLICS-605

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
