### PR TITLE
feat: examtimetable line item welsh description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
 				"pino": "^8.1.0",
 				"pino-http": "^8.1.0",
 				"pino-pretty": "^8.1.0",
-				"pins-data-model": "github:Planning-Inspectorate/data-model#1.4.1",
+				"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.4",
 				"pluralize": "8.0.0",
 				"randexp": "^0.5.3",
 				"redis": "^4.6.10",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 		"pino": "^8.1.0",
 		"pino-http": "^8.1.0",
 		"pino-pretty": "^8.1.0",
-		"pins-data-model": "github:Planning-Inspectorate/data-model#1.4.1",
+		"pins-data-model": "github:Planning-Inspectorate/data-model#1.7.4",
 		"pluralize": "8.0.0",
 		"randexp": "^0.5.3",
 		"redis": "^4.6.10",


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-703

PR adds new Welsh descriptions on the event line items, it will split and format them exactly the same as the standard description. Data model has been updated, and FO is already expecting this format. 

Example broadcast:
```json
 {"examTimetablePayload":{"caseReference":"BC0110001","events":[{"type":"Accompanied Site Inspection","date":"2021-08-19T00:00:00.000","description":"hello\r\n* item 1\r\n* item 2\r\n* item 3","descriptionWelsh":"hellow\r\n* witem 1\r\n* witem 2\r\n* witem 3","eventTitle":"normal","eventTitleWelsh":"wnormal","eventId":1,"eventLineItems":[]},{"type":"Deadline","date":"2025-10-10T00:00:00.000","description":"deadline description something","descriptionWelsh":"welsh deadline description something","eventTitle":"deadlinename","eventTitleWelsh":"wdeadlinename","eventDeadlineStartDate":"2022-10-05T00:00:00.000","eventId":2,"eventLineItems":[{"description":"desc 1","descriptionWelsh":"wdesc 1"},{"description":"desc 2","descriptionWelsh":"wdesc 2"},{"description":"desc 3","descriptionWelsh":"wdesc 3"}]}],"published":true}}
```

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
