### PR TITLE
fix: missing migration broadcasts

### DIFF
--- a/apps/api/src/server/migration/migrators/nsip-exam-timetable-migrator.js
+++ b/apps/api/src/server/migration/migrators/nsip-exam-timetable-migrator.js
@@ -3,6 +3,7 @@ import { buildUpsertForEntity } from './sql-tools.js';
 import { MigratedEntityIdCeiling } from '../migrator.consts.js';
 import { getCaseIdFromRef, getExamTimetableTypeIdFromName } from './utils.js';
 import * as folderRepository from '#repositories/folder.repository.js';
+import { publish as BroadcastExamTimetable } from '../../applications/examination-timetable-items/examination-timetable-items.service.js';
 
 /**
  * Migrate NSIP Exam Timetable
@@ -53,6 +54,8 @@ export const migrateExamTimetables = async (examTimetables) => {
 				databaseConnector.$executeRawUnsafe(statement, ...parameters)
 			]);
 		}
+		console.info(`Broadcasting exam timetable id ${id} for case ${caseId}`);
+		await BroadcastExamTimetable(id);
 	}
 };
 
@@ -155,6 +158,12 @@ const bulletPoint = '*';
  * @returns {string} formattedDescription
  */
 const formatEventDescription = (description) => {
+	if (!description) {
+		return JSON.stringify({
+			preText: '',
+			bulletPoints: []
+		});
+	}
 	const splitDescription = description.split(bulletPoint);
 	const preText = trimNewLines(splitDescription.shift() || '');
 

--- a/apps/api/src/server/migration/migrators/nsip-representation-migrator.js
+++ b/apps/api/src/server/migration/migrators/nsip-representation-migrator.js
@@ -5,6 +5,7 @@ import { databaseConnector } from '#utils/database-connector.js';
 import { omit } from 'lodash-es';
 import * as documentRepository from '#repositories/document.repository.js';
 import * as representationAttachmentRepository from '#repositories/representation.repository.js';
+import { broadcastNsipRepresentationEvent } from '#infrastructure/event-broadcasters.js';
 
 /**
  * @typedef {import('pins-data-model').Schemas.Representation} RepresentationModel
@@ -30,6 +31,9 @@ export const migrateRepresentations = async (representations) => {
 		await databaseConnector.$transaction([
 			databaseConnector.$executeRawUnsafe(representationStatement, ...representationParameters)
 		]);
+
+		console.info('Broadcasting event for representation');
+		await broadcastNsipRepresentationEvent(representationEntity);
 
 		if (representationEntity.redacted) {
 			console.info(

--- a/apps/functions/applications-migration/common/migrators/nsip-representation-migration.js
+++ b/apps/functions/applications-migration/common/migrators/nsip-representation-migration.js
@@ -3,7 +3,7 @@ import { makePostRequest } from '../back-office-api-client.js';
 import { valueToArray } from '../utils.js';
 
 const query = `SELECT *
-			   FROM [odw_curated_db].[dbo].[relevant_representation]
+			   FROM [odw_curated_db].[dbo].[nsip_representation]
 			   WHERE caseRef = ?`;
 
 /**
@@ -58,6 +58,8 @@ export const getRepresentationsForCase = async (log, caseReference) => {
 	const representationEntities = representationRows.map((row) => {
 		return {
 			...row,
+			representationId: parseInt(row.representationId),
+			caseId: parseInt(row.caseId),
 			originalRepresentation: row.originalRepresentation || '',
 			attachmentIds: valueToArray(row.attachmentIds)
 		};


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-825

The exam-timetable and the representation entities were not being published after migration. This PR adds the missing broadcast. It also updates the table name for `representations` to the correct one after checking with ODW.

Note: Full e2e cannot be tested until the following tickets are complete: 
- https://pins-ds.atlassian.net/browse/ODW-1383 
- https://pins-ds.atlassian.net/browse/ODW-1378 

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
