### PR TITLE
fix(api): doc case stages publish fail (applics-1169)

### DIFF
--- a/apps/api/jsconfig.json
+++ b/apps/api/jsconfig.json
@@ -5,6 +5,7 @@
 		"baseUrl": ".",
 		"paths": {
 			"#app-test": ["./src/server/app-test.js"],
+			"#api-constants": ["./src/server/applications/constants.js"],
 			"#config/*": ["./src/server/config/*"],
 			"#infrastructure/*": ["./src/server/infrastructure/*"],
 			"#middleware/*": ["./src/server/middleware/*"],

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -90,6 +90,7 @@
   },
   "imports": {
     "#app-test": "./src/server/app-test.js",
+		"#api-constants": "./src/server/applications/constants.js",
     "#config/*": "./src/server/config/*",
     "#infrastructure/*": "./src/server/infrastructure/*",
     "#middleware/*": "./src/server/middleware/*",

--- a/apps/api/src/server/applications/constants.js
+++ b/apps/api/src/server/applications/constants.js
@@ -25,14 +25,14 @@ export const DOCUMENT_VERSION_TYPES = {
 };
 
 // Define all the document case stages that can be mapped to folders
-const DOCUMENT_CASE_STAGE_PRE_APPLICATION = 'Pre-application';
 const DOCUMENT_CASE_STAGE_ACCEPTANCE = 'Acceptance';
-const DOCUMENT_CASE_STAGE_DEVELOPERS_APPLICATION = "Developer's Application";
-const DOCUMENT_CASE_STAGE_PRE_EXAMINATION = 'Pre-examination';
-const DOCUMENT_CASE_STAGE_EXAMINATION = 'Examination';
-const DOCUMENT_CASE_STAGE_RECOMMENDATION = 'Recommendation';
 const DOCUMENT_CASE_STAGE_DECISION = 'Decision';
+const DOCUMENT_CASE_STAGE_DEVELOPERS_APPLICATION = "Developer's Application";
+const DOCUMENT_CASE_STAGE_EXAMINATION = 'Examination';
 const DOCUMENT_CASE_STAGE_POST_DECISION = 'Post-decision';
+const DOCUMENT_CASE_STAGE_PRE_APPLICATION = 'Pre-application';
+const DOCUMENT_CASE_STAGE_PRE_EXAMINATION = 'Pre-examination';
+const DOCUMENT_CASE_STAGE_RECOMMENDATION = 'Recommendation';
 const DOCUMENT_CASE_STAGE_S51_ADVICE = '0'; // special value required by Front Office
 
 // Define top level document case stage mappings, so we can change in one single place if needed

--- a/apps/api/src/server/migration/migrators/nsip-document-migrator.js
+++ b/apps/api/src/server/migration/migrators/nsip-document-migrator.js
@@ -81,7 +81,7 @@ export const migrateNsipDocuments = async (documents) => {
 		);
 		const documentForServiceBus = await createDocumentVersion(documentVersion);
 
-		await handleCreationOfDocumentAcitivityLogs(documentVersion);
+		await handleCreationOfDocumentActivityLogs(documentVersion);
 
 		if (documentForServiceBus.publishedStatus === 'published') {
 			await broadcastNsipDocumentEvent(documentForServiceBus, EventType.Update, {
@@ -151,7 +151,7 @@ const createDocumentVersion = async (documentVersion) => {
  *
  * @param {object} documentVersion
  */
-const handleCreationOfDocumentAcitivityLogs = async (documentVersion) => {
+const handleCreationOfDocumentActivityLogs = async (documentVersion) => {
 	await createDocumentActivityLog({
 		documentGuid: documentVersion.documentGuid,
 		version: documentVersion.version,

--- a/apps/api/src/server/repositories/folder.repository.js
+++ b/apps/api/src/server/repositories/folder.repository.js
@@ -1,5 +1,5 @@
 import { databaseConnector } from '#utils/database-connector.js';
-import { folderDocumentCaseStageMappings } from '../applications/constants.js';
+import { folderDocumentCaseStageMappings } from '#api-constants';
 
 /** @typedef {import('@pins/applications.api').Schema.Folder} Folder */
 /** @typedef {import('@pins/applications').FolderTemplate} FolderTemplate */

--- a/apps/api/src/server/utils/mapping/__tests__/map-case-status.test.js
+++ b/apps/api/src/server/utils/mapping/__tests__/map-case-status.test.js
@@ -1,0 +1,89 @@
+import {
+	mapCaseStatus,
+	mapDocumentCaseStageToSchema,
+	mapProjectCaseStageToDocumentCaseStageSchema
+} from '../map-case-status';
+
+describe('mapCaseStatus', () => {
+	it('should throw an error if caseStatuses is null', () => {
+		expect(() => mapCaseStatus(null)).toThrow('No Case Statuses Provided');
+	});
+
+	it('should throw an error if caseStatuses is not an array', () => {
+		// @ts-ignore
+		expect(() => mapCaseStatus('not an array')).toThrow('No Case Statuses Provided');
+	});
+
+	it('should throw an error if no valid status is found', () => {
+		const caseStatuses = [
+			{
+				id: 1,
+				status: 'invalid',
+				createdAt: new Date('2024-02-21T17:53:45.407Z'),
+				valid: false,
+				subStateMachineName: null,
+				compoundStateName: null,
+				caseId: 100000001
+			}
+		];
+		expect(() => mapCaseStatus(caseStatuses)).toThrow(
+			'No `Case status` with valid status provided'
+		);
+	});
+
+	it('should return the mapped case status string for a valid status', () => {
+		const caseStatuses = [
+			{
+				id: 71,
+				status: 'pre_application',
+				createdAt: new Date('2024-02-21T17:53:45.407Z'),
+				valid: true,
+				subStateMachineName: null,
+				compoundStateName: null,
+				caseId: 100000001
+			}
+		];
+		const result = mapCaseStatus(caseStatuses);
+		expect(result).toBe('Pre-Application');
+	});
+});
+
+describe('mapDocumentCaseStageToSchema', () => {
+	it('should return null if stage is null', () => {
+		expect(mapDocumentCaseStageToSchema(null)).toBeNull();
+	});
+
+	it('should return the correct schema value for DEVELOPERS_APPLICATION', () => {
+		expect(mapDocumentCaseStageToSchema("Developer's Application")).toBe('developers_application');
+	});
+
+	it('should return the correct schema value for POST_DECISION', () => {
+		expect(mapDocumentCaseStageToSchema('Post-decision')).toBe('post_decision');
+	});
+
+	it('should return the lowercased stage for other values', () => {
+		expect(mapDocumentCaseStageToSchema('Decision')).toBe('decision');
+	});
+
+	it('should return the null stage for null value', () => {
+		expect(mapDocumentCaseStageToSchema(null)).toBe(null);
+	});
+});
+
+describe('mapProjectCaseStageToDocumentCaseStageSchema', () => {
+	it('should return the correct schema value for a given case stage - decision', () => {
+		expect(mapProjectCaseStageToDocumentCaseStageSchema('decision')).toBe('decision');
+	});
+
+	it('should return the correct schema value for a special hyphenated schema  case stage - pre_examination', () => {
+		expect(mapProjectCaseStageToDocumentCaseStageSchema('pre_examination')).toBe('pre-examination');
+	});
+
+	it('should return the correct schema value for a special hyphenated schema case stage - pre_application', () => {
+		expect(mapProjectCaseStageToDocumentCaseStageSchema('pre_application')).toBe('pre-application');
+	});
+
+	it('should return undefined for an unknown case stage', () => {
+		expect(mapProjectCaseStageToDocumentCaseStageSchema('unknownCaseStage')).toBeUndefined();
+	});
+});

--- a/apps/api/src/server/utils/mapping/map-case-status-string.js
+++ b/apps/api/src/server/utils/mapping/map-case-status-string.js
@@ -13,6 +13,20 @@ export const caseStatusMap = {
 };
 
 /**
+ * mapping for the project case stage (CBOS and Schema - both the same) to the document case stage schema value
+ */
+export const projectCaseStageToDocumentCaseStageSchemaMap = {
+	acceptance: 'acceptance',
+	decision: 'decision',
+	examination: 'examination',
+	post_decision: 'post_decision',
+	pre_application: 'pre-application', // note change underscore in project to hyphen in document
+	pre_examination: 'pre-examination', // note change underscore in project to hyphen in document
+	recommendation: 'recommendation',
+	withdrawn: 'withdrawn'
+};
+
+/**
  *
  * @param {string} caseStatus
  * @returns {string}

--- a/apps/api/src/server/utils/mapping/map-case-status.js
+++ b/apps/api/src/server/utils/mapping/map-case-status.js
@@ -1,4 +1,8 @@
-import { mapCaseStatusString } from './map-case-status-string.js';
+import { folderDocumentCaseStageMappings } from '#api-constants';
+import {
+	mapCaseStatusString,
+	projectCaseStageToDocumentCaseStageSchemaMap
+} from './map-case-status-string.js';
 
 /**
  *
@@ -23,4 +27,42 @@ export const mapCaseStatus = (caseStatuses) => {
 	}
 
 	return mapCaseStatusString(validStatus.status);
+};
+
+/**
+ * convert CBOS DB Document Version stage value into the event schema value.
+ * Note that these are different values to the Case stage
+ *
+ * @param {string |null} stage
+ * @returns
+ */
+export const mapDocumentCaseStageToSchema = (stage) => {
+	if (!stage) {
+		return null;
+	}
+
+	const { DEVELOPERS_APPLICATION, POST_DECISION } = folderDocumentCaseStageMappings;
+
+	// mostly the schema value is just the lower equivalent, with some exceptions:
+	switch (stage) {
+		case DEVELOPERS_APPLICATION:
+			return 'developers_application';
+		case POST_DECISION:
+			// note that post decision has inconsistent format in the schema, it uses underscore instead of hyphen
+			// our DB 'Post-decision' maps to 'post_decision'
+			return 'post_decision';
+		default:
+			return stage.toLowerCase();
+	}
+};
+
+/**
+ * Maps the project case stage (CBOS and Schema - both the same) to the document case stage schema value
+ *
+ * @param {string} caseStage
+ * @returns {string |null}
+ */
+export const mapProjectCaseStageToDocumentCaseStageSchema = (caseStage) => {
+	// @ts-ignore
+	return projectCaseStageToDocumentCaseStageSchemaMap[caseStage];
 };


### PR DESCRIPTION
## Describe your changes

- Correct the Document Case Stage mapping functions used to create the service bus broadcasts, to ensure it outputs the correct values for:
-- developers_application
-- post_decision

- note that this was already fixed in a Hotfix that went direct to Prod, this fix is into main trunk to ensure the fix persists
- additionally added an import shortcut `#api-constants` to make it easy to import the API constants file without having to get the correct pathing - eg `import { folderDocumentCaseStageMappings } from '#api-constants';`


## APPLICS-1169 Document Case Stages Publish Fail
https://pins-ds.atlassian.net/browse/APPLICS-1169

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
