### PR TITLE
chore(web): make relevant reps change status notes field optional (applics-1177)

### DIFF
--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/__tests__/__snapshots__/representation-status-notes.test.js.snap
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/__tests__/__snapshots__/representation-status-notes.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Change representation status page GET /applications-service/case/1/relevant-representations/1/representations-details/status-result should render the page 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main"><span class="govuk-caption-l"></span>
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Notes</h1><strong class="govuk-heading-s govuk-!-margin-bottom-6"><strong class="govuk-tag govuk-tag--grey">awaiting review</strong></strong>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-2">Notes (optional)</h1><strong class="govuk-heading-s govuk-!-margin-bottom-6"><strong class="govuk-tag govuk-tag--grey">awaiting review</strong></strong>
     <div     class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <form method="post" novalidate>

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
@@ -13,7 +13,7 @@ import {
  * @returns {{pageHeading: String, radioItems: Object[]}} page heading and title
  */
 const getPageContentByStatus = (newStatus) => {
-	let pageHeading = 'Notes';
+	let pageHeading = 'Notes (optional)';
 	/** @type {Object[]} */
 	let radioItems = [];
 
@@ -74,7 +74,7 @@ const getPageContentByStatus = (newStatus) => {
 			break;
 
 		default:
-			pageHeading = 'Notes';
+			pageHeading = 'Notes (optional)';
 			radioItems = [];
 			break;
 	}

--- a/apps/web/src/server/views/applications/representations/representation-details/representation-status/representation-status-notes.njk
+++ b/apps/web/src/server/views/applications/representations/representation-details/representation-status/representation-status-notes.njk
@@ -38,7 +38,7 @@
                     name: "notes",
                     id: "notes",
                     label: {
-                        text: radioItems|length and "Notes",
+                        text: radioItems|length and "Notes (optional)",
                         classes: "govuk-label--m",
                         isPageHeading: false
                     },


### PR DESCRIPTION
## Describe your changes
- Updated label for relevant reps change status notes field.
- Regenerated snapshots.

## Issue ticket number and link
[APPLICS-1177](https://pins-ds.atlassian.net/browse/APPLICS-1177): CBOS accessibility - Notes field

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
