### PR TITLE
feat(api): doc migration correctly handle versions and renditions (applics-1134)

### DIFF
--- a/apps/api/src/server/utils/__tests__/file-fns.test.js
+++ b/apps/api/src/server/utils/__tests__/file-fns.test.js
@@ -1,0 +1,28 @@
+import { trimDocumentNameSuffix } from '../file-fns';
+
+describe('trimDocumentNameSuffix', () => {
+	it('should remove the extension from the document name', () => {
+		const result = trimDocumentNameSuffix('document.txt');
+		expect(result).toBe('document');
+	});
+
+	it('should return the same name if there is no extension', () => {
+		const result = trimDocumentNameSuffix('document');
+		expect(result).toBe('document');
+	});
+
+	it('should handle multiple dots in the document name', () => {
+		const result = trimDocumentNameSuffix('my.document.name.txt');
+		expect(result).toBe('my.document.name');
+	});
+
+	it('should handle empty string', () => {
+		const result = trimDocumentNameSuffix('');
+		expect(result).toBe('');
+	});
+
+	it('should handle document names with only an extension', () => {
+		const result = trimDocumentNameSuffix('.hiddenfile');
+		expect(result).toBe('');
+	});
+});

--- a/apps/api/src/server/utils/file-fns.js
+++ b/apps/api/src/server/utils/file-fns.js
@@ -1,0 +1,17 @@
+// util script for various file functions
+
+/**
+ * Remove extension from document name
+ *
+ * @param {string} documentNameWithExtension
+ * @returns {string}
+ */
+export const trimDocumentNameSuffix = (documentNameWithExtension) => {
+	if (!documentNameWithExtension.includes('.')) return documentNameWithExtension;
+
+	const documentNameSplit = documentNameWithExtension.split('.');
+
+	documentNameSplit.pop();
+
+	return documentNameSplit.join('.');
+};

--- a/apps/functions/applications-migration/common/migrators/nsip-document-migration.js
+++ b/apps/functions/applications-migration/common/migrators/nsip-document-migration.js
@@ -28,8 +28,10 @@ export const migrationNsipDocumentsByReference = async (log, caseReference) => {
  * @param {string} caseReference
  */
 export const getNsipDocuments = async (log, caseReference) => {
+	// Order by documentId, version, dateCreated to ensure we get the versions in order.  dateCreated is added to ensure the original is before any PDF rendition
+	// because we are going to make original v1 => v1, rendition v1 => v2, original v2 => v3, rendition v2 => v4 etc.
 	const documents = await SynapseDB.query(
-		'SELECT * FROM [odw_curated_migration_db].[dbo].[nsip_document] WHERE caseRef = ?;',
+		'SELECT * FROM [odw_curated_migration_db].[dbo].[nsip_document] WHERE caseRef = ? ORDER BY documentId, version, dateCreated;',
 		{
 			replacements: [caseReference],
 			type: QueryTypes.SELECT
@@ -38,6 +40,7 @@ export const getNsipDocuments = async (log, caseReference) => {
 	if (!documents.length) {
 		return [];
 	}
+
 	return documents.map((document) => ({
 		...document,
 		caseId: parseInt(document?.caseId),


### PR DESCRIPTION
## Describe your changes

- Migrates all versions and renditions of a document to a single document in CBOS, intersplicing PDF renditions if any into the correct order.  This does make a new version numbering, ie 10 doc versions with 10 PDF renditions creates 20 versions in CBOS.
eg original v1 => v1, rendition v1 => v2, original v2 => v3, rendition v2 => v4 etc.
- corrects a bug with datePublished - if there is a NULL date in ODW, it was setting epoch date 1970 in CBOS, now correctly setting it to NULL.
- file display name is maintained from the previous version (as per CBOS UI), and the display name has the file suffix trimmed off (the same as CBOS UI currently does).
- file suffix trim fn `trimDocumentNameSuffix `created in utils in new file `utils/file-fns.js`, and unit tests added.

## APPLICS-1134 Doc Migration - handle versions and renditions
https://pins-ds.atlassian.net/browse/APPLICS-1134

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
