### PR TITLE
fix(api/applications): fix fetching of case stage from document

### DIFF
--- a/apps/api/src/server/applications/application/documents/__tests__/document-payload.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document-payload.test.js
@@ -27,7 +27,10 @@ describe('validateNsipDocument', () => {
 						createdAt: '2022-01-01T11:59:38.129Z',
 						modifiedAt: '2023-03-10T13:49:09.666Z',
 						publishedAt: null,
-						CaseStatus: [{ id: 1, status: 'draft' }]
+						CaseStatus: [
+							{ id: 1, valid: false, status: 'draft' },
+							{ id: 2, valid: true, status: 'examination' }
+						]
 					}
 				}
 			},

--- a/apps/api/src/server/applications/application/documents/__tests__/document.service.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/document.service.test.js
@@ -176,7 +176,8 @@ const docVersionAfterUpdate = {
 				description: 'A description of test case 1 which is a case of subsector type Office Use.',
 				title: 'Office Use Test Application 1',
 				hasUnpublishedChanges: true,
-				applicantId: 100000000
+				applicantId: 100000000,
+				CaseStatus: [{ id: 1, valid: true, status: 'draft' }]
 			}
 		}
 	}
@@ -236,6 +237,7 @@ describe('Document service test', () => {
 	test('createDocumentVersion uploads new version of document and does not unblish the document', async () => {
 		databaseConnector.case.findUnique.mockResolvedValue(application);
 		databaseConnector.document.findUnique.mockResolvedValue(documentWithVersionsUnpublished);
+		databaseConnector.documentVersion.update.mockResolvedValue(docVersionAfterUpdate);
 
 		const response = await createDocumentVersion(document, caseId, documentGuid);
 

--- a/apps/api/src/server/applications/application/documents/__tests__/unpublish-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/unpublish-document.test.js
@@ -15,7 +15,8 @@ const application1 = {
 	id: 1,
 	title: `${caseRef} - NI Case 3 Nam`,
 	description: `${caseRef} - NI Case 3 Name Description`,
-	reference: caseRef
+	reference: caseRef,
+	CaseStatus: [{ id: 1, valid: true, stage: 'examination' }]
 };
 
 /**

--- a/apps/api/src/server/applications/s51advice/__tests__/s51-advice.test.js
+++ b/apps/api/src/server/applications/s51advice/__tests__/s51-advice.test.js
@@ -164,7 +164,8 @@ const folderContainingDocumentToDelete = {
 	stage: null,
 	case: {
 		id: 100000001,
-		reference: 'BC0110001'
+		reference: 'BC0110001',
+		CaseStatus: [{ id: 1, valid: true, status: '0' }]
 	}
 };
 

--- a/apps/api/src/server/infrastructure/payload-builders/nsip-document.js
+++ b/apps/api/src/server/infrastructure/payload-builders/nsip-document.js
@@ -56,6 +56,15 @@ export const buildNsipDocumentPayload = (docVersionWithFullDetails, filePath = '
 		return null;
 	})();
 
+	const documentCaseStage = (() => {
+		const status = document.folder?.case?.CaseStatus?.find((cs) => cs.valid)?.status;
+		if (!status) {
+			return null;
+		}
+
+		return mapDocumentCaseStageToSchema(status);
+	})();
+
 	return {
 		documentId: document.guid,
 		caseRef: caseReference,
@@ -105,7 +114,7 @@ export const buildNsipDocumentPayload = (docVersionWithFullDetails, filePath = '
 			'filter1Welsh',
 			'filter2'
 		]),
-		documentCaseStage: mapDocumentCaseStageToSchema(docVersionWithFullDetails.stage)
+		documentCaseStage
 	};
 };
 
@@ -132,7 +141,7 @@ export const mapDocumentCaseStageToSchema = (stage) => {
 			// our DB 'Post-decision' maps to 'post_decision'
 			return 'post_decision';
 		default:
-			return stage.toLowerCase();
+			return stage.toLowerCase().replace(/_/g, '-');
 	}
 };
 


### PR DESCRIPTION
## Describe your changes

* fix(api/applications): fix fetching of case stage from document
* test(api/applications): update tests to reflect CaseStatus change

We're currently trying to fetch `stage` from the DocumentVersion table, but this is always null. Instead the stage comes from a separate `CaseStage` table.

## Issue ticket number and link

[APPLICS-749](https://pins-ds.atlassian.net/browse/APPLICS-749)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-749]: https://pins-ds.atlassian.net/browse/APPLICS-749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ