### PR TITLE
fix(web): add space between custom folder rename and delete links (applics-1744)

### DIFF
--- a/apps/web/src/styles/7-components/_button-group.scss
+++ b/apps/web/src/styles/7-components/_button-group.scss
@@ -1,4 +1,5 @@
 @use "govuk-frontend/dist/govuk/helpers/_spacing" as govuk-spacing-helper;
+@import "govuk-frontend/dist/govuk/_base";
 
 .pins-button-group {
 	margin-top: govuk-spacing(9);


### PR DESCRIPTION
## Describe your changes

The spacing between the 'Rename folder' and 'Delete folder' links on the custom folders page was found to have disappeared. This PR resolves that issue by adding an import statement to the associated Sass file, allowing the existing govuk-spacing function to work correctly. As this Sass files also applies styling to the custom folder 'Delete' button and 'Create general S51 advice' button, the spacing for these buttons should now also be correct (see ticket for screenshots).

## Issue ticket number and link
[APPLICS-1744](https://pins-ds.atlassian.net/browse/APPLICS-1744): Rename folder and Delete folder spacing

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
