### PR TITLE
fix(web): file upload validate content type and signature (APPLICS-517)

### DIFF
--- a/apps/web/src/client/components/file-uploader/_html.js
+++ b/apps/web/src/client/components/file-uploader/_html.js
@@ -17,6 +17,7 @@ export const errorMessage = (type, replaceValue) => {
 		GENERIC_SINGLE_FILE: `{REPLACE_VALUE} could not be added, try again`,
 		NAME_SINGLE_FILE: `{REPLACE_VALUE} could not be added because the file name is too long or contains special characters. Rename the file and try and upload again.`,
 		TYPE_SINGLE_FILE: `{REPLACE_VALUE} could not be added because it is not an allowed file type`,
+		TYPE_INVALID_FILE_CONTENT: `{REPLACE_VALUE} could not be added because the content is not valid for the file type`,
 		CONFLICT:
 			'{REPLACE_VALUE} could not be added, check if the file does not already exist and try again.',
 		DELETED:

--- a/apps/web/src/server/app/app.router.js
+++ b/apps/web/src/server/app/app.router.js
@@ -18,6 +18,7 @@ import getDocumentsDownload from './components/file-downloader.component.js';
 import {
 	postDocumentsUpload,
 	postUploadDocumentVersion,
+	postValidateFileSignatures,
 	postProcessHTMLFile
 } from './components/file-uploader.component.js';
 import { registerAdviceId, registerDownloadParams } from './app.locals.js';
@@ -69,6 +70,7 @@ router
 	.route('/documents/:caseId/download/:guid/version/:version/:preview?')
 	.get([registerDownloadParams], asyncHandler(getDocumentsDownload));
 router.route('/documents/process-html').post(asyncHandler(postProcessHTMLFile));
+router.route('/documents/validate-file-signatures').post(asyncHandler(postValidateFileSignatures));
 router.use('/applications-service', applicationsRouter);
 
 export default router;

--- a/apps/web/src/server/app/components/__tests__/file-uploader.component.test.js
+++ b/apps/web/src/server/app/components/__tests__/file-uploader.component.test.js
@@ -1,0 +1,93 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+import { postValidateFileSignatures } from '../file-uploader.component.js';
+
+describe('file-uploader.component', () => {
+	describe('postValidateFileSignatures', () => {
+		let request, response;
+		beforeEach(() => {
+			response = { send: jest.fn().mockResolvedValue() };
+		});
+
+		it('should send invalid signature when unknown filetype', async () => {
+			request = { body: [{ fileRowId: '01', fileType: 'unknown', hexSignature: 'ABCDEFGHIJKL' }] };
+			await postValidateFileSignatures(request, response);
+			expect(response.send).toHaveBeenCalledWith({
+				invalidSignatures: ['01']
+			});
+		});
+
+		it('should send no invalid signatures', async () => {
+			request = {
+				body: [
+					{ fileRowId: '01', fileType: 'application/pdf', hexSignature: '255044462DGF' },
+					{ fileRowId: '02', fileType: 'application/msword', hexSignature: 'D0CF11E0ADEA' },
+					{
+						fileRowId: '03',
+						fileType: 'application/vnd.ms-powerpoint',
+						hexSignature: 'D0CF11E000'
+					},
+					{ fileRowId: '04', fileType: 'video/mpeg', hexSignature: '000001B300' },
+					{ fileRowId: '05', fileType: 'video/mpeg', hexSignature: '000001BACC' },
+					{ fileRowId: '06', fileType: 'audio/mpeg', hexSignature: 'FFFB01B300' },
+					{ fileRowId: '07', fileType: 'audio/mpeg', hexSignature: '494433BACC' },
+					{ fileRowId: '08', fileType: 'video/mp4', hexSignature: 'ABCD013466747970' },
+					{ fileRowId: '09', fileType: 'video/mp4', hexSignature: '7070AABB667479701234' },
+					{ fileRowId: '10', fileType: 'video/quicktime', hexSignature: '0000001466747970FF' },
+					{ fileRowId: '11', fileType: 'image/png', hexSignature: '89504E471234' },
+					{ fileRowId: '12', fileType: 'image/tiff', hexSignature: '4D4D002A0471234' },
+					{ fileRowId: '13', fileType: 'image/tiff', hexSignature: '49492A004171234' },
+					{ fileRowId: '14', fileType: 'text/html', hexSignature: '0A3C212D2D207361' }
+				]
+			};
+			await postValidateFileSignatures(request, response);
+			expect(response.send).toHaveBeenCalledWith({
+				invalidSignatures: []
+			});
+		});
+
+		it('should send invalid signatures', async () => {
+			request = {
+				body: [
+					{ fileRowId: '01', fileType: 'application/pdf', hexSignature: '2544462DGF' },
+					{ fileRowId: '02', fileType: 'application/msword', hexSignature: 'D0CFE0ADEA' },
+					{
+						fileRowId: '03',
+						fileType: 'application/vnd.ms-powerpoint',
+						hexSignature: 'D0CF1000'
+					},
+					{ fileRowId: '04', fileType: 'video/mpeg', hexSignature: '0000B300' },
+					{ fileRowId: '05', fileType: 'video/mpeg', hexSignature: '000001CC' },
+					{ fileRowId: '06', fileType: 'audio/mpeg', hexSignature: 'FF01B300' },
+					{ fileRowId: '07', fileType: 'audio/mpeg', hexSignature: '4943BC' },
+					{ fileRowId: '08', fileType: 'video/mp4', hexSignature: 'ABCD0134747970' },
+					{ fileRowId: '09', fileType: 'video/mp4', hexSignature: '7070AABB6479701234' },
+					{ fileRowId: '10', fileType: 'video/quicktime', hexSignature: '00000466747970FF' },
+					{ fileRowId: '11', fileType: 'image/png', hexSignature: '89504E1234' },
+					{ fileRowId: '12', fileType: 'image/tiff', hexSignature: '4D4D002471234' },
+					{ fileRowId: '13', fileType: 'image/tiff', hexSignature: '4949004171234' },
+					{ fileRowId: '14', fileType: 'text/html', hexSignature: '0A3C212D207361' }
+				]
+			};
+			await postValidateFileSignatures(request, response);
+			expect(response.send).toHaveBeenCalledWith({
+				invalidSignatures: [
+					'01',
+					'02',
+					'03',
+					'04',
+					'05',
+					'06',
+					'07',
+					'08',
+					'09',
+					'10',
+					'11',
+					'12',
+					'13',
+					'14'
+				]
+			});
+		});
+	});
+});

--- a/apps/web/src/server/app/components/file-uploader.component.js
+++ b/apps/web/src/server/app/components/file-uploader.component.js
@@ -6,6 +6,7 @@ import { setSuccessBanner } from '../../applications/common/services/session.ser
 /** @typedef {import('@azure/core-auth').AccessToken} AccessToken */
 /** @typedef {{documentName: string, fileRowId: string, blobStoreUrl?: string, username?: string, name?: string}} DocumentUploadInfo */
 /** @typedef {{accessToken: AccessToken, blobStorageHost: string, privateBlobContainer: string, documents: DocumentUploadInfo[]}} UploadInfo */
+/** @typedef {{hexSignature: string, offset: number}} HexSignature */
 
 /**
  * @param {string} caseId
@@ -54,6 +55,63 @@ export async function postProcessHTMLFile({ body }, response) {
 
 		return response.status(err.response.statusCode).send(err.response.body);
 	}
+}
+
+/**
+ * Validate file signatures using
+ *
+ * @param {{body: []}} request
+ * @param {*} response
+ * @returns {Promise<{}>}
+ */
+export async function postValidateFileSignatures({ body }, response) {
+	// TODO: Replace all the "XXXX" withe the actual expected signature
+	const fileSignatures = {
+		/* See the following link for reference: https://www.garykessler.net/library/file_sigs.html */
+		/* .pdf  */ 'application/pdf': { hexSignature: '255044462D' },
+		/* .doc  */ 'application/msword': { hexSignature: 'D0CF11E0' },
+		/* .docx */ 'application/vnd.openxmlformats-officedocument.wordprocessingml.document': {
+			hexSignature: '504B03041400'
+		},
+		/* .ppt  */ 'application/vnd.ms-powerpoint': { hexSignature: 'D0CF11E0' },
+		/* .pptx */ 'application/vnd.openxmlformats-officedocument.presentationml.presentation': {
+			hexSignature: 'D0CF11E0'
+		},
+		/* .xls  */ 'application/vnd.ms-excel': { hexSignature: 'D0CF11E0' },
+		/* .xlsx */ 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': {
+			hexSignature: '504B03041400'
+		},
+		/* .jpg  */ 'image/jpeg': { hexSignature: 'FFD8FFE0' },
+		/* .msg  */ 'application/vnd.ms-outlook': { hexSignature: 'D0CF11E0' },
+		/* .mpeg */ 'video/mpeg': { hexSignature: '000001B3, 000001BA' },
+		/* .mp3  */ 'audio/mpeg': { hexSignature: 'FFFB, 494433' },
+		/* .mp4  */ 'video/mp4': { hexSignature: '66747970', offset: 8 },
+		/* .mov  */ 'video/quicktime': { hexSignature: '0000001466747970' },
+		/* .png  */ 'image/png': { hexSignature: '89504E47' },
+		/* .tif  */ 'image/tiff': { hexSignature: '4D4D002A, 49492A00' }, // 2 possible magic numbers here
+		/* .html */ 'text/html': { hexSignature: '0A3C212D2D207361' },
+		/* .prj  */ 'application/x-anjuta-project': { hexSignature: '' },
+		/* .dbf  */ 'application/dbf': { hexSignature: '4F504C4461746162, 61736546696C65' },
+		/* .shp  */ 'application/vnd.shp': { hexSignature: '' },
+		/* .shx  */ 'application/vnd.shx': { hexSignature: '' }
+		// Add more file signatures as needed
+	};
+	const invalidSignatures = body
+		.filter(({ fileType, hexSignature = '' }) => {
+			const /** @type {HexSignature} */ validFileType = fileSignatures[fileType];
+			if (!validFileType) {
+				return true; // Fail when filetype not supported
+			}
+			if (validFileType.hexSignature.length === 0) {
+				return false; // Pass when valid hexSignature is blank
+			}
+			const offset = validFileType.offset ?? 0;
+			return !validFileType.hexSignature
+				.split(',')
+				.some((magicNumber) => hexSignature.substring(offset).startsWith(magicNumber.trim()));
+		})
+		.map(({ fileRowId }) => fileRowId);
+	return response.send({ invalidSignatures });
 }
 
 /**


### PR DESCRIPTION
## Describe your changes

- Retrieve the hex signature from each uploaded file in web client side
- Make a request and test the hex signature of each file against a table web server side
- Display an error for each file that fails the signature test
- Add some unit tests 
- Fixed any type errors

## APPLICS-517 File upload: validate content type and signature
https://pins-ds.atlassian.net/browse/APPLICS-517

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
