### PR TITLE
fix(api): submitted files and comments are lost (APPLICS-861)

### DIFF
--- a/apps/api/src/server/applications/application/documents/__tests__/create-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/create-document.test.js
@@ -257,6 +257,13 @@ describe('Create documents', () => {
 			},
 			{
 				folderId: 1,
+				documentName: 'test doc',
+				documentType: 'application/pdf',
+				documentSize: 1024,
+				fromFrontOffice: true
+			},
+			{
+				folderId: 1,
 				documentName: 'test doc deleted',
 				documentType: 'application/pdf',
 				documentSize: 1024
@@ -266,7 +273,7 @@ describe('Create documents', () => {
 		// THEN
 		expect(response.status).toEqual(409);
 		expect(response.body).toEqual({
-			failedDocuments: [],
+			failedDocuments: ['test doc'],
 			duplicates: ['test doc'],
 			deleted: ['test doc deleted']
 		});

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -692,16 +692,22 @@ export const markDocumentVersionAsUnpublished = async ({ guid, version }) => {
 export const extractDuplicatesAndDeleted = async (documents) => {
 	const results = await Promise.allSettled(
 		documents.map(
-			({ folderId, documentName }) =>
-				new Promise((resolve, reject) =>
-					documentRepository.getInFolderByName(folderId, documentName, true).then((existing) => {
-						if (existing) {
-							reject({ documentName, isDeleted: existing.isDeleted });
-						} else {
-							resolve(documentName);
-						}
-					})
-				)
+			({ folderId, documentName, fromFrontOffice }) =>
+				new Promise((resolve, reject) => {
+					if (fromFrontOffice) {
+						// Allow duplicates from the front office
+						return resolve(documentName);
+					}
+					return documentRepository
+						.getInFolderByName(folderId, documentName, true)
+						.then((existing) => {
+							if (existing) {
+								reject({ documentName, isDeleted: existing.isDeleted });
+							} else {
+								resolve(documentName);
+							}
+						});
+				})
 		)
 	);
 


### PR DESCRIPTION
## Describe your changes

- Allow uploading of duplicate filenames as long as they were uploaded from front office
- Added to the unit tests to make sure a document with a duplicate filename and the fromFrontOffice property set to true will not be recognised as a duplicate and will be placed in the failed list when the upload fails.

## APPLICS-861 Submitted files/comments are lost
https://pins-ds.atlassian.net/browse/APPLICS-861

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
