### PR TITLE
fix(web): add document type label for update success banner (applics-1118)

### DIFF
--- a/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
+++ b/apps/web/src/server/applications/case/documentation-metadata/documentation-metadata.controller.js
@@ -139,9 +139,10 @@ const layouts = {
 				text: 'No document type'
 			}
 		],
+		pageTitle: 'Select the document type',
+		label: 'Document type',
 		metaDataName: 'documentType',
-		metaDataType: 'radios',
-		pageTitle: 'Select the document type'
+		metaDataType: 'radios'
 	}
 };
 


### PR DESCRIPTION
## Describe your changes
- Added a label to the document type object to be rendered by the update success banner.

## Issue ticket number and link
[APPLICS-1118](https://pins-ds.atlassian.net/browse/APPLICS-1118): Document property update success banner undefined for Document Type

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-1118]: https://pins-ds.atlassian.net/browse/APPLICS-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ