### PR TITLE
fix(web): fix interested party number label overlap (applics-1144)

### DIFF
--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -7084,10 +7084,10 @@ exports[`applications documentation Document properties page page should render 
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/description"> Change<span class="govuk-visually-hidden"> Description</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key white-space--nowrap"> Interested Party number (optional)</dt>
-                            <dd                             class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> Interested Party number (optional)</span></a>
-                                </dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> IP number (optional)</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> IP number (optional)</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who the document is from</dt>
                             <dd                             class="govuk-summary-list__value">Consectetur adipiscing</dd>
@@ -7246,10 +7246,10 @@ exports[`applications documentation Document properties page page should render 
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/11/edit/description"> Change<span class="govuk-visually-hidden"> Description</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key white-space--nowrap"> Interested Party number (optional)</dt>
-                            <dd                             class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/11/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> Interested Party number (optional)</span></a>
-                                </dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> IP number (optional)</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/11/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> IP number (optional)</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who the document is from</dt>
                             <dd                             class="govuk-summary-list__value">Tempor incididunt</dd>
@@ -7416,10 +7416,10 @@ exports[`applications documentation Document properties page should not show pub
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/description"> Change<span class="govuk-visually-hidden"> Description</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key white-space--nowrap"> Interested Party number (optional)</dt>
-                            <dd                             class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> Interested Party number (optional)</span></a>
-                                </dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> IP number (optional)</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> IP number (optional)</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who the document is from</dt>
                             <dd                             class="govuk-summary-list__value">Consectetur adipiscing</dd>
@@ -7578,10 +7578,10 @@ exports[`applications documentation Document properties page should not show pub
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/11/edit/description"> Change<span class="govuk-visually-hidden"> Description</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key white-space--nowrap"> Interested Party number (optional)</dt>
-                            <dd                             class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/11/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> Interested Party number (optional)</span></a>
-                                </dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> IP number (optional)</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/11/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> IP number (optional)</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who the document is from</dt>
                             <dd                             class="govuk-summary-list__value">Tempor incididunt</dd>
@@ -7748,10 +7748,10 @@ exports[`applications documentation Document properties page should show publish
                             <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/description"> Change<span class="govuk-visually-hidden"> Description</span></a>
                             </dd>
                         </div>
-                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key white-space--nowrap"> Interested Party number (optional)</dt>
-                            <dd                             class="govuk-summary-list__value"></dd>
-                                <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> Interested Party number (optional)</span></a>
-                                </dd>
+                        <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> IP number (optional)</dt>
+                            <dd class="govuk-summary-list__value"></dd>
+                            <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/123/project-documentation/21/document/3/edit/interestedPartyNumber"> Change<span class="govuk-visually-hidden"> IP number (optional)</span></a>
+                            </dd>
                         </div>
                         <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Who the document is from</dt>
                             <dd                             class="govuk-summary-list__value">Consectetur adipiscing</dd>

--- a/apps/web/src/server/views/applications/case-documentation/properties/tab-details.component.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/tab-details.component.njk
@@ -46,7 +46,7 @@
 						{label: 'File name', value: documentationFile.fileName, link: 'name'},
 						{label: 'Description', value: documentationFile.description, link: 'description'},
 						welshDescriptionRow,
-            			{label: 'Interested Party number (optional)', value: documentationFile.interestedPartyNumber, link: 'interestedPartyNumber', classes: 'white-space--nowrap'},
+            			{label: 'IP number (optional)', value: documentationFile.interestedPartyNumber, link: 'interestedPartyNumber'},
 						{label: 'Who the document is from', value: documentationFile.author, link: 'author'},
 						welshFromRow,
 						{label: 'Agent (optional)', value: documentationFile.representative, link: 'agent'},


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1144

-Change 'Interested Party number' label text to 'IP number'

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
