### PR TITLE
Fix/applics 1305 breadcrumb error

### DIFF
--- a/apps/web/src/server/applications/case/applications-case.locals.js
+++ b/apps/web/src/server/applications/case/applications-case.locals.js
@@ -108,11 +108,15 @@ export const registerDocumentGuid = async ({ params }, response, next) => {
  * @returns {Promise<BreadcrumbItem[]>}
  */
 export const buildBreadcrumbItems = async (caseId, folderId) => {
-	const folderPath = await getCaseDocumentationFolderPath(caseId, folderId);
-	const folderItems = folderPath.map((folder) => ({
-		href: url('document-category', { caseId, documentationCategory: folder }),
-		text: folder.displayNameEn
-	}));
+	/** @type {BreadcrumbItem[]} **/
+	let folderItems = [];
+	if (folderId) {
+		const folderPath = await getCaseDocumentationFolderPath(caseId, folderId);
+		folderItems = folderPath.map((folder) => ({
+			href: url('document-category', { caseId, documentationCategory: folder }),
+			text: folder.displayNameEn
+		}));
+	}
 
 	return [
 		{

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.service.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.service.js
@@ -264,7 +264,7 @@ export const publishCaseDocumentationFiles = async (caseId, documents, username)
 		return { documents: publishedDocuments };
 	} catch (/** @type {*} */ error) {
 		// log out the actual publishing errors
-		logger.error(`[API] ${error?.response?.body?.errors || 'Unknow error'}`);
+		logger.error(`[API] ${error?.response?.body?.errors || 'Unknown error'}`);
 		return { errors: { msg: 'Your documents could not be published, please try again' } };
 	}
 };

--- a/apps/web/src/server/applications/case/representations/applications-relevant-reps.controller.js
+++ b/apps/web/src/server/applications/case/representations/applications-relevant-reps.controller.js
@@ -16,6 +16,8 @@ import { tableSortLinks } from './utils/table.js';
 import { isRelevantRepsPeriodClosed } from './utils/is-relevant-reps-period-closed.js';
 import { getPublishQueueUrl } from './utils/get-publish-queue-url.js';
 import { getKeyDates } from './utils/get-key-dates.js';
+import documentationSessionHandlers from '../documentation/applications-documentation.session.js';
+import { url } from '../../../lib/nunjucks-filters/index.js';
 
 const view = 'applications/representations/representations.njk';
 
@@ -23,12 +25,19 @@ const view = 'applications/representations/representations.njk';
  * @param {import('express').Request} req
  * @param {import('express').Response} res
  */
-export async function relevantRepsApplications({ query }, res) {
+export async function relevantRepsApplications({ query, session }, res) {
 	const { caseId } = res.locals;
 	const {
 		locals: { serviceUrl }
 	} = res;
 	hasSearchUpdated(query);
+
+	documentationSessionHandlers.setSessionFolderPage(
+		session,
+		url('representations', {
+			caseId
+		})
+	);
 
 	const {
 		searchTerm,

--- a/apps/web/src/server/applications/case/representations/representation-details/applications-relevant-rep-details.service.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/applications-relevant-rep-details.service.js
@@ -12,11 +12,11 @@ export const getRepresentationDetails = async (caseId, representationId) => {
 
 /**
  *
- * @param {string} caseId
+ * @param {number} caseId
  * @return {Promise<*>}
  */
 export const getRelevantRepFolder = async (caseId) => {
-	const folders = await getCaseFolders(Number(caseId));
+	const folders = await getCaseFolders(caseId);
 	return folders.find((folder) => folder.displayNameEn === 'Relevant representations');
 };
 

--- a/apps/web/src/server/applications/case/representations/representation-details/applications-relevant-rep-details.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/applications-relevant-rep-details.view-model.js
@@ -25,7 +25,7 @@ export const getRepresentationDetailsViewModel = async (
 	selectedOptionsText: getSelectedOptionsText(representation),
 	representationExcerpts: getRepresentationExcerpts(representation),
 	representationWorkflowValues: getRepresentationWorkflowValues(representation),
-	relevantRepDocumentFolder: await getRelevantRepFolder(caseId),
+	relevantRepDocumentFolder: await getRelevantRepFolder(Number(caseId)),
 	organisationOrFullname: getOrganisationOrFullname(representation.represented),
 	repModePageURLs: getRepModePageURLs(representation),
 	depublishedRepresentation: depublished === 'true'

--- a/apps/web/src/server/lib/nunjucks-filters/url.js
+++ b/apps/web/src/server/lib/nunjucks-filters/url.js
@@ -133,6 +133,8 @@ export const url = (key, filterArguments = {}) => {
 			return `${domainUrl}/case/${caseId}/examination-timetable/${step}`;
 		case 'timetable-item':
 			return `${domainUrl}/case/${caseId}/examination-timetable/item/${step}/${timetableId}`;
+		case 'representations':
+			return `${domainUrl}/case/${caseId}/relevant-representations`;
 		case 'representation-details':
 			return `${domainUrl}/case/${caseId}/relevant-representations/${representationId}/representation-details`;
 		case 'redact-representation':


### PR DESCRIPTION
## Describe your changes

Fixes an error when building the breadcrumbs to show on the document publish success page. 

- This error only occurs when publishing Relevant Rep attachments, publishing other documents and S51 attachments is unaffected
- The cause is due to an expectation in a function (`getFolderIdFromFolderPath`) that the URL/path will be in a certain format. As the Relevant Representations page has a different path format to other Folders, this function fails (it returns `NaN`).

The fix:
- When visiting the Relevant Reps page, store the `/relevant-representations` page in session (`session.folderPage`) so we know where the user came from once they navigate to the attachment publish page.
- Add a condition so we look up the Relevant Reps `folderId` from the database. This is needed because the path to the Relevant Reps page doesn't contain a `folderId`, so we can't rely on `getFolderIdFromFolderPath`
- For belt and braces, also added an extra condition to `buildBreadcrumbItems` to guard against future scenarios where `folderId` is blank

## Issue ticket number and link

APPLICS-1305

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
