### PR TITLE
fix(api): add new relation to track the latest counter for document reference number

### DIFF
--- a/apps/api/setup-tests.js
+++ b/apps/api/setup-tests.js
@@ -123,6 +123,9 @@ const mockInvoiceCreate = jest.fn().mockResolvedValue({});
 const mockInvoiceUpdate = jest.fn().mockResolvedValue({});
 const mockInvoiceDelete = jest.fn().mockResolvedValue({});
 
+const mockDocumentReferenceCounterUpsert = jest.fn().mockResolvedValue({});
+const mockDocumentReferenceCounterUpdate = jest.fn().mockResolvedValue({});
+
 class MockPrismaClient {
 	get address() {
 		return {
@@ -352,6 +355,13 @@ class MockPrismaClient {
 			create: mockInvoiceCreate,
 			update: mockInvoiceUpdate,
 			delete: mockInvoiceDelete
+		};
+	}
+
+	get documentReferenceNumberCounter() {
+		return {
+			upsert: mockDocumentReferenceCounterUpsert,
+			update: mockDocumentReferenceCounterUpdate
 		};
 	}
 

--- a/apps/api/src/database/migrations/20260428142251_add_document_reference_number_counter/migration.sql
+++ b/apps/api/src/database/migrations/20260428142251_add_document_reference_number_counter/migration.sql
@@ -1,0 +1,23 @@
+BEGIN TRY
+
+BEGIN TRAN;
+
+-- CreateTable
+CREATE TABLE [dbo].[DocumentReferenceNumberCounter] (
+    [caseReference] NVARCHAR(1000) NOT NULL,
+    [count] INT NOT NULL,
+    CONSTRAINT [DocumentReferenceNumberCounter_pkey] PRIMARY KEY CLUSTERED ([caseReference])
+);
+
+COMMIT TRAN;
+
+END TRY
+BEGIN CATCH
+
+IF @@TRANCOUNT > 0
+BEGIN
+    ROLLBACK TRAN;
+END;
+THROW
+
+END CATCH

--- a/apps/api/src/database/schema.prisma
+++ b/apps/api/src/database/schema.prisma
@@ -383,6 +383,11 @@ model DocumentVersion {
   @@index([documentGuid], map: "documentGuid")
 }
 
+model DocumentReferenceNumberCounter {
+  caseReference String @id
+  count         Int
+}
+
 /// Representation model
 model Representation {
   id                     Int                        @id @default(autoincrement())

--- a/apps/api/src/server/applications/application/documents/__tests__/create-document.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/create-document.test.js
@@ -127,6 +127,10 @@ describe('Create documents', () => {
 			databaseConnector.document.findFirst.mockResolvedValueOnce(null);
 			databaseConnector.documentVersion.upsert.mockResolvedValue(upsertedDocVersionResponse);
 			databaseConnector.document.update.mockResolvedValue(updatedDocResponse);
+			databaseConnector.documentReferenceNumberCounter.upsert.mockResolvedValue({
+				caseReference: 'case reference',
+				count: 1
+			});
 
 			// WHEN
 			const response = await request.post('/applications/1/documents').send([
@@ -252,6 +256,10 @@ describe('Create documents', () => {
 			databaseConnector.folder.findUnique.mockResolvedValue({ id: 1, caseId: 1 });
 			databaseConnector.document.create.mockResolvedValue({ id: 1, guid, name: 'test doc' });
 			databaseConnector.document.findFirst.mockResolvedValueOnce(null);
+			databaseConnector.documentReferenceNumberCounter.upsert.mockResolvedValue({
+				caseReference: 'case reference',
+				count: 1
+			});
 
 			const DCOPayload = [
 				{
@@ -298,6 +306,10 @@ describe('Create documents', () => {
 			throw new Error();
 		});
 		databaseConnector.documentVersion.upsert.mockResolvedValue({});
+		databaseConnector.documentReferenceNumberCounter.upsert.mockResolvedValue({
+			caseReference: 'case reference',
+			count: 1
+		});
 
 		// WHEN
 		const response = await request.post('/applications/1/documents').send([

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -15,7 +15,6 @@ import {
 import {
 	getDocumentsInCase,
 	extractDuplicatesAndDeleted,
-	getIndexFromReference,
 	handleUpdateDocuments,
 	makeDocumentReference,
 	markDocumentVersionAsPublished,
@@ -72,29 +71,17 @@ export const createDocumentsOnCase = async ({ params, body }, response) => {
 
 	const filteredToUploadWithMetadata = await attachMetadataToDocuments(theCase, filteredToUpload);
 
-	const { response: dbResponse, failedDocuments } = await documentRepository.executeInTransaction(
-		async (tx) => {
-			const latestDocumentReference =
-				await documentRepository.getLatestDocReferenceByCaseIdExcludingMigrated(
-					{ caseId: /** @type {number} */ (params.id) },
-					tx
-				);
+	for (const doc of filteredToUploadWithMetadata) {
+		const nextReferenceCounter = await documentRepository.getNextDocumentReferenceCounter(
+			theCase.reference
+		);
+		doc.documentReference = makeDocumentReference(theCase.reference, nextReferenceCounter.count);
+	}
 
-			const lastReferenceIndex = latestDocumentReference
-				? getIndexFromReference(latestDocumentReference)
-				: 1;
-			let nextReferenceIndex = lastReferenceIndex ? lastReferenceIndex + 1 : 1;
-
-			for (const doc of filteredToUploadWithMetadata) {
-				//documentReference metadata is part of the transaction as we have to ensure it is unique and sequential
-				doc.documentReference = makeDocumentReference(theCase.reference, nextReferenceIndex);
-
-				nextReferenceIndex++;
-			}
-
-			// create document, documentVersion etc records for the array of docs within the transaction
-			return await createDocuments(filteredToUploadWithMetadata, params.id, false, tx);
-		}
+	// create document, documentVersion etc records for the array of docs within the transaction
+	const { response: dbResponse, failedDocuments } = await createDocuments(
+		filteredToUploadWithMetadata,
+		params.id
 	);
 
 	if (dbResponse === null) {

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -341,7 +341,7 @@ export const createDocuments = async (documentsToUpload, caseId, isS51, tx) => {
 	logger.info(`Documents mapped: ${JSON.stringify(requestToGetDocumentStorageProperties)}`);
 
 	// Step 6: generate the blob storage service properties
-	const documentsWithBlobStorageInfo = await getStorageLocation(
+	const documentsWithBlobStorageInfo = getStorageLocation(
 		requestToGetDocumentStorageProperties,
 		fromDcoPortal
 	);
@@ -477,9 +477,7 @@ export const createDocumentVersion = async (
 
 	// Step 7: generate the blob storage service properties
 	logger.info(`Generate the blob storage properties...`);
-	const documentWithBlobStorageInfo = await getStorageLocation(
-		requestToGetDocumentStorageProperties
-	);
+	const documentWithBlobStorageInfo = getStorageLocation(requestToGetDocumentStorageProperties);
 	logger.info(
 		`Documents with Blob storage service properties: ${JSON.stringify(documentWithBlobStorageInfo)}`
 	);

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -26,14 +26,13 @@ import * as caseRepository from '#repositories/case.repository.js';
 import {
 	makeDocumentReference,
 	createDocuments,
-	deleteDocument,
-	getIndexFromReference
+	deleteDocument
 } from './../application/documents/document.service.js';
 import BackOfficeAppError from '#utils/app-error.js';
 import { mapDateStringToUnixTimestamp } from '#utils/mapping/map-date-string-to-unix-timestamp.js';
 import logger from '#utils/logger.js';
 import isCaseWelsh from '#utils/is-case-welsh.js';
-import { getLatestDocReferenceByCaseIdExcludingMigrated } from '#repositories/document.repository.js';
+import { getNextDocumentReferenceCounter } from '#repositories/document.repository.js';
 
 /**
  * @typedef {import('@pins/applications.api').Schema.Folder} Folder
@@ -169,16 +168,6 @@ export const addDocuments = async ({ params, body }, response) => {
 		throw new BackOfficeAppError(`Case with id: ${caseId} not found.`, 404);
 	}
 
-	// find the latest document reference for this case, and then add 1 for the next free one
-	const latestDocumentReference = await getLatestDocReferenceByCaseIdExcludingMigrated({
-		caseId
-	});
-
-	const lastReferenceIndex = latestDocumentReference
-		? getIndexFromReference(latestDocumentReference)
-		: 1;
-	let nextDocumentReferenceIndex = lastReferenceIndex ? lastReferenceIndex + 1 : 1;
-
 	const { duplicates, deleted, remainder } = await extractDuplicatesAndDeleted(
 		adviceId,
 		/** @type {DocumentToSaveExtended[]} */ (documentsToUpload).map((doc) => doc.documentName)
@@ -189,10 +178,9 @@ export const addDocuments = async ({ params, body }, response) => {
 	);
 
 	for (const doc of filteredToUpload) {
-		doc.documentReference = makeDocumentReference(theCase.reference, nextDocumentReferenceIndex);
+		const nextReferenceCounter = await getNextDocumentReferenceCounter(theCase.reference);
+		doc.documentReference = makeDocumentReference(theCase.reference, nextReferenceCounter.count);
 		doc.folderId = Number(doc.folderId);
-
-		nextDocumentReferenceIndex++;
 	}
 
 	// create document records

--- a/apps/api/src/server/applications/s51advice/s51-advice.service.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.service.js
@@ -9,10 +9,10 @@ import BackOfficeAppError from '#utils/app-error.js';
 import logger from '#utils/logger.js';
 import { publishDocuments, unpublishDocuments } from '../application/documents/document.service.js';
 import {
-	verifyAllS51AdviceHasRequiredPropertiesForPublishing,
-	verifyAllS51DocumentsAreVirusChecked,
 	hasPublishedAdvice,
-	hasPublishedDocument
+	hasPublishedDocument,
+	verifyAllS51AdviceHasRequiredPropertiesForPublishing,
+	verifyAllS51DocumentsAreVirusChecked
 } from './s51-advice.validators.js';
 
 /**
@@ -85,9 +85,7 @@ export const getS51AdviceDocuments = async (caseId, adviceId) => {
 		};
 	});
 
-	const blobResponse = await getStorageLocation(blobStorageRequest);
-
-	return blobResponse;
+	return getStorageLocation(blobStorageRequest);
 };
 
 /**

--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -703,3 +703,28 @@ export const getInFolderByName = (folderId, fileName, includeDeleted) => {
 		}
 	});
 };
+
+/**
+ * Returns the latest unique number for document reference
+ *
+ * @param {string} caseReference
+ * @returns {import('#database-client').PrismaPromise<DocumentReferenceNumber | null>}
+ */
+export async function getNextDocumentReferenceCounter(caseReference) {
+	try {
+		return await databaseConnector.documentReferenceNumberCounter.upsert({
+			where: { caseReference },
+			update: { value: { increment: 1 } },
+			create: { caseReference, value: 1 }
+		});
+	} catch (error) {
+		if (error.code === 'P2002') {
+			// account for the edge case where multiple azure function processes try to initialise the row at the same time
+			return databaseConnector.documentReferenceNumberCounter.update({
+				where: { caseReference },
+				data: { value: { increment: 1 } }
+			});
+		}
+		throw error;
+	}
+}

--- a/apps/api/src/server/utils/document-storage.js
+++ b/apps/api/src/server/utils/document-storage.js
@@ -8,9 +8,9 @@ import config from '../config/config.js';
 /**
  * @param {DocumentBlobStoragePayload[]} documentsToSave
  * @param {boolean} isFromDcoPortal
- * @returns {Promise<import('@pins/applications.api').Api.DocumentAndBlobInfoManyResponse>}
+ * @returns {import('@pins/applications.api').Api.DocumentAndBlobInfoManyResponse}
  */
-export const getStorageLocation = async (documentsToSave, isFromDcoPortal) => {
+export const getStorageLocation = (documentsToSave, isFromDcoPortal) => {
 	return {
 		blobStorageHost: config.blobStorageUrl,
 		privateBlobContainer: config.blobStorageContainer,


### PR DESCRIPTION
## Describe your changes
CBOS creating duplicate document reference numbers

- add new document reference number counter table that can be accessed and updated atomically regardless of how many Azure Function processes are trying to access it.
- is more of a forward fix and will be most effective on new cases - older cases may need to be migrated or documents deleted and reuploaded

## Issue ticket number and link
https://pins-ds.atlassian.net/browse/IRP-80
