### PR TITLE
fix(api): get doc count only for archive info

### DIFF
--- a/apps/api/src/server/migration/archive-folder-info.controller.js
+++ b/apps/api/src/server/migration/archive-folder-info.controller.js
@@ -1,12 +1,10 @@
 import {
-	getDocumentsInFolder,
 	getFolderByName,
 	getFolderPath
 } from '../applications/application/file-folders/folders.service.js';
 import { getByRef as getCaseByRef } from '#repositories/case.repository.js';
 import { getFoldersByParentId } from '#repositories/folder.repository.js';
-
-const MAX_VALUE = 99999;
+import { getDocumentsCountInFolder } from '#repositories/document.repository.js';
 
 /**
  * @type {import("express").RequestHandler<{modelType: string}, ?, any[]>}
@@ -38,7 +36,7 @@ export const getArchiveFolderInformation = async (req, res) => {
 const getAllFolderIdsWithDocCounts = async (caseId, folderId) => {
 	const result = [];
 	const childFolders = await getFoldersByParentId(folderId);
-	const { itemCount: documentCount } = await getDocumentsInFolder(folderId, 1, MAX_VALUE);
+	const documentCount = await getDocumentsCountInFolder(folderId);
 	if (documentCount !== 0) {
 		const folderPathDetails = await getFolderPath(caseId, folderId);
 		const folderPath = folderPathDetails.reduce((accum, pathDetails) => {


### PR DESCRIPTION
## Describe your changes

Replace `document.findMany` query with `document.count` to avoid SQL Server parameter limit error

## Issue ticket number and link

APPLICS-1382

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
