### PR TITLE
fix(tooling): set node-alpine version to node:20-alpine3.20

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-alpine3.20
 WORKDIR /src/app
 
 ARG GIT_SHA

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1/2 - Builder
-FROM node:20-alpine AS pins-web-builder
+node:20-alpine3.20 AS pins-web-builder
 
 RUN apk update
 
@@ -30,7 +30,7 @@ RUN npm run build:release
 # --------------------------------
 
 # Stage 2/2 - App run
-FROM node:20-alpine
+node:20-alpine3.20
 
 ARG GIT_SHA
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1/2 - Builder
-node:20-alpine3.20 AS pins-web-builder
+FROM node:20-alpine3.20 AS pins-web-builder
 
 RUN apk update
 
@@ -30,7 +30,7 @@ RUN npm run build:release
 # --------------------------------
 
 # Stage 2/2 - App run
-node:20-alpine3.20
+FROM node:20-alpine3.20
 
 ARG GIT_SHA
 


### PR DESCRIPTION
## Describe your changes

we don't specify an alpine version in our dockerfiles and things have broken specifically for prisma.
node alpine has been updated, and openssl path has changed, setting node alpine to node:20-alpine3.20

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
