### PR TITLE
fix(functions): move loose s51 attachments to archive in migration

### DIFF
--- a/apps/api/src/server/migration/migration.routes.js
+++ b/apps/api/src/server/migration/migration.routes.js
@@ -3,6 +3,7 @@ import { asyncHandler } from '@pins/express';
 import { postMigrateFolders, postMigrateModel } from './migration.controller.js';
 import { validateMigration } from './validate-migration.controller.js';
 import { getArchiveFolderInformation } from './archive-folder-info.controller.js';
+import { migrationCleanup } from './migrators/migration-cleanup.controller.js';
 
 const router = createRouter();
 
@@ -36,6 +37,36 @@ router.post(
         }
 	 */
 	asyncHandler(postMigrateFolders)
+);
+
+router.post(
+	'/cleanup',
+	/*
+				#swagger.tags = ['Migration']
+				#swagger.path =  'migration/cleanup'
+				#swagger.description = 'Cleanup migration data'
+				#swagger.parameters['query'] = {
+						caseReferences: 'TR020002,TR020003'
+				}
+				#swagger.parameters['x-service-name'] = {
+			in: 'header',
+			type: 'string',
+			description: 'Service name header',
+			default: 'swagger'
+		}
+		#swagger.parameters['x-api-key'] = {
+			in: 'header',
+			type: 'string',
+			description: 'API key header',
+			default: '123'
+		}
+				#swagger.responses[200] = {
+						description: '',
+            schema: { }
+				}
+			*/
+
+	asyncHandler(migrationCleanup)
 );
 
 router.post(
@@ -110,7 +141,7 @@ router.get(
 	/*
 				#swagger.tags = ['Migration']
 				#swagger.path =  'migration/archive-folder-info'
-				#swagger.description = 'Validate migration'
+				#swagger.description = 'Get archive folder information'
 				#swagger.parameters['query'] = {
 						caseReferences: 'TR020002,TR020003'
 				}

--- a/apps/api/src/server/migration/migrators/migration-cleanup.controller.js
+++ b/apps/api/src/server/migration/migrators/migration-cleanup.controller.js
@@ -1,0 +1,73 @@
+import logger from '#utils/logger.js';
+import {
+	createFolder,
+	getFolderByName
+} from '../../applications/application/file-folders/folders.service.js';
+import { getByRef as getCaseByRef } from '#repositories/case.repository.js';
+import * as documentRepository from '#repositories/document.repository.js';
+import { databaseConnector } from '#utils/database-connector.js';
+
+/**
+ * @type {import("express").RequestHandler<{modelType: string}, ?, any[]>}
+ */
+export const migrationCleanup = async (req, res) => {
+	const caseReference = req.body.caseReference;
+
+	res.writeHead(200, { 'Content-Type': 'text/plain', 'transfer-encoding': 'chunked' });
+	res.write(`\nStarting migration cleanup for ${caseReference} ...\n`);
+	res.flush();
+
+	try {
+		await cleanupLooseS51Attachments(caseReference, res);
+		// note: any other cleanup tasks can be added here in the future
+	} catch (error) {
+		logger.error(`Error during migration cleanup: ${error}`);
+		res.write(`Error during migration cleanup: ${error}\n`);
+	} finally {
+		res.write('Clean up successfully complete');
+		res.end();
+	}
+};
+
+const s51UnattachedFolderName = 'S51 Unattached';
+const archiveFolderName = 'Archived Documentation';
+const s51AdviceFolderName = 'S51 advice';
+
+const cleanupLooseS51Attachments = async (caseReference, res) => {
+	res.write(`Starting to clean up loose s51 attachments...\n`);
+	const project = await getCaseByRef(caseReference);
+	const caseId = project.id;
+
+	// get loose s51 attachments
+	const { id: s51AdviceFolderId } = await getFolderByName(caseId, s51AdviceFolderName);
+	const s51DocumentsToMove = await databaseConnector.$queryRaw`
+	SELECT dv.documentGuid, dv.version
+	FROM Document doc
+		   LEFT JOIN S51AdviceDocument adv ON adv.documentGuid = doc.guid
+		   JOIN DocumentVersion dv ON dv.documentGuid = doc.guid
+	WHERE doc.folderId = ${s51AdviceFolderId}
+	  AND adv.documentGuid IS NULL`;
+	if (s51DocumentsToMove.length === 0) {
+		res.write(`No loose s51 attachments found.\n`);
+		res.end();
+	}
+
+	// get or create nested s51 unattached archive folder
+	const archiveFolderDetails = await getFolderByName(caseId, archiveFolderName);
+	const unattachedAdviceFolderDetails = await getFolderByName(caseId, s51UnattachedFolderName);
+	const archiveFolderId = archiveFolderDetails?.id;
+	let s51UnattachedFolderId = unattachedAdviceFolderDetails?.id;
+	if (!s51UnattachedFolderId) {
+		const { id } = await createFolder(caseId, s51UnattachedFolderName, archiveFolderId);
+		s51UnattachedFolderId = id;
+	}
+
+	// move all loose docs to unattached s51 folder
+	await documentRepository.updateDocumentsFolderId({
+		destinationFolderId: s51UnattachedFolderId,
+		destinationFolderStage: '0',
+		documents: s51DocumentsToMove
+	});
+
+	res.write(`Cleaned up loose s51 attachments.\n`);
+};

--- a/apps/functions/applications-migration/common/migration-cleanup.js
+++ b/apps/functions/applications-migration/common/migration-cleanup.js
@@ -1,0 +1,8 @@
+import { makePostRequestStreamResponse } from './back-office-api-client.js';
+
+export const startMigrationCleanup = async (log, caseReference) => {
+	log.info(`Making API request to start migration for case: ${caseReference}`);
+	return makePostRequestStreamResponse(log, '/migration/cleanup', {
+		caseReference
+	});
+};

--- a/apps/functions/applications-migration/migrate-case/index.js
+++ b/apps/functions/applications-migration/migrate-case/index.js
@@ -14,6 +14,7 @@ import { Readable } from 'stream';
 import { validateMigration } from '../common/validate-migration.js';
 import { toBoolean } from '../common/utils.js';
 import { getArchiveFolderInfo } from '../common/get-archive-folder-info.js';
+import { startMigrationCleanup } from '../common/migration-cleanup.js';
 
 app.setup({ enableHttpStream: true });
 app.http('migrate-case', {
@@ -68,10 +69,13 @@ const migrateCase = async (log, caseReferenceList, dryRun = false, isWelshCase =
 			caseReferenceTaskList.push(() => migrateProjectUpdates(log, [caseReference], isWelshCase));
 		}
 
+		caseReferenceTaskList.push(() => startMigrationCleanup(log, caseReference));
+
 		// re-run the nsip-project migration to update the status and broadcast
 		if (!dryRun) {
 			caseReferenceTaskList.push(() => migrateNsipProjectByReference(log, caseReference, true));
 		}
+
 		listOfCaseReferenceTasks.push(caseReferenceTaskList);
 	});
 


### PR DESCRIPTION
## Describe your changes

Ticket: https://pins-ds.atlassian.net/browse/APPLICS-1288

When migrating EN010157 it was noticed that the S51 advice folder had some loose documents that were not tied to an advice.  Whilst these migrate okay they are not visible in C-BOS as docs can only be seen as attachments to advices. This ticket moves those to the archive folder `Archive Documentation/s51 Unattached` folder.

Can be tested with `TR050004` locally or on test env.

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
