### PR TITLE
fix(web): add note for deleting published s51 and remove delete button

### DIFF
--- a/apps/web/src/server/views/applications/case-s51/properties/s51-properties.njk
+++ b/apps/web/src/server/views/applications/case-s51/properties/s51-properties.njk
@@ -127,7 +127,7 @@
 							{
 								label: "Attachments",
 								id: "s51-attachments",
-								panel: { html: s51AttachmentsTab(s51Advice.attachments, caseId, folderId, s51Advice.id) }
+								panel: { html: s51AttachmentsTab(s51Advice.attachments, caseId, folderId, s51Advice.id, s51Advice.publishedStatus) }
 							}
 						]
 					}) }}

--- a/apps/web/src/server/views/applications/case-s51/properties/tab-attachments.component.njk
+++ b/apps/web/src/server/views/applications/case-s51/properties/tab-attachments.component.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% macro s51AttachmentsTab(attachments, caseId, folderId, adviceId) %}
+{% macro s51AttachmentsTab(attachments, caseId, folderId, adviceId, publishedStatus) %}
 
 	{% set attachmentsRows = [] %}
 	{% for attachment in attachments %}
@@ -24,66 +25,72 @@
 		{% endset %}
 
 		{% set activity %}
-		<p>
-			{{ attachment.dateAdded|datestamp({format: 'dd/MM/yyyy'}) }}
-		</p>
-
+			<p>
+				{{ attachment.dateAdded|datestamp({format: 'dd/MM/yyyy'}) }}
+			</p>
 		{% endset %}
 
 		{% set download %}
-		{% if isAttachmentSafe %}
-			<a class='govuk-link' href="{{ 'document-download'|url({caseId: caseId, documentGuid: attachment.documentGuid, version: attachment.version}) }}">
-          Download
-        </a>
-		{% else %}
-			<span></span>
+			{% if isAttachmentSafe %}
+				<a class='govuk-link' href="{{ 'document-download'|url({caseId: caseId, documentGuid: attachment.documentGuid, version: attachment.version}) }}">
+					Download
+				</a>
+			{% else %}
+				<span></span>
+			{% endif %}
+		{% endset %}
+
+		{% if publishedStatus !== 'published' %}
+			{% set delete %}
+				<a class='govuk-link'href='{{'s51-attachment'|url({caseId: caseId, folderId: folderId, adviceId: adviceId, documentGuid: attachment.documentGuid, step: 'delete'})}}' >
+					Delete
+				</a>
+			{% endset %}
 		{% endif %}
-		{% endset %}
-
-		{% set delete %}
-		<a class='govuk-link'href='{{'s51-attachment'|url({caseId: caseId, folderId: folderId, adviceId: adviceId, documentGuid: attachment.documentGuid, step: 'delete'})}}' >
-			Delete
-		</a>
-
-		{% endset %}
 
 		{% set status %}
-      {% set avWaiting = (attachment.status === 'awaiting_virus_check') or (attachment.status === 'awaiting_upload') %}
-      {% set avFailed = attachment.status === 'failed_virus_check' %}
-      {% if avWaiting or avFailed %}
-        <p>
-          {% if avWaiting %}
-            <strong class="govuk-tag govuk-tag--yellow">
-          {% else %}
-            <strong class="govuk-tag govuk-tag--red">
-          {% endif %}
-            {{ attachment.status|statusName }}
-          </strong>
-        </p>
-      {% endif %}
-    {% endset %}
-				{% set row = [
-					{
-						html: name
-					}, {
-						html: activity
-					}, {
-						html: status
-					}, {
-						html: download
-					}, {
-						html: delete
-					}
-				] %}
-				{% set attachmentsRows = attachmentsRows.concat([row]) %}
+			{% set avWaiting = (attachment.status === 'awaiting_virus_check') or (attachment.status === 'awaiting_upload') %}
+			{% set avFailed = attachment.status === 'failed_virus_check' %}
+				{% if avWaiting or avFailed %}
+					<p>
+					{% if avWaiting %}
+						<strong class="govuk-tag govuk-tag--yellow">
+					{% else %}
+						<strong class="govuk-tag govuk-tag--red">
+					{% endif %}
+					{{ attachment.status|statusName }}
+					</strong>
+					</p>
+				{% endif %}
+		{% endset %}
+		{% set row = [
+			{
+				html: name
+			}, {
+				html: activity
+			}, {
+				html: status
+			}, {
+				html: download
+			}, {
+				html: delete
+			}
+		] %}
+		{% set attachmentsRows = attachmentsRows.concat([row]) %}
+	{% endfor %}
 
-			{% endfor %}
+	<h4 class="govuk-heading-m govuk-!-margin-bottom-4">Attachments</h4>
+	{% if publishedStatus == 'published' %}
+		{# <p class="govuk-table__cell">You must unpublish the advice before you can delete the attachments.</p> #}
+		{{ govukWarningText({
+			text: "You must unpublish the advice before you can delete the attachments.",
+			iconFallbackText: "Warning"
+			})
+		}}
+	{% endif %}
 
-			<h4 class="govuk-heading-m govuk-!-margin-bottom-4">Attachments</h4>
-
-			{% if attachmentsRows.length > 0%}
-
-				{{ govukTable({
+	{% if attachmentsRows.length > 0%}
+		{{ govukTable({
 			classes: 'pins-file-versions-table',
             captionClasses: "govuk-table__caption--m",
             head: [
@@ -94,9 +101,9 @@
                 { text: "" }
             ],
             rows: attachmentsRows
-    }) }}
-			{% else %}
-				<p>There are no attachments on this item.</p>
-			{% endif %}
-
-		{% endmacro %}
+			})
+		}}
+	{% else %}
+		<p>There are no attachments on this item.</p>
+	{% endif %}
+{% endmacro %}


### PR DESCRIPTION
## Describe your changes
Removing the option to delete S51 documents if the advice is published. Also added a note to explain to the user how to delete if the advice is published.
https://pins-ds.atlassian.net/jira/software/c/projects/APPLICS/boards/269?selectedIssue=APPLICS-1111

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
