### PR TITLE
fix(api): migrated docs correctly use doc title from hzn (applics-1507)

### DIFF
--- a/apps/api/src/server/utils/__tests__/file-fns.test.js
+++ b/apps/api/src/server/utils/__tests__/file-fns.test.js
@@ -1,28 +1,33 @@
-import { trimDocumentNameSuffix } from '../file-fns';
+import { trimDocumentNameKnownSuffix } from '../file-fns';
 
-describe('trimDocumentNameSuffix', () => {
-	it('should remove the extension from the document name', () => {
-		const result = trimDocumentNameSuffix('document.txt');
+describe('trimDocumentNameKnownSuffix', () => {
+	it('should remove the extension from the document name with lower case suffix', () => {
+		const result = trimDocumentNameKnownSuffix('document.txt');
 		expect(result).toBe('document');
 	});
 
 	it('should return the same name if there is no extension', () => {
-		const result = trimDocumentNameSuffix('document');
+		const result = trimDocumentNameKnownSuffix('document');
 		expect(result).toBe('document');
 	});
 
 	it('should handle multiple dots in the document name', () => {
-		const result = trimDocumentNameSuffix('my.document.name.txt');
+		const result = trimDocumentNameKnownSuffix('my.document.name.txt');
 		expect(result).toBe('my.document.name');
 	});
 
+	it('should handle capital letter suffixes in the document name', () => {
+		const result = trimDocumentNameKnownSuffix('CAPITALS.TXT');
+		expect(result).toBe('CAPITALS');
+	});
+
 	it('should handle empty string', () => {
-		const result = trimDocumentNameSuffix('');
+		const result = trimDocumentNameKnownSuffix('');
 		expect(result).toBe('');
 	});
 
-	it('should handle document names with only an extension', () => {
-		const result = trimDocumentNameSuffix('.hiddenfile');
-		expect(result).toBe('');
+	it('should not trim document names with unknown extensions', () => {
+		const result = trimDocumentNameKnownSuffix('.hiddenfile');
+		expect(result).toBe('.hiddenfile');
 	});
 });

--- a/apps/api/src/server/utils/file-fns.js
+++ b/apps/api/src/server/utils/file-fns.js
@@ -1,17 +1,85 @@
 // util script for various file functions
 
 /**
- * Remove extension from document name
+ * Remove extension from document name, if it is a known extension
  *
  * @param {string} documentNameWithExtension
  * @returns {string}
  */
-export const trimDocumentNameSuffix = (documentNameWithExtension) => {
+export const trimDocumentNameKnownSuffix = (documentNameWithExtension) => {
 	if (!documentNameWithExtension.includes('.')) return documentNameWithExtension;
 
+	const knownExtensions = [
+		'avi',
+		'bmp',
+		'css',
+		'csv',
+		'db',
+		'dbf',
+		'doc',
+		'docm',
+		'docx',
+		'dot',
+		'dotm',
+		'dotx',
+		'eml',
+		'exe',
+		'gif',
+		'htm',
+		'html',
+		'ico',
+		'jfif',
+		'jpeg',
+		'jpg',
+		'json',
+		'lnk',
+		'log',
+		'mdb',
+		'mov',
+		'mp3',
+		'mp4',
+		'msg',
+		'ods',
+		'odt',
+		'pdf',
+		'png',
+		'pps',
+		'ppsx',
+		'ppt',
+		'pptm',
+		'pptx',
+		'prj',
+		'pub',
+		'rtf',
+		'shp',
+		'shx',
+		'sig',
+		'tif',
+		'tiff',
+		'tmp',
+		'txt',
+		'wav',
+		'wbk',
+		'wma',
+		'wmv',
+		'wmz',
+		'wps',
+		'xhtml',
+		'xls',
+		'xlsb',
+		'xlsm',
+		'xlsx',
+		'xml',
+		'xps',
+		'zip'
+	];
 	const documentNameSplit = documentNameWithExtension.split('.');
 
-	documentNameSplit.pop();
+	const thisFileExt = documentNameSplit.pop();
+	if (thisFileExt && knownExtensions.includes(thisFileExt.toLowerCase())) {
+		return documentNameSplit.join('.');
+	}
 
-	return documentNameSplit.join('.');
+	// if the file extension is not in the known extensions list, return the original name
+	return documentNameWithExtension;
 };


### PR DESCRIPTION
## Describe your changes

Document Migration - we identified that we were missing the document "title" from Horizon - ie the name that is displayed and editable by the user.  This is what is used to make the published doc in the blob storage, and therefore renaming is causing issues with NI redirection.  Also if a HZN user has renamed a document, that was lost - we only got the original filename.
HZN View and ODW have been changed to include both the originalFilename, and filename (the doc title).

This change is to amend CBOS to correctly ingest the filetitle, rather than cropping it from the original upload filename.
-Also noticed this:  CBOS functionality is, when a doc is uploaded, to take the original filename, copy it and remove the file suffix (eg .doc, pdf etc) and store that as the document title - the filename field.   We have similar code in migration, but it needed to be limited to only doing it for known file suffixes.  This has been corrected here.

**This can only be delivered AFTER HZN ticket DSBAU1-528 has been delivered, and ODW THEODW-1750**

## APPLICS-1507 Migration - File names incorrect in HZN ODW Document View
https://pins-ds.atlassian.net/browse/APPLICS-1507

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
