### PR TITLE
feat(web): add edit page for additional comments (idas-182)

### DIFF
--- a/apps/web/src/server/applications/case/fees-forecasting/__tests__/__snapshots__/applications-fees-forecasting.test.js.snap
+++ b/apps/web/src/server/applications/case/fees-forecasting/__tests__/__snapshots__/applications-fees-forecasting.test.js.snap
@@ -76,7 +76,7 @@ exports[`Fees and Forecasting GET /case/123/fees-forecasting/ should render the 
                 </div>
                 <div class="govuk-summary-list__row"><dt class="govuk-summary-list__key"> Additional comments (optional)</dt>
                     <dd                     class="govuk-summary-list__value">Some comments</dd>
-                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="#">Change<span class="govuk-visually-hidden"> additional comments</span></a>
+                        <dd class="govuk-summary-list__actions"><a class="govuk-link" href="/applications-service/case/4/fees-forecasting/section/additional-comments">Change<span class="govuk-visually-hidden"> additional comments</span></a>
                         </dd>
                 </div>
             </dl>
@@ -897,6 +897,37 @@ exports[`Fees and Forecasting POST /case/123/fees-forecasting/section/:sectionNa
             </fieldset>
         </div>
         <div class='govuk-grid-column-one-third'>
+            <button type="submit" class="govuk-button" data-module="govuk-button">Save and return</button>
+        </div>
+    </form>
+</main>"
+`;
+
+exports[`Fees and Forecasting POST /case/123/fees-forecasting/section/:sectionName should show an API error for text area if updating comment was NOT successful 1`] = `
+"<main class="govuk-main-wrapper" id="main-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-error-summary" data-module="govuk-error-summary">
+                <div role="alert">
+                    <h2 class="govuk-error-summary__title"> There is a problem</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            <li><a href="#msg">An error occurred, please try again later</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <h1 class="govuk-heading-l">Additional comments (optional)</h1>
+    <form method="post" novalidate="novalidate" class="govuk-grid-row">
+        <div class='govuk-grid-column-two-thirds'>
+            <div class="govuk-form-group">
+                <textarea class="govuk-textarea" id="additionalComments" name="additionalComments"
+                rows="5">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo
+                    ligula eget dolor.</textarea>
+            </div>
             <button type="submit" class="govuk-button" data-module="govuk-button">Save and return</button>
         </div>
     </form>

--- a/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting-index.view-model.test.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting-index.view-model.test.js
@@ -222,7 +222,7 @@ describe('applications fees forecasting index view-model', () => {
 						actions: {
 							items: [
 								{
-									href: '#',
+									href: '/applications-service/case/4/fees-forecasting/section/additional-comments',
 									text: 'Change',
 									visuallyHiddenText: 'additional comments'
 								}

--- a/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting.test.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/__tests__/applications-fees-forecasting.test.js
@@ -294,6 +294,48 @@ describe('Fees and Forecasting', () => {
 			);
 		});
 
+		it('should show an API error for text area if updating comment was NOT successful', async () => {
+			const flags = staticFlags;
+			flags['applics-1845-fees-forecasting'] = true;
+
+			const sectionName = 'additional-comments';
+			const fieldName = 'additionalComments';
+
+			nock('http://test/')
+				.patch(`/applications/123/fees-forecasting/${sectionName}`)
+				.reply(500, {});
+
+			const response = await request.post(`${baseUrl}/section/${sectionName}`).send({
+				[fieldName]:
+					'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.'
+			});
+			const element = parseHtml(response.text);
+
+			expect(element.innerHTML).toMatchSnapshot();
+			expect(element.innerHTML).toContain('There is a problem');
+		});
+
+		it('should redirect to the index page if updating comment was successful', async () => {
+			const flags = staticFlags;
+			flags['applics-1845-fees-forecasting'] = true;
+
+			const sectionName = 'additional-comments';
+			const fieldName = 'additionalComments';
+
+			nock('http://test/')
+				.patch(`/applications/123/fees-forecasting/${sectionName}`)
+				.reply(200, {});
+
+			const response = await request.post(`${baseUrl}/section/${sectionName}`).send({
+				[fieldName]:
+					'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor.'
+			});
+
+			expect(response?.headers?.location).toEqual(
+				'/applications-service/case/123/fees-forecasting/'
+			);
+		});
+
 		it('should create a new fee and redirect when add-new-fee is posted successfully', async () => {
 			const flags = staticFlags;
 			flags['applics-1845-fees-forecasting'] = true;

--- a/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting-index.view-model.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting-index.view-model.js
@@ -148,7 +148,7 @@ export const getFeesForecastingIndexViewModel = ({ caseData, invoices, meetings 
 				: '',
 			actions: [
 				{
-					href: editPageURL,
+					href: getEditPageURL(urlSectionNames.additionalComments, caseData.id),
 					text: genericHrefText,
 					visuallyHiddenText: 'additional comments'
 				}

--- a/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting.controller.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/applications-fees-forecasting.controller.js
@@ -222,6 +222,11 @@ export async function getFeesForecastingEditSection(request, response) {
 				`applications/case-fees-forecasting/fees-forecasting-edit-radioinput.njk`
 			);
 		}
+		case 'text-area':
+			values[fieldName] = response.locals.case.additionalDetails?.[fieldName] || '';
+			return renderTemplate(
+				`applications/case-fees-forecasting/fees-forecasting-edit-textarea.njk`
+			);
 	}
 }
 
@@ -397,6 +402,11 @@ export async function updateFeesForecastingEditSection(request, response) {
 
 			break;
 		}
+		case 'text-area': {
+			const fieldName = editViewModel?.fieldName || '';
+			values[fieldName] = body[fieldName] || '';
+			feesForecastingData[fieldName] = body[fieldName] || '';
+		}
 	}
 
 	if (!validationErrors) {
@@ -404,7 +414,8 @@ export async function updateFeesForecastingEditSection(request, response) {
 			case 'date-input':
 			case 'radio-date-input':
 			case 'text-input':
-			case 'radio-input': {
+			case 'radio-input':
+			case 'text-area': {
 				const { errors } = await updateFeesForecasting(caseId, sectionName, feesForecastingData);
 				apiErrors = errors;
 				break;
@@ -468,6 +479,9 @@ export async function updateFeesForecastingEditSection(request, response) {
 				return renderError(
 					`applications/case-fees-forecasting/fees-forecasting-edit-radioinput.njk`
 				);
+			}
+			case 'text-area': {
+				return renderError(`applications/case-fees-forecasting/fees-forecasting-edit-textarea.njk`);
 			}
 			case 'add-new-fee':
 			case 'manage-fee': {

--- a/apps/web/src/server/applications/case/fees-forecasting/fees-forecasting.config.js
+++ b/apps/web/src/server/applications/case/fees-forecasting/fees-forecasting.config.js
@@ -64,7 +64,8 @@ export const urlSectionNames = {
 	s61SummaryLink: 's61-summary-link',
 	programmeDocumentLink: 'programme-document-link',
 	issuesTrackerLink: 'issues-tracker-link',
-	examiningInspectors: 'examining-inspectors'
+	examiningInspectors: 'examining-inspectors',
+	additionalComments: 'additional-comments'
 };
 
 export const sectionData = {
@@ -265,6 +266,12 @@ export const sectionData = {
 		labelText: 'Number of band 2 inspectors',
 		additionalLabelText: 'Number of band 3 inspectors',
 		componentType: 'text-input'
+	},
+	additionalComments: {
+		sectionTitle: 'Additional comments',
+		pageHeading: 'Additional comments (optional)',
+		fieldName: 'additionalComments',
+		componentType: 'text-area'
 	}
 };
 

--- a/apps/web/src/server/views/applications/case-fees-forecasting/fees-forecasting-edit-textarea.njk
+++ b/apps/web/src/server/views/applications/case-fees-forecasting/fees-forecasting-edit-textarea.njk
@@ -1,0 +1,30 @@
+{% extends "../layouts/applications.layout.njk" %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+	<aside>
+		{{ govukBackLink({
+			text: "Back",
+			href: 'fees-forecasting'|url({caseId: caseId})
+		}) }}
+	</aside>
+{% endblock %}
+
+{% block pageHeading %}
+	<h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+{% endblock %}
+
+{% block pageContent %}
+	<form method="post" novalidate="novalidate" class="govuk-grid-row">
+		<div class='govuk-grid-column-two-thirds'>
+			{{ govukTextarea({
+				name: fieldName,
+				value: values[fieldName]
+			}) }}
+
+			{{ govukButton({ text: 'Save and return' }) }}
+		</div>
+	</form>
+
+{% endblock %}


### PR DESCRIPTION
## Describe your changes
This PR adds a fees and forecasting edit page for additional comments. The requirements state that no validation is required for this text field. The associated unit tests have also been updated. 

## Issue ticket number and link
[IDAS-182](https://pins-ds.atlassian.net/browse/IDAS-182): CBOS NEW Fees and forecasting - Additional comments page

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes


[IDAS-182]: https://pins-ds.atlassian.net/browse/IDAS-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ