### PR TITLE
fix(e2e): excluded material changes test when the feature flag is off

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/editCase.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/editCase.spec.js
@@ -41,6 +41,10 @@ describe('Edit a case', () => {
 	});
 
 	it('Should be able to edit material change field', () => {
+		if (!Cypress.env('featureFlags')['applics-156-material-changes']) {
+			return;
+		}
+
 		casePage.clickChangeLink('Material change application');
 		page.selectRadioButtonByValue('Yes');
 		page.clickButtonByText('Save changes');


### PR DESCRIPTION
## Describe your changes

prevented the Material Changes test to run when the MC Feature Flag is disabled and the files is not rendered

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/APPLICS-878

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
