### PR TITLE
chore(web): remove s51 enquiry method hint text (applics-1180)

### DIFF
--- a/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
+++ b/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
@@ -1392,11 +1392,10 @@ exports[`S51 Advice S51 creation journey Method GET /case/123/project-documentat
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <form method="post" action="" novalidate="novalidate" class="pins-applications-create govuk-!-margin-top-6">
         <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" aria-describedby="enquiryMethod-hint">
+            <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                     <h1 class="govuk-fieldset__heading"> Select the method of enquiry</h1>
                 </legend>
-                <div id="enquiryMethod-hint" class="govuk-hint">How was the enquiry made?</div>
                 <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="enquiryMethod" name="enquiryMethod"

--- a/apps/web/src/server/applications/case/s51/__tests__/applications-s51.test.js
+++ b/apps/web/src/server/applications/case/s51/__tests__/applications-s51.test.js
@@ -296,7 +296,7 @@ describe('S51 Advice', () => {
 						buildPageTitle(['Select the method of enquiry', 'Title CASE/04'])
 					);
 					expect(element.innerHTML).toMatchSnapshot();
-					expect(element.innerHTML).toContain('How was the enquiry made?');
+					expect(element.innerHTML).toContain('Select the method of enquiry');
 
 					const backElement = parseHtml(response.text, { rootElement: '.govuk-back-link' });
 					expect(backElement.innerHTML).toContain(`"${baseUrl}/create/enquirer"`);

--- a/apps/web/src/server/views/applications/case-s51/s51-method.njk
+++ b/apps/web/src/server/views/applications/case-s51/s51-method.njk
@@ -50,7 +50,6 @@
 					classes: "govuk-fieldset__legend--l"
 				}
 			},
-			hint: {text: "How was the enquiry made?"},
 			items: methodsItems,
 			errorMessage: errors.enquiryMethod,
 			items: methodsItems | selectItems({valueKey: 'value', labelKey: 'text', selectedValue: values.enquiryMethod})


### PR DESCRIPTION
## Describe your changes
- Removed S51 enquiry method hint text.
- Updated unit test.
- Regenerated S51 snapshot.

## Issue ticket number and link
[APPLICS-1180](https://pins-ds.atlassian.net/browse/APPLICS-1180): C-BOS accessibility audit - S51 page

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes


[APPLICS-1180]: https://pins-ds.atlassian.net/browse/APPLICS-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ