### PR TITLE
fix(web): set default description to relevant representation attachment(applics-1664)

### DIFF
--- a/apps/api/src/server/applications/application/representations/attachment/attachment.service.js
+++ b/apps/api/src/server/applications/application/representations/attachment/attachment.service.js
@@ -25,7 +25,8 @@ export const addAttachmentRepresentation = async (repId, documentId) => {
 			firstName: representation.represented.firstName,
 			lastName: representation.represented.lastName
 		}),
-		filter1: folderDocumentCaseStageMappings.RELEVANT_REPRESENTATIONS
+		filter1: folderDocumentCaseStageMappings.RELEVANT_REPRESENTATIONS,
+		description: folderDocumentCaseStageMappings.RELEVANT_REPRESENTATIONS
 	});
 
 	return result;


### PR DESCRIPTION
## Describe your changes- Added backend logic to set the Description field to "Relevant representation attachment" by default when uploading a relevant representation attachment, matching the existing Webfilter behavior. Users can still edit the Description value after upload.


    Please include a summary of the change along with any relevant context.-

 This update ensures that when a user uploads a file as a relevant representation attachment, the backend automatically sets both the Webfilter and Description fields to "Relevant representation attachment" by default. This matches the existing behavior for Webfilter and now applies the same logic to Description. Users retain the ability to edit/change the Description value after upload using the current UI.
Relevant context:
The change was made in addAttachmentRepresentation within attachment.service.js.
The value is set using folderDocumentCaseStageMappings.RELEVANT_REPRESENTATIONS, which is already used for Webfilter.



## Issue ticket number and link- ( APPLICS- 1664)    /    https://pins-ds.atlassian.net/browse/APPLICS-1664 

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [X] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes
