### PR TITLE
chore(web): move breadcrumbs on relevant reps folder page (applics-732)

### DIFF
--- a/apps/web/src/server/applications/case/representations/__tests__/__snapshots__/applications-representaions.test.js.snap
+++ b/apps/web/src/server/applications/case/representations/__tests__/__snapshots__/applications-representaions.test.js.snap
@@ -8,14 +8,6 @@ exports[`applications representations GET /applications-service/:caseId/relevant
             <p class="govuk-body">mock title</p><strong class="govuk-heading-s"><strong class="govuk-tag govuk-tag--">in test</strong></strong>
         </div>
     </div>
-    <div class="govuk-breadcrumbs govuk-!-margin-bottom-5">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/applications-service/case/1/project-documentation">Project documentation</a>
-            </li>
-            <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#">Relevant representations</a>
-            </li>
-        </ol>
-    </div>
     <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
     data-module="govuk-notification-banner" id="unpublished-changes-banner">
         <div class="govuk-notification-banner__header">
@@ -198,14 +190,6 @@ exports[`applications representations GET /applications-service/:id/relevant-rep
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-3"> mock title </h1>
             <p class="govuk-body">mock title</p><strong class="govuk-heading-s"><strong class="govuk-tag govuk-tag--">in test</strong></strong>
         </div>
-    </div>
-    <div class="govuk-breadcrumbs govuk-!-margin-bottom-5">
-        <ol class="govuk-breadcrumbs__list">
-            <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="/applications-service/case/1/project-documentation">Project documentation</a>
-            </li>
-            <li class="govuk-breadcrumbs__list-item"><a class="govuk-breadcrumbs__link" href="#">Relevant representations</a>
-            </li>
-        </ol>
     </div>
     <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title"
     data-module="govuk-notification-banner" id="unpublished-changes-banner">

--- a/apps/web/src/server/views/applications/representations/representations.njk
+++ b/apps/web/src/server/views/applications/representations/representations.njk
@@ -10,10 +10,28 @@
 {% from "applications/representations/components/pre-search.component.njk" import preSearch %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
+{% block beforeContent %}
+    <aside>
+	    {{ govukBreadcrumbs({
+		    classes: "govuk-!-margin-top-0 govuk-!-margin-bottom-2",
+		    items: [
+			    {
+				    text: "Project documentation",
+				    href: "/applications-service/case/" + caseId + "/project-documentation"
+			    },
+			    {
+				    text: "Relevant representations",
+				    href: "#"
+			    }
+		    ]
+	    }) }}
+    </aside>
+{% endblock %}
+
 {% block pageHeading %}
 {% endblock %}
 
-{% block pageContent %}
+{% block pageContent %}	
 	<div class="govuk-!-margin-left-0 govuk-!-margin-bottom-7">
 		<div class="pins-masthead-summary govuk-!-padding-4 govuk-!-padding-top-9 govuk-!-padding-bottom-2">
 			<span class="govuk-caption-xl"> {{ caseReference.reference }} </span>
@@ -28,20 +46,6 @@
 			</strong>
 		</div>
 	</div>
-
-	{{ govukBreadcrumbs({
-		classes: "govuk-!-margin-bottom-5",
-		items: [
-			{
-				text: "Project documentation",
-				href: "/applications-service/case/" + caseId + "/project-documentation"
-			},
-			{
-				text: "Relevant representations",
-				href: "#"
-			}
-		]
-	}) }}
 
 	{% if publishedRepsCount > 0 %}
 		{% set successBannerHtml %}


### PR DESCRIPTION
## Describe your changes
- Moved breadcrumbs to the top of the relevant representations folder page, in line with the layout in other folders.
- Regenerated the relevant representations snapshot.

## Issue ticket number and link
[APPLICS-732](https://pins-ds.atlassian.net/browse/APPLICS-732): BO audit - Relevant reps page breadcrumbs

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[APPLICS-732]: https://pins-ds.atlassian.net/browse/APPLICS-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ