### PR TITLE
fix(web): use pagination to find users in AD (APPLICS-365)

### DIFF
--- a/apps/web/src/server/applications/case/project-team/applications-project-team.service.js
+++ b/apps/web/src/server/applications/case/project-team/applications-project-team.service.js
@@ -18,14 +18,13 @@ export const searchProjectTeamMembers = async (searchTerm, allAzureUsers, pageNu
 	const searchResults = allAzureUsers.filter((azureUser) => {
 		const { givenName, surname, userPrincipalName: email } = azureUser;
 
-		// check whether the search matches perfectly the name, the surname or the email
-		// for example, ‘Mil’ will not return ‘Miles’. Users will need to enter ‘Miles’
+		// check whether the search matches partially the name, the surname or the email
 		return (
-			`${givenName || ''} ${surname || ''}`.toLocaleLowerCase() === searchTerm ||
-			`${surname || ''} ${givenName || ''}`.toLocaleLowerCase() === searchTerm ||
-			`${givenName || ''}`.toLocaleLowerCase() === searchTerm ||
-			`${surname || ''}`.toLocaleLowerCase() === searchTerm ||
-			`${email || ''}`.toLocaleLowerCase() === searchTerm
+			`${givenName || ''} ${surname || ''}`.toLocaleLowerCase().includes(searchTerm) ||
+			`${surname || ''} ${givenName || ''}`.toLocaleLowerCase().includes(searchTerm) ||
+			`${givenName || ''}`.toLocaleLowerCase().includes(searchTerm) ||
+			`${surname || ''}`.toLocaleLowerCase().includes(searchTerm) ||
+			`${email || ''}`.toLocaleLowerCase().includes(searchTerm)
 		);
 	});
 

--- a/apps/web/src/server/lib/msGraphRequest.js
+++ b/apps/web/src/server/lib/msGraphRequest.js
@@ -9,7 +9,7 @@ const [requestLogger, responseLogger, retryLogger] = createHttpLoggerHooks(
 );
 const retryParams = createHttpRetryParams(config.retry);
 
-const prefixUrl = 'https://graph.microsoft.com/v1.0/';
+export const prefixUrl = 'https://graph.microsoft.com/v1.0/';
 
 const instance = got.extend({
 	prefixUrl,


### PR DESCRIPTION
## Describe your changes

Use pagination to find partial matches of users in AD
- Based the solution on the pagination solution in appeals
- Added some logging to prove results are being returned from the Active Directory
- Filter on partial matches

## APPLICS-365 Search for a team member: Missing names
https://pins-ds.atlassian.net/browse/APPLICS-365

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
