### PR TITLE
fix(web): add missing govuk-link classes to links and notification ba…

### DIFF
--- a/apps/web/src/server/views/applications/case-documentation/properties/tab-history.component.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/tab-history.component.njk
@@ -11,7 +11,10 @@
 		{% set isPreviewActive = isNotDisabled and (documentVersion.mime === 'application/pdf' or documentVersion.mime === 'image/jpeg' or documentVersion.mime === 'image/png') %}
 
 		{% if isPreviewActive %}
-			<a class="font-weight--700" href="{{ 'document-download'|url({caseId: caseId, documentGuid: documentVersion.documentGuid, version: documentVersion.version, isPreviewActive: isPreviewActive}) }}" class="govuk-link">{{ documentVersion.originalFilename }}</a>
+			<a href="{{ 'document-download'|url({caseId: caseId, documentGuid: documentVersion.documentGuid, version: documentVersion.version, isPreviewActive: isPreviewActive}) }}"
+   class="govuk-link font-weight--700">
+   {{ documentVersion.originalFilename }}
+</a>
 		{% else %}
 			<p class="font-weight--700">
 				{{ documentVersion.originalFilename }}
@@ -51,14 +54,19 @@
 
 		{% set redacted = 'Redacted' if documentVersion.redactedStatus else 'Unredacted'%}
 
-		{% set download %}
-		{% if isNotDisabled %}
-			<a href='{{ 'document-download'|url({caseId: caseId, documentGuid: documentVersion.documentGuid, version: documentVersion.version}) }}'>
-				Download
-				<span class="govuk-visually-hidden">{{ documentVersion.originalFilename }}</span>
-			</a>
-		{% endif %}
-		{% endset %}
+				 {% set download %}
+				 {% if isNotDisabled %}
+						 <a
+							 href='{{ 'document-download'|url({caseId: caseId, documentGuid: documentVersion.documentGuid, version: documentVersion.version}) }}'
+							 class="govuk-link"
+							 target="_blank"
+							 rel="noopener noreferrer"
+						 >
+								 Download
+								 <span class="govuk-visually-hidden">{{ documentVersion.originalFilename }} (opens in new tab)</span>
+						 </a>
+				 {% endif %}
+				 {% endset %}
 
 		{% set row = [
 			{

--- a/apps/web/src/server/views/applications/representations/representations.njk
+++ b/apps/web/src/server/views/applications/representations/representations.njk
@@ -53,7 +53,7 @@
 			</p>
 
 			<p class="govuk-body">
-				<a class="govuk-notification-banner__link" href="{{ publishQueueURL }}">
+				<a class="govuk-link" href="{{ publishQueueURL }}">
 					Preview and publish the changes
 				</a>
 			</p>


### PR DESCRIPTION
…nners

Added the govuk-link class to anchor tags and notification banner links in relevant templates to ensure consistent GOV.UK styling and accessibility. Updated all affected templates as part of APPLICS-1665.

## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
