### PR TITLE
feat(web): add additional options for rel reps invalid status (idas-358)

### DIFF
--- a/apps/api/src/server/applications/application/representations/status/__tests__/patch-status.test.js
+++ b/apps/api/src/server/applications/application/representations/status/__tests__/patch-status.test.js
@@ -221,7 +221,8 @@ describe('Patch Application Representation Status', () => {
 		expect(response.body).toEqual({
 			errors: {
 				status: 'Invalid value',
-				invalidReason: 'Must be a valid: Duplicate,Merged,Not relevant,Resubmitted,Test',
+				invalidReason:
+					'Must be a valid: Duplicate,Merged,Missing information,Not relevant,Resubmitted,Test submission',
 				referredTo: 'Must be a valid: Case Team,Inspector,Central Admin Team,Interested Party'
 			}
 		});

--- a/apps/api/src/server/applications/application/representations/status/status.validator.js
+++ b/apps/api/src/server/applications/application/representations/status/status.validator.js
@@ -3,7 +3,14 @@ import { body } from 'express-validator';
 import { validationErrorHandler } from '../../../../middleware/error-handler.js';
 import { representationsStatusesList } from '../representation.validators.js';
 
-const invalidReasons = ['Duplicate', 'Merged', 'Not relevant', 'Resubmitted', 'Test'];
+const invalidReasons = [
+	'Duplicate',
+	'Merged',
+	'Missing information',
+	'Not relevant',
+	'Resubmitted',
+	'Test submission'
+];
 const referredTo = ['Case Team', 'Inspector', 'Central Admin Team', 'Interested Party'];
 export const representationPatchStatusValidator = composeMiddleware(
 	body('status')

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
@@ -52,6 +52,11 @@ const getPageContentByStatus = (newStatus) => {
 			checked: false
 		},
 		{
+			value: 'Missing information',
+			text: 'Missing information',
+			checked: false
+		},
+		{
 			value: 'Not relevant',
 			text: 'Not relevant',
 			checked: false
@@ -59,6 +64,11 @@ const getPageContentByStatus = (newStatus) => {
 		{
 			value: 'Resubmitted',
 			text: 'Resubmitted',
+			checked: false
+		},
+		{
+			value: 'Test submission',
+			text: 'Test submission',
 			checked: false
 		}
 	];


### PR DESCRIPTION
## Describe your changes
This PR adds two additional options for reasons why a relevant representation has been marked 'Invalid' and updates the API side validation and associated unit test to reflect these changes.

## Issue ticket number and link
[IDAS-358](https://pins-ds.atlassian.net/browse/IDAS-358): Add additional options as reasons for Invalid status

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [X] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [X] I have included unit tests to cover any testable code changes


[IDAS-358]: https://pins-ds.atlassian.net/browse/IDAS-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ