### PR TITLE
fix(web): rename text to material change (applics-1675)

### DIFF
--- a/apps/web/src/server/applications/case/__tests__/__snapshots__/applications-case.test.js.snap
+++ b/apps/web/src/server/applications/case/__tests__/__snapshots__/applications-case.test.js.snap
@@ -402,7 +402,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
                         <td class="govuk-table__cell"></td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table__header">Is this an application for a material change?</th>
+                        <th scope="row" class="govuk-table__header">Material change</th>
                         <td class="govuk-table__cell">No</td>
                         <td class="govuk-table__cell text-align--right"><a class="govuk-link" href="/applications-service/case/4/edit/material-change"
                             id=""> Change</a>
@@ -442,7 +442,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
                                     <td class="govuk-table__cell"></td>
                                 </tr>
                                 <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Is this an application for a material change?</th>
+                                    <th scope="row" class="govuk-table__header">Material change</th>
                                     <td class="govuk-table__cell">No</td>
                                     <td class="govuk-table__cell text-align--right pins-table__cell--s"><a class="govuk-link" href="/applications-service/case/4/edit/material-change"
                                         id=""> Change</a>
@@ -618,7 +618,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
                         <td class="govuk-table__cell"></td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table__header">Is this an application for a material change?</th>
+                        <th scope="row" class="govuk-table__header">Material change</th>
                         <td class="govuk-table__cell">No</td>
                         <td class="govuk-table__cell text-align--right"><a class="govuk-link" href="/applications-service/case/4/edit/material-change"
                             id=""> Change</a>
@@ -658,7 +658,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
                                     <td class="govuk-table__cell"></td>
                                 </tr>
                                 <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Is this an application for a material change?</th>
+                                    <th scope="row" class="govuk-table__header">Material change</th>
                                     <td class="govuk-table__cell">No</td>
                                     <td class="govuk-table__cell text-align--right pins-table__cell--s"><a class="govuk-link" href="/applications-service/case/4/edit/material-change"
                                         id=""> Change</a>
@@ -834,7 +834,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
                         <td class="govuk-table__cell"></td>
                     </tr>
                     <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table__header">Is this an application for a material change?</th>
+                        <th scope="row" class="govuk-table__header">Material change</th>
                         <td class="govuk-table__cell">No</td>
                         <td class="govuk-table__cell text-align--right"><a class="govuk-link" href="/applications-service/case/4/edit/material-change"
                             id=""> Change</a>
@@ -874,7 +874,7 @@ exports[`Applications case pages Project information page GET /case/123/project-
                                     <td class="govuk-table__cell"></td>
                                 </tr>
                                 <tr class="govuk-table__row">
-                                    <th scope="row" class="govuk-table__header">Is this an application for a material change?</th>
+                                    <th scope="row" class="govuk-table__header">Material change</th>
                                     <td class="govuk-table__cell">No</td>
                                     <td class="govuk-table__cell text-align--right pins-table__cell--s"><a class="govuk-link" href="/applications-service/case/4/edit/material-change"
                                         id=""> Change</a>

--- a/apps/web/src/server/lib/nunjucks-globals/__tests__/build-case-information.test.js
+++ b/apps/web/src/server/lib/nunjucks-globals/__tests__/build-case-information.test.js
@@ -38,7 +38,7 @@ const fullParams = {
 const fullResult = [
 	{ title: 'Reference number', text: 'TEST_REFERENCE' },
 	{
-		title: 'Is this an application for a material change?',
+		title: 'Material change',
 		text: 'Yes',
 		url: 'material-change'
 	},

--- a/apps/web/src/server/lib/nunjucks-globals/build-case-information.js
+++ b/apps/web/src/server/lib/nunjucks-globals/build-case-information.js
@@ -46,7 +46,7 @@ export const buildCaseInformation = (params, isWelsh) => [
 		text: params.case.reference
 	},
 	{
-		title: 'Is this an application for a material change?',
+		title: 'Material change',
 		text: params.case.isMaterialChange
 			? isMaterialChangeStaticDataViewModel[0].text
 			: isMaterialChangeStaticDataViewModel[1].text,

--- a/apps/web/src/server/views/applications/case/components/case-info-table.component.njk
+++ b/apps/web/src/server/views/applications/case/components/case-info-table.component.njk
@@ -25,12 +25,12 @@
  %}
 
   {% set caseInfoTableRows = (caseInfoTableRows.push([
-      { text: "Is this an application for a material change?" },
+      { text: "Material change" },
       { text: "Yes" if case.isMaterialChange else "No" },
       { html: caseEditLink({ editStepUrl: "material-change", caseId: case.id }),
         classes: 'text-align--right'
       }
-    ]), caseInfoTableRows) 
+    ]), caseInfoTableRows)
   %}
 
   {% set caseInfoTableRows = (caseInfoTableRows.push(


### PR DESCRIPTION
## Describe your changes-  Updated all user-facing labels from "Is this an application for a material change?" to "Material change" across the Overview and related pages.
Ensured the value for this field is consistently displayed as "Yes" or "No" (not boolean true/false) using the original static data view model logic.
Updated all relevant Nunjucks templates, backend logic, and test files to use the new label and value mapping.
Regenerated and updated test snapshots to reflect the new label.


## Issue ticket number and link - Applics-1675  -  https://pins-ds.atlassian.net/browse/APPLICS-1675 

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [x] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
