### PR TITLE
feat(web): 1628

### DIFF
--- a/apps/web/src/server/views/applications/representations/representations.njk
+++ b/apps/web/src/server/views/applications/representations/representations.njk
@@ -9,7 +9,8 @@
 {% from "applications/components/pagination/results-per-page.component.njk" import uiPageSizeInformation, uiPaginationLinks %}
 {% from "applications/representations/components/pre-search.component.njk" import preSearch %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
-
+{% set pageTitle = "Relevant representations - " + case.title + " - NSIP applications" %}
+{% block title %}{{ pageTitle }}{% endblock %}
 {% block beforeContent %}
     <aside>
 	    {{ govukBreadcrumbs({
@@ -171,5 +172,3 @@
 
 	</form>
 {% endblock %}
-
-


### PR DESCRIPTION
## Description: This PR ensures the "Relevant representations" page displays the correct browser tab title in the format: Relevant representations - [Project name] - NSIP applications
Added a pageTitle variable and {% block title %} to the representations.njk template.
The browser tab now matches the expected title format for consistency across documentation sections.
No functional changes to page content or logic. This improves user experience and navigation clarity.

<!--
    This update ensures the "Relevant representations" page displays the correct browser tab title in the format: Relevant representations - [Project name] - NSIP applications
A pageTitle variable and {% block title %} were added to the representations.njk template. This aligns the page title with other documentation sections for consistency and improves user experience.
Context: Previously, the "Relevant representations" page did not set the browser tab title correctly, which could cause confusion for users navigating between project documentation sections.
Dependencies: No new dependencies are required for this change. No impact on build, runtime, or external packages.
-->

##   APPLICS-1628
  https://pins-ds.atlassian.net/browse/APPLICS-1628

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
