### PR TITLE
fix(functions): convert s51 adviceid to number

### DIFF
--- a/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
+++ b/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
@@ -6,25 +6,6 @@ import { valueToArray } from '../utils.js';
 
 const query = 'SELECT * FROM [odw_curated_db].[dbo].[nsip_s51_advice] WHERE caseReference = ?';
 
-const s51AdviceProperties = [
-	'adviceId',
-	'adviceReference',
-	'caseId',
-	'caseReference',
-	'title',
-	'from',
-	'agent',
-	'method',
-	'enquiryDate',
-	'enquiryDetails',
-	'adviceGivenBy',
-	'adviceDate',
-	'adviceDetails',
-	'status',
-	'redactionStatus',
-	'attachmentIds'
-];
-
 /**
  * Migrate s51-advice
  *
@@ -82,8 +63,22 @@ export const getNsipS51Advice = async (log, caseReference, synapseQuery = query)
 			row.caseReference = BO_GENERAL_S51_CASE_REF;
 		}
 		return {
-			...pick(row, s51AdviceProperties),
-			caseId: Number(row.caseId), // TODO: remove after ODW-1307 is completed
+			...pick(row, [
+				'adviceReference',
+				'caseReference',
+				'title',
+				'from',
+				'agent',
+				'method',
+				'enquiryDate',
+				'enquiryDetails',
+				'adviceGivenBy',
+				'adviceDate',
+				'adviceDetails',
+				'redactionStatus'
+			]),
+			adviceId: Number(row.adviceId),
+			caseId: Number(row.caseId),
 			status: mapStatus(row.status),
 			attachmentIds: valueToArray(row.attachmentIds)
 		};


### PR DESCRIPTION
## Describe your changes

When running the s51 migrator function, the validation is failing because `adviceId` is not an integer. It is currently a string as that is how Sequelize stores `bigint` data from SQL Server (which is the type ODW are using for this column in their curated DB). Therefore, we need to convert it to Number/int before sending the data to the API.


## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
