### PR TITLE
feat(web): make applicant organisation name field mandatory (applics-1302)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/createCase.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/createCase.spec.js
@@ -84,6 +84,15 @@ describe('Create A Case', () => {
 			createCasePage.clickSaveAndContinue();
 			applicationsHomePage.verifyPageTitle('Enter the project email (optional) - Create new case');
 			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Enter the Applicant’s organisation - Create new case');
+			createCasePage.clickSaveAndContinue();
+			applicationsHomePage.verifyPageTitle('Enter the Applicant’s organisation - Create new case', {
+				error: true
+			});
+			createCasePage.validateErrorMessageCountOnPage(1);
+			createCasePage.validateErrorMessage('Enter the Applicant’s organisation');
+			createCasePage.sections.applicantOrganisation.fillOrganisationName(projectInfo.orgName);
+			createCasePage.clickSaveAndContinue();
 			applicationsHomePage.verifyPageTitle(
 				'Choose the Applicant information you have available - Create new case'
 			);

--- a/apps/e2e/cypress/e2e/back-office-applications/sectorAsTraing.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/sectorAsTraing.spec.js
@@ -33,6 +33,8 @@ describe('Create Case with sector as training', () => {
 		createCasePage.clickSaveAndContinue();
 		createCasePage.clickSaveAndContinue();
 		createCasePage.clickSaveAndContinue();
+		createCasePage.sections.applicantOrganisation.fillOrganisationName(projectInfo.orgName);
+		createCasePage.clickSaveAndContinue();
 		createCasePage.clickSaveAndContinue();
 		createCasePage.clickSaveAndContinue();
 		createCasePage.clickButtonByText('I accept - confirm creation of a new case');

--- a/apps/e2e/cypress/page_objects/createCasePage.js
+++ b/apps/e2e/cypress/page_objects/createCasePage.js
@@ -49,9 +49,9 @@ export class CreateCasePage extends Page {
 		if (!mandatoryOnly) {
 			this.sections.projectEmail.fillCaseEmail(projectInformation.projectEmail);
 			this.clickSaveAndContinue();
-			this.sections.applicantInformationAvailable.chooseAll();
-			this.clickSaveAndContinue();
 			this.sections.applicantOrganisation.fillOrganisationName(projectInformation.orgName);
+			this.clickSaveAndContinue();
+			this.sections.applicantInformationAvailable.chooseAll();
 			this.clickSaveAndContinue();
 			this.sections.applicantName.fillApplicantFirstName(projectInformation.applicantFirstName);
 			this.sections.applicantName.fillApplicantLastName(projectInformation.applicantLastName);
@@ -67,6 +67,8 @@ export class CreateCasePage extends Page {
 			this.sections.applicantPhoneNumber.fillPhoneNumber(projectInformation.applicantPhoneNumber);
 			this.clickSaveAndContinue();
 		} else {
+			this.clickSaveAndContinue();
+			this.sections.applicantOrganisation.fillOrganisationName(projectInformation.orgName);
 			this.clickSaveAndContinue();
 			this.clickSaveAndContinue();
 		}

--- a/apps/e2e/cypress/support/utils/options.js
+++ b/apps/e2e/cypress/support/utils/options.js
@@ -22,7 +22,7 @@ export const SECTORS = [
 ];
 
 export const SUBSECTORS = {
-	"Business and Commercial": [
+	'Business and Commercial': [
 		'Office Use',
 		'Research and Development of Products or Processes',
 		'An Industrial Process or Processes',
@@ -51,21 +51,13 @@ export const SUBSECTORS = {
 	],
 	Water: ['Dams and Reservoirs', 'Transfer of Water Resources'],
 	Waste: ['Hazardous Waste Facilities'],
-	"Waste Water": ['Waste Water Treatment Plants'],
+	'Waste Water': ['Waste Water Treatment Plants'],
 	Training: ['Training']
 };
 
-export const ZOOM_LEVELS = [
-	'Country',
-	'Region',
-	'County',
-	'Borough',
-	'District',
-	'None'
-];
+export const ZOOM_LEVELS = ['Country', 'Region', 'County', 'Borough', 'District', 'None'];
 
 export const APPLICANT_INFO = [
-	'Organisation name',
 	"Applicant's contact name",
 	'Address',
 	'Website',

--- a/apps/e2e/cypress/support/utils/utils.js
+++ b/apps/e2e/cypress/support/utils/utils.js
@@ -14,10 +14,7 @@ const caseIsWelsh = (projectInformation) => {
 const validateProjectOverview = (projectInformation, mandatoryOnly = false) => {
 	if (Cypress.env('featureFlags')['applic-55-welsh-translation']) {
 		casePage.validateSummaryItem('Reference number', Cypress.env('currentCreatedCase'));
-		casePage.validateSummaryItem(
-			'Organisation name',
-			mandatoryOnly ? '' : projectInformation.orgName
-		);
+		casePage.validateSummaryItem('Organisation name', projectInformation.orgName);
 		casePage.validateSummaryItem(
 			'Website',
 			mandatoryOnly ? '' : projectInformation.applicantWebsite
@@ -31,7 +28,7 @@ const validateProjectOverview = (projectInformation, mandatoryOnly = false) => {
 		casePage.validateSummaryItem(
 			'Applicant information',
 			mandatoryOnly
-				? ''
+				? `${projectInformation.orgName}`
 				: `${projectInformation.orgName}${projectInformation.applicantEmail}${projectInformation.applicantPhoneNumber}`
 		);
 		casePage.validateSummaryItem(
@@ -76,7 +73,6 @@ const validateProjectDetailsSection = (projectInformation, mandatoryOnly = false
 		'Grid references',
 		`${projectInformation.gridRefEasting} (Easting)${projectInformation.gridRefNorthing} (Northing)`
 	);
-	//casePage.checkProjectAnswer('Regions', projectInformation.regions.join(','));
 	casePage.checkProjectAnswer(
 		'Map zoom level',
 		mandatoryOnly ? 'None' : projectInformation.zoomLevel
@@ -88,11 +84,7 @@ const validateApplicantInfoSection = (
 	mandatoryOnly = false,
 	updated = false
 ) => {
-	casePage.checkProjectAnswer(
-		'Organisation name',
-		mandatoryOnly ? '' : projectInformation.orgName,
-		true
-	);
+	casePage.checkProjectAnswer('Organisation name', projectInformation.orgName);
 	casePage.checkProjectAnswer(
 		'Website',
 		mandatoryOnly ? '' : projectInformation.applicantWebsite,

--- a/apps/web/src/server/applications/common/components/form/form-applicant.component.js
+++ b/apps/web/src/server/applications/common/components/form/form-applicant.component.js
@@ -37,7 +37,11 @@ export async function applicantOrganisationNameData(request, locals) {
  * @param {Record<string, any>} locals
  * @returns {Promise<{properties:ApplicationsCreateApplicantOrganisationNameProps, updatedCaseId?:number }>}
  */
-export async function applicantOrganisationNameDataUpdate({ body }, locals) {
+
+export async function applicantOrganisationNameDataUpdate(
+	{ errors: validationErrors, body },
+	locals
+) {
 	const { caseId, applicantId: id } = locals;
 	const organisationName = body['applicant.organisationName'];
 	const applicantInfo = { id, organisationName };
@@ -48,7 +52,7 @@ export async function applicantOrganisationNameDataUpdate({ body }, locals) {
 
 	return {
 		properties: {
-			errors,
+			errors: validationErrors || errors,
 			values: { 'applicant.organisationName': organisationName }
 		},
 		updatedCaseId

--- a/apps/web/src/server/applications/common/services/session.service.js
+++ b/apps/web/src/server/applications/common/services/session.service.js
@@ -9,6 +9,15 @@
 // Applicant session management
 
 /**
+ * Save in the session the applicant organisation name.
+ *
+ * @param {SessionWithApplicationsCreateApplicantInfoTypes} session
+ */
+export const setSessionApplicantOrganisationName = (session) => {
+	session.infoTypes = ['applicant-organisation-name'];
+};
+
+/**
  * Save in the session the list of information types to be provided in the create-new-applicant form.
  *
  * @param {SessionWithApplicationsCreateApplicantInfoTypes} session
@@ -16,7 +25,7 @@
  * @returns {void}
  */
 export const setSessionApplicantInfoTypes = (session, infoTypes) => {
-	session.infoTypes = ['applicant-information-types', ...infoTypes];
+	session.infoTypes = ['applicant-organisation-name', 'applicant-information-types', ...infoTypes];
 };
 
 /**

--- a/apps/web/src/server/applications/create-new-case/applicant/__tests__/__snapshots__/applications-create-applicant.test.js.snap
+++ b/apps/web/src/server/applications/create-new-case/applicant/__tests__/__snapshots__/applications-create-applicant.test.js.snap
@@ -173,6 +173,62 @@ exports[`applications create applicant Applicant email POST /application-email W
 </main>"
 `;
 
+exports[`applications create applicant Applicant organisation name GET /applicant-organisation-name should render the page 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3"> Enter the Applicant’s organisation</h1>
+    <form method="post" action="" novalidate="novalidate" class="pins-applications-create">
+        <div class="govuk-form-group">
+            <label class="govuk-label govuk-visually-hidden" for="applicant.organisationName">Applicant organisation name</label>
+            <input class="govuk-input govuk-!-width-one-third"
+            id="applicant.organisationName" name="applicant.organisationName" type="text"
+            value="Org name">
+        </div>
+        <div class="govuk-grid-row">
+            <div class="govuk-button-group govuk-grid-column-one-half">
+                <button class="govuk-button" data-module="govuk-button">Save and continue</button>
+            </div>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`applications create applicant Applicant organisation name POST /applicant-organisation-name Web-side validation: should show validation errors if the field is empty 1`] = `
+"<main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#applicant.organisationName">Enter the Applicant’s organisation</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3"> Enter the Applicant’s organisation</h1>
+    <form method="post" action="" novalidate="novalidate" class="pins-applications-create">
+        <div class="govuk-form-group govuk-form-group--error">
+            <label class="govuk-label govuk-visually-hidden" for="applicant.organisationName">Applicant organisation name</label>
+            <p id="applicant.organisationName-error"
+            class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span> Enter the Applicant’s
+                organisation</p>
+            <input class="govuk-input govuk-!-width-one-third govuk-input--error"
+            id="applicant.organisationName" name="applicant.organisationName" type="text"
+            aria-describedby="applicant.organisationName-error">
+        </div>
+        <div class="govuk-grid-row">
+            <div class="govuk-button-group govuk-grid-column-one-half">
+                <button class="govuk-button" data-module="govuk-button">Save and continue</button>
+            </div>
+        </div>
+    </form>
+</main>"
+`;
+
 exports[`applications create applicant Applicant telephone number GET /applicant-telephone-number should render the page when resumed or if there is data in the session 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
     <h1 class="govuk-heading-l govuk-!-margin-bottom-3"> Enter the Applicant’s phone number (optional)</h1>
@@ -320,55 +376,31 @@ exports[`applications create applicant GET /applicant-information-types should r
                 <div class="govuk-checkboxes" data-module="govuk-checkboxes">
                     <div class="govuk-checkboxes__item">
                         <input class="govuk-checkboxes__input" id="selectedApplicantInfoTypes"
-                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-organisation-name">
-                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes">Organisation name</label>
+                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-full-name">
+                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes">Applicant’s contact name</label>
                     </div>
                     <div class="govuk-checkboxes__item">
                         <input class="govuk-checkboxes__input" id="selectedApplicantInfoTypes-2"
-                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-full-name">
-                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-2">Applicant’s contact name</label>
+                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-address">
+                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-2">Address</label>
                     </div>
                     <div class="govuk-checkboxes__item">
                         <input class="govuk-checkboxes__input" id="selectedApplicantInfoTypes-3"
-                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-address">
-                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-3">Address</label>
+                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-website">
+                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-3">Website</label>
                     </div>
                     <div class="govuk-checkboxes__item">
                         <input class="govuk-checkboxes__input" id="selectedApplicantInfoTypes-4"
-                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-website">
-                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-4">Website</label>
+                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-email">
+                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-4">Email address</label>
                     </div>
                     <div class="govuk-checkboxes__item">
                         <input class="govuk-checkboxes__input" id="selectedApplicantInfoTypes-5"
-                        name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-email">
-                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-5">Email address</label>
-                    </div>
-                    <div class="govuk-checkboxes__item">
-                        <input class="govuk-checkboxes__input" id="selectedApplicantInfoTypes-6"
                         name="selectedApplicantInfoTypes[]" type="checkbox" value="applicant-telephone-number">
-                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-6">Telephone number</label>
+                        <label class="govuk-label govuk-checkboxes__label" for="selectedApplicantInfoTypes-5">Telephone number</label>
                     </div>
                 </div>
             </fieldset>
-        </div>
-        <div class="govuk-grid-row">
-            <div class="govuk-button-group govuk-grid-column-one-half">
-                <button class="govuk-button" data-module="govuk-button">Save and continue</button>
-            </div>
-        </div>
-    </form>
-</main>"
-`;
-
-exports[`applications create applicant GET /applicant-organisation-name should render the page when resumed or when there is session data 1`] = `
-"<main class="govuk-main-wrapper " id="main-content" role="main">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-3"> Enter the Applicant’s organisation (optional)</h1>
-    <form method="post" action="" novalidate="novalidate" class="pins-applications-create">
-        <div class="govuk-form-group">
-            <label class="govuk-label govuk-visually-hidden" for="applicant.organisationName">Applicant organisation name</label>
-            <input class="govuk-input govuk-!-width-one-third"
-            id="applicant.organisationName" name="applicant.organisationName" type="text"
-            value="Org name">
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-button-group govuk-grid-column-one-half">

--- a/apps/web/src/server/applications/create-new-case/applicant/__tests__/applications-create-applicant.test.js
+++ b/apps/web/src/server/applications/create-new-case/applicant/__tests__/applications-create-applicant.test.js
@@ -30,6 +30,43 @@ describe('applications create applicant', () => {
 		await request.get('/applications-service/');
 	});
 
+	describe('Applicant organisation name', () => {
+		const baseUrl = '/applications-service/create-new-case/123/applicant-organisation-name';
+
+		beforeEach(async () => {
+			nocks();
+		});
+
+		describe('GET /applicant-organisation-name', () => {
+			it('should render the page', async () => {
+				const response = await request.get(baseUrl);
+				const element = parseHtml(response.text);
+
+				expect(element.innerHTML).toMatchSnapshot();
+				expect(element.innerHTML).toContain('Save and continue');
+			});
+		});
+
+		describe('POST /applicant-organisation-name', () => {
+			beforeEach(async () => {
+				await request.get('/applications-service/');
+			});
+
+			describe('Web-side validation:', () => {
+				it('should show validation errors if the field is empty', async () => {
+					const response = await request.post(baseUrl).send({
+						'applicant.organisationName': ''
+					});
+					const element = parseHtml(response.text);
+
+					expect(element.innerHTML).toMatchSnapshot();
+					expect(element.innerHTML).toContain('govuk-error-summary');
+					expect(element.innerHTML).toContain('applicant.organisationName-error');
+				});
+			});
+		});
+	});
+
 	describe('GET /applicant-information-types', () => {
 		const baseUrl = '/applications-service/create-new-case/123/applicant-information-types';
 
@@ -43,35 +80,6 @@ describe('applications create applicant', () => {
 
 			expect(element.innerHTML).toMatchSnapshot();
 			expect(element.innerHTML).toContain('Save and continue');
-		});
-	});
-
-	describe('GET /applicant-organisation-name', () => {
-		const baseUrl = '/applications-service/create-new-case/123/applicant-organisation-name';
-
-		beforeEach(async () => {
-			nocks();
-		});
-
-		it('should render the page when resumed or when there is session data', async () => {
-			const response = await request.get(baseUrl);
-			const element = parseHtml(response.text);
-
-			expect(element.innerHTML).toMatchSnapshot();
-			expect(element.innerHTML).toContain('Save and continue');
-		});
-
-		it('should not render the page if there is no session data', async () => {
-			await request.post('/applications-service/create-new-case').send({
-				title: 'title',
-				description: 'description'
-			});
-
-			const response = await request.get(baseUrl);
-
-			expect(response?.headers?.location).toMatch(
-				'/applications-service/create-new-case/123/key-dates'
-			);
 		});
 	});
 

--- a/apps/web/src/server/applications/create-new-case/applicant/applications-create-applicant.router.js
+++ b/apps/web/src/server/applications/create-new-case/applicant/applications-create-applicant.router.js
@@ -22,7 +22,10 @@ applicationsCreateApplicantRouter
 		registerCaseWithQuery(['applicant'], true),
 		asyncHandler(controller.viewApplicationsCreateApplicantOrganisationName)
 	)
-	.post(asyncHandler(controller.updateApplicationsCreateApplicantOrganisationName));
+	.post(
+		validators.validateApplicationsCreateApplicantOrganisationName,
+		asyncHandler(controller.updateApplicationsCreateApplicantOrganisationName)
+	);
 
 applicationsCreateApplicantRouter
 	.route('/applicant-full-name/:edit?')

--- a/apps/web/src/server/applications/create-new-case/applicant/applications-create-applicant.service.js
+++ b/apps/web/src/server/applications/create-new-case/applicant/applications-create-applicant.service.js
@@ -15,11 +15,6 @@ import {
 export const getAllApplicantInfoTypes = () => {
 	return [
 		{
-			name: 'applicant-organisation-name',
-			displayNameEn: 'Organisation name',
-			displayNameCy: 'Organisation name'
-		},
-		{
 			name: 'applicant-full-name',
 			displayNameEn: 'Applicant’s contact name',
 			displayNameCy: 'Applicant’s contact name'
@@ -49,6 +44,7 @@ export const getAllApplicantInfoTypes = () => {
 export function getAllowedDestinationPath({ session, path, goToNextPage }) {
 	const canShowInfoTypesPage = getSessionCaseHasNeverBeenResumed(session);
 	const allApplicantPaths = [
+		'applicant-organisation-name',
 		canShowInfoTypesPage ? 'applicant-information-types' : 'team-email',
 		...getAllApplicantInfoTypes().map((infoType) => infoType.name),
 		'key-dates'

--- a/apps/web/src/server/applications/create-new-case/applicant/applications-create-applicant.validators.js
+++ b/apps/web/src/server/applications/create-new-case/applicant/applications-create-applicant.validators.js
@@ -49,3 +49,10 @@ export const validateApplicationsCreateApplicantPostCode = createValidator(
 		.withMessage('Enter a valid postcode'),
 	body('apiReference').trim().not().equals('-1').withMessage('Choose an address from the list')
 );
+
+export const validateApplicationsCreateApplicantOrganisationName = createValidator(
+	body('applicant.organisationName')
+		.trim()
+		.isLength({ min: 1 })
+		.withMessage('Enter the Applicant’s organisation')
+);

--- a/apps/web/src/server/applications/create-new-case/case/applications-create-case.controller.js
+++ b/apps/web/src/server/applications/create-new-case/case/applications-create-case.controller.js
@@ -18,8 +18,8 @@ import {
 } from '../../common/components/form/form-case.component.js';
 import {
 	destroySessionCaseSectorName,
-	getSessionCaseHasNeverBeenResumed,
-	setSessionCaseSectorName
+	setSessionCaseSectorName,
+	setSessionApplicantOrganisationName
 } from '../../common/services/session.service.js';
 
 /** @typedef {import('./applications-create-case.types.js').ApplicationsCreateCaseNameProps} ApplicationsCreateCaseNameProps */
@@ -330,6 +330,7 @@ export async function viewApplicationsCreateCaseTeamEmail(request, response) {
  * {}, ApplicationsCreateCaseTeamEmailBody, {}, {edit?: string}>}
  */
 export async function updateApplicationsCreateCaseTeamEmail(request, response) {
+	const { session } = request;
 	const { properties, updatedCaseId } = await caseTeamEmailDataUpdate(request, response.locals);
 
 	if (properties && (properties?.errors || !updatedCaseId)) {
@@ -342,9 +343,9 @@ export async function updateApplicationsCreateCaseTeamEmail(request, response) {
 		);
 	}
 
-	const nextPath = getSessionCaseHasNeverBeenResumed(request.session)
-		? 'applicant-information-types'
-		: 'applicant-organisation-name';
+	setSessionApplicantOrganisationName(session);
 
-	response.redirect(`/applications-service/create-new-case/${updatedCaseId}/${nextPath}`);
+	response.redirect(
+		`/applications-service/create-new-case/${updatedCaseId}/applicant-organisation-name`
+	);
 }

--- a/apps/web/src/server/views/applications/components/case-form/applicant/organisation-name.njk
+++ b/apps/web/src/server/views/applications/components/case-form/applicant/organisation-name.njk
@@ -9,6 +9,7 @@
 		id: "applicant.organisationName",
 		name: "applicant.organisationName",
 		classes: "govuk-!-width-one-third",
-		value: values['applicant.organisationName']
+		value: values['applicant.organisationName'],
+		errorMessage: errors['applicant.organisationName'] | errorMessage
 	}) }}
 {% endmacro %}


### PR DESCRIPTION
## Describe your changes
- Moved the applicant organisation screen in the journey to be displayed before the applicant information checkbox screen.
- Removed applicant organisation from the applicant information checkbox screen.
- Added validation to the applicant organisation field.
- Updated the unit tests.
- Updated the e2e tests.

## Testing information
The above changes are covered by the following e2e tests: createCase, editCase, smokeTest

## Issue ticket number and link
[APPLICS-1302](https://pins-ds.atlassian.net/browse/APPLICS-1302): Create case 'Applicant's Organisation' field - to be made mandatory

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes


[APPLICS-1302]: https://pins-ds.atlassian.net/browse/APPLICS-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ