### PR TITLE
feat(api): remove start time and end time columns from exam timetable…

### DIFF
--- a/apps/api/src/database/migrations/20241118104001_delete_time_fields_from_exam_timetable_item/migration.sql
+++ b/apps/api/src/database/migrations/20241118104001_delete_time_fields_from_exam_timetable_item/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `endTime` on the `ExaminationTimetableItem` table. All the data in the column will be lost.
+  - You are about to drop the column `startTime` on the `ExaminationTimetableItem` table. All the data in the column will be lost.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[ExaminationTimetableItem] DROP COLUMN [endTime],
+[startTime];
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/database/schema.prisma
+++ b/apps/api/src/database/schema.prisma
@@ -406,8 +406,6 @@ model ExaminationTimetableItem {
   descriptionWelsh         String?                  @db.NText
   date                     DateTime
   startDate                DateTime?
-  startTime                String? // not used anymore as we are using startDate with time
-  endTime                  String? // not used anymore as we are using date with time
   folderId                 Int
   ExaminationTimetableType ExaminationTimetableType @relation(fields: [examinationTypeId], references: [id])
   ExaminationTimetable     ExaminationTimetable     @relation(fields: [examinationTimetableId], references: [id])

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
@@ -181,6 +181,8 @@ export const createExaminationTimetableItem = async ({ body }, response) => {
 	body.examinationTimetableId = examinationTimetable.id;
 	delete body.caseId;
 	delete body.published;
+	delete body.startTime;
+	delete body.endTime;
 	const examinationTimetableItem = await examinationTimetableItemsRepository.create(body);
 
 	await service.createDeadlineSubFolders(
@@ -318,6 +320,9 @@ export const updateExaminationTimetableItem = async ({ params, body }, response)
 	if (body.descriptionWelsh) {
 		body.descriptionWelsh = mapExaminationTimetableItemDescriptionToSave(body.descriptionWelsh);
 	}
+
+	delete body.startTime;
+	delete body.endTime;
 
 	const mappedExamTimetableDetails = mapUpdateExaminationTimetableItemRequest(body);
 


### PR DESCRIPTION
… item table

## Describe your changes
- Removed the startTime and endTime fields from the Prisma schema.
- Created the migration script.
- Removed the startTime and endTime properties from the request body before examinationTimetableItem is created in the examination-timetable-items controller.

## Issue ticket number and link
[APPLICS-997](https://pins-ds.atlassian.net/browse/APPLICS-997): Remove `startTime` and `endTime` columns in ExamTimetableItem table

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-997]: https://pins-ds.atlassian.net/browse/APPLICS-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ