### PR TITLE
chore(tooling): delete specified cases (APPLICS-605)

### DIFF
--- a/azure-pipelines-remove-specified-cases.yml
+++ b/azure-pipelines-remove-specified-cases.yml
@@ -8,6 +8,27 @@ parameters:
           - Test
           - Specified
           - Prod
+    - name: removeAllCases
+      displayName: Remove all cases
+      type: string
+      values:
+          - true
+          - false
+    - name: specifiedCases
+      displayName: Max transaction wait in seconds
+      type: string
+    - name: maxCasesToDelete
+      displayName: Max cases to delete
+      type: number
+      default: 40
+    - name: maxWaitInSeconds
+      displayName: Max transaction wait in seconds
+      type: number
+      default: 20
+    - name: maxTimeoutInSeconds
+      displayName: Max transaction timeout in seconds
+      type: number
+      default: 100
 
 pool: pins-odt-agent-pool
 
@@ -60,10 +81,11 @@ jobs:
                           nodeVersion: 20
                           environmentVariables:
                               DATABASE_URL: $(DATABASE_URL)
-                              REMOVE_ALL_CASES: $(REMOVE_ALL_CASES)
-                              SPECIFIED_CASES: $(SPECIFIED_CASES)
-                              TRANSACTION_MAX_WAIT_IN_SECONDS: $(TRANSACTION_MAX_WAIT_IN_SECONDS)
-                              TRANSACTION_TIMEOUT_IN_SECONDS: $(TRANSACTION_TIMEOUT_IN_SECONDS)
+                              SPECIFIED_CASES: ${{parameters.specifiedCases}}
+                              REMOVE_ALL_CASES: ${{parameters.removeAllCases}}
+                              MAX_CASES_TO_DELETE: ${{parameters.maxCasesToDelete}}
+                              TRANSACTION_MAX_WAIT_IN_SECONDS: ${{parameters.maxWaitInSeconds}}
+                              TRANSACTION_TIMEOUT_IN_SECONDS: ${{parameters.maxTimeoutInSeconds}}
                           script: npm run applications:remove-all-specified-cases
                           workingDirectory: $(Build.Repository.LocalPath)/packages/scripts
       workspace:

--- a/azure-pipelines-remove-specified-cases.yml
+++ b/azure-pipelines-remove-specified-cases.yml
@@ -1,0 +1,71 @@
+parameters:
+    - name: environment
+      displayName: Environment
+      type: string
+      default: Dev
+      values:
+          - Dev
+          - Test
+          - Specified
+          - Prod
+
+pool: pins-odt-agent-pool
+
+pr: none
+
+trigger: none
+
+resources:
+    repositories:
+        - repository: templates
+          type: github
+          endpoint: Planning-Inspectorate
+          name: Planning-Inspectorate/common-pipeline-templates
+          ref: refs/tags/release/3.16.1
+
+variables:
+    - template: variables/environments/${{ lower(parameters.environment )}}.yml@templates
+    - group: pipeline_secrets
+
+
+jobs:
+    - deployment: Remove_specified_cases_from_DB
+      displayName: Remove specified cases from ${{ parameters.environment }} Database
+      environment: ${{ parameters.environment }}
+      strategy:
+        runOnce:
+            deploy:
+                steps:
+                    - download: none
+                    - checkout: self
+                    - template: steps/node_script.yml@templates
+                      parameters:
+                          nodeVersion: 20
+                          script: npm ci
+                    - template: steps/azure_auth.yml@templates
+                    - template: steps/azure_get_secrets.yml@templates
+                      parameters:
+                          secrets:
+                              - name: back-office-sql-server-connection-string
+                                variable: DATABASE_URL
+                    - template: steps/node_script.yml@templates
+                      parameters:
+                          nodeVersion: 20
+                          environmentVariables:
+                              DATABASE_URL: $(DATABASE_URL)
+                          script: npm run prisma-generate
+                          workingDirectory: $(Build.Repository.LocalPath)/apps/api
+                    - template: steps/node_script.yml@templates
+                      parameters:
+                          nodeVersion: 20
+                          environmentVariables:
+                              DATABASE_URL: $(DATABASE_URL)
+                              REMOVE_ALL_CASES: $(REMOVE_ALL_CASES)
+                              SPECIFIED_CASES: $(SPECIFIED_CASES)
+                              TRANSACTION_MAX_WAIT_IN_SECONDS: $(TRANSACTION_MAX_WAIT_IN_SECONDS)
+                              TRANSACTION_TIMEOUT_IN_SECONDS: $(TRANSACTION_TIMEOUT_IN_SECONDS)
+                          script: npm run applications:remove-all-specified-cases
+                          workingDirectory: $(Build.Repository.LocalPath)/packages/scripts
+      workspace:
+        clean: all
+

--- a/azure-pipelines-remove-training-cases.yml
+++ b/azure-pipelines-remove-training-cases.yml
@@ -8,6 +8,24 @@ parameters:
           - Test
           - Training
           - Prod
+    - name: removeAllCases
+      displayName: Remove all cases
+      type: string
+      values:
+          - true
+          - false
+    - name: maxCasesToDelete
+      displayName: Max cases to delete
+      type: number
+      default: 40
+    - name: maxWaitInSeconds
+      displayName: Max transaction wait in seconds
+      type: number
+      default: 20
+    - name: maxTimeoutInSeconds
+      displayName: Max transaction timeout in seconds
+      type: number
+      default: 100
 
 pool: pins-odt-agent-pool
 
@@ -60,10 +78,10 @@ jobs:
                           nodeVersion: 20
                           environmentVariables:
                               DATABASE_URL: $(DATABASE_URL)
-                              REMOVE_ALL_CASES: $(REMOVE_ALL_CASES)
-                              MAX_CASES_TO_DELETE: $(MAX_CASES_TO_DELETE)
-                              TRANSACTION_MAX_WAIT_IN_SECONDS: $(TRANSACTION_MAX_WAIT_IN_SECONDS)
-                              TRANSACTION_TIMEOUT_IN_SECONDS: $(TRANSACTION_TIMEOUT_IN_SECONDS)
+                              REMOVE_ALL_CASES: ${{parameters.removeAllCases}}
+                              MAX_CASES_TO_DELETE: ${{parameters.maxCasesToDelete}}
+                              TRANSACTION_MAX_WAIT_IN_SECONDS: ${{parameters.maxWaitInSeconds}}
+                              TRANSACTION_TIMEOUT_IN_SECONDS: ${{parameters.maxTimeoutInSeconds}}
                           script: npm run applications:remove-all-training-cases
                           workingDirectory: $(Build.Repository.LocalPath)/packages/scripts
       workspace:

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -12,6 +12,7 @@
 		"lint:js:fix": "npx eslint . --fix",
 		"tscheck": "npx tsc -p jsconfig.json --maxNodeModuleJsDepth 0",
 		"applications:regenerate-api-keys": "node ./run/regenerate-api-keys-entry.js",
+		"applications:remove-specified-cases": "node ./run/remove-specified-cases-entry.js",
 		"applications:remove-all-training-cases": "node ./run/remove-all-training-cases-entry.js"
 	},
 	"dependencies": {

--- a/packages/scripts/run/remove-all-training-cases-entry.js
+++ b/packages/scripts/run/remove-all-training-cases-entry.js
@@ -1,4 +1,4 @@
-import { removeAllTrainingCases } from '../src/remove-training-cases.js';
+import { removeAllTrainingCases } from '../src/remove-cases.js';
 
 removeAllTrainingCases()
 	.then(() => {

--- a/packages/scripts/run/remove-specified-cases-entry.js
+++ b/packages/scripts/run/remove-specified-cases-entry.js
@@ -1,0 +1,15 @@
+import { removeSpecifiedCases } from '../src/remove-cases.js';
+
+removeSpecifiedCases()
+	.then(() => {
+		console.log('Successfully removed specified cases from backoffice-applications');
+	})
+	.catch((error) => {
+		throw new Error(
+			`Error occurred while removing specified cases from backoffice-applications: ${JSON.stringify(
+				error,
+				null,
+				2
+			)}`
+		);
+	});

--- a/packages/scripts/src/remove-cases.js
+++ b/packages/scripts/src/remove-cases.js
@@ -277,6 +277,9 @@ const removeCase = async (reference) => {
 		const startTime = Date.now();
 		await databaseConnector.$transaction(
 			async (tx) => {
+				if (!reference.startsWith('TRAIN')) {
+					throw new Error('Case is not a training case ' + reference);
+				}
 				const { id: caseId } = (await getCaseByRef(reference)) || {};
 				if (!caseId) {
 					throw new Error('No such case ' + reference);
@@ -335,7 +338,7 @@ const removeCases = async (references) => {
 	console.log(`Attempting to delete ${references.length} cases\n`);
 
 	for (const reference of references) {
-		const error = await removeCase(reference);
+		const error = await removeCase(reference.toUpperCase());
 		if (error) {
 			errors.push({ reference, error });
 		} else {

--- a/packages/scripts/src/remove-cases.js
+++ b/packages/scripts/src/remove-cases.js
@@ -10,6 +10,8 @@ const maxCasesToDelete =
 	parseInt(process.env.MAX_CASES_TO_DELETE ?? '0') || Number.MAX_SAFE_INTEGER;
 const maxWaitInSeconds = parseInt(process.env.TRANSACTION_MAX_WAIT_IN_SECONDS ?? '0') || 20;
 const maxTimeoutInSeconds = parseInt(process.env.TRANSACTION_TIMEOUT_IN_SECONDS ?? '0') || 100;
+const specifiedCases =
+	process.env.SPECIFIED_CASES?.split(',').map((reference) => reference.trim()) ?? [];
 
 const blobs = [];
 
@@ -322,7 +324,7 @@ const removeCase = async (reference) => {
  * @param {string[]} references
  * @returns {Promise<{successes,errors}>}
  */
-export const removeCases = async (references) => {
+const removeCases = async (references) => {
 	const errors = [];
 	const successes = [];
 
@@ -384,7 +386,20 @@ const getReferencesPrefixedWith = async (startsWith) => {
  * @returns {Promise<void>}
  */
 export const removeAllTrainingCases = async () => {
-	// const references = await getReferencesPrefixedWith('TRAIN0110004');
 	const references = await getReferencesPrefixedWith('TRAIN');
 	await removeCases(references);
+};
+
+/**
+ * Remove all specified cases and associated records
+ *
+ * @returns {Promise<void>}
+ */
+export const removeSpecifiedCases = async () => {
+	if (specifiedCases.length > 0) {
+		console.log('Specified cases to be removed:');
+		specifiedCases.forEach((reference) => console.log('- ' + reference));
+		console.log('');
+	}
+	await removeCases(specifiedCases);
 };


### PR DESCRIPTION
## Describe your changes

A new entry script has been added to allow the ability to pass in a comma separated list of specified case numbers via the environment variable SPECIFIED_CASES to remove those specific cases and associated records as described in the ticket APPLICS-605.  

Please note that without the environment variable REMOVE_ALL_CASES being set to 'true', the transaction for each case is aborted to prevent the removal from actually taking place. 

I have successfully run this locally on my own machine against my local DB with the env var set to true and not set to true.  When set to true, the specified cases and all associated records are deleted successfully.

**Please note the environment variable SPECIFIED_CASES will only accept a comma separated list of case references that are prefixed "TRAIN" to prevent the deletion of any cases that are not training cases.**

## APPLICS-605 Remove Training cases from PROD (Specified cases)
https://pins-ds.atlassian.net/browse/APPLICS-605

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
