### PR TITLE
feat(web): add front office project page link to case overview banner (applics 1504)

### DIFF
--- a/apps/web/src/server/applications/case/applications-case.locals.js
+++ b/apps/web/src/server/applications/case/applications-case.locals.js
@@ -6,6 +6,7 @@ import {
 	getCaseFolder
 } from './documentation/applications-documentation.service.js';
 import { featureFlagClient } from '../../../common/feature-flags.js';
+import config from '../../../../environment/config.js';
 
 /**
  * @typedef {object} ApplicationCaseLocals
@@ -46,6 +47,8 @@ export const registerCase = async (request, response, next) => {
 		pino.error('[WEB] Trying to load a non-draft page for a draft case');
 		return response.render(`app/404.njk`);
 	}
+
+	response.locals.frontOfficeProjectUrl = `${config.frontOfficeURL}/projects/${response.locals.case.reference}`;
 
 	next();
 };

--- a/apps/web/src/server/views/applications/case/layouts/applications-case-layout.njk
+++ b/apps/web/src/server/views/applications/case/layouts/applications-case-layout.njk
@@ -47,6 +47,10 @@
 								{% endif %}
 
 								{{ statusTag(case.status) }}
+
+								{% if case.publishedDate %}
+									<a href="{{ frontOfficeProjectUrl | safe }}" class="govuk-link govuk-!-margin-left-4" rel="noreferrer noopener" target="_blank">View published project page (opens in new tab)</a>
+								{% endif %}
 							</div>
 						</div>
 				{% endblock %}


### PR DESCRIPTION
## Describe your changes
- Updated existing case middleware to generate a URL for the front office project page to be accessed in the case overview banner template.
- Conditionally rendered a link to the project page in the banner template if the project is published.

## Issue ticket number and link
[Applics 1504](https://pins-ds.atlassian.net/browse/APPLICS-1504): CBOS hyperlink to FO project page

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
