### PR TITLE
Fix/applics 1482 correct exam folder fields in migration

### DIFF
--- a/apps/api/src/server/applications/application/file-folders/folders.service.js
+++ b/apps/api/src/server/applications/application/file-folders/folders.service.js
@@ -93,7 +93,7 @@ const getOrderBy = (sortBy = '-dateCreated') => {
 		{ latestDocumentVersion: { [sortField]: sortDirection } },
 		// If the sort field is not dateCreated, then sort by dateCreated as a secondary sort field
 		...(sortField !== 'dateCreated' ? [{ latestDocumentVersion: { dateCreated: 'desc' } }] : [])
-	]
+	];
 };
 
 /**
@@ -168,14 +168,20 @@ export const getChildFolders = async (folderId) => {
  * @param {number} applicationId
  * @param {string} folderName
  * @param {number} [parentFolderId]
+ * @param {number} [displayOrder]
  * @returns {Promise<FolderDetails>}
  * */
-export const createFolder = async (applicationId, folderName, parentFolderId) => {
+export const createFolder = async (
+	applicationId,
+	folderName,
+	parentFolderId,
+	displayOrder = 100
+) => {
 	const input = {
 		displayNameEn: folderName,
 		caseId: applicationId,
 		parentFolderId: parentFolderId ?? null,
-		displayOrder: 100,
+		displayOrder: displayOrder,
 		stage: await getParentFolderStage(parentFolderId)
 	};
 

--- a/apps/api/src/server/migration/migrators/migration-cleanup.controller.js
+++ b/apps/api/src/server/migration/migrators/migration-cleanup.controller.js
@@ -282,6 +282,7 @@ const correctExamTimetableFolders = async (caseId, res) => {
 				res.write(`Updated timetable item ${itemId} to match folder to ${matchingFolder.id}.\n`);
 
 				// and check the exam timetable item folder has the correct stage, displayOrder and isCustom set
+				// stage = Examination, displayOrder = <formattedDate>, isCustom = false
 				let folderUpdateRequired = false;
 				let updateCodes = [];
 				if (matchingFolder.stage !== EXAMINATION_STAGE) {
@@ -292,9 +293,9 @@ const correctExamTimetableFolders = async (caseId, res) => {
 					folderUpdateRequired = true;
 					updateCodes.push(`displayOrder = '${formattedDate}'`);
 				}
-				if (matchingFolder.isCustom !== true) {
+				if (matchingFolder.isCustom !== false) {
 					folderUpdateRequired = true;
-					updateCodes.push(`isCustom = true`);
+					updateCodes.push(`isCustom = false`);
 				}
 
 				if (folderUpdateRequired) {

--- a/apps/functions/applications-migration/common/utils.js
+++ b/apps/functions/applications-migration/common/utils.js
@@ -72,5 +72,11 @@ export const getServiceUserUnder18AndCountyValue = (value) => {
  * @returns
  */
 export const toBoolean = (value) => {
-	return value === true || value?.toLowerCase() === 'true';
+	let isBool = false;
+	if (typeof value === 'boolean') {
+		isBool = value;
+	} else if (typeof value === 'string' && value.length > 0) {
+		isBool = value.toLowerCase() === 'true';
+	}
+	return isBool;
 };


### PR DESCRIPTION
## Describe your changes

Fixes to the migration code for cases, specifically:
- fix the ToBoolean fn, as it crashed when handling bool false (though string "false") did work.
- added code to the cleanup fn to check and fix the exam timetable folders (inc new ones) to ensure they have the correct
--  displayOrder (ie examm date in yyyymmdd format), 
-- isCustom = false (so exam item folders are NOT used editable and deletable), and
-- stage = 'Examination'

This matches the values that are set when an Exam Item is created via the UI in CBOS.

## APPLICS-1482 Opening Exam timetable generates a service error
https://pins-ds.atlassian.net/browse/APPLICS-1482

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
