### PR TITLE
fix(web): update relevant representation e2e test (applics-1241)

### DIFF
--- a/apps/e2e/cypress/page_objects/representationPage.js
+++ b/apps/e2e/cypress/page_objects/representationPage.js
@@ -45,7 +45,6 @@ export class RepresentationPage extends Page {
 			cy.get(
 				'body > div:nth-child(4) > main:nth-child(2) > form:nth-child(2) > div:nth-child(3) > fieldset:nth-child(1) > div:nth-child(3) > div:nth-child(1) > div:nth-child(3) > input:nth-child(2'
 			),
-		viewPublishQueue: () => cy.get('#main-content > form:nth-child(4) > p:nth-child(2) > a'),
 		statusVerify: () => cy.get('#list-convictions-status-1'),
 		optionStatusInvalid: () => cy.get('#changeStatus')
 	};
@@ -105,7 +104,7 @@ export class RepresentationPage extends Page {
 		this.clickSaveAndReturn();
 		searchResultsPage.clickLinkByText('Project documentation');
 		searchResultsPage.clickLinkByText('Relevant representations');
-		this.elements.viewPublishQueue().click();
+		this.clickLinkByText('View publishing queue');
 		this.clickButtonByText('Publish representations');
 		this.elements.statusVerify().contains('PUBLISHED');
 		this.elements.reviewLink().click();


### PR DESCRIPTION
## Describe your changes
Since the relevant representations breadcrumbs were moved to the top of the page, the relevant representations e2e test has not been able to locate the 'View publishing queue' link which is now further down the page. This PR replaces the viewPublishQueue method previously used in the test to locate the element with the clickLinkByText method, as this allows the test to scroll down the page to find the link. 

## Issue ticket number and link
[APPLICS-1241](https://pins-ds.atlassian.net/browse/APPLICS-1241): Fix Relevant Representation E2E Test

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-1241]: https://pins-ds.atlassian.net/browse/APPLICS-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ