### PR TITLE
fix(web): add validation for exam timetable deadlines (applics-1403)

### DIFF
--- a/apps/e2e/cypress/e2e/back-office-applications/examTimetable.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/examTimetable.spec.js
@@ -137,7 +137,7 @@ describe('Examination Timetable', () => {
 		examTimetablePage.checkAnswer('Item name', options.itemName);
 		examTimetablePage.checkAnswer('Start time', options.startTimeFormatted);
 		examTimetablePage.checkAnswer('End time', options.endTimeFormatted);
-		examTimetablePage.checkAnswer('Timetable item description', options.description);
+		examTimetablePage.checkTimetableDescription('Timetable item description', options.description);
 		examTimetablePage.clickButtonByText('Save item');
 		examTimetablePage.validateSuccessPanelTitle(texts.successMessageText);
 		examTimetablePage.validateSuccessPanelBody(projectInfo.projectName);
@@ -156,7 +156,7 @@ describe('Examination Timetable', () => {
 		examTimetablePage.checkAnswer('End date', options.endDateFullDeadLine);
 		examTimetablePage.checkAnswer('Start time', options.startTimeFormatted);
 		examTimetablePage.checkAnswer('End time', options.endTimeFormatted);
-		examTimetablePage.checkAnswer('Timetable item description', options.description);
+		examTimetablePage.checkTimetableDescription('Timetable item description', options.description);
 		examTimetablePage.clickButtonByText('Save item');
 		examTimetablePage.validateSuccessPanelTitle(texts.successMessageText);
 		examTimetablePage.validateSuccessPanelBody(projectInfo.projectName);
@@ -172,7 +172,7 @@ describe('Examination Timetable', () => {
 		examTimetablePage.checkAnswer('Item type', 'Issued By');
 		examTimetablePage.checkAnswer('Item name', options.itemName);
 		examTimetablePage.checkAnswer('Date', options.startDateFullDeadLine);
-		examTimetablePage.checkAnswer('Timetable item description', options.description);
+		examTimetablePage.checkTimetableDescription('Timetable item description', options.description);
 		examTimetablePage.clickButtonByText('Save item');
 		examTimetablePage.validateSuccessPanelTitle(texts.successMessageText);
 		examTimetablePage.validateSuccessPanelBody(projectInfo.projectName);
@@ -190,7 +190,7 @@ describe('Examination Timetable', () => {
 		examTimetablePage.checkAnswer('Date', options.startDateFullDeadLine);
 		examTimetablePage.checkAnswer('Start time', options.startTimeFormatted);
 		examTimetablePage.checkAnswer('End time', options.endTimeFormatted);
-		examTimetablePage.checkAnswer('Timetable item description', options.description);
+		examTimetablePage.checkTimetableDescription('Timetable item description', options.description);
 		examTimetablePage.clickButtonByText('Save item');
 		examTimetablePage.validateSuccessPanelTitle(texts.successMessageText);
 		examTimetablePage.clickLinkByText('Go back to examination timetable');

--- a/apps/e2e/cypress/e2e/back-office-applications/smokeTests.spec.js
+++ b/apps/e2e/cypress/e2e/back-office-applications/smokeTests.spec.js
@@ -83,7 +83,7 @@ describe('Smoke tests', { browser: '!electron' }, () => {
 		examTimetablePage.checkAnswer('Item name', options.itemName);
 		examTimetablePage.checkAnswer('Start time', options.startTimeFormatted);
 		examTimetablePage.checkAnswer('End time', options.endTimeFormatted);
-		examTimetablePage.checkAnswer('Timetable item description', options.description);
+		examTimetablePage.checkTimetableDescription('Timetable item description', options.description);
 		examTimetablePage.clickButtonByText('Save item');
 		examTimetablePage.validateSuccessPanelTitle(texts.successMessageText);
 		examTimetablePage.clickLinkByText('Go back to examination timetable');

--- a/apps/e2e/cypress/page_objects/basePage.js
+++ b/apps/e2e/cypress/page_objects/basePage.js
@@ -140,6 +140,14 @@ export class Page {
 		});
 	}
 
+	checkTimetableDescription(question) {
+		this.basePageElements.answerCell(question).then(($elem) => {
+			cy.wrap($elem)
+				.invoke('text')
+				.then((text) => expect(text.trim()).to.contains('Exam timetable description'));
+		});
+	}
+
 	checkPartialAnswer(question, answer) {
 		this.basePageElements.answerCell(question).then(($elem) => {
 			cy.wrap($elem)

--- a/apps/e2e/cypress/support/utils/createTimetableItemInfo.js
+++ b/apps/e2e/cypress/support/utils/createTimetableItemInfo.js
@@ -8,7 +8,8 @@ export const timetableItem = () => {
 
 	const itemName = `Test_Item_${now}`;
 	Cypress.env('currentCreatedItem', itemName);
-	const description = 'Exam time table example';
+	const description = `Exam timetable description
+  * Exam timetable item`;
 
 	const dayAsInteger = faker.datatype.number({
 		min: 10,

--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.controller.js
@@ -565,7 +565,11 @@ export async function postApplicationsCaseTimetableItemDescriptionWelsh(
 	response
 ) {
 	const timetableId = parseInt(params.timetableId);
-	const { description, submissions } = await getCaseTimetableItemById(timetableId);
+	const { description, submissions, ExaminationTimetableType } = await getCaseTimetableItemById(
+		timetableId
+	);
+
+	const timetableItemType = ExaminationTimetableType.templateType;
 
 	// if there are submissions against timetable item, we shouldn't edit it
 	if (submissions) {
@@ -582,6 +586,21 @@ export async function postApplicationsCaseTimetableItemDescriptionWelsh(
 				location: 'body'
 			},
 			...errors //errors from validator should supersede bullet point error
+		};
+	}
+
+	if (
+		!validateWelshItemDescriptionFormat(body.descriptionWelsh) &&
+		(timetableItemType === 'deadline' || timetableItemType === 'procedural-deadline')
+	) {
+		errors = {
+			descriptionWelsh: {
+				value: body.descriptionWelsh,
+				msg: 'You must enter the deadline description in Welsh before the deadline item(s) in Welsh',
+				param: 'descriptionWelsh',
+				location: 'body'
+			},
+			...errors
 		};
 	}
 
@@ -805,4 +824,15 @@ const validateWelshItemDescriptionBulletPoints = (englishDescription, welshDescr
 	const { bulletPoints: welshBulletPointsArr } = JSON.parse(welshDescription);
 
 	return englishBulletPointsArr.length === welshBulletPointsArr.length;
+};
+
+/**
+ * @param {string|undefined} welshDescriptionBody
+ * @returns {boolean}
+ */
+const validateWelshItemDescriptionFormat = (welshDescriptionBody) => {
+	const welshDescription = prepareDescriptionPayload(welshDescriptionBody);
+	const parsedWelshDescription = JSON.parse(welshDescription);
+
+	return parsedWelshDescription.preText;
 };

--- a/apps/web/src/server/applications/case/examination-timetable/applications-timetable.validators.js
+++ b/apps/web/src/server/applications/case/examination-timetable/applications-timetable.validators.js
@@ -68,6 +68,20 @@ const descriptionValidationChain = (data, isMandatory) =>
 					.trim()
 					.isLength({ min: 1 })
 					.withMessage('You must enter the timetable item description')
+					.custom((value) => {
+						if (!value.includes('*')) {
+							throw new Error(
+								'You must use a bullet point for each deadline item denoted by an asterisk'
+							);
+						}
+						const regex = /^[^*]*[a-zA-Z][^*]*\*/ms;
+						if (!regex.test(value)) {
+							throw new Error(
+								'You must enter the deadline description before the deadline item(s)'
+							);
+						}
+						return true;
+					})
 		  ]
 		: [];
 


### PR DESCRIPTION
## Describe your changes
- Added additional validation for exam timetable deadlines and procedural deadlines in English. This checks that the format for each deadline includes a description followed by a bullet point, denoted by an asterisk, for each deadline item. This then ensures that the information displays correctly in FO.
- Added additional validation to the above exam timetable item types in Welsh to ensure a description is included before any bullet points.
- Updated the end-to-end tests with the new exam timetable description format. 
- Changed how the end-to-end tests compare the entered exam timetable description with the text on the 'Check your answers page' as the former contains asterisks and the latter contains bullet point symbols.

## Issue ticket number and link
[1403](https://pins-ds.atlassian.net/browse/APPLICS-1403): Able to create a deadline without deadline items

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
