### PR TITLE
fix(api): changes to project updates are not published to FO (APPLICS-885)

### DIFF
--- a/apps/api/src/server/applications/application/project-updates/project-updates.routes.js
+++ b/apps/api/src/server/applications/application/project-updates/project-updates.routes.js
@@ -333,6 +333,59 @@ router.patch(
 	asyncHandler(controller.patchProjectUpdate)
 );
 
+router.post(
+	'/:id/project-updates/:projectUpdateId/finalise-status',
+	/*
+        #swagger.tags = ['Applications']
+        #swagger.path = '/applications/{id}/project-updates/{projectUpdateId}/finalise-status'
+        #swagger.description = 'Update a project update and finalise status'
+        #swagger.parameters['id'] = {
+            in: 'path',
+			description: 'Application ID',
+			required: true,
+			type: 'integer'
+		}
+        #swagger.parameters['projectUpdateId'] = {
+            in: 'path',
+			description: 'Project Update ID',
+			required: true,
+			type: 'integer'
+		}
+		#swagger.parameters['x-service-name'] = {
+			in: 'header',
+			type: 'string',
+			description: 'Service name header',
+			default: 'swagger'
+		}
+		#swagger.parameters['x-api-key'] = {
+			in: 'header',
+			type: 'string',
+			description: 'API key header',
+			default: '123'
+		}
+        #swagger.responses[200] = {
+            description: 'The project update',
+			schema: { $ref: '#/definitions/ApplicationProjectUpdate' },
+        }
+        #swagger.responses[400] = {
+            description: 'Bad request',
+            schema: { $ref: '#/definitions/ApplicationProjectUpdateCreateBadRequest' }
+        }
+        #swagger.responses[404] = {
+            description: 'Not found',
+            schema: { $ref: '#/definitions/NotFound' }
+        }
+        #swagger.responses[500] = {
+            description: 'Internal server error',
+            schema: { $ref: '#/definitions/InternalError' }
+        }
+    */
+	validateApplicationId,
+	validateProjectUpdateId,
+	validateUpdateProjectUpdate,
+	asyncHandler(controller.postProjectUpdateFinaliseStatus)
+);
+
 router.delete(
 	'/:id/project-updates/:projectUpdateId',
 	/*

--- a/apps/api/src/server/applications/application/project-updates/project-updates.service.js
+++ b/apps/api/src/server/applications/application/project-updates/project-updates.service.js
@@ -56,10 +56,9 @@ export async function createProjectUpdateService(body, caseId) {
  *
  * @param {*} body
  * @param {number} projectUpdateId
- * @param {boolean} shouldFinalise
  * @returns {Promise<import('@pins/applications').ProjectUpdate>}
  */
-export async function updateProjectUpdateService(body, projectUpdateId, shouldFinalise = false) {
+export async function updateProjectUpdateService(body, projectUpdateId) {
 	const updateReq = projectUpdateUpdateReq(body);
 
 	const initialUpdate = await getProjectUpdate(projectUpdateId);
@@ -82,7 +81,7 @@ export async function updateProjectUpdateService(body, projectUpdateId, shouldFi
 		await eventClient.sendEvents(
 			NSIP_PROJECT_UPDATE,
 			[buildProjectUpdatePayload(update, update.case.reference)],
-			statusToEventType(update.status, shouldFinalise)
+			statusToEventType(update.status)
 		);
 	} catch (/** @type {*} */ err) {
 		logger.error({ error: err.message }, 'Blocked sending event for project update');

--- a/apps/api/src/server/applications/application/project-updates/project-updates.service.js
+++ b/apps/api/src/server/applications/application/project-updates/project-updates.service.js
@@ -112,6 +112,8 @@ export async function finaliseProjectUpdateService(projectUpdateId) {
 		case ProjectUpdate.Status.readyToUnpublish:
 			updateReq.status = ProjectUpdate.Status.unpublished;
 			break;
+		case ProjectUpdate.Status.draft:
+			return mapProjectUpdate(initialUpdate);
 		default:
 			throw BackOfficeAppError(
 				`Project update with ID ${projectUpdateId} has invalid status ${initialUpdate.status}.`,

--- a/apps/api/src/server/repositories/project-update.respository.js
+++ b/apps/api/src/server/repositories/project-update.respository.js
@@ -92,10 +92,12 @@ export async function createProjectUpdate(req) {
  * Get a project update
  *
  * @param {number} id
+ * @param {*} include
  * @returns {Promise<import('@prisma/client').ProjectUpdate|null>}
  */
-export async function getProjectUpdate(id) {
+export async function getProjectUpdate(id, include = {}) {
 	return databaseConnector.projectUpdate.findUnique({
+		include,
 		where: {
 			id
 		}
@@ -221,3 +223,4 @@ export async function createNotificationLogs(logs) {
 
 export class ProjectUpdateDeleteError extends BackOfficeAppError {}
 export class ProjectUpdateStatusError extends BackOfficeAppError {}
+export class PostProjectUpdateFinaliseStatusError extends BackOfficeAppError {}

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -3539,6 +3539,68 @@
 				}
 			}
 		},
+		"/applications/{id}/project-updates/{projectUpdateId}/finalise-status": {
+			"post": {
+				"tags": ["Applications"],
+				"description": "Update a project update and finalise status",
+				"parameters": [
+					{
+						"name": "id",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Application ID"
+					},
+					{
+						"name": "projectUpdateId",
+						"in": "path",
+						"required": true,
+						"type": "integer",
+						"description": "Project Update ID"
+					},
+					{
+						"name": "x-service-name",
+						"in": "header",
+						"type": "string",
+						"description": "Service name header",
+						"default": "swagger"
+					},
+					{
+						"name": "x-api-key",
+						"in": "header",
+						"type": "string",
+						"description": "API key header",
+						"default": "123"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "The project update",
+						"schema": {
+							"$ref": "#/definitions/ApplicationProjectUpdate"
+						}
+					},
+					"400": {
+						"description": "Bad request",
+						"schema": {
+							"$ref": "#/definitions/ApplicationProjectUpdateCreateBadRequest"
+						}
+					},
+					"404": {
+						"description": "Not found",
+						"schema": {
+							"$ref": "#/definitions/NotFound"
+						}
+					},
+					"500": {
+						"description": "Internal server error",
+						"schema": {
+							"$ref": "#/definitions/InternalError"
+						}
+					}
+				}
+			}
+		},
 		"/applications/documents/{documentGUID}/status": {
 			"patch": {
 				"tags": ["Applications"],

--- a/apps/web/src/server/applications/case/project-updates/__tests__/project-updates.test.js
+++ b/apps/web/src/server/applications/case/project-updates/__tests__/project-updates.test.js
@@ -317,7 +317,9 @@ describe('project-updates', () => {
 		beforeEach(async () => {
 			nocks();
 			nock('http://test/')
-				.patch(`/applications/${mockCaseReference.id}/project-updates/${mockProjectUpdate.id}`)
+				.post(
+					`/applications/${mockCaseReference.id}/project-updates/${mockProjectUpdate.id}/finalise-status`
+				)
 				.reply(200)
 				.persist();
 			await request.get('/applications-service/');

--- a/apps/web/src/server/applications/case/project-updates/project-updates.controller.js
+++ b/apps/web/src/server/applications/case/project-updates/project-updates.controller.js
@@ -14,7 +14,8 @@ import {
 	deleteProjectUpdate,
 	getProjectUpdate,
 	getProjectUpdates,
-	patchProjectUpdate
+	patchProjectUpdate,
+	postProjectUpdateFinaliseStatus
 } from './project-updates.service.js';
 import {
 	createDetailsView,
@@ -329,7 +330,7 @@ export async function projectUpdatesCheckAnswersPost(req, res) {
 	const { caseId, projectUpdateId } = res.locals;
 
 	if (req.body.status) {
-		await patchProjectUpdate(caseId, projectUpdateId, { status: req.body.status });
+		await postProjectUpdateFinaliseStatus(caseId, projectUpdateId);
 	}
 	let action = 'saved';
 	const projectUpdate = await getProjectUpdate(caseId, projectUpdateId);

--- a/apps/web/src/server/applications/case/project-updates/project-updates.service.js
+++ b/apps/web/src/server/applications/case/project-updates/project-updates.service.js
@@ -44,6 +44,15 @@ export async function patchProjectUpdate(caseId, id, update) {
 /**
  * @param {string} caseId
  * @param {string} id
+ * @returns {Promise<any>}
+ */
+export async function postProjectUpdateFinaliseStatus(caseId, id) {
+	return post(`applications/${caseId}/project-updates/${id}/finalise-status`);
+}
+
+/**
+ * @param {string} caseId
+ * @param {string} id
  * @returns {Promise<void>}
  */
 export async function deleteProjectUpdate(caseId, id) {


### PR DESCRIPTION
## Describe your changes

Allow project updates update events to be sent on every update.
Make sure duplicate publish and unpublish events are not sent.

API:
- created a new end point for finalising project updates
- updated unit tests for the new end point

WEB:
- call new end point when "Publish Changes" or "Unpublish Changes" buttons are pressed
- updated unit tests for above

## APPLICS-885 Live bug: Changes to project updates are not published to FO
https://pins-ds.atlassian.net/browse/APPLICS-885

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
