### PR TITLE
fix(web): move documents list not loading after navigating back from …

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/utils.unit.test.js
+++ b/apps/web/src/server/applications/case/documentation/__tests__/utils.unit.test.js
@@ -201,4 +201,31 @@ describe('utils.js', () => {
 			});
 		});
 	});
+
+	describe('#getFolderExplorerURL', () => {
+		it('should return the correct URL when all parameters are provided', () => {
+			const result = utils.getFolderExplorerURL(1, 2, 'Test');
+			expect(result).toBe(
+				'/applications-service/case/1/project-documentation/2/Test/move-documents/folder-explorer'
+			);
+		});
+
+		it('should throw an error when caseId is missing', () => {
+			expect(() => utils.getFolderExplorerURL(null, 2, 'Test')).toThrow(
+				'Missing required parameters to get folder explorer URL'
+			);
+		});
+
+		it('should throw an error when folderId is missing', () => {
+			expect(() => utils.getFolderExplorerURL(1, null, 'Test')).toThrow(
+				'Missing required parameters to get folder explorer URL'
+			);
+		});
+
+		it('should throw an error when folder name is missing', () => {
+			expect(() => utils.getFolderExplorerURL(1, 2, null)).toThrow(
+				'Missing required parameters to get folder explorer URL'
+			);
+		});
+	});
 });

--- a/apps/web/src/server/applications/case/documentation/utils/move-documents/utils.js
+++ b/apps/web/src/server/applications/case/documentation/utils/move-documents/utils.js
@@ -171,6 +171,26 @@ const getMoveDocumentsPayload = (session) => {
 	return moveDocumentsPayload;
 };
 
+/**
+ * @param {number} caseId
+ * @param {number} folderId
+ * @param {string} folderName
+ * @returns {string}
+ */
+
+const getFolderExplorerURL = (caseId, folderId, folderName) => {
+	if (!caseId || !folderId || !folderName) {
+		throw new Error('Missing required parameters to get folder explorer URL');
+	}
+	const baseMoveDocumentsUrl = url('move-documents', {
+		caseId,
+		folderId,
+		folderName
+	});
+
+	return `${baseMoveDocumentsUrl}/folder-explorer`;
+};
+
 export default {
 	getFolderList,
 	isFolderRoot,
@@ -179,5 +199,6 @@ export default {
 	getFolderNameById,
 	getFolderViewData,
 	formatFolderList,
-	getMoveDocumentsPayload
+	getMoveDocumentsPayload,
+	getFolderExplorerURL
 };

--- a/apps/web/src/server/lib/nunjucks-filters/url.js
+++ b/apps/web/src/server/lib/nunjucks-filters/url.js
@@ -6,6 +6,7 @@ import slugify from 'slugify';
  * @typedef {object} urlFilterArguments
  * @property {number=} caseId
  * @property {number=} folderId
+ * @property {string=} folderName
  * @property {number=} representationId
  * @property {number=} projectUpdateId
  * @property {string=} documentGuid

--- a/apps/web/src/server/views/applications/case-documentation/move-documents/document-list.njk
+++ b/apps/web/src/server/views/applications/case-documentation/move-documents/document-list.njk
@@ -2,8 +2,6 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set folderExplorerURL = 'move-documents'|url({caseId: caseId, folderId: folderId, folderName: activeFolderSlug }) + '/folder-explorer' %}
-
 {% block beforeContent %}
 <aside>
   {{ govukBackLink({


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1250

-Navigating back from folder explorer was causing an error due to the `folderId` not being available on locals for the `url` filter to access in the template. Fix explicitly sets the URL and passes from the controller.

-tidy up the move documents utils name

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
