### PR TITLE
feat(api): add two new fields to representation table and add migration file (applics-1698)

### DIFF
--- a/apps/api/src/database/migrations/20250905095144_representation_add_new_columns/migration.sql
+++ b/apps/api/src/database/migrations/20250905095144_representation_add_new_columns/migration.sql
@@ -1,0 +1,20 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- AlterTable
+ALTER TABLE [dbo].[Representation] ADD [editNotes] NTEXT,
+[editedRepresentation] NTEXT;
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/database/schema.prisma
+++ b/apps/api/src/database/schema.prisma
@@ -358,6 +358,8 @@ model Representation {
   representationActions  RepresentationAction[]
   representative         ServiceUser?               @relation("Representative", fields: [representativeId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   represented            ServiceUser?               @relation("Represented", fields: [representedId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  editedRepresentation   String?                    @db.NText
+  editNotes              String?                    @db.NText
 
   @@index([reference], name: "reference")
 }


### PR DESCRIPTION
## Describe your changes
This pull request adds the editedRepresentation and editNotes fields to the Representation table and adds the associated migration file. This is to facilitate the development of new functionality that will allow users to edit relevant representations.

## Issue ticket number and link
[APPLICS-1698](https://pins-ds.atlassian.net/browse/APPLICS-1698): Create data fields for 'Edited Representation' and 'Edit Notes'

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[APPLICS-1698]: https://pins-ds.atlassian.net/browse/APPLICS-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ