### PR TITLE
feat(functions): doc migration set doc version doc type correctly (applics-1103)

### DIFF
--- a/apps/api/src/server/applications/constants.js
+++ b/apps/api/src/server/applications/constants.js
@@ -3,10 +3,25 @@ export const DEFAULT_PAGE_SIZE = 25;
 
 export const SYSTEM_USER_NAME = 'System';
 
+/**
+ * These are used in documentType the Document table
+ */
 export const DOCUMENT_TYPES = {
 	Document: 'document',
 	S51Attachment: 's51-attachment',
 	RelevantRepresentation: 'relevant-representation'
+};
+
+/**
+ * These are used in documentType in the DocumentVersion table
+ */
+export const DOCUMENT_VERSION_TYPES = {
+	DCODecisionLetterApprove: 'DCO decision letter (SoS)(approve)',
+	DCODecisionLetterRefuse: 'DCO decision letter (SoS)(refuse)',
+	EventRecording: 'Event recording',
+	Rule6Letter: 'Rule 6 letter',
+	Rule8Letter: 'Rule 8 letter',
+	ExamLibrary: 'Exam library'
 };
 
 // Define all the document case stages that can be mapped to folders

--- a/apps/functions/applications-migration/README.md
+++ b/apps/functions/applications-migration/README.md
@@ -20,6 +20,10 @@ In order for your local machine to be able to query the Synapse instance, you mu
 
 ```
 # set the required environment variables
+There is a settings file local.settings.json.example.
+Copy this file to local.settings.json, and make sure the settings are correct for your environment.
+You may need to check with dev colleagues for secret values.
+
 export SYNAPSE_SQL_HOST='pins-synw-odw-test-uks-ondemand.sql.azuresynapse.net'
 export API_HOST='localhost:3000'
 export BLOB_STORAGE_ACCOUNT_CUSTOM_DOMAIN=example.org

--- a/apps/functions/applications-migration/local.settings.json.example
+++ b/apps/functions/applications-migration/local.settings.json.example
@@ -1,0 +1,10 @@
+{
+	"IsEncrypted": false,
+	"Values": {
+		"FUNCTIONS_WORKER_RUNTIME": "node",
+		"AzureWebJobsStorage": "UseDevelopmentStorage=true",
+		"API_HOST": "localhost:3000",
+		"SYNAPSE_SQL_HOST": "pins-synw-odw-test-uks-ondemand.sql.azuresynapse.net",
+		"BLOB_STORAGE_ACCOUNT_CUSTOM_DOMAIN": "< get_correct_url_from_colleagues >"
+	}
+}


### PR DESCRIPTION

## Describe your changes

- Migration: Correctly map the document types from Horizon to the correct subset for CBOS. Note that this is for the DocumentType in the DocumentVersion table
- also added a .example file for the migration:  local.settings.json file, and updated the README

## APPLICS-1103 doc migration set doc version doc type correctly
https://pins-ds.atlassian.net/browse/APPLICS-1103

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
