### PR TITLE
feat(web): add edit page for examining inspectors (idas-79)

### DIFF
--- a/apps/web/src/server/applications/case/fees-forecasting/__tests__/__snapshots__/applications-fees-forecasting.test.js.snap
+++ b/apps/web/src/server/applications/case/fees-forecasting/__tests__/__snapshots__/applications-fees-forecasting.test.js.snap
@@ -66,7 +66,7 @@ exports[`Fees and Forecasting GET /case/123/fees-forecasting/ should render the 
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Examining inspectors</dt>
                     <dd class="govuk-summary-list__value">2 band 2 inspectors
                         <br>1 band 3 inspectors</dd>
-                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#">Change<span class="govuk-visually-hidden"> examining inspectors</span></a>
+                    <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/4/fees-forecasting/section/examining-inspectors">Change<span class="govuk-visually-hidden"> examining inspectors</span></a>
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> MEM last updated</dt>
@@ -854,6 +854,121 @@ exports[`Fees and Forecasting GET /case/123/fees-forecasting/section/project-mat
 </main>"
 `;
 
+exports[`Fees and Forecasting POST /case/123/fees-forecasting/section/:sectionName should show an API error for date input if updating date was NOT successful 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#msg">An error occurred, please try again later</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <h1 class="govuk-heading-l">Maturity Evaluation Matrix (MEM) last updated</h1>
+    <form method="post" novalidate="novalidate" class="govuk-grid-row">
+        <div class="govuk-form-group govuk-grid-column-full ">
+            <fieldset class="govuk-fieldset">
+                <div class="govuk-grid-column-one-third">
+                    <div class="govuk-grid-row pins-date-form-group">
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-hint" for="memLastUpdated.day">Day</label>
+                            <input class="govuk-input" id="memLastUpdated.day" name="memLastUpdated.day"
+                            type="text" value="01">
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-hint" for="memLastUpdated.month">Month</label>
+                            <input class="govuk-input" id="memLastUpdated.month" name="memLastUpdated.month"
+                            type="text" value="02">
+                        </div>
+                        <div class="govuk-form-group">
+                            <label class="govuk-label govuk-hint" for="memLastUpdated.year">Year</label>
+                            <input class="govuk-input" id="memLastUpdated.year" name="memLastUpdated.year"
+                            type="text" value="2000">
+                        </div>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <div class='govuk-grid-column-one-third'>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Save and return</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Fees and Forecasting POST /case/123/fees-forecasting/section/:sectionName should show an API error for text input if updating hyperlink was NOT successful 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#msg">An error occurred, please try again later</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <h1 class="govuk-heading-l">Link to the issues tracker</h1>
+    <form method="post" novalidate="novalidate" class="govuk-grid-row">
+        <div class='govuk-grid-column-two-thirds'>
+            <div class="govuk-form-group">
+                <input class="govuk-input" id="issuesTracker" name="issuesTracker" type="text"
+                value="test.hyperlink.com/">
+            </div>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Save and return</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Fees and Forecasting POST /case/123/fees-forecasting/section/:sectionName should show an API error for text input if updating inspector number was NOT successful 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#msg">An error occurred, please try again later</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <h1 class="govuk-heading-l">Examining inspectors</h1>
+    <form method="post" novalidate="novalidate" class="govuk-grid-row">
+        <div class='govuk-grid-column-two-thirds'>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="numberBand2Inspectors">Number of band 2 inspectors</label>
+                <input class="govuk-input govuk-input--width-5"
+                id="numberBand2Inspectors" name="numberBand2Inspectors" type="text" value="2">
+            </div>
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="numberBand3Inspectors">Number of band 3 inspectors</label>
+                <input class="govuk-input govuk-input--width-5"
+                id="numberBand3Inspectors" name="numberBand3Inspectors" type="text" value="3">
+            </div>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Save and return</button>
+        </div>
+    </form>
+</main>"
+`;
+
 exports[`Fees and Forecasting POST /case/123/fees-forecasting/section/:sectionName should show an API error if creating a project meeting was NOT successful 1`] = `
 "<main class="govuk-main-wrapper" id="main-content">
     <div class="govuk-grid-row">
@@ -1017,55 +1132,6 @@ exports[`Fees and Forecasting POST /case/123/fees-forecasting/section/:sectionNa
             </fieldset>
         </div>
         <div class='govuk-grid-column-one-third govuk-button-group'>
-            <button type="submit" class="govuk-button" data-module="govuk-button">Save and return</button>
-        </div>
-    </form>
-</main>"
-`;
-
-exports[`Fees and Forecasting POST /case/123/fees-forecasting/section/:sectionName should show an API error if updating was NOT successful 1`] = `
-"<main class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-error-summary" data-module="govuk-error-summary">
-                <div role="alert">
-                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
-                    <div class="govuk-error-summary__body">
-                        <ul class="govuk-list govuk-error-summary__list">
-                            <li><a href="#msg">An error occurred, please try again later</a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <h1 class="govuk-heading-l">Maturity Evaluation Matrix (MEM) last updated</h1>
-    <form method="post" novalidate="novalidate" class="govuk-grid-row">
-        <div class="govuk-form-group govuk-grid-column-full ">
-            <fieldset class="govuk-fieldset">
-                <div class="govuk-grid-column-one-third">
-                    <div class="govuk-grid-row pins-date-form-group">
-                        <div class="govuk-form-group">
-                            <label class="govuk-label govuk-hint" for="memLastUpdated.day">Day</label>
-                            <input class="govuk-input" id="memLastUpdated.day" name="memLastUpdated.day"
-                            type="text" value="01">
-                        </div>
-                        <div class="govuk-form-group">
-                            <label class="govuk-label govuk-hint" for="memLastUpdated.month">Month</label>
-                            <input class="govuk-input" id="memLastUpdated.month" name="memLastUpdated.month"
-                            type="text" value="02">
-                        </div>
-                        <div class="govuk-form-group">
-                            <label class="govuk-label govuk-hint" for="memLastUpdated.year">Year</label>
-                            <input class="govuk-input" id="memLastUpdated.year" name="memLastUpdated.year"
-                            type="text" value="2000">
-                        </div>
-                    </div>
-                </div>
-            </fieldset>
-        </div>
-        <div class='govuk-grid-column-one-third'>
             <button type="submit" class="govuk-button" data-module="govuk-button">Save and return</button>
         </div>
     </form>

--- a/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting-edit.view-model.test.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting-edit.view-model.test.js
@@ -45,12 +45,15 @@ describe('applications fees forecasting edit view model', () => {
 				pageTitle: 'Test section - Test case',
 				pageHeading: 'Test page heading',
 				fieldName: 'testSection',
+				additionalFieldName: '',
 				dateFieldName: '',
 				hintText: 'Test section hint text',
 				componentType: 'date-input',
 				radioFieldPath: '',
 				dateFieldPath: '',
-				radioOptions: []
+				radioOptions: [],
+				labelText: '',
+				additionalLabelText: ''
 			});
 		});
 
@@ -77,11 +80,14 @@ describe('applications fees forecasting edit view model', () => {
 				pageHeading: '',
 				fieldName: '',
 				dateFieldName: '',
+				additionalFieldName: '',
 				hintText: '',
 				componentType: 'date-input',
 				radioFieldPath: '',
 				dateFieldPath: '',
-				radioOptions: []
+				radioOptions: [],
+				labelText: '',
+				additionalLabelText: ''
 			});
 		});
 
@@ -112,11 +118,14 @@ describe('applications fees forecasting edit view model', () => {
 				pageHeading: 'Principal area disagreement summary statement (PADSS)',
 				fieldName: 'principalAreaDisagreementSummaryStmt',
 				dateFieldName: 'principalAreaDisagreementSummaryStmtSubmittedDate',
+				additionalFieldName: '',
 				hintText: '',
 				componentType: 'radio-date-input',
 				radioFieldPath: 'additionalDetails.principalAreaDisagreementSummaryStmt',
 				dateFieldPath: 'keyDates.preApplication.principalAreaDisagreementSummaryStmtSubmittedDate',
-				radioOptions: []
+				radioOptions: [],
+				labelText: '',
+				additionalLabelText: ''
 			});
 		});
 
@@ -154,6 +163,7 @@ describe('applications fees forecasting edit view model', () => {
 				pageHeading: 'What is the new maturity of the project?',
 				fieldName: 'newMaturity',
 				dateFieldName: '',
+				additionalFieldName: '',
 				hintText: '',
 				componentType: 'radio-input',
 				radioFieldPath: 'additionalDetails.newMaturity',
@@ -166,7 +176,47 @@ describe('applications fees forecasting edit view model', () => {
 					{ value: 'e', text: 'E' },
 					{ value: 'f', text: 'F' },
 					{ value: 'g', text: 'G' }
-				]
+				],
+				labelText: '',
+				additionalLabelText: ''
+			});
+		});
+
+		it('should correctly map data for text-input components to the view model when provided', async () => {
+			const { getSectionData } = await import('../applications-fees-forecasting.utils.js');
+
+			getSectionData.mockReturnValue({
+				sectionTitle: 'Test section',
+				pageHeading: 'Test page heading',
+				fieldName: 'testSection',
+				additionalFieldName: 'additionalTestSection',
+				labelText: 'Test label',
+				additionalLabelText: 'Additional test label',
+				componentType: 'text-input'
+			});
+
+			const projectName = 'Test case';
+
+			const { getFeesForecastingEditViewModel } = await import(
+				'../applications-fees-forecasting-edit.view-model.js'
+			);
+
+			const result = getFeesForecastingEditViewModel(projectName, sectionName);
+
+			expect(result).toEqual({
+				selectedPageType: 'fees-forecasting',
+				pageTitle: 'Test section - Test case',
+				pageHeading: 'Test page heading',
+				fieldName: 'testSection',
+				dateFieldName: '',
+				additionalFieldName: 'additionalTestSection',
+				hintText: '',
+				componentType: 'text-input',
+				radioFieldPath: '',
+				dateFieldPath: '',
+				radioOptions: [],
+				labelText: 'Test label',
+				additionalLabelText: 'Additional test label'
 			});
 		});
 	});

--- a/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting-index.view-model.test.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting-index.view-model.test.js
@@ -194,7 +194,7 @@ describe('applications fees forecasting index view-model', () => {
 						actions: {
 							items: [
 								{
-									href: '#',
+									href: '/applications-service/case/4/fees-forecasting/section/examining-inspectors',
 									text: 'Change',
 									visuallyHiddenText: 'examining inspectors'
 								}

--- a/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting.test.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting.test.js
@@ -116,7 +116,7 @@ describe('Fees and Forecasting', () => {
 	});
 
 	describe('POST /case/123/fees-forecasting/section/:sectionName', () => {
-		it('should show a validation error when value is NOT entered in correct format', async () => {
+		it('should show a validation error for date input when date is NOT entered in correct format', async () => {
 			const flags = staticFlags;
 			flags['applics-1845-fees-forecasting'] = true;
 
@@ -132,7 +132,7 @@ describe('Fees and Forecasting', () => {
 			expect(element.innerHTML).toContain('Enter a valid year');
 		});
 
-		it('should show an API error if updating was NOT successful', async () => {
+		it('should show an API error for date input if updating date was NOT successful', async () => {
 			const flags = staticFlags;
 			flags['applics-1845-fees-forecasting'] = true;
 
@@ -154,7 +154,7 @@ describe('Fees and Forecasting', () => {
 			expect(element.innerHTML).toContain('There is a problem');
 		});
 
-		it('should redirect to the index page if updating was successful', async () => {
+		it('should redirect to the index page if updating date was successful', async () => {
 			const flags = staticFlags;
 			flags['applics-1845-fees-forecasting'] = true;
 
@@ -169,6 +169,124 @@ describe('Fees and Forecasting', () => {
 				[fieldName + '.day']: '01',
 				[fieldName + '.month']: '02',
 				[fieldName + '.year']: '2000'
+			});
+
+			expect(response?.headers?.location).toEqual(
+				'/applications-service/case/123/fees-forecasting/'
+			);
+		});
+
+		it('should show a validation error for text input when hyperlink is NOT entered in correct format', async () => {
+			const flags = staticFlags;
+			flags['applics-1845-fees-forecasting'] = true;
+
+			const sectionName = 'issues-tracker-link';
+			const fieldName = 'issuesTracker';
+
+			const response = await request.post(`${baseUrl}/section/${sectionName}`).send({
+				[fieldName]: 'test@hyperlink'
+			});
+
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toContain('Enter a valid hyperlink');
+		});
+
+		it('should show an API error for text input if updating hyperlink was NOT successful', async () => {
+			const flags = staticFlags;
+			flags['applics-1845-fees-forecasting'] = true;
+
+			const sectionName = 'issues-tracker-link';
+			const fieldName = 'issuesTracker';
+
+			nock('http://test/')
+				.patch(`/applications/123/fees-forecasting/${sectionName}`)
+				.reply(500, {});
+
+			const response = await request.post(`${baseUrl}/section/${sectionName}`).send({
+				[fieldName]: 'test.hyperlink.com/'
+			});
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('There is a problem');
+		});
+
+		it('should redirect to the index page if updating hyperlink was successful', async () => {
+			const flags = staticFlags;
+			flags['applics-1845-fees-forecasting'] = true;
+
+			const sectionName = 'issues-tracker-link';
+			const fieldName = 'issuesTracker';
+
+			nock('http://test/')
+				.patch(`/applications/123/fees-forecasting/${sectionName}`)
+				.reply(200, {});
+
+			const response = await request.post(`${baseUrl}/section/${sectionName}`).send({
+				[fieldName]: 'test.hyperlink.com/'
+			});
+
+			expect(response?.headers?.location).toEqual(
+				'/applications-service/case/123/fees-forecasting/'
+			);
+		});
+
+		it('should show a validation error for text input when inspector number is NOT entered in correct format', async () => {
+			const flags = staticFlags;
+			flags['applics-1845-fees-forecasting'] = true;
+
+			const sectionName = 'examining-inspectors';
+			const fieldName = 'numberBand2Inspectors';
+			const additionalFieldName = 'numberBand3Inspectors';
+
+			const response = await request.post(`${baseUrl}/section/${sectionName}`).send({
+				[fieldName]: 'abc',
+				[additionalFieldName]: '5'
+			});
+
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toContain('Enter a number of band 2 inspectors between 0 and 99');
+		});
+
+		it('should show an API error for text input if updating inspector number was NOT successful', async () => {
+			const flags = staticFlags;
+			flags['applics-1845-fees-forecasting'] = true;
+
+			const sectionName = 'examining-inspectors';
+			const fieldName = 'numberBand2Inspectors';
+			const additionalFieldName = 'numberBand3Inspectors';
+
+			nock('http://test/')
+				.patch(`/applications/123/fees-forecasting/${sectionName}`)
+				.reply(500, {});
+
+			const response = await request.post(`${baseUrl}/section/${sectionName}`).send({
+				[fieldName]: '2',
+				[additionalFieldName]: '3'
+			});
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('There is a problem');
+		});
+
+		it('should redirect to the index page if updating inspector number was successful', async () => {
+			const flags = staticFlags;
+			flags['applics-1845-fees-forecasting'] = true;
+
+			const sectionName = 'examining-inspectors';
+			const fieldName = 'numberBand2Inspectors';
+			const additionalFieldName = 'numberBand3Inspectors';
+
+			nock('http://test/')
+				.patch(`/applications/123/fees-forecasting/${sectionName}`)
+				.reply(200, {});
+
+			const response = await request.post(`${baseUrl}/section/${sectionName}`).send({
+				[fieldName]: '2',
+				[additionalFieldName]: '3'
 			});
 
 			expect(response?.headers?.location).toEqual(

--- a/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting-edit.view-model.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting-edit.view-model.js
@@ -16,10 +16,13 @@ export const getFeesForecastingEditViewModel = (projectName, sectionName) => {
 		pageHeading: section?.pageHeading || '',
 		fieldName: section?.fieldName || '',
 		dateFieldName: section?.dateFieldName || '',
+		additionalFieldName: section?.additionalFieldName || '',
 		hintText: section?.hintText || '',
 		componentType: section?.componentType || '',
 		radioFieldPath: section?.radioFieldPath || '',
 		dateFieldPath: section?.dateFieldPath || '',
-		radioOptions: section?.radioOptions || []
+		radioOptions: section?.radioOptions || [],
+		labelText: section?.labelText || '',
+		additionalLabelText: section?.additionalLabelText || ''
 	};
 };

--- a/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting-index.view-model.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting-index.view-model.js
@@ -124,7 +124,7 @@ export const getFeesForecastingIndexViewModel = ({ caseData, invoices, meetings 
 				.join('<br/>'),
 			actions: [
 				{
-					href: editPageURL,
+					href: getEditPageURL(urlSectionNames.examiningInspectors, caseData.id),
 					text: genericHrefText,
 					visuallyHiddenText: 'examining inspectors'
 				}

--- a/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting.controller.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting.controller.js
@@ -193,11 +193,16 @@ export async function getFeesForecastingEditSection(request, response) {
 				`applications/case-fees-forecasting/fees-forecasting-edit-radiodateinput.njk`
 			);
 		}
-		case 'text-input':
+		case 'text-input': {
+			const additionalFieldName = editViewModel?.additionalFieldName || '';
 			values[fieldName] = response.locals.case.additionalDetails?.[fieldName] || '';
+			values[additionalFieldName] =
+				response.locals.case.additionalDetails?.[additionalFieldName] || '';
+
 			return renderTemplate(
 				`applications/case-fees-forecasting/fees-forecasting-edit-textinput.njk`
 			);
+		}
 		case 'radio-input': {
 			const radioFieldPath = editViewModel.radioFieldPath;
 
@@ -328,11 +333,9 @@ export async function updateFeesForecastingEditSection(request, response) {
 
 				if (dateFieldMatch) {
 					mapDateValues(dateFieldMatch[1]);
-				} else {
-					if (body[key] !== '') {
-						values[key] = body[key];
-						feesForecastingData[key] = body[key];
-					}
+				} else if (body[key] !== '') {
+					values[key] = body[key];
+					feesForecastingData[key] = body[key];
 				}
 			});
 
@@ -360,10 +363,18 @@ export async function updateFeesForecastingEditSection(request, response) {
 
 			break;
 		}
+		// preserves alphabetic strings and converts numeric strings to numbers
 		case 'text-input': {
-			const fieldName = editViewModel?.fieldName || '';
-			values[fieldName] = body[fieldName] || '';
-			feesForecastingData[fieldName] = body[fieldName] || '';
+			Object.keys(body).forEach((key) => {
+				values[key] = body[key] || '';
+				const formattedValue = body[key] ? Number(body[key]) : '';
+
+				if (Number.isNaN(formattedValue)) {
+					feesForecastingData[key] = body[key];
+				} else if (formattedValue !== '') {
+					feesForecastingData[key] = formattedValue;
+				}
+			});
 
 			break;
 		}

--- a/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting.validators.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting.validators.js
@@ -54,9 +54,10 @@ export const feesForecastingValidator = (request, response, next) => {
 		'public-sector-equality-duty': validateFeesForecastingRadioDateInput,
 		'fast-track-admission': validateFeesForecastingRadioDateInput,
 		'multiparty-application': validateFeesForecastingRadioDateInput,
-		's61-summary-link': validateFeesForecastingTextInput,
-		'programme-document-link': validateFeesForecastingTextInput,
-		'issues-tracker-link': validateFeesForecastingTextInput
+		's61-summary-link': validateFeesForecastingHyperlink,
+		'programme-document-link': validateFeesForecastingHyperlink,
+		'issues-tracker-link': validateFeesForecastingHyperlink,
+		'examining-inspectors': validateFeesForecastingInspectorNumbers
 	};
 
 	if (Object.keys(validators).includes(sectionName)) {
@@ -241,11 +242,11 @@ export const validateFeesForecastingRadioInput = (request, response, next) => {
 };
 
 /**
- * Checks text-input data is formatted correctly
+ * Checks hyperlinks are formatted correctly
  *
  * @type {RequestHandler}
  */
-export const validateFeesForecastingTextInput = (request, response, next) => {
+export const validateFeesForecastingHyperlink = (request, response, next) => {
 	const { sectionName } = request.params;
 	const section = getSectionData(sectionName, urlSectionNames, sectionData);
 	const fieldName = section?.fieldName || '';
@@ -267,6 +268,30 @@ export const validateFeesForecastingTextInput = (request, response, next) => {
 				allow_fragments: false
 			})
 			.withMessage('Enter a valid hyperlink')
+	];
+
+	return createValidator(validator)(request, response, next);
+};
+
+/**
+ * Checks inspector numbers are formatted correctly
+ *
+ * @type {RequestHandler}
+ */
+export const validateFeesForecastingInspectorNumbers = (request, response, next) => {
+	const validator = [
+		body('numberBand2Inspectors')
+			.trim()
+			.notEmpty()
+			.withMessage('Enter a number of band 2 inspectors between 0 and 99')
+			.isInt({ min: 0, max: 99 })
+			.withMessage('Enter a number of band 2 inspectors between 0 and 99'),
+		body('numberBand3Inspectors')
+			.trim()
+			.notEmpty()
+			.withMessage('Enter a number of band 3 inspectors between 0 and 99')
+			.isInt({ min: 0, max: 99 })
+			.withMessage('Enter a number of band 3 inspectors between 0 and 99')
 	];
 
 	return createValidator(validator)(request, response, next);

--- a/apps/web/src/server/applications/case/fees-forecasting/fees-forecasting.config.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/fees-forecasting.config.js
@@ -63,7 +63,8 @@ export const urlSectionNames = {
 	multipartyApplicationCheckDocument: 'multiparty-application',
 	s61SummaryLink: 's61-summary-link',
 	programmeDocumentLink: 'programme-document-link',
-	issuesTrackerLink: 'issues-tracker-link'
+	issuesTrackerLink: 'issues-tracker-link',
+	examiningInspectors: 'examining-inspectors'
 };
 
 export const sectionData = {
@@ -254,6 +255,15 @@ export const sectionData = {
 		sectionTitle: 'Link to the issues tracker',
 		pageHeading: 'Link to the issues tracker',
 		fieldName: 'issuesTracker',
+		componentType: 'text-input'
+	},
+	examiningInspectors: {
+		sectionTitle: 'Examining inspectors',
+		pageHeading: 'Examining inspectors',
+		fieldName: 'numberBand2Inspectors',
+		additionalFieldName: 'numberBand3Inspectors',
+		labelText: 'Number of band 2 inspectors',
+		additionalLabelText: 'Number of band 3 inspectors',
 		componentType: 'text-input'
 	}
 };

--- a/apps/web/src/server/views/applications/case-fees-forecasting/fees-forecasting-edit-textinput.njk
+++ b/apps/web/src/server/views/applications/case-fees-forecasting/fees-forecasting-edit-textinput.njk
@@ -18,13 +18,29 @@
 {% block pageContent %}
 	<form method="post" novalidate="novalidate" class="govuk-grid-row">
 		<div class='govuk-grid-column-two-thirds'>
+			{% set widthClass = "govuk-input--width-5" if additionalFieldName else false %}
+
 			{{ govukInput({
+				label: labelText and { text: labelText },
 				name: fieldName,
 				errorMessage: errors[fieldName] and {
 					text: errors[fieldName].msg
 				},
-				value: values[fieldName]
+				value: values[fieldName],
+				classes: widthClass
 			}) }}
+
+			{% if additionalFieldName %}
+				{{ govukInput({
+					label: { text: additionalLabelText },
+					name: additionalFieldName,
+					errorMessage: errors[additionalFieldName] and {
+						text: errors[additionalFieldName].msg
+					},
+					value: values[additionalFieldName],
+					classes: "govuk-input--width-5"
+				}) }}
+			{% endif %}
 
 			{{ govukButton({ text: 'Save and return' }) }}
 		</div>


### PR DESCRIPTION
## Describe your changes
This PR adds a fees forecasting edit page for examining inspectors and updates the associated unit tests.

## Issue ticket number and link
[IDAS-79](https://pins-ds.atlassian.net/browse/IDAS-79): CBOS NEW Fees and forecasting - Examining inspectors page

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes


[IDAS-79]: https://pins-ds.atlassian.net/browse/IDAS-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ