### PR TITLE
fix(web): can change status form unpublished to ready to publish (applics-1423)

### DIFF
--- a/apps/web/src/server/applications/case/project-updates/__tests__/__snapshots__/project-updates.test.js.snap
+++ b/apps/web/src/server/applications/case/project-updates/__tests__/__snapshots__/project-updates.test.js.snap
@@ -243,7 +243,7 @@ exports[`project-updates GET /applications-service/:caseId/project-updates/:proj
                                 <div class="govuk-radios__item">
                                     <input class="govuk-radios__input" id="status-2" name="status" type="radio"
                                     value="ready-to-publish">
-                                    <label class="govuk-label govuk-radios__label" for="status-2">Ready to Publish</label>
+                                    <label class="govuk-label govuk-radios__label" for="status-2">Ready to publish</label>
                                 </div>
                             </div>
                         </fieldset>

--- a/apps/web/src/server/applications/case/project-updates/__tests__/project-updates.test.js
+++ b/apps/web/src/server/applications/case/project-updates/__tests__/project-updates.test.js
@@ -261,7 +261,7 @@ describe('project-updates', () => {
 			// check - project updates form present
 			expect(element.innerHTML).toContain('Set status');
 			expect(element.innerHTML).toContain('Draft');
-			expect(element.innerHTML).toContain('Publish');
+			expect(element.innerHTML).toContain('publish');
 		});
 	});
 

--- a/apps/web/src/server/applications/case/project-updates/project-updates.view-model.js
+++ b/apps/web/src/server/applications/case/project-updates/project-updates.view-model.js
@@ -352,7 +352,7 @@ export function statusRadioOption(status) {
 			text = 'Draft';
 			break;
 		case ProjectUpdate.Status.readyToPublish:
-			text = 'Ready to Publish';
+			text = 'Ready to publish';
 			break;
 		case ProjectUpdate.Status.published:
 			text = 'Published';

--- a/packages/applications/lib/application/project-update.js
+++ b/packages/applications/lib/application/project-update.js
@@ -38,7 +38,7 @@ export class ProjectUpdate {
 			[status.published]: [status.readyToUnpublish],
 			[status.archived]: [],
 			[status.readyToUnpublish]: [status.unpublished, status.published],
-			[status.unpublished]: [status.archived]
+			[status.unpublished]: [status.archived, status.readyToPublish]
 		});
 	}
 


### PR DESCRIPTION
[Applics-1423: Project updates improvement](https://pins-ds.atlassian.net/browse/APPLICS-1423)

## Describe your changes
Users can change the status of an update from "Unpublished" to "Ready to publish"
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
