### PR TITLE
fix(api): revert migration fix for html video title (applics-1490)

### DIFF
--- a/apps/api/src/server/applications/documents/documents.service.js
+++ b/apps/api/src/server/applications/documents/documents.service.js
@@ -116,6 +116,7 @@ export const extractYouTubeTitleFromHTML = (html) => {
  * @returns {string}
  * */
 export const renderYouTubeTemplate = (youtubeUrl, htmlTitle = 'Video title') => {
+	// APPLICS-1490 NOTE: the html validation expects the title to be 'Video title', so we cant change it to anything else here
 	let newHTML = YouTubeHTMLTemplate;
 	newHTML = newHTML.replace('{{youtubeUrl}}', youtubeUrl);
 	newHTML = newHTML.replace('{{htmlTitle}}', htmlTitle);

--- a/apps/api/src/server/migration/migrators/cleanup/htmlTemplates.js
+++ b/apps/api/src/server/migration/migrators/cleanup/htmlTemplates.js
@@ -3,7 +3,6 @@ import { getDocumentsInCase } from '../../../applications/application/documents/
 import { Readable } from 'stream';
 import {
 	extractYouTubeURLFromHTML,
-	extractYouTubeTitleFromHTML,
 	renderYouTubeTemplate
 } from '../../../applications/documents/documents.service.js';
 import config from '../../../config/config.js';
@@ -90,11 +89,10 @@ export const processHtml = (guid, htmlString, res) => {
 		return '';
 	}
 
-	// extract the you tube url and the title from the html.  ONly poss in migration as we have an unsanitised version
+	// extract the you tube url.  WE cant replace title as it will fail validation on required fixed string 'Video title'
 	const youtubeUrl = extractYouTubeURLFromHTML(htmlString);
-	const htmlTitle = extractYouTubeTitleFromHTML(htmlString);
 
-	return renderYouTubeTemplate(youtubeUrl, htmlTitle);
+	return renderYouTubeTemplate(youtubeUrl);
 };
 
 /**


### PR DESCRIPTION
## Describe your changes

When migrating cases, it converts HTML YouTube files from old HZN format to new CBOS format.
Previous code had attempted to extract the title and insert into the HTML.
However these are now failing to publish as the publish validation checks against a template that has a fixed string "Video title".
Note that HTMLs uploaded by UI are not affected by this issue.

This ticket reverts things so that the title remains "Video title", and the doc can then publish during migration.

## APPLICS-1490 Revert migration fix for html video title
https://pins-ds.atlassian.net/browse/APPLICS-1490

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
