### PR TITLE
feat(web): make applicant organisation mandatory on project overview (applics-1306)

### DIFF
--- a/apps/web/src/server/applications/case/applications-case.router.js
+++ b/apps/web/src/server/applications/case/applications-case.router.js
@@ -57,6 +57,7 @@ applicationsCaseSummaryRouter
 		)
 	)
 	.post(
+		[validators.validateApplicationsCreateCaseOrganisationName],
 		[validators.validateApplicationsCreateCaseNameWelsh],
 		[validators.validateApplicationsCreateCaseDescriptionWelsh],
 		[validators.validateApplicationsCreateCaseLocationWelsh],

--- a/apps/web/src/server/applications/case/edit/applicant/__tests__/__snapshots__/applications-edit-applicant.test.js.snap
+++ b/apps/web/src/server/applications/case/edit/applicant/__tests__/__snapshots__/applications-edit-applicant.test.js.snap
@@ -113,7 +113,7 @@ exports[`applications create applicant GET edit/applicant-full-name should rende
 
 exports[`applications create applicant GET edit/applicant-organisation-name should render the page 1`] = `
 "<main class="govuk-main-wrapper " id="main-content" role="main">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-3"> Enter the Applicant’s organisation (optional)</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-3"> Enter the Applicant’s organisation</h1>
     <form method="post" action="" novalidate="novalidate" class="pins-applications-create">
         <div class="govuk-form-group">
             <label class="govuk-label govuk-visually-hidden" for="applicant.organisationName">Applicant organisation name</label>

--- a/apps/web/src/server/applications/case/edit/applicant/applications-edit-applicant.controller.js
+++ b/apps/web/src/server/applications/case/edit/applicant/applications-edit-applicant.controller.js
@@ -34,7 +34,7 @@ import { getUpdatedField } from '../applications-edit.service.js';
 /** @typedef {import('../../../create-new-case/applicant/applications-create-applicant.types.js').ApplicationsCreateApplicantAddressBody} ApplicationsCreateApplicantAddressBody */
 
 const organisationNameLayout = {
-	pageTitle: 'Enter the Applicant’s organisation (optional)',
+	pageTitle: 'Enter the Applicant’s organisation',
 	components: ['organisation-name'],
 	isEdit: true
 };

--- a/apps/web/src/server/applications/case/edit/applicant/applications-edit-applicant.router.js
+++ b/apps/web/src/server/applications/case/edit/applicant/applications-edit-applicant.router.js
@@ -15,7 +15,10 @@ applicationsEditApplicantRouter
 		registerCaseWithQuery(['applicant']),
 		asyncHandler(controller.viewApplicationsEditApplicantOrganisationName)
 	)
-	.post(asyncHandler(controller.updateApplicationsEditApplicantOrganisationName));
+	.post(
+		validators.validateApplicationsCreateApplicantOrganisationName,
+		asyncHandler(controller.updateApplicationsEditApplicantOrganisationName)
+	);
 
 applicationsEditApplicantRouter
 	.route('/applicant-full-name')

--- a/apps/web/src/server/applications/create-new-case/case/applications-create-case.validators.js
+++ b/apps/web/src/server/applications/create-new-case/case/applications-create-case.validators.js
@@ -13,6 +13,7 @@ export const validateApplicationsCreateCaseName = createValidator(
 
 export const validateApplicationsCreateCaseNameWelsh = createValidator(
 	body('titleWelsh')
+		.if(body('titleWelsh').exists())
 		.trim()
 		.isLength({ min: 1 })
 		.withMessage('Enter project name in Welsh')
@@ -31,6 +32,7 @@ export const validateApplicationsCreateCaseDescription = createValidator(
 
 export const validateApplicationsCreateCaseDescriptionWelsh = createValidator(
 	body('descriptionWelsh')
+		.if(body('descriptionWelsh').exists())
 		.trim()
 		.isLength({ min: 1 })
 		.withMessage('Enter project description in Welsh')
@@ -66,6 +68,7 @@ export const validateApplicationsCreateCaseLocation = createValidator(
 
 export const validateApplicationsCreateCaseLocationWelsh = createValidator(
 	body('geographicalInformation.locationDescriptionWelsh')
+		.if(body('geographicalInformation.locationDescriptionWelsh').exists())
 		.trim()
 		.isLength({ min: 1 })
 		.withMessage(getErrorMessageCaseCreate('projectLocationWelsh'))
@@ -112,4 +115,11 @@ export const validateApplicationsCreateCaseStage = createValidator(
 		.withMessage('Set a stage for the case')
 		.isLength({ max: 50 })
 		.withMessage('The case stage must be 50 characters or fewer')
+);
+
+export const validateApplicationsCreateCaseOrganisationName = createValidator(
+	body('organisationName')
+		.trim()
+		.isLength({ min: 1 })
+		.withMessage('You must enter the Applicant’s organisation to publish the project')
 );

--- a/apps/web/src/server/views/applications/case/overview.njk
+++ b/apps/web/src/server/views/applications/case/overview.njk
@@ -17,6 +17,7 @@
 	<h2 class="govuk-heading-m">{{pageTitle}}</h2>
 	<div class="govuk-!-margin-top-6">
 		<form method="post">
+      <input type="hidden" value="{{ case.applicant.organisationName }}" name="organisationName" >
       {% if ('applic-55-welsh-translation' | isFeatureActive) %}
         {% set buttonText = 'Publish latest changes' if case.publishedDate and case.hasUnpublishedChanges else 'Publish project' %}
 
@@ -31,7 +32,7 @@
         {% else %}
           {{ govukButton({
             text: buttonText,
-            href: 'case-view'| url({caseId:case.id, step: 'preview-and-publish'})
+            attributes: { formaction: 'case-view'| url({caseId:case.id, step: 'overview'})}
           }) }}
         {% endif %}
       {% else %}


### PR DESCRIPTION
## Describe your changes
- Added validation to the applicant organisation field on the project overview page and the edit applicant organisation page.
- Added validators to routers.
- Updated existing validators for Welsh fields on the project overview page so this validation is only applied to Welsh cases.
- Updated the project overview template to prevent validation being bypassed for non-Welsh cases on form submission and add the applicant organisation data to the request body.
- Regenerated the relevant snapshot.

## Issue ticket number and link
[APPLICS-1306](https://pins-ds.atlassian.net/browse/APPLICS-1306): Overview page - Applicant's organisation field to be mandatory

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes


[APPLICS-1306]: https://pins-ds.atlassian.net/browse/APPLICS-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ