### PR TITLE
feat(functions): exam timetable unassigned folder (applics-1534)

### DIFF
--- a/apps/functions/applications-command-handlers/deadline-submission-command/__tests__/deadline-submission-command.test.js
+++ b/apps/functions/applications-command-handlers/deadline-submission-command/__tests__/deadline-submission-command.test.js
@@ -9,8 +9,18 @@ describe('deadline-submission-command', () => {
 	const mockSendEvents = jest.fn();
 
 	beforeEach(() => {
+		// assumptions:
+		/* case id = 1
+		 * exam timetable item id = 1
+		 * exam item folder id = 1
+		 * exam sub item folder id = 2
+		 * unassigned folder id = 3
+		 */
 		api.getCaseID = jest.fn().mockResolvedValue(1);
-		api.getFolderID = jest.fn().mockResolvedValue(1);
+		api.examTimetableItemFolderExists = jest.fn().mockResolvedValue(true);
+		api.getExamTimetableLineItemFolderID = jest.fn().mockResolvedValue(2);
+		// api.getOrCreateUnassignedFolderId = jest.fn().mockResolvedValue(3);
+
 		api.getTimetableItem = jest.fn().mockResolvedValue({
 			id: 1,
 			name: 'timetableItemName',
@@ -60,7 +70,7 @@ describe('deadline-submission-command', () => {
 				filter1Welsh: 'timetableItemName Welsh',
 				documentType: 'application/octet-stream',
 				documentSize: 1,
-				folderID: 1,
+				folderID: 2,
 				userEmail: mockMsg.email
 			})
 		);

--- a/apps/functions/applications-command-handlers/deadline-submission-command/back-office-api-client.js
+++ b/apps/functions/applications-command-handlers/deadline-submission-command/back-office-api-client.js
@@ -185,7 +185,7 @@ async function getUnassignedFolderId(caseID, timetableItemFolderId, context) {
 async function getOrCreateUnassignedFolderId(caseID, timetableItemFolderId, context) {
 	// try to get the Unassigned folder ID
 	let unassignedFolderId = await getUnassignedFolderId(caseID, timetableItemFolderId, context);
-	if (!unassignedFolderId && unassignedFolderId > 0) {
+	if (!unassignedFolderId) {
 		context.log(`Unassigned folder not initially found, creating it...`);
 
 		try {

--- a/apps/functions/applications-command-handlers/deadline-submission-command/back-office-api-client.js
+++ b/apps/functions/applications-command-handlers/deadline-submission-command/back-office-api-client.js
@@ -171,23 +171,28 @@ async function getOrCreateUnassignedFolderId(caseID, timetableItemFolderId, cont
 		context.log(
 			`No Unassigned folder found in parent folder ID ${timetableItemFolderId}, creating it...`
 		);
-		unassignedFolder = await requestWithApiKey
-			.post(`https://${config.apiHost}/applications/${caseID}/create-folder`, {
-				json: {
-					parentFolderId: timetableItemFolderId,
-					name: UNASSIGNED_FOLDER_NAME
-				}
-			})
-			.json();
-		if (!unassignedFolder) {
+		try {
+			unassignedFolder = await requestWithApiKey
+				.post(`https://${config.apiHost}/applications/${caseID}/create-folder`, {
+					json: {
+						parentFolderId: timetableItemFolderId,
+						name: UNASSIGNED_FOLDER_NAME
+					}
+				})
+				.json();
+			context.log(`Unassigned folder creation response: ${unassignedFolder}`);
+		} catch (err) {
+			context.log(
+				`Unassigned folder: Error creating Unassigned folder in parent folder ID ${timetableItemFolderId}: ${err}`
+			);
 			throw new Error(
-				`Unassigned folder: Failed to create Unassigned folder in parent folder ID ${timetableItemFolderId}`
+				`Unassigned folder: Failed to create Unassigned folder in parent folder ID ${timetableItemFolderId}: Error: ${err}`
 			);
 		}
-		context.log(`Unassigned folder created with ID ${unassignedFolder.id}`);
+		context.log(`Unassigned folder created with ID ${unassignedFolder?.id}`);
 	}
 
-	return unassignedFolder.id;
+	return unassignedFolder?.id;
 }
 
 /**

--- a/apps/functions/applications-command-handlers/deadline-submission-command/back-office-api-client.js
+++ b/apps/functions/applications-command-handlers/deadline-submission-command/back-office-api-client.js
@@ -173,7 +173,7 @@ async function getOrCreateUnassignedFolderId(caseID, timetableItemFolderId, cont
 		);
 		try {
 			unassignedFolder = await requestWithApiKey
-				.post(`https://${config.apiHost}/applications/${caseID}/create-folder`, {
+				.post(`https://${config.apiHost}/applications/${caseID}/folders/create-folder`, {
 					json: {
 						parentFolderId: timetableItemFolderId,
 						name: UNASSIGNED_FOLDER_NAME

--- a/apps/functions/applications-command-handlers/deadline-submission-command/lib.js
+++ b/apps/functions/applications-command-handlers/deadline-submission-command/lib.js
@@ -5,6 +5,7 @@
  * @property {string | null} nameWelsh
  * @property {string} description
  * @property {string | null} descriptionWelsh
+ * @property {number} folderId
  * */
 
 /**


### PR DESCRIPTION
## Describe your changes

Some "Have your Say" submissions from the Front Office were failing in CBOS (eg a submission against an Exam Timetable deadline/sub item), if it cannot find the correct folder to deliver the files to.
This ticket addresses this in CBOS by
- refactored code to more efficiently identify the exam item (deadline) and its folder
- added code when checking to find the sub-item (Line item) folder, if it does not exist, then to not fail, but instead put the files into an "Unassigned" folder in that deadline.
- If an Unassigned folder does not exist on that deadline, then create it, and use that for the files

## APPLICS-1534 Allow Have your Say Journey to succeed even if it cannot find the matching exam subfolder, by putting the files in an Unassigned folder.
https://pins-ds.atlassian.net/browse/APPLICS-1534

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
