### PR TITLE
fix(api): update folder mapping for sos decision folder

### DIFF
--- a/apps/api/src/server/migration/migrators/folder/folder.js
+++ b/apps/api/src/server/migration/migrators/folder/folder.js
@@ -969,7 +969,7 @@ const folderMapping = {
 		'Decision > SoS consultation > Consultation documents',
 	'Decision > SoS Consultation > Post Exam Submissions':
 		'Decision > SoS consultation > Post examination submissions',
-	'Decision > SoS Decision': 'Decision > SoS Decision',
+	'Decision > SoS Decision': 'Decision > SoS decision',
 
 	'Post Decision': 'Post-decision',
 	'Post Decision > Feedback': 'Post-decision > Feedback',


### PR DESCRIPTION
## Describe your changes

Updates migration folder mapping. The issue was an inconsistency between a folder name used in the `folderMapping` map, and the map generated by `getFolderIdMap` and due to case sensitivity, an empty result being returned.

I've checked all the folders in `folderMapping` and only `Decision > SoS decision` was named inconsistently, so have just updated the name accordingly.

## Issue ticket number and link

APPLICS-1381

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
