### PR TITLE
chore(web): move @planning-inspectorate/address-lookup into the codebase

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "@planning-inspectorate/address-lookup": "*",
     "@toast-ui/editor": "*",
     "accessible-autocomplete": "*",
+    "axios": "*",
     "applicationinsights": "*",
     "body-parser": "*",
     "classnames": "*",

--- a/apps/web/setup-tests.js
+++ b/apps/web/setup-tests.js
@@ -25,3 +25,9 @@ jest.unstable_mockModule('./src/server/lib/ai-redaction-client', () => ({
 		})
 	}
 }));
+
+jest.unstable_mockModule('axios', () => ({
+	default: {
+		get: jest.fn(() => Promise.resolve())
+	}
+}));

--- a/apps/web/src/server/applications/common/services/address-lookup/README.md
+++ b/apps/web/src/server/applications/common/services/address-lookup/README.md
@@ -1,0 +1,130 @@
+Migrated from the legacy service-common repo. Only used by back-office so teh code has been moved here, 05/2026.
+
+It has been left largely as-is and not tidied up inline with best practices and patterns used in the repo; expect for replacing require with ES6 imports.
+
+# address-lookup
+
+A service to retrieve UK addresses by postcode.
+
+The service consumes the OS Apis (https://apidocs.os.uk/), specifically the DPA dataset (https://apidocs.os.uk/docs/os-places-dpa-output).
+
+## Installation
+
+```
+npm i @planning-inspectorate/address-lookup
+```
+
+And add the API key in  .env of your project:
+```
+OS_PLACES_API_KEY = {insert key}
+```
+You can then use the service importing
+```
+import {findAddressListByPostcode} from "@planning-inspectorate/address-lookup";
+    
+const {errors, addressList} = await findAddressListByPostcode('EC2M7PD', {maxResults: 10});
+```
+
+## Params
+The function needs a `postcode` parameter with the postcode and an optional `options` parameter to refine the query.
+
+This is the structure:
+
+```
+{
+ postcode: string, 
+ options: {
+    maxResults: integer, 
+ }
+}
+```
+### postcode
+`postcode` should be a ``string``.
+
+It does not get validated inside the function: in case it's not valid the API will just return an empty list of addresses.
+
+A previous validation of it could be useful to prevent useless requests.
+
+
+- ⚠️ The OS Api does not require specifically postcodes. The string could be a street or a geographical indication as well. However that's not the purpose of this function
+
+### options
+`options` is optional and contains two parameters.
+#### maxResults
+Should be an `integer`.
+
+Set the maximum number of results (could possibly be less if the API can't find enough) returned by the function.
+
+Default is 100.
+
+
+## Return value:
+
+### Success
+If the API key is defined and the postcode is valid, the function will return an object containing a property named ``addressList``
+```
+const {addressList} = await findAddressListByPostcode('EC2M7PD');
+```
+``addressList`` is an array of objects with this structure:
+```
+{
+    apiReference: string, //unique reference
+    addressLine1: string, // street number and street name
+    addressLine2: string, //extra info like flat number or organisation name, most likely empty
+    displayAddress: string, // string to be displayed in the dropdown: extra info, number and street, town, postcode
+    postcode: string,
+    town: string
+}
+```
+- ⚠️ ``findAddressListByPostcode`` is an async function. Will return a Promise if used without the await
+- ⚠️ ``addressList`` can be empty if the API can't find any match with the given postcode. Always check for `errors`
+
+### Fail
+If the function does not return an addressList then an error has occurred. In that case it will return:
+```
+const {errors} = await findAddressListByPostcode('EC2M7PD');
+```
+
+``errors`` is an object and it's meant to be integrated with the GOVUK design system mechanism to show error messages (hence its structure with the `msg` property).  
+This is its structure:
+```
+{
+    apiKey?: {msg: string}
+    postcode?: {msg: string}
+}
+```
+
+ #### apiKey
+The `apiKey` property will be defined when the function cannot find an API key.
+
+The content of the message will be:
+
+``An error occurred, please try again later``
+
+Cannot be more specific because this is meant to be shown to users. However an error log will explaing what's happening.
+
+When the api key error message is returned, ``addressList`` is also returned as an empty array
+#### postcode
+
+The `postcode` property will be defined when the API cannot find any address or for any not-200 response of the OS API.
+
+
+The content of the message will be:
+
+``Enter a valid postcode``
+
+ When the postcode error message is returned, ``addressList`` is also returned as an empty array
+
+
+## Dev
+
+To execute Jest tests for the function and its utilities, run 
+
+`` npm run test``
+
+To verify the actual response of the function run
+
+`` npm run dev INSERT_API_KEY_HERE``
+
+It will return some address for a specific postcode hardcoded in `src/dev.js`.
+It can be changed without affecting anything else.

--- a/apps/web/src/server/applications/common/services/address-lookup/index.d.ts
+++ b/apps/web/src/server/applications/common/services/address-lookup/index.d.ts
@@ -1,0 +1,40 @@
+export interface OSApiAddress {
+	DPA: {
+		UPRN: string;
+		UDPRN: string;
+		DEPARTMENT_NAME: string;
+		SUB_BUILDING_NAME: string;
+		BUILDING_NAME: string;
+		ADDRESS: string;
+		POSTCODE: string;
+		ORGANISATION_NAME: string;
+		POST_TOWN: string;
+		THOROUGHFARE_NAME: string;
+		BUILDING_NUMBER: string;
+	};
+}
+
+export interface address {
+	apiReference: string;
+	addressLine1: string;
+	addressLine2: string;
+	displayAddress: string;
+	postcode: string;
+	town: string;
+}
+
+export type ValidationErrors = {
+	apiKey?: { msg: string };
+	postcode?: { msg: string };
+};
+
+export const findAddressListByPostcode: (
+	postcode: string,
+	options?: { maxResults: number }
+) => Promise<{ addressList: address[]; errors?: ValidationErrors }>;
+
+declare const addressLookup: {
+	findAddressListByPostcode;
+};
+
+export default addressLookup;

--- a/apps/web/src/server/applications/common/services/address-lookup/index.js
+++ b/apps/web/src/server/applications/common/services/address-lookup/index.js
@@ -1,0 +1,1 @@
+export * from './services/findAddressListByPostcode.js';

--- a/apps/web/src/server/applications/common/services/address-lookup/services/findAddressListByPostcode.js
+++ b/apps/web/src/server/applications/common/services/address-lookup/services/findAddressListByPostcode.js
@@ -1,0 +1,74 @@
+// @ts-nocheck
+import axios from 'axios';
+import logger from '../utils/logger.js';
+import capitalizeString from '../utils/capitalizeString.js';
+import formatDisplayAddress from '../utils/formatAddress.js';
+
+/** @typedef {import('../index.d.ts').OSApiAddress} OSApiAddress */
+/** @typedef {import('../index.d.ts').findAddressListByPostcode} findAddressListByPostcode */
+
+/** @type {findAddressListByPostcode} */
+export const findAddressListByPostcode = async (postcode, options = { maxResults: 100 }) => {
+	const apiKey = process.env.OS_PLACES_API_KEY;
+	const { maxResults } = options;
+
+	if (!apiKey) {
+		logger.error('OSApiKey is not defined');
+		return {
+			errors: { apiKey: { msg: 'An error occurred, please try again later' } },
+			addressList: []
+		};
+	}
+	/** @type {OSApiAddress[]} */
+	const rawAddresses = await axios
+		.get(
+			`https://api.os.uk/search/places/v1/postcode?maxresults=${maxResults}&postcode=${postcode}&key=${apiKey}`
+		)
+		.then((response) => response?.data?.results || [])
+		.catch(() => []);
+
+	if (!Array.isArray(rawAddresses) || rawAddresses.length === 0) {
+		return {
+			errors: { postcode: { msg: 'Enter a valid postcode' } },
+			addressList: []
+		};
+	}
+
+	const addressList = rawAddresses.map((r) => {
+		const {
+			UPRN = '',
+			UDPRN = '',
+			DEPARTMENT_NAME = '',
+			SUB_BUILDING_NAME = '',
+			BUILDING_NAME = '',
+			ADDRESS = '',
+			POSTCODE = '',
+			ORGANISATION_NAME = '',
+			POST_TOWN = '',
+			THOROUGHFARE_NAME = '',
+			BUILDING_NUMBER = ''
+		} = r.DPA;
+
+		const apiReference = `${UPRN}_${UDPRN}`;
+		const town = capitalizeString(POST_TOWN);
+		const displayAddress = formatDisplayAddress(ADDRESS);
+		const addressLine1 = `${BUILDING_NUMBER || BUILDING_NAME} ${capitalizeString(
+			THOROUGHFARE_NAME
+		)}`;
+		const addressLine2 = [ORGANISATION_NAME, DEPARTMENT_NAME, SUB_BUILDING_NAME]
+			.filter((p) => p !== '')
+			.map((p) => capitalizeString(p))
+			.join(', ');
+
+		return {
+			apiReference,
+			addressLine1,
+			addressLine2,
+			displayAddress,
+			postcode: POSTCODE,
+			town
+		};
+	});
+
+	return { addressList };
+};

--- a/apps/web/src/server/applications/common/services/address-lookup/services/services.test.js
+++ b/apps/web/src/server/applications/common/services/address-lookup/services/services.test.js
@@ -1,0 +1,123 @@
+// @ts-nocheck
+import { findAddressListByPostcode } from './findAddressListByPostcode.js';
+import axios from 'axios';
+
+const mockResponseAddresses = {
+	data: {
+		results: [
+			{
+				DPA: {
+					UPRN: '100022933878',
+					UDPRN: '8185441',
+					ADDRESS: 'SOME ORGANISATION, 27, LIVERPOOL STREET, LONDON, EC2M 7PD',
+					ORGANISATION_NAME: 'SOME ORGANISATION',
+					BUILDING_NUMBER: '27',
+					THOROUGHFARE_NAME: 'LIVERPOOL STREET',
+					POST_TOWN: 'LONDON',
+					POSTCODE: 'EC2M 7PD'
+				}
+			},
+			{
+				DPA: {
+					UPRN: '1000229338001',
+					UDPRN: '818000',
+					ADDRESS: '11, SOME ROAD, LONDON, EC2M 7PD',
+					BUILDING_NUMBER: '11',
+					THOROUGHFARE_NAME: 'SOME ROAD',
+					POST_TOWN: 'LONDON',
+					POSTCODE: 'EC2M 7PD'
+				}
+			},
+			{
+				DPA: {
+					UPRN: '100022966001',
+					UDPRN: '816660',
+					ADDRESS: '1A, OTHER ROAD, LONDON, EC2M 7PD',
+					BUILDING_NAME: '1A',
+					THOROUGHFARE_NAME: 'OTHER ROAD',
+					POST_TOWN: 'LONDON',
+					POSTCODE: 'EC2M 7PD'
+				}
+			},
+			{
+				DPA: {
+					UPRN: '111111',
+					UDPRN: '222222',
+					ADDRESS: 'FLAT B, 39, TEST STREET, LONDON, EC2M 7PD',
+					SUB_BUILDING_NAME: 'FLAT B',
+					BUILDING_NUMBER: '39',
+					THOROUGHFARE_NAME: 'TEST STREET',
+					POST_TOWN: 'LONDON',
+					POSTCODE: 'EC2M 7PD'
+				}
+			}
+		]
+	}
+};
+
+const formattedAddress = {
+	addressList: [
+		{
+			addressLine1: '27 Liverpool Street ',
+			addressLine2: 'Some Organisation ',
+			apiReference: '100022933878_8185441',
+			displayAddress: 'Some Organisation, 27, Liverpool Street, London, EC2M 7PD',
+			postcode: 'EC2M 7PD',
+			town: 'London '
+		},
+		{
+			addressLine1: '11 Some Road ',
+			addressLine2: '',
+			apiReference: '1000229338001_818000',
+			displayAddress: '11, Some Road, London, EC2M 7PD',
+			postcode: 'EC2M 7PD',
+			town: 'London '
+		},
+		{
+			addressLine1: '1A Other Road ',
+			addressLine2: '',
+			apiReference: '100022966001_816660',
+			displayAddress: '1a, Other Road, London, EC2M 7PD',
+			postcode: 'EC2M 7PD',
+			town: 'London '
+		},
+		{
+			addressLine1: '39 Test Street ',
+			addressLine2: 'Flat B ',
+			apiReference: '111111_222222',
+			displayAddress: 'Flat B, 39, Test Street, London, EC2M 7PD',
+			postcode: 'EC2M 7PD',
+			town: 'London '
+		}
+	]
+};
+
+describe('find address by postcode', () => {
+	it('should return an error if apikey is not provided', async () => {
+		const serviceResponse = await findAddressListByPostcode('EC2M 7PD');
+		const expectedResult = {
+			errors: { apiKey: { msg: 'An error occurred, please try again later' } }
+		};
+
+		expect(serviceResponse).toMatchObject(expectedResult);
+	});
+
+	it('should return an error if postcode is not valid', async () => {
+		process.env.OS_PLACES_API_KEY = 'key';
+		axios.get.mockResolvedValueOnce({});
+		const serviceResponse = await findAddressListByPostcode('');
+		const expectedResult = {
+			errors: { postcode: { msg: 'Enter a valid postcode' } }
+		};
+
+		expect(serviceResponse).toMatchObject(expectedResult);
+	});
+
+	it('should return the address if the postcode exists', async () => {
+		process.env.OS_PLACES_API_KEY = 'key';
+		axios.get.mockResolvedValueOnce(mockResponseAddresses);
+		const serviceResponse = await findAddressListByPostcode('EC2M 7PD');
+
+		expect(serviceResponse).toMatchObject(formattedAddress);
+	});
+});

--- a/apps/web/src/server/applications/common/services/address-lookup/utils/capitalizeString.js
+++ b/apps/web/src/server/applications/common/services/address-lookup/utils/capitalizeString.js
@@ -1,0 +1,13 @@
+export default /**
+ * Capitalize uppercase string
+ *
+ * @param {string} uppercaseString
+ * @returns {string}
+ */
+(uppercaseString) =>
+	uppercaseString
+		.split(' ')
+		.reduce(
+			(previousWords, word) => `${previousWords}${word.charAt(0)}${word.slice(1).toLowerCase()} `,
+			''
+		);

--- a/apps/web/src/server/applications/common/services/address-lookup/utils/formatAddress.js
+++ b/apps/web/src/server/applications/common/services/address-lookup/utils/formatAddress.js
@@ -1,0 +1,19 @@
+import capitalizeString from './capitalizeString.js';
+
+/**
+ * Capitalize all words for the display address
+ *
+ * @param {string} rawAddress
+ * @returns {string}
+ */
+export default (rawAddress) => {
+	// additional info, number, road, town, postcode
+	const addressParts = rawAddress.split(', ');
+
+	let formattedAddress = addressParts.slice(0, -1).reduce((previousParts, currentPart) => {
+		return `${previousParts}${capitalizeString(currentPart).slice(0, -1)}, `;
+	}, '');
+	formattedAddress += addressParts[addressParts.length - 1];
+
+	return formattedAddress;
+};

--- a/apps/web/src/server/applications/common/services/address-lookup/utils/logger.js
+++ b/apps/web/src/server/applications/common/services/address-lookup/utils/logger.js
@@ -1,0 +1,13 @@
+import pinoLib from 'pino';
+// const pretty = require("pino-pretty");
+
+const pino = pinoLib({
+	transport: {
+		target: 'pino-pretty',
+		options: {
+			colorize: true,
+			ignore: 'pid,hostname,time'
+		}
+	}
+});
+export default pino;

--- a/apps/web/src/server/applications/common/services/address-lookup/utils/utils.test.js
+++ b/apps/web/src/server/applications/common/services/address-lookup/utils/utils.test.js
@@ -1,0 +1,21 @@
+// @ts-nocheck
+import capitalizeString from './capitalizeString.js';
+import formatDisplayAddress from './formatAddress.js';
+
+describe('Capitalize util function', () => {
+	it('should capitalize any group of words', () => {
+		const upperCaseString = 'A STRING WRITTEN IN UPPERCASE';
+		const expectedString = 'A String Written In Uppercase';
+		const capitalizedString = capitalizeString(upperCaseString);
+
+		expect(capitalizedString).toMatch(expectedString);
+	});
+
+	it('should format the address string correctly', () => {
+		const rawAddress = 'SOME INFO, 45, SOME STREET ALL UPPERCASE, A TOWN, AB1 2CD';
+		const expectedAddress = 'Some Info, 45, Some Street All Uppercase, A Town, AB1 2CD';
+		const formattedAddress = formatDisplayAddress(rawAddress);
+
+		expect(formattedAddress).toMatch(expectedAddress);
+	});
+});

--- a/apps/web/src/server/applications/common/services/address.service.js
+++ b/apps/web/src/server/applications/common/services/address.service.js
@@ -1,10 +1,10 @@
 import config from '@pins/applications.web/environment/config.js';
-import { findAddressListByPostcode } from '@planning-inspectorate/address-lookup';
+import { findAddressListByPostcode } from './address-lookup/index.js';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 
-/** @typedef {import('@planning-inspectorate/address-lookup').address} address */
-/** @typedef {import('@planning-inspectorate/address-lookup').ValidationErrors} AddressLookupValidationErrors */
+/** @typedef {import('./address-lookup').address} address */
+/** @typedef {import('./address-lookup').ValidationErrors} AddressLookupValidationErrors */
 
 /**
  * Only lookup addresses when not in development *

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
 				"ajv": "^8.18.0",
 				"ajv-formats": "^2.1.1",
 				"applicationinsights": "^2.9.1",
+				"axios": "^1.15.2",
 				"body-parser": "1.20.3",
 				"chai": "^4.3.7",
 				"classnames": "^2.3.1",
@@ -375,6 +376,7 @@
 				"@toast-ui/editor": "*",
 				"accessible-autocomplete": "*",
 				"applicationinsights": "*",
+				"axios": "*",
 				"body-parser": "*",
 				"classnames": "*",
 				"compression": "*",
@@ -8219,14 +8221,23 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.7.7",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-			"integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+			"integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
+				"proxy-from-env": "^2.1.0"
+			}
+		},
+		"node_modules/axios/node_modules/proxy-from-env": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/azure-functions-core-tools": {
@@ -9358,6 +9369,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/call-me-maybe": {
@@ -11814,6 +11838,20 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/duplexify": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
@@ -12067,13 +12105,10 @@
 			}
 		},
 		"node_modules/es-define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"license": "MIT",
-			"dependencies": {
-				"get-intrinsic": "^1.2.4"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -12168,10 +12203,9 @@
 			"peer": true
 		},
 		"node_modules/es-object-atoms": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-			"dev": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -12181,15 +12215,15 @@
 			}
 		},
 		"node_modules/es-set-tostringtag": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
-			"dev": true,
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
 			"license": "MIT",
 			"dependencies": {
-				"get-intrinsic": "^1.2.4",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
 				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.1"
+				"hasown": "^2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13571,13 +13605,15 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
@@ -13772,16 +13808,21 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"license": "MIT",
 			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.0"
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13806,6 +13847,19 @@
 			"integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ==",
 			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/get-stream": {
 			"version": "6.0.1",
@@ -14102,12 +14156,12 @@
 			}
 		},
 		"node_modules/gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"license": "MIT",
-			"dependencies": {
-				"get-intrinsic": "^1.1.3"
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -14212,6 +14266,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
 			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -14221,9 +14276,9 @@
 			}
 		},
 		"node_modules/has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -14236,7 +14291,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -19178,6 +19232,15 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -21793,6 +21856,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
 			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/psl": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"ajv": "^8.18.0",
 		"ajv-formats": "^2.1.1",
 		"applicationinsights": "^2.9.1",
+		"axios": "^1.15.2",
 		"body-parser": "1.20.3",
 		"chai": "^4.3.7",
 		"classnames": "^2.3.1",


### PR DESCRIPTION
@planning-inspectorate/address-lookup is from the legacy service-common repo, and only referenced by this project.

I have copied the address-lookup code as-is, switched it to ES6 imports, and replaced references to it.

Once merged this package will be removed/archived from service-common.