### PR TITLE
chore(web): remove relevant rep change status tag (applics-1171)

### DIFF
--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/__tests__/__snapshots__/representation-status.test.js.snap
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/__tests__/__snapshots__/representation-status.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`Change representation status page GET /applications-service/case/1/relevant-representations/1/representations-details/change-status should render the page 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main"><span class="govuk-caption-l">Mrs Sue</span>
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Change status</h1><strong class="govuk-heading-s govuk-!-margin-bottom-6"><strong class="govuk-tag govuk-tag--grey">awaiting review</strong></strong>
-    <div     class="govuk-grid-row">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Change status</h1>
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
             <form method="post" novalidate>
                 <div class="govuk-form-group">
@@ -11,7 +11,7 @@ exports[`Change representation status page GET /applications-service/case/1/rele
                         <div class="govuk-radios" data-module="govuk-radios">
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="changeStatus" name="changeStatus"
-                                type="radio" value="AWAITING_REVIEW">
+                                type="radio" value="AWAITING_REVIEW" checked>
                                 <label class="govuk-label govuk-radios__label" for="changeStatus">Awaiting review</label>
                             </div>
                             <div class="govuk-radios__item">
@@ -40,6 +40,6 @@ exports[`Change representation status page GET /applications-service/case/1/rele
                 <button type="submit" class="govuk-button govuk-!-margin-top-3" data-module="govuk-button">Continue</button>
             </form>
         </div>
-        </div>
+    </div>
 </main>"
 `;

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status.view-model.js
@@ -8,10 +8,10 @@ import { formatContactDetails } from '../../representation/representation.utilit
 
 /**
  * @param {string} status
- * @param {string|boolean} isStatusEdit
  * @returns {Array<Object>}
  */
-const getRadioItems = (status, isStatusEdit) => {
+
+const getRadioItems = (status) => {
 	const optionsList = [
 		{
 			value: repStatusMap.awaitingReview,
@@ -41,7 +41,7 @@ const getRadioItems = (status, isStatusEdit) => {
 	];
 
 	return optionsList.map((option) => {
-		if (!!isStatusEdit && option.value === status) {
+		if (option.value === status) {
 			option.checked = true;
 		}
 		return option;
@@ -71,8 +71,7 @@ export const getRepresentationStatusViewModel = (
 		repId,
 		orgOrName: represented.organisationName ? represented.organisationName : represented.fullName,
 		pageHeading: 'Change status',
-		status,
-		radioItems: getRadioItems(status, isStatusEdit),
+		radioItems: getRadioItems(status),
 		backLinkUrl: getRepresentationDetailsPageUrl(caseId, repId)
 	};
 };

--- a/apps/web/src/server/views/applications/representations/representation-details/representation-status/representation-status.njk
+++ b/apps/web/src/server/views/applications/representations/representation-details/representation-status/representation-status.njk
@@ -4,7 +4,6 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "../components/representation-status-tag.njk" import representationStatusTag %}
 
 {% block pageHeading %}
 {% endblock %}
@@ -14,7 +13,6 @@
 
 	<span class="govuk-caption-l">{{ orgOrName}}</span>
     <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ pageHeading }}</h1>
-    <strong class="govuk-heading-s govuk-!-margin-bottom-6">{{ representationStatusTag(status) }}</strong>
 
 	<div class="govuk-grid-row">
 		<div class="govuk-grid-column-one-half">


### PR DESCRIPTION
## Describe your changes
- Removed the relevant reps status tag on the  change status screen.
- Changed the relevant reps status radio button logic to allow the selected button to display as checked. 
- Regenerated the relevant reps snapshot.

## Issue ticket number and link
[APPLICS-1171](https://pins-ds.atlassian.net/browse/APPLICS-1171): C-BOS accessibility audit - 'Change status' of relevant rep

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-1171]: https://pins-ds.atlassian.net/browse/APPLICS-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ