### PR TITLE
fix(api): fix document reference not unique (applics-1082)

### DIFF
--- a/apps/api/src/server/repositories/__tests__/document.repository.test.js
+++ b/apps/api/src/server/repositories/__tests__/document.repository.test.js
@@ -1,0 +1,147 @@
+import { jest } from '@jest/globals';
+import {
+	create,
+	getById,
+	getByCaseId,
+	getDocumentsInFolder,
+	deleteDocument
+} from '../document.repository.js';
+const { databaseConnector } = await import('#utils/database-connector.js');
+
+// jest.mock('#utils/database-connector.js');
+
+describe('Document Repository', () => {
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('create', () => {
+		it('creates a new document successfully', async () => {
+			const mockDocument = { guid: '123', name: 'Test Document' };
+			databaseConnector.document.create.mockResolvedValue(mockDocument);
+
+			const result = await create(mockDocument);
+
+			expect(databaseConnector.document.create).toHaveBeenCalledWith({ data: mockDocument });
+			expect(result).toEqual(mockDocument);
+		});
+
+		it('throws an error when creation fails', async () => {
+			const mockDocument = { guid: '123', name: 'Test Document' };
+			databaseConnector.document.create.mockRejectedValue(new Error('Database error'));
+
+			await expect(create(mockDocument)).rejects.toThrow('Database error');
+		});
+	});
+
+	describe('getById', () => {
+		it('retrieves a document by its guid', async () => {
+			const mockDocument = { guid: '123', name: 'Test Document' };
+			databaseConnector.document.findUnique.mockResolvedValue(mockDocument);
+
+			const result = await getById('123');
+
+			expect(databaseConnector.document.findUnique).toHaveBeenCalledWith({
+				where: { guid: '123' }
+			});
+			expect(result).toEqual(mockDocument);
+		});
+
+		it('returns null if no document is found', async () => {
+			databaseConnector.document.findUnique.mockResolvedValue(null);
+
+			const result = await getById('non-existent-guid');
+
+			expect(databaseConnector.document.findUnique).toHaveBeenCalledWith({
+				where: { guid: 'non-existent-guid' }
+			});
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('getByCaseId', () => {
+		it('retrieves documents by caseId with pagination', async () => {
+			const mockDocuments = [{ guid: '123' }, { guid: '456' }];
+			databaseConnector.document.findMany.mockResolvedValue(mockDocuments);
+
+			const result = await getByCaseId({ caseId: 1, skipValue: 0, pageSize: 10 });
+
+			expect(databaseConnector.document.findMany).toHaveBeenCalledWith({
+				where: { caseId: 1, isDeleted: false },
+				skip: 0,
+				take: 10,
+				orderBy: [{ createdAt: 'desc' }]
+			});
+			expect(result).toEqual(mockDocuments);
+		});
+
+		it('returns an empty array if no documents are found', async () => {
+			databaseConnector.document.findMany.mockResolvedValue([]);
+
+			const result = await getByCaseId({ caseId: 1, skipValue: 0, pageSize: 10 });
+
+			expect(databaseConnector.document.findMany).toHaveBeenCalledWith({
+				where: { caseId: 1, isDeleted: false },
+				skip: 0,
+				take: 10,
+				orderBy: [{ createdAt: 'desc' }]
+			});
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('getDocumentsInFolder', () => {
+		it('retrieves documents in a folder', async () => {
+			const mockDocuments = [{ guid: '123' }, { guid: '456' }];
+			databaseConnector.document.findMany.mockResolvedValue(mockDocuments);
+
+			const result = await getDocumentsInFolder(1);
+
+			expect(databaseConnector.document.findMany).toHaveBeenCalledWith({
+				include: {
+					documentVersion: true,
+					latestDocumentVersion: true,
+					folder: true
+				},
+				where: { folderId: 1, isDeleted: false },
+				orderBy: { createdAt: 'desc' }
+			});
+			expect(result).toEqual(mockDocuments);
+		});
+
+		it('returns an empty array if no documents are found in the folder', async () => {
+			databaseConnector.document.findMany.mockResolvedValue([]);
+
+			const result = await getDocumentsInFolder(1);
+
+			expect(databaseConnector.document.findMany).toHaveBeenCalledWith({
+				include: {
+					documentVersion: true,
+					latestDocumentVersion: true,
+					folder: true
+				},
+				where: { folderId: 1, isDeleted: false },
+				orderBy: { createdAt: 'desc' }
+			});
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('deleteDocument', () => {
+		it('deletes a document by its guid', async () => {
+			const mockDocument = { guid: '123', name: 'Test Document' };
+			databaseConnector.document.delete.mockResolvedValue(mockDocument);
+
+			const result = await deleteDocument('123');
+
+			expect(databaseConnector.document.delete).toHaveBeenCalledWith({ where: { guid: '123' } });
+			expect(result).toEqual(mockDocument);
+		});
+
+		it('throws an error when deletion fails', async () => {
+			databaseConnector.document.delete.mockRejectedValue(new Error('Database error'));
+
+			await expect(deleteDocument('123')).rejects.toThrow('Database error');
+		});
+	});
+});

--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -92,6 +92,7 @@ export const getDocumentVersionsByCaseId = async (caseId) => {
 
 /**
  * Get latest document reference (excluding ones from migration (with -M-)
+ * Includes deleted docs, and orders by documentReference descending
  *
  * @param {{ caseId: number, skipValue?: number, pageSize?: number }} _
  * @returns {Promise<string>}
@@ -100,13 +101,12 @@ export const getLatestDocReferenceByCaseIdExcludingMigrated = async ({ caseId })
 	const latestDoc = await databaseConnector.document.findMany({
 		where: {
 			caseId,
-			isDeleted: false,
 			NOT: { documentReference: { contains: '-M-' } } // Migration created doc references are `${document.caseRef}-M-${documentId}`, so we want to exclude that when finding latest one
 		},
 		take: 1,
 		orderBy: [
 			{
-				createdAt: 'desc'
+				documentReference: 'desc'
 			}
 		]
 	});


### PR DESCRIPTION
## Describe your changes

This ticket fixes several issues:
- when an S51 Attachment is added to the case, rather than finding the latest document reference number on a case in order to make the next one, it is counting the latest S51 Advice reference number.  So if a case has 10 docs numbered 00001 … 00010, but 3 S51 Advice, adding an S51 Advice attachment makes a duplicate 00004.

- The issue is further compounded by another fault, this time in the document side.  The fn that gets the latest document on a case uses created date order, rather than document reference.  So in the case above where the S51 attachment is made with 00004, this becomes the latest doc ref, and all documents added after that start from 00005 onwards, duplicating all existing docs.

- There is a 3rd issue in that deleted docs are ignored.  So if there are docs 00001 to 00004, and 00004 is deleted, the current code returns 00004 as the next number to use.  We should be including deleted docs in order to keep the doc ref unique. 

## APPLICS-1082 - Live bug: Document Reference numbers are not unique
https://pins-ds.atlassian.net/browse/APPLICS-1082

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
