### PR TITLE
fix(functions): ensure originalRepresentation field cannot be empty

### DIFF
--- a/apps/api/src/server/migration/migrators/nsip-representation-migrator.js
+++ b/apps/api/src/server/migration/migrators/nsip-representation-migrator.js
@@ -94,7 +94,7 @@ const mapModelToRepresentationEntity = async ({
 		originalRepresentation,
 		redactedRepresentation,
 		redacted,
-		received: dateReceived,
+		received: new Date(dateReceived),
 		type: representationType,
 		unpublishedUpdates: false,
 		representativeId: representativeId ? parseInt(representativeId) : null,
@@ -112,6 +112,6 @@ const mapRepresentationRedactionAction = ({
 	representationId,
 	type: 'REDACTION',
 	actionBy: redactedBy || '',
-	actionDate: dateReceived,
+	actionDate: new Date(dateReceived),
 	notes: redactedNotes
 });

--- a/apps/functions/applications-migration/common/migrators/nsip-representation-migration.js
+++ b/apps/functions/applications-migration/common/migrators/nsip-representation-migration.js
@@ -46,10 +46,19 @@ export const getRepresentationsForCase = async (log, caseReference) => {
 			...row,
 			representationId: parseInt(row.representationId),
 			caseId: parseInt(row.caseId),
-			originalRepresentation: row.originalRepresentation || '',
+			originalRepresentation: constructOriginalRepresentation(
+				row.originalRepresentation,
+				row.redactedRepresentation
+			),
 			attachmentIds: valueToArray(row.attachmentIds)
 		};
 	});
 
 	return { representationEntities, count };
+};
+
+const constructOriginalRepresentation = (originalRepresentation, redactedRepresentation) => {
+	if (originalRepresentation?.trim()) return originalRepresentation.trim();
+	if (redactedRepresentation?.trim()) return redactedRepresentation.trim();
+	return 'No data in original record';
 };


### PR DESCRIPTION
## Describe your changes
[Ticket](https://pins-ds.atlassian.net/jira/software/c/projects/APPLICS/boards/238?selectedIssue=APPLICS-779)
This change ensures that any empty `originalRepresentation` fields are handled and given either a placeholder string or the value of the `redactedRepresentation`.
Also there is a slight fix to how some of the date values are put to the db. Previously they were just put as strings where as now they are correctly formatted ISO strings in UTC

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
