### PR TITLE
fix(api): fix migration cleanup bugs (applics-1635)

### DIFF
--- a/apps/api/src/server/migration/migrators/cleanup/htmlTemplates.js
+++ b/apps/api/src/server/migration/migrators/cleanup/htmlTemplates.js
@@ -80,8 +80,8 @@ export const downloadHtmlBlob = async (blobName) => {
  */
 export const processHtml = (guid, htmlString, res) => {
 	if (!(htmlString.includes('youtube') || htmlString.includes('youtu.be'))) {
-		res.write(`No YouTube video found in document ${guid} with content: ${htmlString}`);
-		throw Error('No YouTube video found in document');
+		res.write(`No YouTube video found in document ${guid}`);
+		return null;
 	}
 
 	// New templates include `div class="video-container"` so we can ignore them


### PR DESCRIPTION
## Describe your changes

- when checking HTML files for YouTube content, if the file does not contain a YouTube link, it reports out the whole html file - which is unnecessary
- when checking HTML files for YouTube content, if the file does not contain a YouTube link, it throws an error - this is not handled at the higher level, and so the cleanup completes at that point, before running the Exam Folder fixes (if selected)
- When fixing values for the Exam timetable folders, it assigns a stage “Examination” for all exam folders, but for the case of Exam Type id:10 (Procedural Deadline (Pre-Examination)), the stage should be set to 'Pre-examination'
- when creating new missing exam timetable folders, the code uses std fn createFolder which sets isCustom to true, this should be set to false - use underlying DB repository fn to achieve this.

## APPLICS-1635 Fix Migration Cleanup - Small Bugs
https://pins-ds.atlassian.net/browse/APPLICS-1635

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
