### PR TITLE
feat(functions): display archive folder info post migration

### DIFF
--- a/apps/api/src/server/migration/archive-folder-info.controller.js
+++ b/apps/api/src/server/migration/archive-folder-info.controller.js
@@ -1,0 +1,55 @@
+import {
+	getDocumentsInFolder,
+	getFolderByName,
+	getFolderPath
+} from '../applications/application/file-folders/folders.service.js';
+import { getByRef as getCaseByRef } from '#repositories/case.repository.js';
+import { getFoldersByParentId } from '#repositories/folder.repository.js';
+
+const MAX_VALUE = 99999;
+
+/**
+ * @type {import("express").RequestHandler<{modelType: string}, ?, any[]>}
+ */
+export const getArchiveFolderInformation = async (req, res) => {
+	if (!req.query.caseReferences || req.query.caseReferences.length === 0) {
+		res.status(400).send({ message: 'caseReferences are required' });
+		return;
+	}
+
+	const caseReferences = Array.isArray(req.query.caseReferences)
+		? req.query.caseReferences
+		: [req.query.caseReferences];
+
+	const data = {};
+	for (const caseReference of caseReferences) {
+		const project = await getCaseByRef(caseReference);
+		if (!project) {
+			data[caseReference] = null;
+			continue;
+		}
+		const caseId = project.id;
+		const { id } = await getFolderByName(caseId, 'Archived documentation');
+		data[caseReference] = await getAllFolderIdsWithDocCounts(caseId, id);
+	}
+	res.status(200).send(data);
+};
+
+const getAllFolderIdsWithDocCounts = async (caseId, folderId) => {
+	const result = [];
+	const childFolders = await getFoldersByParentId(folderId);
+	const { itemCount: documentCount } = await getDocumentsInFolder(folderId, 1, MAX_VALUE);
+	if (documentCount !== 0) {
+		const folderPathDetails = await getFolderPath(caseId, folderId);
+		const folderPath = folderPathDetails.reduce((accum, pathDetails) => {
+			return `${accum}/${pathDetails.displayNameEn.trim()}`;
+		}, '');
+		result.push({ [folderPath]: documentCount });
+	}
+
+	for (const folder of childFolders) {
+		const childResults = await getAllFolderIdsWithDocCounts(caseId, folder.id);
+		result.push(...childResults);
+	}
+	return result;
+};

--- a/apps/api/src/server/migration/migration.routes.js
+++ b/apps/api/src/server/migration/migration.routes.js
@@ -2,6 +2,7 @@ import { Router as createRouter } from 'express';
 import { asyncHandler } from '@pins/express';
 import { postMigrateFolders, postMigrateModel } from './migration.controller.js';
 import { validateMigration } from './validate-migration.controller.js';
+import { getArchiveFolderInformation } from './archive-folder-info.controller.js';
 
 const router = createRouter();
 
@@ -102,6 +103,36 @@ router.get(
 			*/
 
 	asyncHandler(validateMigration)
+);
+
+router.get(
+	'/archive-folder-info',
+	/*
+				#swagger.tags = ['Migration']
+				#swagger.path =  'migration/archive-folder-info'
+				#swagger.description = 'Validate migration'
+				#swagger.parameters['query'] = {
+						caseReferences: 'TR020002,TR020003'
+				}
+				#swagger.parameters['x-service-name'] = {
+			in: 'header',
+			type: 'string',
+			description: 'Service name header',
+			default: 'swagger'
+		}
+		#swagger.parameters['x-api-key'] = {
+			in: 'header',
+			type: 'string',
+			description: 'API key header',
+			default: '123'
+		}
+				#swagger.responses[200] = {
+						description: '',
+            schema: { }
+				}
+			*/
+
+	asyncHandler(getArchiveFolderInformation)
 );
 
 export { router as migrationRoutes };

--- a/apps/functions/applications-migration/common/get-archive-folder-info.js
+++ b/apps/functions/applications-migration/common/get-archive-folder-info.js
@@ -1,0 +1,11 @@
+import { makeGetRequest } from './back-office-api-client.js';
+
+/**
+ * @param {import('@azure/functions').Logger} log
+ * @param {string[]} caseReferences
+ * @returns {Promise<Object>}
+ */
+export const getArchiveFolderInfo = async (log, caseReferences) => {
+	log.info(`Getting archive folder info for cases: ${JSON.stringify(caseReferences)}`);
+	return await makeGetRequest(log, '/migration/archive-folder-info', { caseReferences });
+};

--- a/apps/functions/applications-migration/migrate-case/index.js
+++ b/apps/functions/applications-migration/migrate-case/index.js
@@ -13,6 +13,7 @@ import { app } from '@azure/functions';
 import { Readable } from 'stream';
 import { validateMigration } from '../common/validate-migration.js';
 import { toBoolean } from '../common/utils.js';
+import { getArchiveFolderInfo } from '../common/get-archive-folder-info.js';
 
 app.setup({ enableHttpStream: true });
 app.http('migrate-case', {
@@ -36,7 +37,8 @@ app.http('migrate-case', {
 		return handleMigrationWithResponse(context, {
 			caseReferences: caseReferences,
 			entityName,
-			migrationStream:  () => migrateCase(context, caseReferences, toBoolean(dryRun), toBoolean(isWelshCase))
+			migrationStream: () =>
+				migrateCase(context, caseReferences, toBoolean(dryRun), toBoolean(isWelshCase))
 		});
 	}
 });
@@ -95,7 +97,11 @@ const migrateCase = async (log, caseReferenceList, dryRun = false, isWelshCase =
 			}
 			yield '\nStarting validation process...\n';
 			const validationResult = await validateMigration(log, caseReferenceList);
-			yield 'Validation result: \n' + JSON.stringify(validationResult, null, 2);
+			yield 'Validation Result: \n' + JSON.stringify(validationResult, null, 2);
+			yield '\nGetting archive folder information... \n';
+			const folderInformationResult = await getArchiveFolderInfo(log, caseReferenceList);
+			yield `Archive Folder Information is in format {folderPath}: {documentCount} \n`;
+			yield 'Archive Folder Information: \n' + JSON.stringify(folderInformationResult, null, 2);
 		})()
 	);
 };


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-1257

Show archive folder paths and counts after migration. Displayed like this:
![image](https://github.com/user-attachments/assets/0a2cbff5-a078-4af7-937a-ba05ff1408e8)


## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
