### PR TITLE
chore(readme.md): added instructions on adding a dummy user data file when running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ A normal npm i may not correctly pull the latest version of the schemas.  If you
 ```shell
 npm uninstall pins-data-model && npm prune && npm install github:Planning-Inspectorate/data-model#1.0.1
 ```
+#### Dummy User Data
+
+When running locally there is a DUMMY_USER_DATA flag that allows the application to read in some dummy user data in the form of a dummy_user_data.json file.
+
+```shell
+const dummyUserDataFile = path.join(process.cwd(), 'dummy_user_data.json');
+return JSON.parse(await fs.readFile(dummyUserDataFile, 'utf8'));
+```
+
+This file isn't committed to source control and is included in the Git ignore source file (.gitignore). Please request this file from a team member and place it in your local back-office\apps\web\ folder.  Without this file you will see an error when attempting to view cases on the front end.
 
 ### Running Locally the Applications Stack
 


### PR DESCRIPTION
## Describe your changes

A documentation update for developers to include a section on adding a dummy user data file to the back office solution when running the solution locally.

## Type of change 🧩

- [X] Documentation update

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [X] I have made corresponding changes to the documentation

