### PR TITLE
feat(api): increase location description size in database and validator (applics-1033)

### DIFF
--- a/apps/api/src/database/migrations/20241211144106_application_details_location_description_size_increase/migration.sql
+++ b/apps/api/src/database/migrations/20241211144106_application_details_location_description_size_increase/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `locationDescription` on the `ApplicationDetails` table. The data in that column could be lost. The data in that column will be cast from `NVarChar(1000)` to `VarChar(2000)`.
+  - You are about to alter the column `locationDescriptionWelsh` on the `ApplicationDetails` table. The data in that column could be lost. The data in that column will be cast from `NVarChar(1000)` to `VarChar(2000)`.
+
+*/
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[ApplicationDetails] ALTER COLUMN [locationDescription] VARCHAR(2000) NULL;
+ALTER TABLE [dbo].[ApplicationDetails] ALTER COLUMN [locationDescriptionWelsh] VARCHAR(2000) NULL;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/database/schema.prisma
+++ b/apps/api/src/database/schema.prisma
@@ -106,8 +106,8 @@ model ApplicationDetails {
   id                                                Int                           @id @default(autoincrement())
   caseId                                            Int                           @unique
   subSectorId                                       Int?
-  locationDescription                               String?
-  locationDescriptionWelsh                          String?
+  locationDescription                               String?                       @db.VarChar(2000)
+  locationDescriptionWelsh                          String?                       @db.VarChar(2000)
   zoomLevelId                                       Int?
   caseEmail                                         String?
   // Key Dates

--- a/apps/web/src/server/applications/create-new-case/case/applications-create-case.validators.js
+++ b/apps/web/src/server/applications/create-new-case/case/applications-create-case.validators.js
@@ -60,8 +60,8 @@ export const validateApplicationsCreateCaseLocation = createValidator(
 		.trim()
 		.isLength({ min: 1 })
 		.withMessage(getErrorMessageCaseCreate('projectLocation'))
-		.isLength({ max: 500 })
-		.withMessage('Project location must be 500 characters or less')
+		.isLength({ max: 2000 })
+		.withMessage('Project location must be 2000 characters or less')
 );
 
 export const validateApplicationsCreateCaseLocationWelsh = createValidator(
@@ -69,8 +69,8 @@ export const validateApplicationsCreateCaseLocationWelsh = createValidator(
 		.trim()
 		.isLength({ min: 1 })
 		.withMessage(getErrorMessageCaseCreate('projectLocationWelsh'))
-		.isLength({ max: 500 })
-		.withMessage('Project location in Welsh must be 500 characters or less')
+		.isLength({ max: 2000 })
+		.withMessage('Project location in Welsh must be 2000 characters or less')
 );
 
 export const validateApplicationsCreateCaseEasting = createValidator(


### PR DESCRIPTION
## Describe your changes
- Increased location description character allowance to 2000 in validator function.
- Increased location description character allowance to 2000 in Prisma schema.

Manual testing of validation completed for creating a new case, check your answers page and updating the location for an existing case.

## Issue ticket number and link
[APPLICS-1003](https://pins-ds.atlassian.net/browse/APPLICS-1033): Increase project location character limit

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-1003]: https://pins-ds.atlassian.net/browse/APPLICS-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ