### PR TITLE
feat(functions): default text for adviceGivenBy in migration

### DIFF
--- a/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
+++ b/apps/functions/applications-migration/common/migrators/s51-advice-migration.js
@@ -57,7 +57,6 @@ export const getNsipS51Advice = async (log, caseReference, synapseQuery = query)
 				'agent',
 				'method',
 				'enquiryDate',
-				'adviceGivenBy',
 				'adviceDate',
 				'redactionStatus'
 			]),
@@ -66,7 +65,8 @@ export const getNsipS51Advice = async (log, caseReference, synapseQuery = query)
 			status: mapStatus(row.status),
 			attachmentIds: valueToArray(row.attachmentIds),
 			enquiryDetails: row.enquiryDetails ?? '',
-			adviceDetails: row.adviceDetails ?? ''
+			adviceDetails: row.adviceDetails ?? '',
+			adviceGivenBy: row.adviceGivenBy ? row.adviceGivenBy : 'Not recorded in Horizon'
 		};
 	});
 


### PR DESCRIPTION
## Describe your changes

adviceGivenBy is sometimes null or empty string in Horizon. This change adds a default value of 'Not recorded in Horizon' when migrating from ODW. 

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
