### PR TITLE
feat(api): remove rename link and delete link for new exam timetable folders (applics 1538)

### DIFF
--- a/apps/api/src/server/applications/examination-timetable-items/__tests__/examination-timetable-items.test.js
+++ b/apps/api/src/server/applications/examination-timetable-items/__tests__/examination-timetable-items.test.js
@@ -370,7 +370,7 @@ describe('Test examination timetable items API', () => {
 				stage: 'Examination',
 				parentFolderId: 1,
 				displayOrder: 20230227,
-				isCustom: true
+				isCustom: false
 			}
 		});
 		expect(databaseConnector.examinationTimetable.create).toHaveBeenCalledTimes(1);
@@ -406,7 +406,7 @@ describe('Test examination timetable items API', () => {
 				stage: 'Pre-examination',
 				parentFolderId: 1,
 				displayOrder: 20230227,
-				isCustom: true
+				isCustom: false
 			}
 		});
 		expect(databaseConnector.examinationTimetable.create).toHaveBeenCalledTimes(1);
@@ -481,7 +481,7 @@ describe('Test examination timetable items API', () => {
 				displayNameEn: '27 Feb 2023 - Examination Timetable Item',
 				parentFolderId: 1,
 				stage: 'Examination',
-				isCustom: true
+				isCustom: false
 			}
 		});
 
@@ -490,7 +490,7 @@ describe('Test examination timetable items API', () => {
 			displayOrder: 100,
 			parentFolderId: 1,
 			stage: 'Examination',
-			isCustom: true
+			isCustom: false
 		};
 
 		expect(databaseConnector.folder.create).toHaveBeenNthCalledWith(2, {
@@ -805,7 +805,7 @@ describe('Test examination timetable items API', () => {
 			displayOrder: 100,
 			parentFolderId: 1234,
 			stage: 'Examination',
-			isCustom: true
+			isCustom: false
 		};
 
 		expect(databaseConnector.folder.create).toHaveBeenNthCalledWith(1, {

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.controller.js
@@ -155,8 +155,9 @@ export const createExaminationTimetableItem = async ({ body }, response) => {
 				: examinationFolder.stage,
 		displayOrder
 	};
+	const isCustom = false;
 
-	const itemFolder = await folderRepository.createFolder(folder);
+	const itemFolder = await folderRepository.createFolder(folder, isCustom);
 	if (!itemFolder) {
 		throw new BackOfficeAppError('Failed to create sub folder for the examination item.', 500);
 	}

--- a/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.service.js
+++ b/apps/api/src/server/applications/examination-timetable-items/examination-timetable-items.service.js
@@ -240,7 +240,8 @@ export const createDeadlineSubFolders = async (
 		stage,
 		displayOrder: 100
 	};
-	createFolderPromise.push(folderRepository.createFolder(otherFolder));
+	const isCustom = false;
+	createFolderPromise.push(folderRepository.createFolder(otherFolder, isCustom));
 
 	if (!description?.bulletPoints || description?.bulletPoints?.length === 0) {
 		logger.info('No bulletpoints');
@@ -255,7 +256,8 @@ export const createDeadlineSubFolders = async (
 			stage,
 			displayOrder: 100
 		};
-		createFolderPromise.push(folderRepository.createFolder(subFolder));
+		const isCustom = false;
+		createFolderPromise.push(folderRepository.createFolder(subFolder, isCustom));
 	});
 
 	logger.info('Create sub folders');

--- a/apps/api/src/server/repositories/folder.repository.js
+++ b/apps/api/src/server/repositories/folder.repository.js
@@ -143,15 +143,16 @@ export const getFoldersByParentId = (parentFolderId, options = null) => {
 
 /**
  * @param {Object} folder
+ * @param {boolean} isCustom
  * @param {string} folder.displayNameEn
  * @param {number} folder.caseId
  * @param {number|null} folder.parentFolderId
  * @param {number|null} folder.displayOrder
  * @returns {Promise<(Folder |null)>}
  */
-export const createFolder = (folder) => {
+export const createFolder = (folder, isCustom = true) => {
 	return databaseConnector.folder.create({
-		data: { ...folder, isCustom: true }
+		data: { ...folder, isCustom }
 	});
 };
 


### PR DESCRIPTION
## Describe your changes
This PR sets the isCustom value to false for new exam timetable folders and subfolders on creation. This prevents the rename link and delete link being rendered in the browser for those folders. The default value for isCustom is set to true for custom folders created anywhere else. The relevant unit test has also been updated.

## Issue ticket number and link
[APPLICS 1538](https://pins-ds.atlassian.net/browse/APPLICS-1538): Locking Exam timetable folders

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
