### PR TITLE
fix(web): accessibility audit - validation error (APPLICS-828)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/addTeam.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/addTeam.spec.js
@@ -28,12 +28,14 @@ describe('Project team related scenarios ', () => {
 		applicationsHomePage.loadCurrentCase();
 		searchResultsPage.clickLinkByText('Project team');
 		searchResultsPage.clickButtonByText('Add team member');
+		projectTeamPage.verifyPageTitle('Search for a team member - Project team');
 	});
 
 	it('As a user able to add team member and verify the role is added to project team', () => {
 		email = Cypress.env('CASE_ADMIN_EMAIL');
 		projectTeamPage.addTeamMeber(email);
 		projectTeamPage.verifyCaseManagerRoleAdded();
+		projectTeamPage.verifyPageTitle(`${projectInfo.projectName} - Project team`);
 	});
 
 	it('As a user able to verify team member is added', () => {
@@ -54,5 +56,6 @@ describe('Project team related scenarios ', () => {
 
 	it('As a user able to verify the error message without entering the search criteria', () => {
 		projectTeamPage.validateErrorMessageWithoutEnteringAnything();
+		projectTeamPage.verifyPageTitle('Search for a team member - Project team', { error: true });
 	});
 });

--- a/apps/e2e/cypress/e2e/back-office-applications/createCase.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/createCase.spec.js
@@ -23,8 +23,12 @@ describe('Create A Case', () => {
 		it('As a user able to validate that all input validation errors in the create case flow', () => {
 			cy.login(applicationsUsers.caseAdmin);
 			cy.visit('/');
+			applicationsHomePage.verifyPageTitle('Applications - NSIP Applications');
 			applicationsHomePage.clickCreateNewCaseButton();
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Enter name and description', {
+				error: true
+			});
 			createCasePage.validateErrorMessageCountOnPage(2);
 			createCasePage.validateErrorMessage('Enter project name');
 			createCasePage.validateErrorMessage('Enter project description');
@@ -33,20 +37,28 @@ describe('Create A Case', () => {
 				projectInfo.projectDescription
 			);
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Choose a sector');
 
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Choose a sector', { error: true });
 			createCasePage.validateErrorMessageCountOnPage(1);
 			createCasePage.validateErrorMessage('Choose the sector of the project');
 
 			createCasePage.sections.sector.chooseSector(projectInfo.sector);
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Choose a subsector');
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Choose a subsector', { error: true });
 			createCasePage.validateErrorMessageCountOnPage(1);
 			createCasePage.validateErrorMessage('Choose the subsector of the project');
 			createCasePage.sections.subSector.chooseSubsector(projectInfo.sector, projectInfo.subsector);
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Enter geographical information');
 
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Enter geographical information', {
+				error: true
+			});
 			createCasePage.validateErrorMessageCountOnPage(3);
 			createCasePage.validateErrorMessage('Enter project location');
 			createCasePage.validateErrorMessage('Enter the Grid reference Easting');
@@ -59,17 +71,28 @@ describe('Create A Case', () => {
 				projectInfo.gridRefNorthing
 			);
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Choose one or multiple regions');
 
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Choose one or multiple regions', {
+				error: true
+			});
 			createCasePage.validateErrorMessageCountOnPage(1);
 			createCasePage.validateErrorMessage('Choose at least one region');
 			createCasePage.sections.regions.chooseRegions(projectInfo.regions);
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Choose map zoom level');
 
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Enter the project email (optional)');
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle(
+				'Create new case - Choose the Applicant information you have available'
+			);
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Enter the key dates of the project');
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Create new case - Check your answers');
 			createCasePage.sections.checkYourAnswers.checkAllAnswers(projectInfo, true);
 			createCasePage.clickButtonByText('I accept - confirm creation of a new case');
 			createCasePage.sections.caseCreated.validateCaseCreated();

--- a/apps/e2e/cypress/e2e/back-office-applications/documentProperties.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/documentProperties.spec.js
@@ -52,14 +52,22 @@ describe('Document Properties', () => {
 	it('As a user should be able to upload a document to a case', () => {
 		applicationsHomePage.loadCurrentCase();
 		validateProjectOverview(projectInfo);
+		if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
+			searchResultsPage.verifyPageTitle(`${projectInfo.projectName} - Overview`);
+		} else {
+			documentPropertiesPage.verifyPageTitle(`${projectInfo.projectName} - Project information`);
+		}
 		searchResultsPage.clickLinkByText('Project documentation');
 		searchResultsPage.clickLinkByText('Project management');
+		fileUploadPage.verifyPageTitle(`${projectInfo.projectName} - NSIP Applications`);
 		fileUploadPage.verifyUploadButtonIsVisible();
 		fileUploadPage.uploadFile('test.pdf');
-		searchResultsPage.clickButtonByText('Save and continue');
+		fileUploadPage.clickButtonByText('Save and continue');
+		fileUploadPage.verifyPageTitle(`${projectInfo.projectName} - NSIP Applications`);
 		fileUploadPage.verifyFolderDocuments(1);
 		fileUploadPage.verifyUploadIsComplete();
 		fileUploadPage.clickLinkByText('View/Edit properties');
+		documentPropertiesPage.verifyPageTitle(`${projectInfo.projectName} - Project documentation`);
 		documentPropertiesPage.updateDocumentProperty('File name', fileName());
 		documentPropertiesPage.updateDocumentProperty('Description', description(), 'textarea');
 		documentPropertiesPage.updateDocumentProperty('Who the document is from', from(), 'textarea');
@@ -68,5 +76,6 @@ describe('Document Properties', () => {
 		documentPropertiesPage.updateDocumentType('No document type');
 		documentPropertiesPage.updateDate('Date received', getDate(true));
 		documentPropertiesPage.updateRedactionStatus('Redacted');
+		documentPropertiesPage.verifyPageTitle(`${projectInfo.projectName} - Project documentation`);
 	});
 });

--- a/apps/e2e/cypress/e2e/back-office-applications/documentPropertiesWelsh.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/documentPropertiesWelsh.spec.js
@@ -51,8 +51,10 @@ describe('Document Properties including welsh fields', () => {
 	beforeEach(() => {
 		if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
 			applicationsHomePage.loadCurrentCase();
+			searchResultsPage.verifyPageTitle(`${projectInfo.projectName} - Overview`);
 			searchResultsPage.clickLinkByText('Project documentation');
 			searchResultsPage.clickLinkByText('Project management');
+			fileUploadPage.verifyPageTitle(`${projectInfo.projectName} - NSIP Applications`);
 		}
 	});
 
@@ -60,7 +62,8 @@ describe('Document Properties including welsh fields', () => {
 		if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
 			fileUploadPage.verifyUploadButtonIsVisible();
 			fileUploadPage.uploadFile('test.pdf');
-			searchResultsPage.clickButtonByText('Save and continue');
+			fileUploadPage.clickButtonByText('Save and continue');
+			fileUploadPage.verifyPageTitle(`${projectInfo.projectName} - NSIP Applications`);
 			fileUploadPage.verifyFolderDocuments(1);
 			fileUploadPage.verifyUploadIsComplete();
 			fileUploadPage.clickLinkByText('View/Edit properties');
@@ -92,9 +95,11 @@ describe('Document Properties including welsh fields', () => {
 			documentPropertiesPage.updateDate('Date received', getDate(true));
 			documentPropertiesPage.updateRedactionStatus('Redacted');
 			cy.get('.govuk-back-link').click();
+			documentPropertiesPage.verifyPageTitle(`${projectInfo.projectName} - NSIP Applications`);
 			folderPage.markAllReadyToPublish();
 			folderPage.clickLinkByText('View publishing queue');
 			folderPage.publishAllDocumentsInList();
+			documentPropertiesPage.verifyPageTitle('Document/s successfully published');
 		}
 	});
 
@@ -117,7 +122,11 @@ describe('Document Properties including welsh fields', () => {
 			documentPropertiesPage.updateDate('Date received', getDate(true));
 			documentPropertiesPage.updateRedactionStatus('Redacted');
 			cy.get('.govuk-back-link').click();
+			documentPropertiesPage.verifyPageTitle(`${projectInfo.projectName} - NSIP Applications`);
 			folderPage.markAllReadyToPublish();
+			documentPropertiesPage.verifyPageTitle(`${projectInfo.projectName} - NSIP Applications`, {
+				error: true
+			});
 			documentPropertiesPage.validateSummaryErrorMessage(
 				'You must fill in all mandatory document properties to publish a document'
 			);

--- a/apps/e2e/cypress/page_objects/basePage.js
+++ b/apps/e2e/cypress/page_objects/basePage.js
@@ -220,6 +220,11 @@ export class Page {
 
 	// A S S E R T I O N S
 
+	verifyPageTitle(title, options) {
+		const pageTitle = `${options?.error ? 'Error: ' : ''}Casework Back Office System - ${title}`;
+		cy.title().should('eq', pageTitle);
+	}
+
 	verifyTableCellText(options) {
 		this.basePageElements
 			.tableBody()

--- a/apps/e2e/cypress/page_objects/createCaseSections/caseCreated.js
+++ b/apps/e2e/cypress/page_objects/createCaseSections/caseCreated.js
@@ -8,6 +8,7 @@ export class CaseCreatedSection extends SectionBase {
 			.then((text) => {
 				cy.wrap(text.trim()).should('equal', 'New case has been created');
 			});
+		this.verifyPageTitle('NSIP Applications');
 		this.saveCaseReference();
 		this.saveCaseIdFromUrl();
 	}

--- a/apps/e2e/cypress/page_objects/projectTeamPage.js
+++ b/apps/e2e/cypress/page_objects/projectTeamPage.js
@@ -52,6 +52,9 @@ export class ProjectTeamPage extends Page {
 	validateErrorMessageWithoutEnteringAnything() {
 		this.elements.searchTeamMemberButton().click();
 		this.elements.errorMessageForSearch().contains('Enter a search term');
+		this.verifyPageTitle('Search for a team member - Project team', {
+			error: true
+		});
 	}
 	verifyRoleChangedToOperationsManager() {
 		this.elements.changeRoleLink().click();

--- a/apps/web/src/server/applications/case/examination-timetable/__tests__/applications-timetable.test.js
+++ b/apps/web/src/server/applications/case/examination-timetable/__tests__/applications-timetable.test.js
@@ -9,6 +9,7 @@ import {
 	fixtureTimetableWelshCase
 } from '../../../../../../testing/applications/fixtures/timetable-types.js';
 import { createTestEnvironment } from '../../../../../../testing/index.js';
+import { buildPageTitle, getPageTitle } from '../../../../../../testing/util/title.js';
 
 const { app } = createTestEnvironment();
 const request = supertest(app);
@@ -291,6 +292,10 @@ describe('Edit examination timetable', () => {
 
 			const element = parseHtml(response.text);
 
+			expect(getPageTitle(response)).toEqual(
+				buildPageTitle(['Edit timetable item', 'Examination timetable'])
+			);
+
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('Edit timetable item');
 		});
@@ -308,6 +313,10 @@ describe('Edit examination timetable', () => {
 				);
 
 				const element = parseHtml(response.text, { rootElement: 'h1' });
+
+				expect(getPageTitle(response)).toEqual(
+					buildPageTitle(['Item name in Welsh', 'Examination timetable'])
+				);
 
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('Item name in Welsh');
@@ -331,6 +340,10 @@ describe('Edit examination timetable', () => {
 
 						const element = parseHtml(response.text, { rootElement: '.govuk-error-summary' });
 
+						expect(getPageTitle(response)).toEqual(
+							buildPageTitle(['Item name in Welsh', 'Examination timetable'], { error: true })
+						);
+
 						expect(element.innerHTML).toContain('Enter item name in Welsh');
 					});
 					it('should show an error when submitted welsh name is too long', async () => {
@@ -342,6 +355,10 @@ describe('Edit examination timetable', () => {
 							});
 
 						const element = parseHtml(response.text, { rootElement: '.govuk-error-summary' });
+
+						expect(getPageTitle(response)).toEqual(
+							buildPageTitle(['Item name in Welsh', 'Examination timetable'], { error: true })
+						);
 
 						expect(element.innerHTML).toContain(
 							'Item name in Welsh must be 200 characters or less'
@@ -378,6 +395,10 @@ describe('Edit examination timetable', () => {
 				);
 
 				const element = parseHtml(response.text, { rootElement: 'h1' });
+
+				expect(getPageTitle(response)).toEqual(
+					buildPageTitle(['Item description in Welsh', 'Examination timetable'])
+				);
 
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('Item description in Welsh');

--- a/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
+++ b/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
@@ -72,7 +72,7 @@ exports[`S51 Advice S51 Attachment delete POST /case/123/project-documentation/2
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
             <div class="govuk-panel govuk-panel--confirmation">
-                <h1 class="govuk-panel__title"> Attachmment deleted successfully </h1>
+                <h1 class="govuk-panel__title"> Attachment deleted successfully </h1>
                 <div class="govuk-panel__body">
                     <p class='govuk-!-font-size-19'>Case: Title CASE/04
                         <br>Reference: CASE/04</p>

--- a/apps/web/src/server/applications/case/s51/__tests__/applications-s51.test.js
+++ b/apps/web/src/server/applications/case/s51/__tests__/applications-s51.test.js
@@ -9,6 +9,7 @@ import {
 import { fixtureCases } from '../../../../../../testing/applications/applications.js';
 import { fixturePaginatedS51Advice } from '../../../../../../testing/applications/fixtures/s51-advice.js';
 import { createS51Advice } from '../../../../../../testing/applications/factory/s51-advice.js';
+import { buildPageTitle, getPageTitle } from '../../../../../../testing/util/title.js';
 
 const { app, installMockApi, teardown } = createTestEnvironment();
 const request = supertest(app);
@@ -53,10 +54,12 @@ describe('S51 Advice', () => {
 		describe('GET /case/123/project-documentation/21/s51-advice/', () => {
 			it('should render the page', async () => {
 				await request.get('/applications-service/');
-
 				const response = await request.get(`${baseUrl}`);
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(
+					buildPageTitle(['Title CASE/04', 'NSIP Applications'])
+				);
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('S51 advice folder');
 			});
@@ -127,6 +130,9 @@ describe('S51 Advice', () => {
 					const response = await request.get(`${baseUrl}/create/title`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enter the S51 advice title', 'S51 advice'])
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Enter the S51 advice title');
 
@@ -161,6 +167,10 @@ describe('S51 Advice', () => {
 						.post(`${baseUrl}/create/title`)
 						.send({ title: 'existing title' });
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enter the S51 advice title', 'S51 advice'], { error: true })
+					);
+
 					const element = parseHtml(response.text);
 					expect(element.innerHTML).toContain('Enter a new title');
 				});
@@ -180,6 +190,10 @@ describe('S51 Advice', () => {
 					// test value is saved in the session
 					const response2 = await request.get(`${baseUrl}/create/title`);
 					const element = parseHtml(response2.text);
+
+					expect(getPageTitle(response2)).toEqual(
+						buildPageTitle(['Enter the S51 advice title', 'S51 advice'])
+					);
 					expect(element.innerHTML).toContain('sent s51 title');
 				});
 			});
@@ -199,6 +213,10 @@ describe('S51 Advice', () => {
 					expect(element.innerHTML).toContain('Enter who the enquiry was from');
 
 					const backElement = parseHtml(response.text, { rootElement: '.govuk-back-link' });
+
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enter who the enquiry was from', 'S51 advice'])
+					);
 					expect(backElement.innerHTML).toContain(`"${baseUrl}/create/title"`);
 				});
 			});
@@ -208,6 +226,9 @@ describe('S51 Advice', () => {
 					const response = await request.post(`${baseUrl}/create/enquirer`).send({});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enter who the enquiry was from', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('You must enter either a name, organisation or both');
 				});
@@ -218,6 +239,9 @@ describe('S51 Advice', () => {
 						.send({ enquirerFirstName: 'Joe' });
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enter who the enquiry was from', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('You must enter a last name');
 				});
@@ -228,6 +252,9 @@ describe('S51 Advice', () => {
 						.send({ enquirerLastName: 'Joe' });
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enter who the enquiry was from', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('You must enter a first name');
 				});
@@ -244,6 +271,9 @@ describe('S51 Advice', () => {
 					// test data is saved in the session
 					const response2 = await request.get(`${baseUrl}/create/enquirer`);
 					const element = parseHtml(response2.text);
+					expect(getPageTitle(response2)).toEqual(
+						buildPageTitle(['Enter who the enquiry was from', 'S51 advice'])
+					);
 					expect(element.innerHTML).toContain('Joe');
 					expect(element.innerHTML).toContain('Doe');
 					expect(element.innerHTML).toContain('Joes Organization');
@@ -261,6 +291,9 @@ describe('S51 Advice', () => {
 					const response = await request.get(`${baseUrl}/create/method`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Select the method of enquiry', 'S51 advice'])
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('How was the enquiry made?');
 
@@ -274,6 +307,9 @@ describe('S51 Advice', () => {
 					const response = await request.post(`${baseUrl}/create/method`).send({});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Select the method of enquiry', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toContain('You must select a method of enquiry');
 				});
 
@@ -286,6 +322,9 @@ describe('S51 Advice', () => {
 					// test data is saved in the session
 					const response2 = await request.get(`${baseUrl}/create/method`);
 					const element = parseHtml(response2.text);
+					expect(getPageTitle(response2)).toEqual(
+						buildPageTitle(['Select the method of enquiry', 'S51 advice'])
+					);
 					expect(element.innerHTML).toContain('value="email" checked');
 				});
 			});
@@ -301,6 +340,7 @@ describe('S51 Advice', () => {
 					const response = await request.get(`${baseUrl}/create/enquiry-details`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(buildPageTitle(['Enquiry details', 'S51 advice']));
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Enquiry details');
 
@@ -314,6 +354,9 @@ describe('S51 Advice', () => {
 					const response = await request.post(`${baseUrl}/create/enquiry-details`).send({});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enquiry details', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toContain('You must enter the date');
 					expect(element.innerHTML).toContain('You must enter the enquiry details');
 				});
@@ -340,6 +383,9 @@ describe('S51 Advice', () => {
 					});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enquiry details', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toContain('The date cannot be in the future');
 				});
 
@@ -355,6 +401,9 @@ describe('S51 Advice', () => {
 					// test data is saved in the session
 					const response2 = await request.get(`${baseUrl}/create/enquiry-details`);
 					const element = parseHtml(response2.text);
+					expect(getPageTitle(response2)).toEqual(
+						buildPageTitle(['Enquiry details', 'S51 advice'])
+					);
 					expect(element.innerHTML).toContain('01');
 					expect(element.innerHTML).toContain('12');
 					expect(element.innerHTML).toContain('2020');
@@ -373,6 +422,9 @@ describe('S51 Advice', () => {
 					const response = await request.get(`${baseUrl}/create/person`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enter who gave the advice', 'S51 advice'])
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Enter the name of the person who gave the advice');
 
@@ -386,6 +438,9 @@ describe('S51 Advice', () => {
 					const response = await request.post(`${baseUrl}/create/person`).send({});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Enter who gave the advice', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toContain('You must enter a name');
 				});
 
@@ -398,6 +453,9 @@ describe('S51 Advice', () => {
 					// test data is saved in the session
 					const response2 = await request.get(`${baseUrl}/create/person`);
 					const element = parseHtml(response2.text);
+					expect(getPageTitle(response2)).toEqual(
+						buildPageTitle(['Enter who gave the advice', 'S51 advice'])
+					);
 					expect(element.innerHTML).toContain('Joe Doe');
 				});
 			});
@@ -414,6 +472,7 @@ describe('S51 Advice', () => {
 
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(buildPageTitle(['Advice details', 'S51 advice']));
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Advice details');
 
@@ -427,6 +486,9 @@ describe('S51 Advice', () => {
 					const response = await request.post(`${baseUrl}/create/advice-details`).send({});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Advice details', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toContain('You must enter the date');
 					expect(element.innerHTML).toContain('You must enter the advice given');
 				});
@@ -441,6 +503,9 @@ describe('S51 Advice', () => {
 
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Advice details', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toContain('Enter a valid');
 				});
 
@@ -453,6 +518,9 @@ describe('S51 Advice', () => {
 					});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['Advice details', 'S51 advice'], { error: true })
+					);
 					expect(element.innerHTML).toContain('The date cannot be in the future');
 				});
 
@@ -468,6 +536,8 @@ describe('S51 Advice', () => {
 					// test data is saved in the session
 					const response2 = await request.get(`${baseUrl}/create/advice-details`);
 					const element = parseHtml(response2.text);
+
+					expect(getPageTitle(response2)).toEqual(buildPageTitle(['Advice details', 'S51 advice']));
 					expect(element.innerHTML).toContain('01');
 					expect(element.innerHTML).toContain('12');
 					expect(element.innerHTML).toContain('2020');
@@ -486,6 +556,7 @@ describe('S51 Advice', () => {
 					const response = await request.get(`${baseUrl}/create/check-your-answers`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(buildPageTitle(['NSIP Applications']));
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Check your answers');
 				});
@@ -496,6 +567,9 @@ describe('S51 Advice', () => {
 					const response = await request.post(`${baseUrl}/create/check-your-answers`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['NSIP Applications'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('An error occurred, please try again later');
 				});
@@ -521,6 +595,7 @@ describe('S51 Advice', () => {
 					const response2 = await request.get(`${baseUrl}/1/properties`);
 					const element = parseHtml(response2.text);
 
+					expect(getPageTitle(response2)).toEqual(buildPageTitle(['NSIP Applications']));
 					expect(element.innerHTML).toContain('New S51 advice item created');
 				});
 			});
@@ -537,6 +612,7 @@ describe('S51 Advice', () => {
 				const response = await request.get(`${baseUrl}/1/properties`);
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(buildPageTitle(['NSIP Applications']));
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('S51 advice properties');
 
@@ -548,6 +624,7 @@ describe('S51 Advice', () => {
 				const response = await request.get(`${baseUrl}/1/properties#s51-attachments`);
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(buildPageTitle(['NSIP Applications']));
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('File name');
 			});
@@ -564,6 +641,9 @@ describe('S51 Advice', () => {
 				const response = await request.get(`${baseUrl}/1/delete`);
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(
+					buildPageTitle(['Delete selected S51 advice', 'S51 advice'])
+				);
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('Delete selected S51 advice');
 
@@ -584,6 +664,9 @@ describe('S51 Advice', () => {
 				const response = await request.get(`${baseUrl}/1/attachments/${documentGuid}/delete`);
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(
+					buildPageTitle(['Delete selected attachment', 'S51 advice'])
+				);
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('Delete selected attachment');
 
@@ -609,6 +692,9 @@ describe('S51 Advice', () => {
 
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(
+					buildPageTitle(['Delete selected S51 advice', 'S51 advice'], { error: true })
+				);
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('Your item could not be deleted');
 			});
@@ -629,8 +715,9 @@ describe('S51 Advice', () => {
 
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(buildPageTitle(['Attachment deleted successfully']));
 				expect(element.innerHTML).toMatchSnapshot();
-				expect(element.innerHTML).toContain('Attachmment deleted successfully');
+				expect(element.innerHTML).toContain('Attachment deleted successfully');
 			});
 		});
 	});
@@ -645,6 +732,7 @@ describe('S51 Advice', () => {
 				const response = await request.get(`${baseUrl}/publishing-queue`);
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(buildPageTitle(['NSIP Applications']));
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('Select items for publishing');
 
@@ -658,6 +746,9 @@ describe('S51 Advice', () => {
 				const response = await request.get(`${baseUrl}/publishing-queue/remove/1`);
 				const element = parseHtml(response.text);
 
+				expect(getPageTitle(response)).toEqual(
+					buildPageTitle(['NSIP Applications'], { error: true })
+				);
 				expect(element.innerHTML).toMatchSnapshot();
 				expect(element.innerHTML).toContain('Select items for publishing');
 				expect(element.innerHTML).toContain('An error occurred, please try again later');
@@ -681,6 +772,7 @@ describe('S51 Advice', () => {
 					const response = await request.get(`${baseUrl}/222/edit/title-in-welsh`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(buildPageTitle(['NSIP Applications']));
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('S51 title in Welsh');
 
@@ -698,6 +790,9 @@ describe('S51 Advice', () => {
 					const response = await request.post(`${baseUrl}/222/edit/title-in-welsh`).send({});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['NSIP Applications'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Enter the S51 title in Welsh');
 				});
@@ -708,6 +803,9 @@ describe('S51 Advice', () => {
 					});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['NSIP Applications'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain(
 						'The S51 title in Welsh must be 255 characters or fewer'
@@ -724,6 +822,7 @@ describe('S51 Advice', () => {
 					const response = await request.get(`${baseUrl}/222/edit/enquiry-detail-in-welsh`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(buildPageTitle(['NSIP Applications']));
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Enquiry details in Welsh');
 
@@ -743,6 +842,9 @@ describe('S51 Advice', () => {
 						.send({});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['NSIP Applications'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Enter the S51 Enquiry details in Welsh');
 				});
@@ -753,6 +855,9 @@ describe('S51 Advice', () => {
 					});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['NSIP Applications'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain(
 						'The S51 Enquiry details in Welsh must be 255 characters or fewer'
@@ -769,6 +874,7 @@ describe('S51 Advice', () => {
 					const response = await request.get(`${baseUrl}/222/edit/advice-detail-in-welsh`);
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(buildPageTitle(['NSIP Applications']));
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Advice given in Welsh');
 
@@ -788,6 +894,9 @@ describe('S51 Advice', () => {
 						.send({});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['NSIP Applications'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain('Enter the S51 Advice given in Welsh');
 				});
@@ -798,6 +907,9 @@ describe('S51 Advice', () => {
 					});
 					const element = parseHtml(response.text);
 
+					expect(getPageTitle(response)).toEqual(
+						buildPageTitle(['NSIP Applications'], { error: true })
+					);
 					expect(element.innerHTML).toMatchSnapshot();
 					expect(element.innerHTML).toContain(
 						'The S51 Advice given in Welsh must be 255 characters or fewer'
@@ -828,6 +940,9 @@ describe('S51 pages when user belongs to wrong group', () => {
 
 			const element = parseHtml(response.text);
 
+			expect(getPageTitle(response)).toEqual(
+				buildPageTitle(['Sorry, there is a problem with your login'])
+			);
 			expect(element.innerHTML).toContain('You are not permitted to access this URL');
 		});
 	});

--- a/apps/web/src/server/views/app/layouts/app.layout.njk
+++ b/apps/web/src/server/views/app/layouts/app.layout.njk
@@ -17,11 +17,13 @@
 {% set appName = 'Casework Back Office System' %}
 
 {% block pageTitle %}
+	{% if errors %}
+		Error:
+	{% endif %}
 	{{appName}}
 	{{ '- '+pageTitle if pageTitle or '' }}
 	{{ '- '+serviceName if serviceName or '' }}
-
-{% endblock %}
+{%- endblock %}
 
 {% block header %}
 	{% set domainName = 'Planning Inspectorate'%}

--- a/apps/web/src/server/views/applications/case-s51/s51-attachment-successfully-deleted.njk
+++ b/apps/web/src/server/views/applications/case-s51/s51-attachment-successfully-deleted.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% set serviceName = ["Attachmment deleted successfully ", action] | join %}
+{% set serviceName = ["Attachment deleted successfully ", action] | join %}
 
 {% block beforeContent %}{% endblock %}
 {% block pageHeading %}{% endblock %}

--- a/apps/web/testing/util/title.js
+++ b/apps/web/testing/util/title.js
@@ -1,0 +1,25 @@
+/**
+ * Returns the title text extracted from the title tag within the response without formatting
+ *
+ * @param {{text: string}} response
+ * @returns {*|null}
+ */
+export const getPageTitle = (response) => {
+	const match = response.text.match(/<title>([^<]*)<\/title>/);
+	return match
+		? match[1].replaceAll('\t', ' ').replaceAll('\n', '').replaceAll('  ', ' ').trim()
+		: null;
+};
+
+/**
+ * Builds the expected page title from the page elements
+ *
+ * @param {string[]} pageElements
+ * @param {{error?: boolean}} options
+ * @returns {`${string}${string}`}
+ */
+export const buildPageTitle = (pageElements, options = {}) => {
+	return `${options?.error ? 'Error: ' : ''}${['Casework Back Office System', ...pageElements].join(
+		' - '
+	)}`;
+};


### PR DESCRIPTION
## Describe your changes
- Changed the main nunjucks layout to prefix the title with "Error: " if the page contains errors.
- Created the "verifyPageTitle" function to check the title within e2e tests.
- Applied the "verifyPageTitle" function to several e2e specs to prove the title is prefixed with "Error: " only when required. 
- Created the "getTitle" and "buildTitle" within the jest utils to allow the unit tests to prove the title is prefixed with "Error: " only when required. 
- Applied the above to some of the unit tests to prove the functionality works.

## APPLICS-828 C-BOS accessibility audit - validation error
https://pins-ds.atlassian.net/browse/APPLICS-828

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
