### PR TITLE
fix(api): fix relevant rep delete attachment bug (applics-1025)

### DIFF
--- a/apps/api/src/server/applications/application/representations/__tests__/get-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/get-representation.test.js
@@ -1,5 +1,5 @@
-import { request } from '../../../../app-test.js';
-const { databaseConnector } = await import('../../../../utils/database-connector.js');
+import { request } from '#app-test';
+const { databaseConnector } = await import('#utils/database-connector.js');
 
 const existingRepresentation = {
 	id: 1,
@@ -10,7 +10,11 @@ const existingRepresentation = {
 	attachments: [
 		{
 			id: 1,
-			documentGuid: 'document-guid'
+			documentGuid: 'document-guid',
+			Document: {
+				guid: 'document-guid',
+				isDeleted: false
+			}
 		}
 	],
 	representationActions: []

--- a/apps/api/src/server/applications/application/representations/__tests__/get-representations.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/get-representations.test.js
@@ -1,6 +1,6 @@
-import { request } from '../../../../app-test.js';
+import { request } from '#app-test';
 
-const { databaseConnector } = await import('../../../../utils/database-connector.js');
+const { databaseConnector } = await import('#utils/database-connector.js');
 
 const existingRepresentations = [
 	{

--- a/apps/api/src/server/applications/application/representations/attachment/__tests__/post-attachment.test.js
+++ b/apps/api/src/server/applications/application/representations/attachment/__tests__/post-attachment.test.js
@@ -1,6 +1,6 @@
-import { request } from '../../../../../app-test.js';
+import { request } from '#app-test';
 
-const { databaseConnector } = await import('../../../../../utils/database-connector.js');
+const { databaseConnector } = await import('#utils/database-connector.js');
 
 const existingRepresentations = [
 	{

--- a/apps/api/src/server/applications/application/representations/attachment/attachment.route.js
+++ b/apps/api/src/server/applications/application/representations/attachment/attachment.route.js
@@ -20,13 +20,19 @@ router.post(
 			required: true,
 			type: 'integer'
 		},
-				#swagger.parameters['body'] = {
+		#swagger.parameters['body'] = {
             in: 'body',
             description: 'Document Details',
             schema: {
-            documentId: 'a guid',
+            	documentId: 'a guid',
             }
         }
+		#swagger.parameters['x-api-key'] = {
+			in: 'header',
+			type: 'string',
+			description: 'API key header',
+			default: '123'
+		}
         #swagger.responses[200] = {
             description: 'Representation',
             schema: {
@@ -52,6 +58,30 @@ router.delete(
 			required: true,
 			type: 'integer'
 		},
+		#swagger.parameters['repId'] = {
+			in: 'path',
+			description: 'Representation ID',
+			required: true,
+			type: 'integer'
+		}
+		#swagger.parameters['attachmentId'] = {
+			in: 'path',
+			description: 'Attachment ID',
+			required: true,
+			type: 'integer'
+		}
+		#swagger.parameters['x-service-name'] = {
+			in: 'header',
+			type: 'string',
+			description: 'Service name header',
+			default: 'swagger'
+		}
+		#swagger.parameters['x-api-key'] = {
+			in: 'header',
+			type: 'string',
+			description: 'API key header',
+			default: '123'
+		}
         #swagger.responses[200] = {
             description: 'Attachment',
             schema: {

--- a/apps/api/src/server/applications/application/representations/attachment/attachment.service.js
+++ b/apps/api/src/server/applications/application/representations/attachment/attachment.service.js
@@ -1,5 +1,5 @@
-import * as representationsRepository from '../../../../repositories/representation.repository.js';
-import * as documentRepository from '../../../../repositories/document.repository.js';
+import * as representationsRepository from '#repositories/representation.repository.js';
+import * as documentRepository from '#repositories/document.repository.js';
 import { DOCUMENT_TYPES } from '../../../constants.js';
 
 /**
@@ -20,6 +20,8 @@ export const addAttachmentRepresentation = async (repId, documentId) => {
 };
 
 /**
+ * Soft deletes an attached document on a representation.
+ *
  * @param {number} repId
  * @param {number} attachmentId
  * */

--- a/apps/api/src/server/applications/application/representations/representations.controller.js
+++ b/apps/api/src/server/applications/application/representations/representations.controller.js
@@ -30,7 +30,13 @@ export const getRepresentation = async ({ params }, response) => {
 	}
 
 	const latestRedaction = getLatestRedaction(representation);
-	representation.attachments = mapDocumentRepresentationAttachments(representation.attachments);
+	// Filter the attachments to only get the undeleted docs
+	representation.attachments = mapDocumentRepresentationAttachments(
+		representation.attachments.filter(
+			(/** @type {{ Document: { isDeleted: boolean; }; }} */ attach) =>
+				attach.Document.isDeleted === false
+		)
+	);
 
 	return response.send({
 		...representation,

--- a/apps/api/src/server/repositories/__tests__/representation.repository.test.js
+++ b/apps/api/src/server/repositories/__tests__/representation.repository.test.js
@@ -452,6 +452,7 @@ describe('Representation repository', () => {
 				select: {
 					Document: {
 						select: {
+							isDeleted: true,
 							latestDocumentVersion: {
 								select: {
 									fileName: true

--- a/apps/api/src/server/repositories/representation.repository.js
+++ b/apps/api/src/server/repositories/representation.repository.js
@@ -154,6 +154,7 @@ export const getById = async (id) =>
 				select: {
 					Document: {
 						select: {
+							isDeleted: true,
 							latestDocumentVersion: {
 								select: {
 									fileName: true
@@ -503,12 +504,15 @@ export const upsertApplicationRepresentationAttachment = async (representationId
 };
 
 /**
+ * Soft deletes an attached document on a representation.
  *
  * @param {number} repId
  * @param {number} attachmentId
  * @returns {Promise<*>}
  */
 export const deleteApplicationRepresentationAttachment = async (repId, attachmentId) => {
+	// Note: this does NOT delete the record in the associative table RepresentationAttachment,
+	//		 it just marks the document as isDeleted in the Document table
 	const representation = await getFirstById(repId);
 
 	const transactionItems = [
@@ -517,6 +521,7 @@ export const deleteApplicationRepresentationAttachment = async (repId, attachmen
 		})
 	];
 
+	// if the representation is already published, this also sets the unpublishedUpdates flag on the rep
 	if (representation.status === 'PUBLISHED')
 		transactionItems.push(
 			databaseConnector.representation.update({

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -1377,6 +1377,13 @@
 								}
 							}
 						}
+					},
+					{
+						"name": "x-api-key",
+						"in": "header",
+						"type": "string",
+						"description": "API key header",
+						"default": "123"
 					}
 				],
 				"responses": {
@@ -1414,13 +1421,29 @@
 						"name": "repId",
 						"in": "path",
 						"required": true,
-						"type": "string"
+						"type": "integer",
+						"description": "Representation ID"
 					},
 					{
 						"name": "attachmentId",
 						"in": "path",
 						"required": true,
-						"type": "string"
+						"type": "integer",
+						"description": "Attachment ID"
+					},
+					{
+						"name": "x-service-name",
+						"in": "header",
+						"type": "string",
+						"description": "Service name header",
+						"default": "swagger"
+					},
+					{
+						"name": "x-api-key",
+						"in": "header",
+						"type": "string",
+						"description": "API key header",
+						"default": "123"
 					}
 				],
 				"responses": {

--- a/apps/web/src/server/applications/case/s51/applications-s51.controller.js
+++ b/apps/web/src/server/applications/case/s51/applications-s51.controller.js
@@ -420,6 +420,7 @@ export async function deleteApplicationsCaseS51Attachment({ params, body }, resp
 	const { adviceId, attachmentId } = params;
 	const { caseId } = response.locals;
 
+	// NOTE: whilst this soft deletes the document, it does NOT delete the record from the associative table S51AdviceDocument.  This is just in case we want to undelete the doc.
 	const { errors: apiErrors } = await deleteCaseDocumentationFile(
 		caseId,
 		attachmentId,


### PR DESCRIPTION
## Describe your changes

When deleting a document attachment on a Relevant Rep, it says that is attachment has been deleted, but the page showing the rep still has the document, and it can be looked at, downloaded, etc.
Reason was that the doc was soft deleted, but the view rep page did not filter on undeleted only.

## [Issue ticket number and link]
APPLICS-1025 Live bug: Deleting a document attached to a Relevant Representation did not delete the document
(https://pins-ds.atlassian.net/browse/APPLICS-1025)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
