### PR TITLE
feat(tooling): create remove training cases script fix parameter (APPLICS-605)

### DIFF
--- a/azure-pipelines-remove-specified-cases.yml
+++ b/azure-pipelines-remove-specified-cases.yml
@@ -15,7 +15,7 @@ parameters:
           - true
           - false
     - name: specifiedCases
-      displayName: Max transaction wait in seconds
+      displayName: Comma separated case references
       type: string
     - name: maxCasesToDelete
       displayName: Max cases to delete


### PR DESCRIPTION
## Describe your changes

Fixed parameter display name for specified cases

## APPLICS-605 Remove Training cases from PROD (Specified cases)
https://pins-ds.atlassian.net/browse/APPLICS-605

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review
A new entry script has been added to allow the ability to pass in a comma separated list of specified case numbers via the environment variable SPECIFIED_CASES to remove those specific cases and associated records as described in the ticket APPLICS-605.  

Please note that without the environment variable REMOVE_ALL_CASES being set to 'true', the transaction for each case is aborted to prevent the removal from actually taking place. 

I have successfully run this locally on my own machine against my local DB with the env var set to true and not set to true.  When set to true, the specified cases and all associated records are deleted successfully.

**Please note the environment variable SPECIFIED_CASES will only accept a comma separated list of case references that are prefixed "TRAIN" to prevent the deletion of any cases that are not training cases.**

## APPLICS-605 Remove Training cases from PROD (Specified cases)
https://pins-ds.atlassian.net/browse/APPLICS-605

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
