### PR TITLE
fix(web): representation entity to display correct value (applics-1293)

### DIFF
--- a/apps/web/src/server/applications/case/representations/representation-details/__fixtures__/representation-details.fixture.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/__fixtures__/representation-details.fixture.js
@@ -15,7 +15,7 @@ export const representationDetailsFixture = {
 		'(Redacted) Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla con.',
 	user: null,
 	type: 'Local authorities',
-	representedType: undefined,
+	representedType: 'AGENT',
 	represented: {
 		id: 1,
 		firstName: 'Mrs',

--- a/apps/web/src/server/applications/case/representations/representation-details/applications-relevant-rep-details.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/applications-relevant-rep-details.view-model.js
@@ -28,6 +28,5 @@ export const getRepresentationDetailsViewModel = async (
 	relevantRepDocumentFolder: await getRelevantRepFolder(caseId),
 	organisationOrFullname: getOrganisationOrFullname(representation.represented),
 	repModePageURLs: getRepModePageURLs(representation),
-	depublishedRepresentation: depublished === 'true',
-	representedType: representation.representative?.id ? 'AGENT' : representation.representedType
+	depublishedRepresentation: depublished === 'true'
 });

--- a/apps/web/src/server/applications/case/representations/representation/representation-entity/__tests__/__snapshots__/represetation-entity.test.js.snap
+++ b/apps/web/src/server/applications/case/representations/representation/representation-entity/__tests__/__snapshots__/represetation-entity.test.js.snap
@@ -24,7 +24,7 @@ exports[`Representation representation type GET /applications-service/case/1/rel
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="representationEntity-3" name="representationEntity"
-                                type="radio" value="AGENT" checked>
+                                type="radio" value="AGENT">
                                 <label class="govuk-label govuk-radios__label" for="representationEntity-3">A representative on behalf of another person, family group or organisation</label>
                             </div>
                         </div>
@@ -77,7 +77,7 @@ exports[`Representation representation type POST /applications-service/case/1/re
                             </div>
                             <div class="govuk-radios__item">
                                 <input class="govuk-radios__input" id="representationEntity-3" name="representationEntity"
-                                type="radio" value="AGENT" checked>
+                                type="radio" value="AGENT">
                                 <label class="govuk-label govuk-radios__label" for="representationEntity-3">A representative on behalf of another person, family group or organisation</label>
                             </div>
                 </div>

--- a/apps/web/src/server/applications/case/representations/representation/representation-entity/entity.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation/representation-entity/entity.view-model.js
@@ -14,10 +14,7 @@ const titles = {
 
 /**
  * @param {object} representation
- * @param {object} representation.representative
- * @param {string|*} representation.representative.id
  * @param {string|undefined} representation.representedType
- * @param {object} representation.represented
  * @returns {Array<RepresentationEntityOption>} contactMethodOptions array
  */
 export const getRepresentationEntityOptions = (representation) => {
@@ -39,10 +36,8 @@ export const getRepresentationEntityOptions = (representation) => {
 		}
 	];
 
-	const type = representation.representative?.id ? 'AGENT' : representation.representedType;
-
 	return optionsList.map((option) => {
-		if (option.value === type) {
+		if (option.value === representation.representedType) {
 			option.checked = true;
 		}
 		return option;

--- a/apps/web/src/server/views/applications/representations/representation-details/index.njk
+++ b/apps/web/src/server/views/applications/representations/representation-details/index.njk
@@ -26,10 +26,13 @@
       {% else %}
         {{ representationDetailsHeading(organisationOrFullname, representation.status, case.projectName) }}
       {% endif %}
+
       {% include "./includes/represented-details.include.njk" %}
-      {% if representedType == 'AGENT' %}
+
+      {% if representation.representedType == 'AGENT' %}
         {% include "./includes/representative-details.include.njk" %}
       {% endif %}
+      
       {% if representation.status == 'DRAFT' %}
         {% include "./includes/check/representation.include.njk" %}
         {% include "./includes/check/attachments.include.njk" %}


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/APPLICS-1293

There was a disjoint between user actions and the state of the representation entity.

Current logic was depending on `representative.id` to display entity selection for the representation. This was a problem In a situation where there was an agent assigned to representation (`representedType`), and then this was changed to  PERSON or ORGANISATION later on. Since AGENT used to be selected, `representative.id` was still present in the data and the UI was defaulting to display AGENT version of the label on the radio UI, despite (`representedType`) currently saved for that representation being PERSON or ORGANISATION. 

This PR uses (`representedType`) do drive the display logic, allowing us to display the currently stored `representedType` correctly but also to preserve agent details if the selection was made back to agent (AGENT->PERSON->AGENT).


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
