### PR TITLE
feat(web): documents page UI alignment (applics-1248)

### DIFF
--- a/apps/web/src/client/components/files-list/_html.js
+++ b/apps/web/src/client/components/files-list/_html.js
@@ -7,7 +7,7 @@
 export const buildErrorBanner = (errorMessage) => {
 	return `
 	<div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-full">
           <div class="govuk-error-summary" aria-labelledby="error-summary-title" data-module="govuk-error-summary">
   				<h2 class="govuk-error-summary__title" id="error-summary-title">
     				There is a problem

--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -100,7 +100,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class="pins-files-list" method="post">
                 <caption><span class="display--sr-only">Manage Documents in this location</span>
                 </caption>
-                <div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
+                <div class="govuk-grid-row display--flex">
                     <div class="govuk-grid-column-two-thirds">
                         <div class="pins-files-list__statuses">
                             <h3 class="govuk-heading-s">Statuses</h3>
@@ -154,7 +154,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                                     </div>
                                 </div>
                                 <div>
-                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state"> Clear selected</a>
+                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-0"> Clear selected</a>
                                 </div>
                             </div>
                         </div>
@@ -960,7 +960,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class="pins-files-list" method="post">
                 <caption><span class="display--sr-only">Manage Documents in this location</span>
                 </caption>
-                <div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
+                <div class="govuk-grid-row display--flex">
                     <div class="govuk-grid-column-two-thirds">
                         <div class="pins-files-list__statuses">
                             <h3 class="govuk-heading-s">Statuses</h3>
@@ -1014,7 +1014,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                                     </div>
                                 </div>
                                 <div>
-                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state"> Clear selected</a>
+                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-0"> Clear selected</a>
                                 </div>
                             </div>
                         </div>
@@ -2325,7 +2325,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class="pins-files-list" method="post">
                 <caption><span class="display--sr-only">Manage Documents in this location</span>
                 </caption>
-                <div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
+                <div class="govuk-grid-row display--flex">
                     <div class="govuk-grid-column-two-thirds">
                         <div class="pins-files-list__statuses">
                             <h3 class="govuk-heading-s">Statuses</h3>
@@ -2379,7 +2379,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                                     </div>
                                 </div>
                                 <div>
-                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state"> Clear selected</a>
+                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-0"> Clear selected</a>
                                 </div>
                             </div>
                         </div>
@@ -3207,7 +3207,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class="pins-files-list" method="post">
                 <caption><span class="display--sr-only">Manage Documents in this location</span>
                 </caption>
-                <div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
+                <div class="govuk-grid-row display--flex">
                     <div class="govuk-grid-column-two-thirds">
                         <div class="pins-files-list__statuses">
                             <h3 class="govuk-heading-s">Statuses</h3>
@@ -3261,7 +3261,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                                     </div>
                                 </div>
                                 <div>
-                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state"> Clear selected</a>
+                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-0"> Clear selected</a>
                                 </div>
                             </div>
                         </div>
@@ -3273,7 +3273,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             id="bulkDownload">Download selected</button>
                             <button type="submit" formaction="./unpublishing-queue"
                             class="govuk-link pins-files-list__button-link">Unpublish selected</button>
-                            <button type="submit" formaction="/applications-service/case/123/project-documentation/21//move-documents"
+                            <button type="submit" formaction="/applications-service/case/123/project-documentation/21/sub-folder-level2/move-documents"
                             class="govuk-link pins-files-list__button-link">Move selected</button>
                         </div>
                     </div>
@@ -4488,7 +4488,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class="pins-files-list" method="post">
                 <caption><span class="display--sr-only">Manage Documents in this location</span>
                 </caption>
-                <div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
+                <div class="govuk-grid-row display--flex">
                     <div class="govuk-grid-column-two-thirds">
                         <div class="pins-files-list__statuses">
                             <h3 class="govuk-heading-s">Statuses</h3>
@@ -4542,7 +4542,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                                     </div>
                                 </div>
                                 <div>
-                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state"> Clear selected</a>
+                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-0"> Clear selected</a>
                                 </div>
                             </div>
                         </div>
@@ -4554,7 +4554,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             id="bulkDownload">Download selected</button>
                             <button type="submit" formaction="./unpublishing-queue"
                             class="govuk-link pins-files-list__button-link">Unpublish selected</button>
-                            <button type="submit" formaction="/applications-service/case/123/project-documentation/21//move-documents"
+                            <button type="submit" formaction="/applications-service/case/123/project-documentation/21/sub-folder-level2/move-documents"
                             class="govuk-link pins-files-list__button-link">Move selected</button>
                         </div>
                     </div>
@@ -5767,7 +5767,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
             <form class="pins-files-list" method="post">
                 <caption><span class="display--sr-only">Manage Documents in this location</span>
                 </caption>
-                <div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
+                <div class="govuk-grid-row display--flex">
                     <div class="govuk-grid-column-two-thirds">
                         <div class="pins-files-list__statuses">
                             <h3 class="govuk-heading-s">Statuses</h3>
@@ -5821,7 +5821,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                                     </div>
                                 </div>
                                 <div>
-                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state"> Clear selected</a>
+                                    <button class="govuk-button" data-module="govuk-button">Apply changes</button><a href="." class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-0"> Clear selected</a>
                                 </div>
                             </div>
                         </div>
@@ -5833,7 +5833,7 @@ exports[`applications documentation /case/123/project-documentation/21/sub-folde
                             id="bulkDownload">Download selected</button>
                             <button type="submit" formaction="./unpublishing-queue"
                             class="govuk-link pins-files-list__button-link">Unpublish selected</button>
-                            <button type="submit" formaction="/applications-service/case/123/project-documentation/21//move-documents"
+                            <button type="submit" formaction="/applications-service/case/123/project-documentation/21/sub-folder-level2/move-documents"
                             class="govuk-link pins-files-list__button-link">Move selected</button>
                         </div>
                     </div>

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -141,6 +141,7 @@ export async function updateApplicationsCaseDocumentationFolder(request, respons
 
 		return response.render(`applications/components/folder/folder`, {
 			...properties,
+			activeFolderSlug: request.params.folderName,
 			errors: validationErrors ||
 				itemErrors || { msg: 'Something went wrong. Please, try again later.' },
 			failedItems
@@ -190,6 +191,7 @@ export async function viewApplicationsCaseDocumentationUnpublishPage(request, re
 
 		return response.render('applications/components/folder/folder', {
 			...properties,
+			activeFolderSlug: request.params.folderName,
 			errors: request.errors
 		});
 	}
@@ -209,6 +211,7 @@ export async function viewApplicationsCaseDocumentationUnpublishPage(request, re
 
 		return response.render('applications/components/folder/folder', {
 			...properties,
+			activeFolderSlug: request.params.folderName,
 			errors: 'Your selected documents are not published so you cannot unpublish them.'
 		});
 	}

--- a/apps/web/src/server/views/applications/components/folder/folder-actions.component.njk
+++ b/apps/web/src/server/views/applications/components/folder/folder-actions.component.njk
@@ -3,7 +3,7 @@
 
 {% macro folderActions(isS51folder) %}
 
-	<div class="govuk-grid-row govuk-!-margin-left-0 display--flex">
+	<div class="govuk-grid-row display--flex">
 		<div class="govuk-grid-column-two-thirds">
 			<div class="pins-files-list__statuses">
 				<h3 class="govuk-heading-s">Statuses</h3>
@@ -54,7 +54,7 @@
 												}) }}</div>
 					<div>
 						{{ govukButton({ text: 'Apply changes' }) }}
-						<a href="." class="govuk-link govuk-link--no-visited-state">
+						<a href="." class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-0">
 							Clear selected
 						</a>
 					</div>


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1248

## Describe your changes
-update the documents folder page:
-- align the 'Clear Selected' link
-- make download error summary box same width as other errors

-add missing folder name to templates rendering on error

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
