### PR TITLE
feat(api): new training cases feature flag (applics-1030)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "scripts": {
     "test": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --forceExit --coverage",
+		"test:nocov": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --forceExit",
     "test:watch": "npm run test -- --watch",
     "coverage": "npm run prisma-generate && cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --forceExit --coverage",
     "dev": "cross-env TZ=utc npm run prisma-generate && nodemon --experimental-json-modules -e js ./src/server.js",

--- a/apps/api/src/server/applications/all-applications/__tests__/get-applications.test.js
+++ b/apps/api/src/server/applications/all-applications/__tests__/get-applications.test.js
@@ -101,7 +101,7 @@ describe('Get applications', () => {
 		// Feature Flag TRAINING not active
 		test('gets all applications - Training Feature Flag OFF', async () => {
 			// GIVEN
-			databaseConnector.case.findMany.mockResolvedValue([trainingCase]);
+			databaseConnector.case.findMany.mockResolvedValue([]);
 
 			// WHEN
 			const response = await request.get('/applications');

--- a/apps/api/src/server/applications/all-applications/__tests__/get-applications.test.js
+++ b/apps/api/src/server/applications/all-applications/__tests__/get-applications.test.js
@@ -30,25 +30,26 @@ let trainingCase = applicationFactoryForTests({
 		subSector: true
 	}
 });
-if (trainingCase.ApplicationDetails) {
-	trainingCase.ApplicationDetails.subSectorId = 26;
 
-	trainingCase.ApplicationDetails.subSector = {
-		id: 26,
-		abbreviation: 'TRAIN01',
+// @ts-ignore
+trainingCase.ApplicationDetails.subSectorId = 26;
+
+// @ts-ignore
+trainingCase.ApplicationDetails.subSector = {
+	id: 26,
+	abbreviation: 'TRAIN01',
+	name: 'training',
+	displayNameEn: 'Training',
+	displayNameCy: 'Training',
+	sectorId: 7,
+	sector: {
+		id: 7,
+		abbreviation: 'TRAIN',
 		name: 'training',
 		displayNameEn: 'Training',
-		displayNameCy: 'Training',
-		sectorId: 7,
-		sector: {
-			id: 7,
-			abbreviation: 'TRAIN',
-			name: 'training',
-			displayNameEn: 'Training',
-			displayNameCy: 'Training'
-		}
-	};
-}
+		displayNameCy: 'Training'
+	}
+};
 
 describe('Get applications', () => {
 	test('gets all applications', async () => {

--- a/apps/api/src/server/applications/search/__tests__/case-search.test.js
+++ b/apps/api/src/server/applications/search/__tests__/case-search.test.js
@@ -1,6 +1,9 @@
-import { BO_GENERAL_S51_CASE_REF } from '@pins/applications';
-import { request } from '../../../app-test.js';
+import { request } from '#app-test';
 import { applicationFactoryForTests } from '#utils/application-factory-for-tests.js';
+import {
+	buildTrainingCasesWhereClause,
+	whereNotGeneralS51AdviceCase
+} from '#repositories/case.repository.js';
 const { databaseConnector } = await import('#utils/database-connector.js');
 
 const searchString = 'EN010003 - NI Case 3 Name';
@@ -25,6 +28,7 @@ const application = applicationFactoryForTests({
  * @returns {object}
  */
 const expectedSearchParameters = (skip, take, query) => {
+	const whereTrainingCriteria = buildTrainingCasesWhereClause();
 	return {
 		skip,
 		take,
@@ -35,18 +39,8 @@ const expectedSearchParameters = (skip, take, query) => {
 		],
 		where: {
 			AND: [
-				{
-					OR: [
-						{
-							reference: {
-								not: BO_GENERAL_S51_CASE_REF
-							}
-						},
-						{
-							reference: null
-						}
-					]
-				},
+				whereNotGeneralS51AdviceCase,
+				whereTrainingCriteria,
 				{
 					OR: [
 						{

--- a/apps/api/src/server/repositories/__tests__/case.repository.test.js
+++ b/apps/api/src/server/repositories/__tests__/case.repository.test.js
@@ -1,0 +1,348 @@
+import { databaseConnector } from '#utils/database-connector.js';
+import {
+	getByStatus,
+	getBySearchCriteria,
+	getApplicationsCountBySearchCriteria,
+	createApplication,
+	updateApplication,
+	publishCase,
+	unpublishCase,
+	getById,
+	getByRef,
+	updateApplicationStatusAndDataById,
+	buildTrainingCasesWhereClause,
+	whereNotGeneralS51AdviceCase
+} from '../case.repository.js';
+
+/**
+ *
+ * @param {number} skip
+ * @param {number} take
+ * @param {string} query
+ * @returns {object}
+ */
+const expectedSearchParameters = (skip, take, query) => {
+	const whereTrainingCriteria = buildTrainingCasesWhereClause();
+	return {
+		skip,
+		take,
+		orderBy: [
+			{
+				createdAt: 'desc'
+			}
+		],
+		where: {
+			AND: [
+				whereNotGeneralS51AdviceCase,
+				whereTrainingCriteria,
+				{
+					OR: [
+						{
+							title: { contains: query }
+						},
+						{
+							reference: { contains: query }
+						},
+						{
+							description: { contains: query }
+						}
+					]
+				}
+			]
+		},
+		include: {
+			ApplicationDetails: {
+				include: {
+					subSector: {
+						include: {
+							sector: true
+						}
+					}
+				}
+			},
+			CaseStatus: {
+				where: {
+					valid: true
+				}
+			}
+		}
+	};
+};
+
+describe('Case Repository', () => {
+	describe('getByStatus', () => {
+		it('should fetch cases by status', async () => {
+			const statusArray = ['draft', 'submitted'];
+			const mockCases = [
+				{ id: 1, status: 'draft' },
+				{ id: 2, status: 'submitted' }
+			];
+			databaseConnector.case.findMany.mockResolvedValue(mockCases);
+
+			const result = await getByStatus(statusArray);
+
+			expect(databaseConnector.case.findMany).toHaveBeenCalledWith({
+				orderBy: [{ ApplicationDetails: { subSector: { abbreviation: 'asc' } } }],
+				where: {
+					AND: [
+						whereNotGeneralS51AdviceCase,
+						buildTrainingCasesWhereClause(),
+						{
+							CaseStatus: {
+								some: {
+									status: {
+										in: statusArray
+									},
+									valid: true
+								}
+							}
+						}
+					]
+				},
+				include: {
+					ApplicationDetails: {
+						include: {
+							subSector: {
+								include: {
+									sector: true
+								}
+							}
+						}
+					},
+					CaseStatus: {
+						where: {
+							valid: true
+						}
+					}
+				}
+			});
+			expect(result).toEqual(mockCases);
+		});
+	});
+
+	describe('getBySearchCriteria', () => {
+		it('should fetch cases by search criteria', async () => {
+			const query = 'test';
+			const skipValue = 0;
+			const pageSize = 10;
+			const mockCases = [{ id: 1, title: 'test case' }];
+			databaseConnector.case.findMany.mockResolvedValue(mockCases);
+
+			const result = await getBySearchCriteria(query, skipValue, pageSize);
+
+			expect(databaseConnector.case.findMany).toHaveBeenCalledWith(
+				expectedSearchParameters(0, 10, query)
+			);
+			expect(result).toEqual(mockCases);
+		});
+	});
+
+	describe('getApplicationsCountBySearchCriteria', () => {
+		it('should count applications by search criteria', async () => {
+			const query = 'test';
+			const mockCount = 5;
+			databaseConnector.case.count.mockResolvedValue(mockCount);
+			const whereTrainingCriteria = buildTrainingCasesWhereClause();
+
+			const result = await getApplicationsCountBySearchCriteria(query);
+
+			expect(databaseConnector.case.count).toHaveBeenCalledWith({
+				where: {
+					AND: [
+						whereNotGeneralS51AdviceCase,
+						whereTrainingCriteria,
+						{
+							OR: [
+								{
+									title: { contains: query }
+								},
+								{
+									reference: { contains: query }
+								},
+								{
+									description: { contains: query }
+								}
+							]
+						}
+					]
+				}
+			});
+			expect(result).toEqual(mockCount);
+		});
+	});
+
+	describe('createApplication', () => {
+		it('should create a new application', async () => {
+			const caseInfo = {
+				caseDetails: { title: 'New Case' },
+				gridReference: { easting: 123, northing: 456 },
+				applicationDetails: { locationDescription: 'Test Location' },
+				mapZoomLevelName: 'Level 1',
+				subSectorName: 'Sub Sector',
+				regionNames: ['Region 1'],
+				applicant: { firstName: 'John', lastName: 'Doe' },
+				applicantAddress: { addressLine1: '123 Street' }
+			};
+			const mockCase = { id: 1, ...caseInfo };
+			databaseConnector.case.create.mockResolvedValue(mockCase);
+
+			const result = await createApplication(caseInfo);
+
+			expect(databaseConnector.case.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					data: expect.objectContaining({
+						...caseInfo.caseDetails,
+						gridReference: { create: caseInfo.gridReference },
+						ApplicationDetails: expect.objectContaining({
+							create: expect.objectContaining({
+								...caseInfo.applicationDetails,
+								subSector: { connect: { name: caseInfo.subSectorName } },
+								zoomLevel: { connect: { name: caseInfo.mapZoomLevelName } },
+								regions: {
+									create: expect.arrayContaining([{ region: { connect: { name: 'Region 1' } } }])
+								}
+							})
+						}),
+						applicant: expect.objectContaining({
+							create: expect.objectContaining({
+								...caseInfo.applicant,
+								address: { create: caseInfo.applicantAddress }
+							})
+						}),
+						CaseStatus: { create: { status: 'draft' } }
+					})
+				})
+			);
+			expect(result).toEqual(mockCase);
+		});
+	});
+
+	describe('updateApplication', () => {
+		it('should update an existing application', async () => {
+			const caseInfo = {
+				caseId: 1,
+				caseDetails: { title: 'Updated Case' },
+				gridReference: { easting: 123, northing: 456 },
+				applicationDetails: { locationDescription: 'Updated Location' },
+				mapZoomLevelName: 'Level 2',
+				subSectorName: 'Updated Sub Sector',
+				regionNames: ['Updated Region'],
+				applicant: { firstName: 'Jane', lastName: 'Doe' },
+				applicantAddress: { addressLine1: '456 Avenue' },
+				hasUnpublishedChanges: true,
+				isMaterialChange: false
+			};
+			const mockCase = { id: 1, ...caseInfo };
+			databaseConnector.case.findUnique.mockResolvedValue(mockCase);
+			databaseConnector.case.update.mockResolvedValue(mockCase);
+
+			const result = await updateApplication(caseInfo);
+			expect(result).toEqual(mockCase);
+		});
+	});
+
+	describe('publishCase', () => {
+		it('should publish a case', async () => {
+			const caseId = 1;
+			const mockCase = {
+				id: caseId,
+				hasUnpublishedChanges: false,
+				CasePublishedState: { isPublished: true }
+			};
+			databaseConnector.case.update.mockResolvedValue(mockCase);
+			databaseConnector.case.findUnique.mockResolvedValue(mockCase);
+
+			const result = await publishCase({ caseId });
+
+			expect(databaseConnector.case.update).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { id: caseId },
+					data: expect.objectContaining({
+						hasUnpublishedChanges: false,
+						CasePublishedState: { create: { isPublished: true } }
+					})
+				})
+			);
+			expect(result).toEqual(mockCase);
+		});
+	});
+
+	describe('unpublishCase', () => {
+		it('should unpublish a case', async () => {
+			const caseId = 1;
+			const mockCase = { id: caseId, CasePublishedState: { isPublished: false } };
+			databaseConnector.case.update.mockResolvedValue(mockCase);
+			databaseConnector.case.findUnique.mockResolvedValue(mockCase);
+
+			const result = await unpublishCase({ caseId });
+
+			expect(databaseConnector.case.update).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { id: caseId },
+					data: expect.objectContaining({
+						CasePublishedState: { create: { isPublished: false } }
+					})
+				})
+			);
+			expect(result).toEqual(mockCase);
+		});
+	});
+
+	describe('getById', () => {
+		it('should fetch a case by ID', async () => {
+			const caseId = 1;
+			const mockCase = { id: caseId, title: 'Test Case' };
+			databaseConnector.case.findUnique.mockResolvedValue(mockCase);
+
+			const result = await getById(caseId, {});
+
+			expect(databaseConnector.case.findUnique).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { id: caseId }
+				})
+			);
+			expect(result).toEqual(mockCase);
+		});
+	});
+
+	describe('getByRef', () => {
+		it('should fetch a case by reference', async () => {
+			const reference = 'CASE123';
+			const mockCase = { id: 1, reference };
+			databaseConnector.case.findFirst.mockResolvedValue(mockCase);
+
+			const result = await getByRef(reference);
+
+			expect(databaseConnector.case.findFirst).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { reference }
+				})
+			);
+			expect(result).toEqual(mockCase);
+		});
+	});
+
+	describe('updateApplicationStatusAndDataById', () => {
+		it('should update application status and data by ID', async () => {
+			const caseId = 1;
+			const applicationDetailsId = 1;
+			const updateData = {
+				status: 'submitted',
+				data: { regionNames: ['Region 1'] },
+				currentStatuses: [{ id: 1, status: 'draft' }],
+				setReference: false
+			};
+			const additionalTransactions = [];
+			const mockCase = { id: caseId, title: 'Test Case' };
+
+			const result = await updateApplicationStatusAndDataById(
+				caseId,
+				applicationDetailsId,
+				updateData,
+				additionalTransactions
+			);
+
+			expect(result).toEqual(mockCase);
+		});
+	});
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "start": "node ./src/server/server.js",
     "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=8192\" npx jest  --coverage",
     "test:cov": "cross-env NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",
+		"test:nocov": "cross-env NODE_ENV=test NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=8192\" npx jest",
     "tscheck": "npx tsc -p jsconfig.json --maxNodeModuleJsDepth 0",
     "watch:rollup": "chokidar \"src/client/**/*.js\" --silent -c \"npm run rollup\"",
     "watch:sass": "chokidar \"src/styles/**/*.scss\" --silent -c \"npm run sass\""

--- a/apps/web/src/server/applications/common/components/form/form-case.component.js
+++ b/apps/web/src/server/applications/common/components/form/form-case.component.js
@@ -9,6 +9,7 @@ import {
 } from '../../services/entities.service.js';
 import { getSessionCaseSectorName } from '../../services/session.service.js';
 import { camelToSnake } from '../../../../lib/camel-to-snake.js';
+import { featureFlagClient } from '../../../../../common/feature-flags.js';
 
 /** @typedef {import('../../../applications.types').Region} Region */
 /** @typedef {import('../../../create-new-case/case/applications-create-case.types').ApplicationsCreateCaseNameProps} ApplicationsCreateCaseNameProps */
@@ -134,7 +135,12 @@ export async function caseNameAndDescriptionDataUpdate(
  */
 export async function caseSectorData({ session }, locals) {
 	const { currentCase } = locals;
-	const allSectors = await getAllSectors();
+	let allSectors = await getAllSectors();
+
+	// If Training Sector Feature is not activated, don't include the Training sector
+	if (!featureFlagClient.isFeatureActive('applics-1036-training-sector')) {
+		allSectors = allSectors.filter((sector) => sector.name !== 'training');
+	}
 
 	const { sector } = currentCase;
 	const selectedSectorName = getSessionCaseSectorName(session) || sector?.name;

--- a/packages/feature-flags/src/static-feature-flags.js
+++ b/packages/feature-flags/src/static-feature-flags.js
@@ -3,5 +3,6 @@ export default {
 	'applic-55-welsh-translation': true,
 	'applic-625-custom-folders': true,
 	'applics-156-material-changes': true,
-	'applics-861-fo-submissions': true
+	'applics-861-fo-submissions': true,
+	'applics-1036-training-sector': false
 };


### PR DESCRIPTION
## Describe your changes

New feature flag to conditionally allow the Training Sector, and training cases

Specifically:
- on the main dashboard, the training sector and any training cases will not display unless the flag is enabled
- when searching for cases, any training cases will not be included in the results unless the flag is enabled
- when creating new cases, the training sector is not visible / selectable unless the flag is enabled
- The flag `applics-1036-training-sector` is disabled by default (no training cases display)
- note that training cases in draft status will appear in the draft list, but the option to continue with training sector is not available

- also added `npm run test:nocov` to allow for running a single test (eg for debugging in local dev) without the visual clutter of the coverage report

## APPLICS-1030 New feature flag to manage training sector visibility
https://pins-ds.atlassian.net/browse/APPLICS-1030

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
