### PR TITLE
feat(web): add new invalid document status (idas-227)

### DIFF
--- a/apps/web/src/server/lib/nunjucks-filters/status-name.js
+++ b/apps/web/src/server/lib/nunjucks-filters/status-name.js
@@ -27,6 +27,8 @@ export const statusName = (key) => {
 			return 'Unpublishing';
 		case 'unpublished':
 			return 'Unpublished';
+		case 'invalid':
+			return 'Invalid shapefile';
 		default:
 			return '';
 	}

--- a/apps/web/src/server/views/applications/case-documentation/documentation-table.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-table.njk
@@ -65,7 +65,8 @@
 			</tr>
 			{% for item in items.items %}
 				{# Files in a disabled status can be edited but not published #}
-				{% set isNotDisabled = (item.publishedStatus !== 'awaiting_upload') and (item.publishedStatus !== 'awaiting_virus_check') and (item.publishedStatus !== 'failed_virus_check') %}
+				{% set isNotDisabled = not item.publishedStatus in ['awaiting_upload', 'awaiting_virus_check', 'failed_virus_check', 'invalid'] %}
+				{% set downloadNotDisabled = not item.publishedStatus in ['awaiting_upload', 'awaiting_virus_check', 'failed_virus_check'] %}
 
 				<tr class="govuk-table__row {{ "" if isNotDisabled else "govuk-table__row--disabled" }} {{ "govuk-table__row--failed" if item.error else "" }}">
 					<td class="govuk-table__cell">
@@ -86,7 +87,7 @@
 					<td class="govuk-table__cell">
 						{% if item.error %}
 							<span class='govuk-body-s govuk-!-font-weight-bold colour--red'>{{item.error}}</span>{% endif %}
-						{% set isPreviewActive = isNotDisabled and(item.mime === 'application/pdf' or item.mime === 'image/jpeg' or item.mime === 'image/png') %}
+						{% set isPreviewActive = downloadNotDisabled and(item.mime === 'application/pdf' or item.mime === 'image/jpeg' or item.mime === 'image/png') %}
 						{{ createOptionalLink(
 												{
 													classes: 'govuk-body-s govuk-!-font-weight-bold',
@@ -109,12 +110,13 @@
 					<td class="govuk-table__cell">
 						{% set avWaiting = item.publishedStatus === 'awaiting_virus_check' or item.publishedStatus === 'awaiting_upload'%}
 						{% set avFailed = item.publishedStatus === 'failed_virus_check' %}
+						{% set invalidShapefile = item.publishedStatus === 'invalid' %}
 						{% if isNotDisabled %}
 							{{ item.publishedStatus|statusName }}
 						{% else %}
 							{% if avWaiting %}
 								<strong class="govuk-tag govuk-tag--yellow">
-								{% elif avFailed %}
+								{% elif avFailed or invalidShapefile %}
 									<strong class="govuk-tag govuk-tag--red">
 									{% else %}
 										<strong class="govuk-tag">
@@ -133,7 +135,7 @@
 												},
 												true
 											) }}
-								{% if isNotDisabled %}
+								{% if downloadNotDisabled %}
 									{{ createOptionalLink(
 												{
 													classes: 'govuk-body-s',
@@ -142,7 +144,7 @@
 													text:'Download',
 													visuallyHiddenText: item.fileName
 												},
-												isNotDisabled
+												downloadNotDisabled
 											) }}
 								{% endif %}
 							</td>

--- a/apps/web/src/server/views/applications/case-documentation/properties/tab-details.component.njk
+++ b/apps/web/src/server/views/applications/case-documentation/properties/tab-details.component.njk
@@ -40,7 +40,7 @@
 	{% endif %}
 
 	{% set publishedDate = (documentationFile.datePublished|datestamp({format: 'dd/MM/yyyy'})) if documentationFile.publishedStatus === 'published' else null %}
-	{% set statusCanBeChanged = not documentationFile.publishedStatus in ['published', 'awaiting_upload', 'awaiting_virus_check', 'failed_virus_check'] %}
+	{% set statusCanBeChanged = not documentationFile.publishedStatus in ['published', 'awaiting_upload', 'awaiting_virus_check', 'failed_virus_check', 'invalid'] %}
 
 	{% set properties = [
 						{label: 'File name', value: documentationFile.fileName, link: 'name'},


### PR DESCRIPTION
## Describe your changes
This PR:
- Allows the new 'invalid' document status to be displayed in the UI as 'Invalid shapefile'
- Prevents users from changing 'invalid' status once set (to prevent publishing)
- Allows users to download documents with 'invalid' status

## Issue ticket number and link
[IDAS-227](https://pins-ds.atlassian.net/browse/IDAS-227): Add new “Invalid” document status to CBOS

## Type of change 🧩

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [X] I have referenced the ticket number above
- [X] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[IDAS-227]: https://pins-ds.atlassian.net/browse/IDAS-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ