### PR TITLE
feat(api): migration remove multiple spaces from filename (applics-1598)

### DIFF
--- a/apps/api/src/server/migration/migrators/nsip-document-migrator.js
+++ b/apps/api/src/server/migration/migrators/nsip-document-migrator.js
@@ -7,7 +7,7 @@ import { getDocumentFolderId } from './folder/folder.js';
 import logger from '#utils/logger.js';
 import { broadcastNsipDocumentEvent } from '#infrastructure/event-broadcasters.js';
 import { EventType } from '@pins/event-client/src/event-type.js';
-import { trimDocumentNameKnownSuffix } from '#utils/file-fns.js';
+import { removeMultipleSpacesAndTrim, trimDocumentNameKnownSuffix } from '#utils/file-fns.js';
 
 /**
  * Convert HZN Document Version DocumentType to CBOS Document Version DocumentType
@@ -52,7 +52,10 @@ export const migrateNsipDocuments = async (documents, updateProgress) => {
 	for (const [index, document] of documents.entries()) {
 		const folderId = await getDocumentFolderId(document, caseId);
 		let documentId = document.documentId;
-		let documentFilename = trimDocumentNameKnownSuffix(document.filename); // take HZN display name and trim off file suffix if in known list
+		// take HZN display name and trim off file suffix if in known list. and then trim and remove any multiple spaces
+		let documentFilename = removeMultipleSpacesAndTrim(
+			trimDocumentNameKnownSuffix(document.filename)
+		);
 		if (documentId !== parentDocumentId) {
 			// new doc to process
 			parentDocumentId = documentId;

--- a/apps/api/src/server/utils/__tests__/file-fns.test.js
+++ b/apps/api/src/server/utils/__tests__/file-fns.test.js
@@ -1,4 +1,4 @@
-import { trimDocumentNameKnownSuffix } from '../file-fns';
+import { trimDocumentNameKnownSuffix, removeMultipleSpacesAndTrim } from '../file-fns';
 
 describe('trimDocumentNameKnownSuffix', () => {
 	it('should remove the extension from the document name with lower case suffix', () => {
@@ -29,5 +29,40 @@ describe('trimDocumentNameKnownSuffix', () => {
 	it('should not trim document names with unknown extensions', () => {
 		const result = trimDocumentNameKnownSuffix('.hiddenfile');
 		expect(result).toBe('.hiddenfile');
+	});
+
+	describe('removeMultipleSpacesAndTrim', () => {
+		it('should remove multiple spaces and trim the string', () => {
+			expect(removeMultipleSpacesAndTrim('  hello   world  ')).toBe('hello world');
+		});
+
+		it('should handle tabs and newlines as spaces', () => {
+			expect(removeMultipleSpacesAndTrim('\thello\t\tworld\n')).toBe('hello world');
+		});
+
+		it('should return empty string if input is only spaces', () => {
+			expect(removeMultipleSpacesAndTrim('     ')).toBe('');
+		});
+
+		it('should return the same string if there are no extra spaces', () => {
+			expect(removeMultipleSpacesAndTrim('hello world')).toBe('hello world');
+		});
+
+		it('should handle empty string', () => {
+			expect(removeMultipleSpacesAndTrim('')).toBe('');
+		});
+
+		it('should replace all whitespace characters with single spaces', () => {
+			expect(removeMultipleSpacesAndTrim('a\tb\nc\rd')).toBe('a b c d');
+		});
+		it('should return empty string for empty input', () => {
+			// @ts-ignore
+			expect(removeMultipleSpacesAndTrim('')).toBe('');
+		});
+		// add test for null input
+		it('should return empty string for null input', () => {
+			// @ts-ignore
+			expect(removeMultipleSpacesAndTrim(null)).toBe(null);
+		});
 	});
 });

--- a/apps/api/src/server/utils/__tests__/file-fns.test.js
+++ b/apps/api/src/server/utils/__tests__/file-fns.test.js
@@ -55,11 +55,6 @@ describe('trimDocumentNameKnownSuffix', () => {
 		it('should replace all whitespace characters with single spaces', () => {
 			expect(removeMultipleSpacesAndTrim('a\tb\nc\rd')).toBe('a b c d');
 		});
-		it('should return empty string for empty input', () => {
-			// @ts-ignore
-			expect(removeMultipleSpacesAndTrim('')).toBe('');
-		});
-		// add test for null input
 		it('should return empty string for null input', () => {
 			// @ts-ignore
 			expect(removeMultipleSpacesAndTrim(null)).toBe(null);

--- a/apps/api/src/server/utils/file-fns.js
+++ b/apps/api/src/server/utils/file-fns.js
@@ -83,3 +83,17 @@ export const trimDocumentNameKnownSuffix = (documentNameWithExtension) => {
 	// if the file extension is not in the known extensions list, return the original name
 	return documentNameWithExtension;
 };
+
+/**
+ * Removes all multiple spaces from a string, and trims
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+export const removeMultipleSpacesAndTrim = (str) => {
+	if (str === null || str === undefined) {
+		return str;
+	} else {
+		return str.replace(/\s+/gm, ' ').trim();
+	}
+};


### PR DESCRIPTION
## Describe your changes

When migrating documents, the document title is created by taking the doc title from HZN, and stripping off any know file suffix - to be compatible with existing CBOS functionality.  This PR also removes any multiple spaces from the title, and also trims.  This is consistent with what old NSIP website did when it received published docs.

## APPLICS-1598 Migration - Remove multiple spaces from filename
https://pins-ds.atlassian.net/browse/APPLICS-1598

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
