### PR TITLE
fix(api): migrate html template title (applics-1490)

### DIFF
--- a/apps/api/src/server/applications/documents/documents.service.js
+++ b/apps/api/src/server/applications/documents/documents.service.js
@@ -75,10 +75,50 @@ export const extractYouTubeURLFromHTML = (originalHtml) => {
 };
 
 /**
- * Render HTML YouTube template for Front Office
+ * Try to get the title from html template (old HZN version).
+ * Currently only working for migration, as the UI upload version sanitises the html and removes all but the iframe attr
+ *
+ * @param {string} html
+ */
+export const extractYouTubeTitleFromHTML = (html) => {
+	let htmlTitle = '';
+	/* and try to extract the title
+
+	 should look like this:
+        <p>
+
+          <!-- ************************************ -->
+
+          <!-- Recording details -->
+
+          <span style="text-align:center"><strong>Here is the title to display</strong></span>
+
+        </p>
+	*/
+	//	console.log('\n\n==============================================\n\nhtml:', JSON.stringify(html));
+	if (html.includes('Recording details')) {
+		console.log('Recording details found in old HTML template');
+		const titleSection = html.substring(html.indexOf('Recording details'), html.indexOf('</span>'));
+		if (titleSection.includes('<span style="text-align:center"><strong>')) {
+			htmlTitle = titleSection
+				.substring(titleSection.indexOf('<strong>') + 8, titleSection.indexOf('</strong>'))
+				.trim();
+		}
+	}
+	return htmlTitle;
+};
+
+/**
+ * Render HTML YouTube template for Front Office, inserting YouTube URL and Title
  *
  * @param {string} youtubeUrl
+ * @param {string |undefined} htmlTitle
  * @returns {string}
  * */
-export const renderYouTubeTemplate = (youtubeUrl) =>
-	YouTubeHTMLTemplate.replace('{{youtubeUrl}}', youtubeUrl);
+export const renderYouTubeTemplate = (youtubeUrl, htmlTitle = 'Video title') => {
+	let newHTML = YouTubeHTMLTemplate;
+	newHTML = newHTML.replace('{{youtubeUrl}}', youtubeUrl);
+	newHTML = newHTML.replace('{{htmlTitle}}', htmlTitle);
+
+	return newHTML;
+};

--- a/apps/api/src/server/applications/documents/youtube-html-template.js
+++ b/apps/api/src/server/applications/documents/youtube-html-template.js
@@ -115,7 +115,7 @@ export const YouTubeHTMLTemplate = `
 <main>
 	<div class="container">
 		<!-- Update page heading below  -->
-		<h1>Video title</h1>
+		<h1>{{htmlTitle}}</h1>
 
 		<div class="video-container">
 			<!-- Update embed video iframe src below -->

--- a/apps/api/src/server/migration/migrators/cleanup/htmlTemplates.js
+++ b/apps/api/src/server/migration/migrators/cleanup/htmlTemplates.js
@@ -3,6 +3,7 @@ import { getDocumentsInCase } from '../../../applications/application/documents/
 import { Readable } from 'stream';
 import {
 	extractYouTubeURLFromHTML,
+	extractYouTubeTitleFromHTML,
 	renderYouTubeTemplate
 } from '../../../applications/documents/documents.service.js';
 import config from '../../../config/config.js';
@@ -53,6 +54,7 @@ export const getHtmlDocumentVersions = async (caseId) => {
 const getBlobClient = () => {
 	return BlobStorageClient.fromUrl(config.blobStorageUrl);
 };
+
 /**
  *
  * @param {string} blobName
@@ -70,6 +72,8 @@ export const downloadHtmlBlob = async (blobName) => {
 };
 
 /**
+ * convert an old HZN version HTML Template into the new CBOS version
+ *
  * @param {string} guid
  * @param {string} htmlString
  * @param {import("express").Response} res
@@ -83,11 +87,14 @@ export const processHtml = (guid, htmlString, res) => {
 	// New templates include `div class="video-container"` so we can ignore them
 	if (htmlString.includes('video-container')) {
 		res.write(`Document ${guid} already has a YouTube video template`);
-		return ''
+		return '';
 	}
 
+	// extract the you tube url and the title from the html.  ONly poss in migration as we have an unsanitised version
 	const youtubeUrl = extractYouTubeURLFromHTML(htmlString);
-	return renderYouTubeTemplate(youtubeUrl);
+	const htmlTitle = extractYouTubeTitleFromHTML(htmlString);
+
+	return renderYouTubeTemplate(youtubeUrl, htmlTitle);
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

For Migrated HTML Template files, it was not adding the title in the new template.  
This is for migrated templates only, not for ones uploaded via the UI

## APPLICS-1490 Fix migrated HTML template title
https://pins-ds.atlassian.net/browse/APPLICS-1490


## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
