### PR TITLE
fix(api): publish reps on migration

### DIFF
--- a/apps/api/src/server/migration/migrators/nsip-representation-migrator.js
+++ b/apps/api/src/server/migration/migrators/nsip-representation-migrator.js
@@ -7,6 +7,7 @@ import * as documentRepository from '#repositories/document.repository.js';
 import * as representationAttachmentRepository from '#repositories/representation.repository.js';
 import { broadcastNsipRepresentationEvent } from '#infrastructure/event-broadcasters.js';
 import { representationsStatusesList } from '../../applications/application/representations/representation.validators.js';
+import { EventType } from '@pins/event-client';
 
 /**
  * @typedef {import('pins-data-model').Schemas.Representation} RepresentationModel
@@ -33,8 +34,10 @@ export const migrateRepresentations = async (representations) => {
 			databaseConnector.$executeRawUnsafe(representationStatement, ...representationParameters)
 		]);
 
-		console.info('Broadcasting event for representation');
-		await broadcastNsipRepresentationEvent(representationEntity);
+		if (representationEntity.status === 'PUBLISHED') {
+			console.info('Broadcasting event for representation');
+			await broadcastNsipRepresentationEvent(representationEntity, EventType.Publish);
+		}
 
 		if (representationEntity.redacted) {
 			console.info(


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-1120

We were publishing after migrating representations, but we were using the `UPDATE` eventType. We need to use `PUBLISH` for the first representation publish as FO only uses `UPDATE` to change the status, not the consume the whole entity. This change will unblock FO and allow it to consume migrated representations as soon as they are published.

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
