### PR TITLE
fix(api): correct rel rep agent publishing (applics-1290)

### DIFF
--- a/apps/api/src/server/applications/application/representations/__tests__/create-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/create-representation.test.js
@@ -269,7 +269,8 @@ describe('Create Representation', () => {
 		const createdRepresentationFullDetailsWithUsers = {
 			...createdRepresentationFullDetails,
 			representative: representativeRec,
-			represented: representedRec
+			represented: representedRec,
+			representedType: 'AGENT'
 		};
 
 		databaseConnector.representation.findFirst

--- a/apps/api/src/server/applications/application/representations/__tests__/patch-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/__tests__/patch-representation.test.js
@@ -18,6 +18,7 @@ const existingRepresentations = [
 		received: new Date('2023-03-14T14:28:25.704Z'),
 		originalRepresentation: 'the original representation',
 		redactedRepresentation: 'redacted version',
+		representedType: 'AGENT',
 		case: { id: 1, reference: 'BC0110001' },
 		representationActions: [
 			{

--- a/apps/api/src/server/applications/application/representations/publish/__tests__/publish-representation.test.js
+++ b/apps/api/src/server/applications/application/representations/publish/__tests__/publish-representation.test.js
@@ -18,7 +18,7 @@ const representations = [
 		redacted: true,
 		userId: null,
 		received: new Date('2023-08-11T10:52:56.516Z'),
-		type: null,
+		type: 'Members of the public/businesses',
 		user: null,
 		attachments: [
 			{
@@ -86,7 +86,7 @@ const representations = [
 		redacted: false,
 		userId: null,
 		received: new Date('2023-08-11T10:52:56.516Z'),
-		type: null,
+		type: 'Members of the public/businesses',
 		user: null,
 		attachments: [],
 		case: {
@@ -98,7 +98,7 @@ const representations = [
 			publishedAt: null,
 			title: 'Office Use Test Application 1'
 		},
-		representedType: undefined, // this is not captured if rep has representative/agent
+		representedType: 'AGENT',
 		represented: {
 			id: 10381,
 			representationId: 6579,
@@ -145,8 +145,12 @@ const representations = [
 	}
 ];
 
+/**
+ * This holds the array of obj with values after they have been mapped through the payload builder
+ */
 const expectedNsipRepresentationPayload = buildPayloadEventsForSchema(NSIP_REPRESENTATION, [
 	{
+		representationId: 6409,
 		attachmentIds: ['8e706443-3404-4b89-9fda-280ab7fd6b68'],
 		caseRef: 'BC0110001',
 		caseId: 151,
@@ -158,11 +162,11 @@ const expectedNsipRepresentationPayload = buildPayloadEventsForSchema(NSIP_REPRE
 		redactedBy: 'Bloggs, Joe',
 		redactedNotes: 'some redaction notes',
 		referenceId: 'BC0110001-55',
-		representationId: 6409,
 		representedId: '10105',
 		status: 'published',
-		registerFor: 'ORGANISATION',
-		representationFrom: 'ORGANISATION'
+		registerFor: null,
+		representationFrom: 'ORGANISATION',
+		representationType: 'Members of the Public/Businesses'
 	},
 	{
 		attachmentIds: [],
@@ -177,7 +181,9 @@ const expectedNsipRepresentationPayload = buildPayloadEventsForSchema(NSIP_REPRE
 		representativeId: '10382',
 		representedId: '10381',
 		status: 'published',
-		representationFrom: 'AGENT'
+		registerFor: null,
+		representationFrom: 'AGENT',
+		representationType: 'Members of the Public/Businesses'
 	}
 ]);
 

--- a/apps/api/src/server/applications/application/representations/redact/__tests__/patch-redact.test.js
+++ b/apps/api/src/server/applications/application/representations/redact/__tests__/patch-redact.test.js
@@ -18,6 +18,8 @@ const existingRepresentations = [
 		originalRepresentation: 'the original representation',
 		redactedRepresentation: 'redacted version',
 		case: { id: 1, reference: 'BC0110001' },
+		type: 'Members of the public/businesses',
+		representedType: 'AGENT',
 		representationActions: [],
 		represented: {
 			id: 10381,
@@ -70,7 +72,9 @@ const existingRepresentations = [
 		status: 'PUBLISHED',
 		redacted: true,
 		received: new Date('2023-03-14T14:28:25.704Z'),
-		unpublishedUpdates: false
+		unpublishedUpdates: false,
+		type: 'Members of the public/businesses',
+		representedType: 'AGENT'
 	}
 ];
 
@@ -88,7 +92,7 @@ const rep1UpdatePayload = buildPayloadEventsForSchema(NSIP_REPRESENTATION, {
 	status: 'valid',
 	registerFor: null,
 	representationFrom: 'AGENT',
-	representationType: null,
+	representationType: 'Members of the Public/Businesses',
 	representativeId: '10382',
 	representedId: '10381'
 })[0];

--- a/apps/api/src/server/applications/application/representations/status/__tests__/patch-status.test.js
+++ b/apps/api/src/server/applications/application/representations/status/__tests__/patch-status.test.js
@@ -16,6 +16,8 @@ const existingRepresentations = [
 		received: new Date('2023-03-14T14:28:25.704Z'),
 		originalRepresentation: 'the original representation',
 		redactedRepresentation: 'redacted version',
+		type: 'Members of the public/businesses',
+		representedType: 'AGENT',
 		case: { id: 1, reference: 'BC0110001' },
 		representationActions: [],
 		represented: {
@@ -68,7 +70,9 @@ const existingRepresentations = [
 		reference: 'BC0110001-55',
 		status: 'PUBLISHED',
 		redacted: true,
-		received: new Date('2023-08-11T10:52:56.516Z')
+		received: new Date('2023-08-11T10:52:56.516Z'),
+		type: 'Members of the public/businesses',
+		representedType: 'AGENT'
 	}
 ];
 
@@ -84,6 +88,7 @@ const expectedRepresentationUpdatePayload = buildPayloadEventsForSchema(NSIP_REP
 	representedId: '10381',
 	representativeId: '10382',
 	representationFrom: 'AGENT',
+	representationType: 'Members of the Public/Businesses',
 	dateReceived: '2023-03-14T14:28:25.704Z',
 	attachmentIds: [],
 	redactedRepresentation: 'redacted version'

--- a/apps/api/src/server/applications/constants.js
+++ b/apps/api/src/server/applications/constants.js
@@ -54,3 +54,14 @@ export const folderDocumentCaseStageMappings = {
 	DECISION: DOCUMENT_CASE_STAGE_DECISION,
 	POST_DECISION: DOCUMENT_CASE_STAGE_POST_DECISION
 };
+
+/**
+ * who is making the representation?
+ * Stored in CBOS field Representation.representedType,
+ * and in ODW as representationFrom
+ */
+export const REPRESENTATION_FROM_TYPE = {
+	AGENT: 'AGENT',
+	ORGANISATION: 'ORGANISATION',
+	PERSON: 'PERSON'
+};

--- a/apps/api/src/server/infrastructure/payload-builders/nsip-representation.js
+++ b/apps/api/src/server/infrastructure/payload-builders/nsip-representation.js
@@ -7,11 +7,12 @@
  */
 
 import { buildServiceUserPayload } from '#infrastructure/payload-builders/service-user.js';
+import { REPRESENTATION_FROM_TYPE } from '#api-constants';
 
 /**
  * Build Representation message event payload
  *
- * @param {function(RepresentationModel): Representation} representation
+ * @param {RepresentationWithFullDetails} representation
  * @returns {NSIPRepresentationSchema}
  */
 export const buildNsipRepresentationPayload = (representation) => {
@@ -32,11 +33,12 @@ export const buildNsipRepresentationPayload = (representation) => {
 		originalRepresentation: representation.originalRepresentation,
 		representationType: mapRepresentationTypeToSchema(representation.type),
 		representedId: representation.represented?.id.toString() ?? null,
-		representativeId: representation.representative?.id.toString() ?? null,
-		representationFrom: representation.representative?.id
-			? 'AGENT'
-			: representation.representedType ?? null,
-		registerFor: representation.representedType ?? null,
+		representativeId:
+			representation.representedType == REPRESENTATION_FROM_TYPE.AGENT
+				? representation.representative?.id.toString()
+				: null,
+		representationFrom: representation.representedType ?? null,
+		registerFor: null, // unused in CBOS - used in FO journey only
 		dateReceived: representation.received?.toISOString() ?? '',
 		attachmentIds: representation.attachments?.map((attachment) => attachment.documentGuid)
 	};

--- a/apps/api/src/server/infrastructure/payload-builders/nsip-representation.js
+++ b/apps/api/src/server/infrastructure/payload-builders/nsip-representation.js
@@ -35,7 +35,7 @@ export const buildNsipRepresentationPayload = (representation) => {
 		representedId: representation.represented?.id.toString() ?? null,
 		representativeId:
 			representation.representedType == REPRESENTATION_FROM_TYPE.AGENT
-				? representation.representative?.id.toString()
+				? representation.representative?.id?.toString()
 				: null,
 		representationFrom: representation.representedType ?? null,
 		registerFor: null, // unused in CBOS - used in FO journey only


### PR DESCRIPTION
## Describe your changes

The representationFrom field in the service bus broadcast is currently being overridden if there is an agent, this is not correct, we should just be populating the value of the CBOS field Representation.representedType.

schema field representativeId - In the case where a rep was marked as having an agent, but later changed, we want to retain this information in CBOS in case they set the agent back again.  But we do not want to broadcast the agent id if they have not currently set the Representation.representedType field to be AGENT.  Therefore if Representation.representedTypeis AGENT, populate the schema field representativeId  with the agentId, else NULL.

Change the broadcast payload build to send NULL value for registerFor field.  This field is only used by Front Office when reps come into them from the public, not used CBOS side.  

- schema field representativeId to only have a value if Representation.representedTypeis AGENT, else NULL
- Also schema field registerFor should send a null value
- schema field representationFrom should just populate with the CBOS Representation.representedType value
- and update tests

## Relevant Representation publishing error - where represented person is an agent
https://pins-ds.atlassian.net/browse/APPLICS-1290

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
