### PR TITLE
fix(api): fix db errors when adding new doc version (applics-1287)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -381,6 +381,11 @@ export const createDocumentVersion = async (documentToUpload, caseId, documentId
 	currentDocumentVersion[0].size = documentToSendToDatabase.documentSize;
 	currentDocumentVersion[0].owner = documentToUpload.username;
 	currentDocumentVersion[0].originalFilename = documentToUpload.documentName;
+	currentDocumentVersion[0].datePublished = null;
+	currentDocumentVersion[0].publishedBlobPath = null;
+	currentDocumentVersion[0].publishedBlobContainer = null;
+	currentDocumentVersion[0].publishedStatusPrev = null;
+	currentDocumentVersion[0].redactedStatus = null;
 
 	await documentVersionRepository.upsert(currentDocumentVersion[0]);
 

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -369,25 +369,25 @@ export const createDocumentVersion = async (documentToUpload, caseId, documentId
 
 	const { documentVersion } = documentFromDatabase;
 
-	const currentDocumentVersion = documentVersion.filter(
+	const newDocumentVersion = documentVersion.filter(
 		(/** @type {{ version: number; }} */ d) => d.version === documentFromDatabase.latestVersionId
-	);
+	)[0];
 
 	const previousDocumentVersion = documentFromDatabase.documentVersion.pop();
 	// copy all meta data from previous version except below properties.
-	currentDocumentVersion[0].version = version;
-	currentDocumentVersion[0].mime = documentToSendToDatabase.documentType;
-	currentDocumentVersion[0].fileName = previousDocumentVersion?.fileName ?? fileName;
-	currentDocumentVersion[0].size = documentToSendToDatabase.documentSize;
-	currentDocumentVersion[0].owner = documentToUpload.username;
-	currentDocumentVersion[0].originalFilename = documentToUpload.documentName;
-	currentDocumentVersion[0].datePublished = null;
-	currentDocumentVersion[0].publishedBlobPath = null;
-	currentDocumentVersion[0].publishedBlobContainer = null;
-	currentDocumentVersion[0].publishedStatusPrev = null;
-	currentDocumentVersion[0].redactedStatus = null;
+	newDocumentVersion.version = version;
+	newDocumentVersion.mime = documentToSendToDatabase.documentType;
+	newDocumentVersion.fileName = previousDocumentVersion?.fileName ?? fileName;
+	newDocumentVersion.size = documentToSendToDatabase.documentSize;
+	newDocumentVersion.owner = documentToUpload.username;
+	newDocumentVersion.originalFilename = documentToUpload.documentName;
+	newDocumentVersion.datePublished = null;
+	newDocumentVersion.publishedBlobPath = null;
+	newDocumentVersion.publishedBlobContainer = null;
+	newDocumentVersion.publishedStatusPrev = null;
+	newDocumentVersion.redactedStatus = null;
 
-	await documentVersionRepository.upsert(currentDocumentVersion[0]);
+	await documentVersionRepository.upsert(newDocumentVersion);
 
 	await documentActivityLogRepository.create({
 		documentGuid: documentId,


### PR DESCRIPTION
## Describe your changes

when addind a new document version, the following fields are copied from the previous version, creating incorrect data - eg published blob paths etc:
- publishedBlobContainer 
- PublishedBlobPath 
- publishedStatusPrev 
- datePublished 
- redactedStatus 

These should all be reset to null.

## APPLICS-1287 CBOS DB data errors when adding new doc versions
https://pins-ds.atlassian.net/browse/APPLICS-1287

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
