### PR TITLE
Fix/boas 1482 exam timetable not displaying for migrated cases

### DIFF
--- a/apps/api/src/server/migration/migration.routes.js
+++ b/apps/api/src/server/migration/migration.routes.js
@@ -47,7 +47,7 @@ router.post(
 		#swagger.description = 'Cleanup migration data for a case'
 		#swagger.parameters['body'] = {
 			in: 'body',
-			description: 'Case migration paremeters',
+			description: 'Case migration parameters',
 			schema: {
 				caseReference: 'EN070007',
 				skipLooseS51Attachments: false,

--- a/apps/api/src/server/migration/migration.routes.js
+++ b/apps/api/src/server/migration/migration.routes.js
@@ -35,20 +35,27 @@ router.post(
         #swagger.responses[200] = {
             description: 'Models successfully migrated',
         }
-	 */
+	*/
 	asyncHandler(postMigrateFolders)
 );
 
 router.post(
 	'/cleanup',
 	/*
-				#swagger.tags = ['Migration']
-				#swagger.path =  'migration/cleanup'
-				#swagger.description = 'Cleanup migration data'
-				#swagger.parameters['query'] = {
-						caseReferences: 'TR020002,TR020003'
-				}
-				#swagger.parameters['x-service-name'] = {
+		#swagger.tags = ['Migration']
+		#swagger.path = '/migration/cleanup'
+		#swagger.description = 'Cleanup migration data for a case'
+		#swagger.parameters['body'] = {
+			in: 'body',
+			description: 'Case migration paremeters',
+			schema: {
+				caseReference: 'EN070007',
+				skipLooseS51Attachments: false,
+				skipHtmlTransform: false,
+				skipFixExamFolders: false
+			}
+		}
+		#swagger.parameters['x-service-name'] = {
 			in: 'header',
 			type: 'string',
 			description: 'Service name header',
@@ -60,12 +67,11 @@ router.post(
 			description: 'API key header',
 			default: '123'
 		}
-				#swagger.responses[200] = {
-						description: '',
+		#swagger.responses[200] = {
+			description: '',
             schema: { }
-				}
-			*/
-
+		}
+	*/
 	asyncHandler(migrationCleanup)
 );
 
@@ -74,7 +80,7 @@ router.post(
 	/*
         #swagger.tags = ['Migration']
         #swagger.path =  '/migration/{modelType}'
-        #swagger.description = 'Updates document status from state machine'
+        #swagger.description = 'Case Migration'
         #swagger.parameters['modelType'] = {
             in: 'path',
             description: 'Model type to migrate',
@@ -101,7 +107,7 @@ router.post(
         #swagger.responses[200] = {
             description: 'Models successfully migrated',
         }
-	 */
+	*/
 	asyncHandler(postMigrateModel)
 );
 // takes caseReference array as query parameter
@@ -109,13 +115,13 @@ router.post(
 router.get(
 	'/validate',
 	/*
-				#swagger.tags = ['Migration']
-				#swagger.path =  '/migration/validate'
-				#swagger.description = 'Validate migration'
-				#swagger.parameters['query'] = {
-						caseReferences: 'TR020002,TR020003'
-				}
-				#swagger.parameters['x-service-name'] = {
+		#swagger.tags = ['Migration']
+		#swagger.path =  '/migration/validate'
+		#swagger.description = 'Validate migration'
+		#swagger.parameters['query'] = {
+			caseReferences: 'TR020002,TR020003'
+		}
+		#swagger.parameters['x-service-name'] = {
 			in: 'header',
 			type: 'string',
 			description: 'Service name header',
@@ -127,25 +133,24 @@ router.get(
 			description: 'API key header',
 			default: '123'
 		}
-				#swagger.responses[200] = {
-						description: 'Document status updated',
+		#swagger.responses[200] = {
+			description: 'Document status updated',
             schema: { }
-				}
-			*/
-
+		}
+	*/
 	asyncHandler(validateMigration)
 );
 
 router.get(
 	'/archive-folder-info',
 	/*
-				#swagger.tags = ['Migration']
-				#swagger.path =  'migration/archive-folder-info'
-				#swagger.description = 'Get archive folder information'
-				#swagger.parameters['query'] = {
-						caseReferences: 'TR020002,TR020003'
-				}
-				#swagger.parameters['x-service-name'] = {
+		#swagger.tags = ['Migration']
+		#swagger.path =  'migration/archive-folder-info'
+		#swagger.description = 'Get archive folder information'
+		#swagger.parameters['query'] = {
+				caseReferences: 'TR020002,TR020003'
+		}
+		#swagger.parameters['x-service-name'] = {
 			in: 'header',
 			type: 'string',
 			description: 'Service name header',
@@ -157,12 +162,11 @@ router.get(
 			description: 'API key header',
 			default: '123'
 		}
-				#swagger.responses[200] = {
-						description: '',
-            schema: { }
-				}
-			*/
-
+		#swagger.responses[200] = {
+			description: '',
+			schema: { }
+		}
+	*/
 	asyncHandler(getArchiveFolderInformation)
 );
 

--- a/apps/api/src/server/migration/migrators/migration-cleanup.controller.js
+++ b/apps/api/src/server/migration/migrators/migration-cleanup.controller.js
@@ -176,7 +176,7 @@ const convertOldHtmlToNewHtmlDocuments = async (caseId, res) => {
 const correctExamTimetableFolders = async (caseId, res) => {
 	const examTimetableFolderName = 'Examination Timetable';
 
-	res.write(`Starting to fix exam timetable foldersfor caseId ${caseId} ...\n`);
+	res.write(`Starting to fix exam timetable folders for caseId ${caseId} ...\n`);
 
 	// get the Examination Timetable main folder
 	const { id: examTimetableFolderId } = await getFolderByName(caseId, examTimetableFolderName);
@@ -211,7 +211,7 @@ const correctExamTimetableFolders = async (caseId, res) => {
 	for (const item of examTimetableItems) {
 		const { id: itemId, folderId, name, date: itemDate } = item;
 		// res.write(`Exam timetable item ${itemId} with folder id ${folderId} and name ${name} found.\n`);
-		if (folderId == examTimetableFolderId) {
+		if (folderId === examTimetableFolderId) {
 			res.write('----------------------------------------------------\n');
 			res.write(
 				`Examination timetable item ${itemId} ${name} incorrectly pointed to main timetable folder.\n`

--- a/apps/api/src/server/migration/migrators/nsip-exam-timetable-migrator.js
+++ b/apps/api/src/server/migration/migrators/nsip-exam-timetable-migrator.js
@@ -6,6 +6,7 @@ import * as folderRepository from '#repositories/folder.repository.js';
 import { publish as BroadcastExamTimetable } from '../../applications/examination-timetable-items/examination-timetable-items.service.js';
 import { handleDateTimeToUTC, mapDateTimesToCorrectFields } from '#utils/migration-dates.js';
 import { examTimetableItemTypes } from '@pins/examination-timetable-utils';
+
 /**
  * Migrate NSIP Exam Timetable
  *
@@ -63,9 +64,11 @@ export const migrateExamTimetables = async (examTimetables) => {
 };
 
 /**
- * TODO: We have a dependency on nsip-folder being migrated (where the individual timetable item folders will be migrated)
+ * Gets the parent Examination Timetable folder ID for the case - the folder where all the sub folders for each exam item will be.
+ * Note: We have a dependency on nsip-folder being migrated (where the individual timetable item folders will be migrated)
  * For now, newly created projects get an 'Examination timetable' folder by default - so we can test Exam TT migration against cases which
  * are created manually on the portal.
+ * There is a separate task in post migration cleanup to correct the exam item records to point to the correct folder, and create a new one if missing.
  *
  * @param {number} caseId
  * @returns {Promise<number>} examTimetableFolderId
@@ -73,7 +76,7 @@ export const migrateExamTimetables = async (examTimetables) => {
 const getExamTimetableFolderId = async (caseId) => {
 	const examinationFolder = await folderRepository.getFolderByNameAndCaseId(
 		caseId,
-		'Examination timetable' // TODO: we'll need to make sure the Examination timetable folder is properly migrated
+		'Examination timetable' // Note: we'll need to make sure the Examination timetable folder is properly migrated - performed in post migration cleanup
 	);
 
 	if (!examinationFolder) {

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -57,16 +57,36 @@
 				}
 			}
 		},
-		"migration/cleanup": {
+		"/migration/cleanup": {
 			"post": {
 				"tags": ["Migration"],
-				"description": "Cleanup migration data",
+				"description": "Cleanup migration data for a case",
 				"parameters": [
 					{
-						"name": "query",
-						"caseReferences": "TR020002,TR020003",
-						"in": "query",
-						"type": "string"
+						"name": "body",
+						"in": "body",
+						"description": "Case migration paremeters",
+						"schema": {
+							"type": "object",
+							"properties": {
+								"caseReference": {
+									"type": "string",
+									"example": "EN070007"
+								},
+								"skipLooseS51Attachments": {
+									"type": "boolean",
+									"example": false
+								},
+								"skipHtmlTransform": {
+									"type": "boolean",
+									"example": false
+								},
+								"skipFixExamFolders": {
+									"type": "boolean",
+									"example": false
+								}
+							}
+						}
 					},
 					{
 						"name": "x-service-name",
@@ -100,7 +120,7 @@
 		"/migration/{modelType}": {
 			"post": {
 				"tags": ["Migration"],
-				"description": "Updates document status from state machine",
+				"description": "Case Migration",
 				"parameters": [
 					{
 						"name": "modelType",

--- a/apps/api/src/server/swagger-output.json
+++ b/apps/api/src/server/swagger-output.json
@@ -65,7 +65,7 @@
 					{
 						"name": "body",
 						"in": "body",
-						"description": "Case migration paremeters",
+						"description": "Case migration parameters",
 						"schema": {
 							"type": "object",
 							"properties": {

--- a/apps/functions/applications-migration/common/migration-cleanup.js
+++ b/apps/functions/applications-migration/common/migration-cleanup.js
@@ -1,9 +1,26 @@
 import { makePostRequestStreamResponse } from './back-office-api-client.js';
 
-export const startMigrationCleanup = async (log, caseReference, skipHtmlTransform) => {
+/**
+ *
+ * @param {*} log
+ * @param {string} caseReference
+ * @param {boolean} skipLooseS51Attachments
+ * @param {boolean} skipHtmlTransform
+ * @param {boolean} skipFixExamFolders
+ * @returns
+ */
+export const startMigrationCleanup = async (
+	log,
+	caseReference,
+	skipLooseS51Attachments,
+	skipHtmlTransform,
+	skipFixExamFolders
+) => {
 	log.info(`Making API request to start migration for case: ${caseReference}`);
 	return makePostRequestStreamResponse(log, '/migration/cleanup', {
 		caseReference,
-		skipHtmlTransform
+		skipLooseS51Attachments,
+		skipHtmlTransform,
+		skipFixExamFolders
 	});
 };

--- a/apps/functions/applications-migration/post-migration/index.js
+++ b/apps/functions/applications-migration/post-migration/index.js
@@ -20,28 +20,53 @@ app.http('post-migration', {
 	 */
 	handler: async (request, context) => {
 		// @ts-ignore
-		const { caseReferences, skipHtmlTransform } = await request.json();
+		const { caseReferences, skipLooseS51Attachments, skipHtmlTransform, skipFixExamFolders } =
+			await request.json();
 		const entityName = 'post-migration';
 		return handleMigrationWithResponse(context, {
 			caseReferences: caseReferences,
 			entityName,
-			migrationStream: () => runPostMigrationTasks(context, caseReferences, skipHtmlTransform)
+			migrationStream: () =>
+				runPostMigrationTasks(
+					context,
+					caseReferences,
+					skipLooseS51Attachments,
+					skipHtmlTransform,
+					skipFixExamFolders
+				)
 		});
 	}
 });
 
 /**
- * Migrate a whole case
+ * Performs post migration tasks for the given case references
  *
  * @param {import("@azure/functions").InvocationContext} log
  * @param {string[]} caseReferenceList
+ * @param {boolean} skipLooseS51Attachments
  * @param {boolean} skipHtmlTransform
+ * @param {boolean} skipFixExamFolders
  */
-const runPostMigrationTasks = async (log, caseReferenceList, skipHtmlTransform) => {
+const runPostMigrationTasks = async (
+	log,
+	caseReferenceList,
+	skipLooseS51Attachments,
+	skipHtmlTransform,
+	skipFixExamFolders
+) => {
 	/** @type {Function[][]} */
 	const listOfCaseReferenceTasks = [];
 	caseReferenceList.forEach((caseReference) => {
-		const caseReferenceTaskList = [() => startMigrationCleanup(log, caseReference, skipHtmlTransform)];
+		const caseReferenceTaskList = [
+			() =>
+				startMigrationCleanup(
+					log,
+					caseReference,
+					skipLooseS51Attachments,
+					skipHtmlTransform,
+					skipFixExamFolders
+				)
+		];
 		listOfCaseReferenceTasks.push(caseReferenceTaskList);
 	});
 


### PR DESCRIPTION
## Describe your changes

Fix to correct the exam timetable item records for migrated cases, so that they point to their matching exam item folder in the Examination timetable folder.  Currently migration points them all to the parent exam folder, and this causes the page to crash in CBOS when trying to multiply process the whole fold and all item subfolders, for each exam item.

- The fix is to add cleanup functionality to the post-migration task to identify the matching folders and correct the exam records, and to make new matching folders if there are none found (which would be the case if there no migrated docs in an exam item folder).
- also made all parts of the post-migration clean up runnable depending on parameters - eg 
-- skipLooseS51Attachments: false,
-- skipHtmlTransform: false,
-- skipFixExamFolders: false
- updated some incorrect swagger details

## APPLICS-1482 Opening a migrated exam timetable generates a service error
https://pins-ds.atlassian.net/browse/APPLICS-1482

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
