### PR TITLE
feat(web): rename documents on deletion (applics-1386)

### DIFF
--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -1,4 +1,5 @@
 import { databaseConnector } from '#utils/database-connector.js';
+import { getFileNameWithoutSuffix } from '../applications/application/documents/document.service.js';
 
 /**
  * @typedef {import('@prisma/client').Document} Document
@@ -381,7 +382,7 @@ export const getDocumentsInFolder = (folderId, options = {}) => {
 			isDeleted: false
 		},
 		...options,
-		orderBy,
+		orderBy
 	});
 };
 
@@ -666,11 +667,13 @@ export const getDocumentsCountInByPublishStatus = (caseId) => {
  * @param {boolean} [includeDeleted]
  * @returns {import('@prisma/client').PrismaPromise<Document | null>}
  */
-export const getInFolderByName = (folderId, fileName, includeDeleted) =>
-	databaseConnector.document.findFirst({
+export const getInFolderByName = (folderId, fileName, includeDeleted) => {
+	const fileNameWithoutSuffix = getFileNameWithoutSuffix(fileName);
+	return databaseConnector.document.findFirst({
 		where: {
 			folderId,
-			latestDocumentVersion: { originalFilename: fileName },
+			latestDocumentVersion: { fileName: fileNameWithoutSuffix },
 			...(includeDeleted ? {} : { isDeleted: false })
 		}
 	});
+};

--- a/apps/api/src/server/repositories/s51-advice-document.repository.js
+++ b/apps/api/src/server/repositories/s51-advice-document.repository.js
@@ -1,4 +1,5 @@
 import { databaseConnector } from '../utils/database-connector.js';
+import { getFileNameWithoutSuffix } from '../applications/application/documents/document.service.js';
 
 /**
  * @typedef {import('@prisma/client').Prisma.S51AdviceDocumentGetPayload<{include: {Document: {include: {latestDocumentVersion: true }} }}>} S51AdviceDocumentWithLatestVersion
@@ -42,17 +43,19 @@ export const getForAdvice = (adviceId) =>
  * @param {string} documentName
  * @returns {import('@prisma/client').PrismaPromise<import('@pins/applications.api').Schema.S51AdviceDocument | null>}
  * */
-export const getDocumentInAdviceByName = (adviceId, documentName) =>
-	databaseConnector.s51AdviceDocument.findFirst({
+export const getDocumentInAdviceByName = (adviceId, documentName) => {
+	const fileNameWithoutSuffix = getFileNameWithoutSuffix(documentName);
+	return databaseConnector.s51AdviceDocument.findFirst({
 		where: {
 			adviceId,
 			Document: {
 				latestDocumentVersion: {
-					originalFilename: documentName
+					fileName: fileNameWithoutSuffix
 				}
 			}
 		}
 	});
+};
 
 /**
  *

--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -7126,7 +7126,8 @@ exports[`applications documentation Document properties delete page GET /case/12
             </p>
             <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                 <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> This will delete
-                    all versions of this document.</strong>
+                    all versions of this document and rename the document to 12 Ullamco laboris
+                    nisi ut_deleted_20231101_000000.</strong>
             </div>
             <button class="govuk-button govuk-button--warning" data-module="govuk-button">Delete</button>
         </form>
@@ -7164,7 +7165,7 @@ exports[`applications documentation Document properties delete page GET /case/12
             </p>
             <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                 <strong                 class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> This will delete
-                    all versions of this document.</strong>
+                    all versions of this document and rename the document to 4 Elit sed_deleted_20231101_000000.</strong>
             </div>
             <button class="govuk-button govuk-button--warning" data-module="govuk-button">Delete</button>
         </form>

--- a/apps/web/src/server/applications/case/documentation/__tests__/applications-documentation.test.js
+++ b/apps/web/src/server/applications/case/documentation/__tests__/applications-documentation.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { parseHtml } from '@pins/platform';
 import nock from 'nock';
 import supertest from 'supertest';
@@ -72,6 +73,8 @@ const nocks = () => {
 		.times(2)
 		.reply(200, { isDeleted: true });
 };
+
+const mockDate = new Date('2023-11-01T00:00:00Z');
 
 describe('applications documentation', () => {
 	beforeEach(installMockApi);
@@ -341,6 +344,15 @@ describe('applications documentation', () => {
 			await request.get('/applications-service/');
 		});
 
+		beforeAll(() => {
+			jest.useFakeTimers({ advanceTimers: true }).setSystemTime(mockDate);
+		});
+
+		afterAll(() => {
+			jest.runOnlyPendingTimers();
+			jest.useRealTimers();
+		});
+
 		describe('GET /case/123/project-documentation/21/100/delete', () => {
 			it('page should render', async () => {
 				const response = await request.get(
@@ -363,6 +375,7 @@ describe('applications documentation', () => {
 				expect(element.innerHTML).toContain('is in the publishing queue ready to be published');
 			});
 		});
+
 		describe('POST /case/123/project-documentation/21/100/delete', () => {
 			it('should go to success page if status is not "ready-to-publish"', async () => {
 				const response = await request.post(

--- a/apps/web/src/server/applications/case/documentation/__tests__/generate-document-name-one-deletion.test.js
+++ b/apps/web/src/server/applications/case/documentation/__tests__/generate-document-name-one-deletion.test.js
@@ -1,0 +1,22 @@
+import { jest } from '@jest/globals';
+import { generateDocumentNameOnDeletion } from '../utils/generate-document-name-on-deletion.js';
+
+const mockDate = new Date('2023-11-01T00:00:00Z');
+
+describe('generate-document-name-on-deletion.js', () => {
+	beforeAll(() => {
+		jest.useFakeTimers({ advanceTimers: true }).setSystemTime(mockDate);
+	});
+
+	afterAll(() => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	});
+
+	it('should generate a document name with deletion suffix and timestamp', () => {
+		const mockDocumentName = 'mock-document';
+		const result = generateDocumentNameOnDeletion(mockDocumentName);
+
+		expect(result).toBe(`mock-document_deleted_20231101_000000`);
+	});
+});

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -8,7 +8,10 @@ import {
 	destroySuccessBanner,
 	getSessionBanner,
 	deleteSessionBanner,
-	setSessionBanner
+	setSessionBanner,
+	setSessionDocumentNameOnDeletion,
+	getSessionDocumentNameOnDeletion,
+	deleteSessionDocumentNameOnDeletion
 } from '../../common/services/session.service.js';
 import { buildBreadcrumbItems } from '../applications-case.locals.js';
 import {
@@ -39,6 +42,8 @@ import logger from '../../../lib/logger.js';
 import moveDocumentsUtils from './utils/move-documents/utils.js';
 import { getRelevantRepFolder } from '../representations/representation-details/applications-relevant-rep-details.service.js';
 import { tableSortLinks } from './utils/table.js';
+import { generateDocumentNameOnDeletion } from './utils/generate-document-name-on-deletion.js';
+import { updateDocumentMetaData } from '../documentation-metadata/documentation-metadata.service.js';
 
 /** @typedef {import('@pins/express').ValidationErrors} ValidationErrors */
 /** @typedef {import('../applications-case.locals.js').ApplicationCaseLocals} ApplicationCaseLocals */
@@ -284,9 +289,9 @@ export async function viewApplicationsCaseDocumentationProperties({ session }, r
 /**
  * View the documentation pages
  *
- * @type {import('@pins/express').RenderHandler<{documentationFile: DocumentationFile, warningText: string|null}, {}>}
+ * @type {import('@pins/express').RenderHandler<{documentationFile: DocumentationFile, warningText: string|null, documentNameOnDeletion: string}, {}>}
  */
-export async function viewApplicationsCaseDocumentationPages({ params }, response) {
+export async function viewApplicationsCaseDocumentationPages({ params, session }, response) {
 	const { action } = params;
 	if (!['delete', 'edit', 'publish', 'unpublish', 'upload'].includes(action)) {
 		return response.render('apps/500.njk');
@@ -301,9 +306,15 @@ export async function viewApplicationsCaseDocumentationPages({ params }, respons
 		? 'This document is in the publishing queue ready to be published.'
 		: null;
 
+	const documentNameOnDeletion = generateDocumentNameOnDeletion(
+		documentationFile?.fileName || 'document'
+	);
+	setSessionDocumentNameOnDeletion(session, documentNameOnDeletion);
+
 	response.render(`applications/case-documentation/documentation-${action}`, {
 		documentationFile,
-		warningText
+		warningText,
+		documentNameOnDeletion
 	});
 }
 
@@ -313,12 +324,13 @@ export async function viewApplicationsCaseDocumentationPages({ params }, respons
  * @type {import('@pins/express').RenderHandler<{documentationFile?: DocumentationFile, errors?: ValidationErrors} | {serviceName?: string, successMessage?: string}, {}>}
  */
 export async function updateApplicationsCaseDocumentationDelete(
-	{ errors: validationErrors },
+	{ errors: validationErrors, session },
 	response
 ) {
 	const { caseId, documentGuid } = response.locals;
 	const { title: caseName, reference: caseReference } = response.locals.case;
 	const documentationFile = await getCaseDocumentationFileInfo(caseId, documentGuid);
+	const documentNameOnDeletion = getSessionDocumentNameOnDeletion(session);
 
 	const { errors } = validationErrors
 		? { errors: validationErrors }
@@ -330,6 +342,10 @@ export async function updateApplicationsCaseDocumentationDelete(
 			errors
 		});
 	}
+
+	await updateDocumentMetaData(caseId, documentGuid, { fileName: documentNameOnDeletion });
+
+	deleteSessionDocumentNameOnDeletion(session);
 
 	response.render(`applications/case-documentation/documentation-success-banner`, {
 		serviceName: 'Document successfully deleted',

--- a/apps/web/src/server/applications/case/documentation/utils/generate-document-name-on-deletion.js
+++ b/apps/web/src/server/applications/case/documentation/utils/generate-document-name-on-deletion.js
@@ -1,0 +1,15 @@
+import { format } from 'date-fns';
+
+/**
+ *
+ * @param {string} documentName
+ * @returns {string}
+ */
+export const generateDocumentNameOnDeletion = (documentName) => {
+	const deletionDate = new Date();
+	const dateFormat = 'yyyyMMdd_HHmmss';
+
+	const formattedDeletionDate = format(deletionDate, dateFormat);
+
+	return `${documentName}_deleted_${formattedDeletionDate}`;
+};

--- a/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
+++ b/apps/web/src/server/applications/case/s51/__tests__/__snapshots__/applications-s51.test.js.snap
@@ -20,6 +20,11 @@ exports[`S51 Advice S51 Attachment delete GET /case/123/project-documentation/21
                 </tr>
             </tbody>
         </table>
+        <div class="govuk-warning-text"><span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong             class="govuk-warning-text__text"><span class="govuk-warning-text__assistive">Warning</span> This will delete
+                all versions of this document and rename the document to Minim veniam quis
+                nostrud_deleted_20231101_000000.</strong>
+        </div>
         <button class="govuk-button govuk-!-margin-top-6 govuk-button--warning"
         data-module="govuk-button">Delete</button>
     </form>

--- a/apps/web/src/server/applications/case/s51/__tests__/applications-s51.test.js
+++ b/apps/web/src/server/applications/case/s51/__tests__/applications-s51.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import { parseHtml } from '@pins/platform';
 import nock from 'nock';
 import supertest from 'supertest';
@@ -37,6 +38,8 @@ const nocks = () => {
 };
 
 const projectName = 'Title CASE/04';
+
+const mockDate = new Date('2023-11-01T00:00:00Z');
 
 describe('S51 Advice', () => {
 	beforeEach(installMockApi);
@@ -672,6 +675,15 @@ describe('S51 Advice', () => {
 		});
 
 		describe('GET /case/123/project-documentation/21/s51-advice/1/attachments/:documentGuid/delete', () => {
+			beforeAll(() => {
+				jest.useFakeTimers({ advanceTimers: true }).setSystemTime(mockDate);
+			});
+
+			afterAll(() => {
+				jest.runOnlyPendingTimers();
+				jest.useRealTimers();
+			});
+
 			it('should render the page', async () => {
 				const documentGuid = createS51Advice({ id: 1 }).attachments[0].documentGuid;
 				const response = await request.get(`${baseUrl}/1/attachments/${documentGuid}/delete`);

--- a/apps/web/src/server/applications/common/services/session.service.js
+++ b/apps/web/src/server/applications/common/services/session.service.js
@@ -4,6 +4,7 @@
  * @typedef {import('express-session').Session & { infoTypes?: string[] }} SessionWithApplicationsCreateApplicantInfoTypes
  * @typedef {import('express-session').Session & { filesNumberOnList?: number }} SessionWithFilesNumberOnList
  * @typedef {import('express-session').Session & { showSuccessBanner?: boolean }} SessionWithSuccessBanner
+ * @typedef {import('express-session').Session & { documentNameOnDeletion?: string }} SessionWithDocumentNameOnDeletion
  */
 
 // Applicant session management
@@ -200,4 +201,34 @@ export function setSessionBanner(session, banner) {
  */
 export function deleteSessionBanner(session) {
 	delete session.banner;
+}
+
+// Renaming documents on deletion
+
+/**
+ * Set the document name to be used when deleting a document in the session.
+ * @param {SessionWithDocumentNameOnDeletion} session
+ * @param {string} documentNameOnDeletion
+ * @returns {void}
+ */
+export function setSessionDocumentNameOnDeletion(session, documentNameOnDeletion) {
+	session.documentNameOnDeletion = documentNameOnDeletion;
+}
+
+/**
+ * Get the document name to be used when deleting a document from the session.
+ * @param {SessionWithDocumentNameOnDeletion} session
+ * @returns {string|undefined}
+ */
+export function getSessionDocumentNameOnDeletion(session) {
+	return session.documentNameOnDeletion;
+}
+
+/**
+ * Delete the document name from the session.
+ * @param {SessionWithDocumentNameOnDeletion} session
+ * @returns {void}
+ */
+export function deleteSessionDocumentNameOnDeletion(session) {
+	delete session.documentNameOnDeletion;
 }

--- a/apps/web/src/server/views/applications/case-documentation/documentation-delete.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-delete.njk
@@ -74,7 +74,7 @@
                 {% endfor %}
             </p>
 			{{ govukWarningText({
-				text: "This will delete all versions of this document.",
+				text: "This will delete all versions of this document and rename the document to " + documentNameOnDeletion + ".",
 				iconFallbackText: "Warning"
 			}) }}
             {{ govukButton({ text: "Delete",  classes: "govuk-button--warning" }) }}

--- a/apps/web/src/server/views/applications/case-s51/s51-delete-attachment.njk
+++ b/apps/web/src/server/views/applications/case-s51/s51-delete-attachment.njk
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 
 {% set serviceName = case.title if case.title else "S51 advice" %}
@@ -50,7 +51,10 @@
 					]
 				]
 			}) }}
-
+		{{ govukWarningText({
+			text: "This will delete all versions of this document and rename the document to " + documentNameOnDeletion + ".",
+			iconFallbackText: "Warning"
+		}) }}
         {{ govukButton({ text: 'Delete', classes: 'govuk-!-margin-top-6 govuk-button--warning'}) }}
     </form>
 {% endblock %}


### PR DESCRIPTION
## Describe your changes
This PR makes the following changes to allow users to upload a document with the same name as a deleted document:
- Generates a new document name on deletion by creating a UTC timestamp and appending this to the existing document name.
- Displays the document name on deletion to the user before deletion.
- Replaces the existing fileName in the database with the newly generated document name  following successful deletion.
- Updates the code that checks whether a file name already exists so it removes the file extension from the new file name before comparing and checks against fileName rather than originalFileName.
- Updates existing unit tests and regenerates failing snapshots.

## Issue ticket number and link
[APPLICS-1386](https://pins-ds.atlassian.net/browse/APPLICS-1386): Renaming documents upon deletion

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes


[APPLICS-1386]: https://pins-ds.atlassian.net/browse/APPLICS-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ