### PR TITLE
feat(functions): migration under18 rep service users

### DIFF
--- a/apps/api/src/server/migration/migrators/service-user-migrator.js
+++ b/apps/api/src/server/migration/migrators/service-user-migrator.js
@@ -78,7 +78,8 @@ const mapModelToServiceUserEntity = ({
 	role,
 	telephoneNumber,
 	emailAddress,
-	webAddress
+	webAddress,
+	under18
 }) => {
 	const parsedId = Number(id);
 	if (!parsedId) throw `Invalid ServiceUser ID: ${id}`;
@@ -91,7 +92,8 @@ const mapModelToServiceUserEntity = ({
 		email: emailAddress,
 		website: webAddress,
 		phoneNumber: telephoneNumber,
-		jobTitle: role
+		jobTitle: role,
+		under18
 	};
 };
 

--- a/apps/functions/applications-migration/common/migrators/service-user-migration.js
+++ b/apps/functions/applications-migration/common/migrators/service-user-migration.js
@@ -1,5 +1,6 @@
 import { SynapseDB } from '../synapse-db.js';
 import { makePostRequest } from '../back-office-api-client.js';
+import { getServiceUserUnder18AndCountyValue } from '../utils.js';
 
 /**
  * Migrate service-users for a case
@@ -17,6 +18,7 @@ export const migrateServiceUsers = async (log, caseReference) => {
 		if (serviceUsers.length > 0) {
 			const mappedServiceUsers = serviceUsers.map((serviceUser) => ({
 				...serviceUser,
+				...getServiceUserUnder18AndCountyValue(serviceUser.addressCounty),
 				sourceSuid: serviceUser.sourceSuid ?? '',
 				caseReference
 			}));

--- a/apps/functions/applications-migration/common/utils.js
+++ b/apps/functions/applications-migration/common/utils.js
@@ -54,3 +54,14 @@ export const stringToStream = (string) => {
 };
 
 export const valueToArray = (value) => (value ? JSON.parse(value) : []);
+
+export const getServiceUserUnder18AndCountyValue = (value) => {
+	switch (value) {
+		case 'under18':
+			return { under18: true, addressCounty: null };
+		case 'over18':
+			return { under18: false, addressCounty: null };
+		default:
+			return { under18: null, addressCounty: value };
+	}
+};

--- a/apps/functions/applications-migration/common/utils.test.js
+++ b/apps/functions/applications-migration/common/utils.test.js
@@ -1,0 +1,33 @@
+import { getServiceUserUnder18AndCountyValue } from './utils';
+
+describe('utils', () => {
+	describe('getServiceUserUnder18AndCountyValue', () => {
+		describe('when input is "under18"', () => {
+			it('should return an object with under18 as true and county as null', () => {
+				const result = getServiceUserUnder18AndCountyValue('under18');
+				expect(result).toEqual({ under18: true, addressCounty: null });
+			});
+		});
+
+		describe('when input is "over18"', () => {
+			it('should return an object with under18 as false and county as null', () => {
+				const result = getServiceUserUnder18AndCountyValue('over18');
+				expect(result).toEqual({ under18: false, addressCounty: null });
+			});
+		});
+
+		describe('when input is neither "under18" nor "over18"', () => {
+			it('should return an object with under18 as null and county as the input value', () => {
+				const result = getServiceUserUnder18AndCountyValue('some other value');
+				expect(result).toEqual({ under18: null, addressCounty: 'some other value' });
+			});
+		});
+
+		describe('when input is null', () => {
+			it('should return an object with under18 as null and county as null', () => {
+				const result = getServiceUserUnder18AndCountyValue(null);
+				expect(result).toEqual({ under18: null, addressCounty: null });
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-1093

CBOS DB has a boolean field over18 to store if a representation service user is under 18 or over 18. There was no field for this in Horizon so this value was stored in address county. Either there would be a normal county value or it would store age information (under18 or over18). 

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
