### PR TITLE
fix(web): strip newline and carriage returns from examination descrip…

### DIFF
--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
@@ -776,7 +776,7 @@ const getTimetableRows = (timetableItem) => {
 };
 
 /**
- * Prepare the payload for the description
+ * Prepare examination timetable description payload
  * @param {string|undefined} descriptionBody
  * @returns {string}
  */
@@ -784,9 +784,10 @@ const prepareDescriptionPayload = (descriptionBody) => {
 	if (typeof descriptionBody !== 'string') {
 		throw new Error('Description body must be a string');
 	}
+
 	const splitDescription = sanitizeHtml(descriptionBody, {}).split('*');
 	const preText = splitDescription.shift();
-	const bulletPoints = splitDescription;
+	const bulletPoints = splitDescription.map((bullet) => bullet.replace(/[\n\r]/g, ''));
 
 	return JSON.stringify({ preText, bulletPoints });
 };


### PR DESCRIPTION
…tion payload (applics-1378)

https://pins-ds.atlassian.net/browse/APPLICS-1378

Since individual timetable items are later used to create folders where submissions are to be stored, submissions made against individual deadline items were not saved in folders if they contained newline/carriage returns.  This fix removes newline and carriage returns which were creating this mismatch in names between FO and CBOS.


<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
