### PR TITLE
fix(web): replace backticks in relevant representation comments (applics-1551)

### DIFF
--- a/apps/web/src/server/applications/case/representations/representation-details/redact-representation/__tests__/redact-representation.test.view-model.unit.test.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/redact-representation/__tests__/redact-representation.test.view-model.unit.test.js
@@ -18,12 +18,12 @@ describe('redact-representation view-models', () => {
 					'/applications-service/case/1/relevant-representations/1/representation-details',
 				caseId: '1',
 				organisationOrFullname: 'Mrs Sue',
-				originalRepresentation:
+				originalRepresentationWithoutBackticks:
 					'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla con.',
 				projectName: 'mock case reference title',
 				representationId: '1',
 				statusText: 'AWAITING_REVIEW',
-				redactedRepresentation:
+				redactedRepresentationWithoutBackticks:
 					'(Redacted) Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla con.',
 				notes: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.',
 				redactedBy: 'mock redacted by'

--- a/apps/web/src/server/applications/case/representations/representation-details/redact-representation/redact-representation.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/redact-representation/redact-representation.view-model.js
@@ -12,6 +12,14 @@ export const getPreviousPageUrl = (caseId, representationId) =>
 	});
 
 /**
+ * @param { string } representation
+ * @returns { string }
+ */
+export const getRepresentationWithoutBackticks = (representation) => {
+	return representation ? representation.replace(/`/g, "'") : '';
+};
+
+/**
  * @param {string} caseId
  * @param {string} representationId
  * @param {object} representation
@@ -25,7 +33,7 @@ export const getPreviousPageUrl = (caseId, representationId) =>
  * @param {string?} representation.represented.organisationName
  * @param {string} projectName
  * @param {string} statusText
- * @returns {{ caseId: string, representationId: string, backLinkUrl: string, originalRepresentation: string, redactedRepresentation: string, notes: string?, redactedBy: string?, projectName: string, statusText: string, organisationOrFullname: string? }}
+ * @returns {{ caseId: string, representationId: string, backLinkUrl: string, originalRepresentationWithoutBackticks: string, redactedRepresentationWithoutBackticks: string, notes: string?, redactedBy: string?, projectName: string, statusText: string, organisationOrFullname: string? }}
  *
  */
 export const getRedactRepresentationViewModel = (
@@ -44,8 +52,10 @@ export const getRedactRepresentationViewModel = (
 	caseId,
 	representationId,
 	backLinkUrl: getPreviousPageUrl(caseId, representationId),
-	originalRepresentation,
-	redactedRepresentation: redactedRepresentation ? redactedRepresentation : originalRepresentation,
+	originalRepresentationWithoutBackticks: getRepresentationWithoutBackticks(originalRepresentation),
+	redactedRepresentationWithoutBackticks: redactedRepresentation
+		? getRepresentationWithoutBackticks(redactedRepresentation)
+		: getRepresentationWithoutBackticks(originalRepresentation),
 	organisationOrFullname: `${firstName || ''} ${lastName || ''}`.trim() || organisationName,
 	notes: redactedNotes,
 	redactedBy,

--- a/apps/web/src/server/applications/case/representations/representation-details/utils/get-representation-excerpts.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/utils/get-representation-excerpts.js
@@ -15,11 +15,11 @@ const getExcerpt = (text) =>
  * @return {object}
  */
 export const getRepresentationExcerpts = ({
-	originalRepresentation,
-	redactedRepresentation,
-	redactedNotes
+	originalRepresentationWithoutBackticks,
+	redactedRepresentationWithoutBackticks,
+	redactedNotesWithoutBackticks
 }) => ({
-	originalRepresentationExcerpt: getExcerpt(originalRepresentation),
-	redactedRepresentationExcerpt: getExcerpt(redactedRepresentation),
-	redactedNotesExcerpt: getExcerpt(redactedNotes)
+	originalRepresentationWithoutBackticksExcerpt: getExcerpt(originalRepresentationWithoutBackticks),
+	redactedRepresentationWithoutBackticksExcerpt: getExcerpt(redactedRepresentationWithoutBackticks),
+	redactedNotesWithoutBackticksExcerpt: getExcerpt(redactedNotesWithoutBackticks)
 });

--- a/apps/web/src/server/applications/case/representations/representation/representation.middleware.js
+++ b/apps/web/src/server/applications/case/representations/representation/representation.middleware.js
@@ -70,6 +70,21 @@ export const addRepresentationToLocals = async (req, res, next) => {
 			};
 		}
 
+		res.locals.representation.originalRepresentationWithoutBackticks = res.locals.representation
+			.originalRepresentation
+			? res.locals.representation.originalRepresentation.replace(/`/g, "'")
+			: '';
+
+		res.locals.representation.redactedRepresentationWithoutBackticks = res.locals.representation
+			.redactedRepresentation
+			? res.locals.representation.redactedRepresentation.replace(/`/g, "'")
+			: '';
+
+		res.locals.representation.redactedNotesWithoutBackticks = res.locals.representation
+			.redactedNotes
+			? res.locals.representation.redactedNotes.replace(/`/g, "'")
+			: '';
+
 		return next();
 	} catch (e) {
 		return next(e);

--- a/apps/web/src/server/views/applications/representations/representation-details/includes/change/representation.include.njk
+++ b/apps/web/src/server/views/applications/representations/representation-details/includes/change/representation.include.njk
@@ -26,16 +26,16 @@
     </dt>
 
     <dd class="govuk-summary-list__value">
-      {% if representationExcerpts.originalRepresentationExcerpt | length %}
+      {% if representationExcerpts.originalRepresentationWithoutBackticksExcerpt | length %}
         <p class="section-text govuk-body white-space--pre-line">
-          <noscript>{{ representation.originalRepresentation }}</noscript>
+          <noscript>{{ representation.originalRepresentationWithoutBackticks | safe }}</noscript>
         </p>
 
         <p class="govuk-body govuk-!-margin-bottom-4">
           <a href="#" hidden class="section-text-toggle govuk-link govuk-link--no-visited-state">Show full representation</a>
         </p>
       {% else %}
-        <p class="govuk-body white-space--pre-line">{{ representation.originalRepresentation }}</p>
+        <p class="govuk-body white-space--pre-line">{{ representation.originalRepresentationWithoutBackticks | safe }}</p>
       {% endif %}
     </dd>
 
@@ -53,16 +53,16 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        {% if representationExcerpts.redactedRepresentationExcerpt | length %}
+        {% if representationExcerpts.redactedRepresentationWithoutBackticksExcerpt | length %}
           <p class="section-text govuk-body white-space--pre-line">
-            <noscript>{{ representation.redactedRepresentation }}</noscript>
+            <noscript>{{ representation.redactedRepresentationWithoutBackticks | safe }}</noscript>
           </p>
 
           <p class="govuk-body govuk-!-margin-bottom-4">
             <a href="#" hidden class="section-text-toggle govuk-link govuk-link--no-visited-state">Show full redacted representation</a>
           </p>
         {% else %}
-          <p class="govuk-body white-space--pre-line">{{ representation.redactedRepresentation }}</p>
+          <p class="govuk-body white-space--pre-line">{{ representation.redactedRepresentationWithoutBackticks | safe }}</p>
         {% endif %}
       </dd>
     </div>
@@ -73,16 +73,16 @@
       </dt>
 
       <dd class="govuk-summary-list__value">
-        {% if representationExcerpts.redactedNotesExcerpt | length %}
+        {% if representationExcerpts.redactedNotesWithoutBackticksExcerpt | length %}
           <p class="section-text govuk-body white-space--pre-line">
-            <noscript>{{ representation.redactedNotes }}</noscript>
+            <noscript>{{ representation.redactedNotesWithoutBackticks | safe }}</noscript>
           </p>
 
           <p class="govuk-body govuk-!-margin-bottom-4">
             <a href="#" hidden class="section-text-toggle govuk-link govuk-link--no-visited-state">Show full redacted notes</a>
           </p>
         {% else %}
-          <p class="govuk-body white-space--pre-line">{{ representation.redactedNotes }}</p>
+          <p class="govuk-body white-space--pre-line">{{ representation.redactedNotesWithoutBackticks | safe }}</p>
         {% endif %}
       </dd>
     </div>
@@ -129,32 +129,32 @@
     }
   }
 
-  {% if representationExcerpts.originalRepresentationExcerpt | length %}
+  {% if representationExcerpts.originalRepresentationWithoutBackticksExcerpt | length %}
     const toggleRepresentationText = new ToggleText();
     toggleRepresentationText.toggle(
       '#original-representation-section',
-      `{{ representation.originalRepresentation }}`,
-      `{{ representationExcerpts.originalRepresentationExcerpt }}...`,
+      `{{ representation.originalRepresentationWithoutBackticks | safe }}`,
+      `{{ representationExcerpts.originalRepresentationWithoutBackticksExcerpt | safe }}...`,
       'representation'
     );
   {% endif %}
 
-  {% if representationExcerpts.redactedRepresentationExcerpt | length %}
+  {% if representationExcerpts.redactedRepresentationWithoutBackticksExcerpt | length %}
     const toggleRedactedRepresentationText = new ToggleText();
     toggleRedactedRepresentationText.toggle(
       '#redacted-representation-section',
-      `{{ representation.redactedRepresentation }}`,
-      `{{ representationExcerpts.redactedRepresentationExcerpt }}...`,
+      `{{ representation.redactedRepresentationWithoutBackticks | safe }}`,
+      `{{ representationExcerpts.redactedRepresentationWithoutBackticksExcerpt |safe }}...`,
       'redacted representation'
     );
   {% endif %}
 
-  {% if representationExcerpts.redactedNotesExcerpt | length %}
+  {% if representationExcerpts.redactedNotesWithoutBackticksExcerpt | length %}
     const toggleRedactedNotesText = new ToggleText();
     toggleRedactedNotesText.toggle(
       '#redacted-notes-section',
-      `{{ representation.redactedNotes }}`,
-      `{{ representationExcerpts.redactedNotesExcerpt }}...`,
+      `{{ representation.redactedNotesWithoutBackticks | safe }}`,
+      `{{ representationExcerpts.redactedNotesWithoutBackticksExcerpt | safe }}...`,
       'redacted notes'
     );
   {% endif %}

--- a/apps/web/src/server/views/applications/representations/representation-details/redact-representation/redact-representation.njk
+++ b/apps/web/src/server/views/applications/representations/representation-details/redact-representation/redact-representation.njk
@@ -30,7 +30,7 @@
           </a>
         </span>
 
-				<p class="govuk-body white-space--pre-line word-break--break-word">{{ originalRepresentation }}</p>
+				<p class="govuk-body white-space--pre-line word-break--break-word">{{ originalRepresentationWithoutBackticks }}</p>
 			</div>
 
 			<div class="govuk-grid-column-one-half" id="redact-representation-section">
@@ -45,7 +45,7 @@
 						text: "Redact representation"
 					},
 					name: "redactedRepresentation",
-					value: redactedRepresentation
+					value: redactedRepresentationWithoutBackticks
 				}) }}
 
 				{{ govukButton({


### PR DESCRIPTION
## Describe your changes
A relevant representation comment submitted via Front Office was not visible on the CBOS relevant representation detail page. When the 'Redact' link was clicked, the full comment was visible. 

Comments are wrapped in backticks in a script in the Nunjucks template that allows users to toggle between a comment excerpt and the full comment. Because this particular comment contained backticks, the script errored and the comment was not displayed.

This PR replaces backticks with apostrophes in comments on the relevant representation detail page and redaction page. The corresponding templates have been updated to use these new values with no backticks. Unit tests have also been updated.

## Issue ticket number and link
[APPLICS-1551](https://pins-ds.atlassian.net/browse/APPLICS-1551): Blank Relevant representation field

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes


[APPLICS-1551]: https://pins-ds.atlassian.net/browse/APPLICS-1551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ