### PR TITLE
feat(web): enable zip uploads for gis shapefiles folder (idas-192)

### DIFF
--- a/apps/web/src/client/components/file-uploader/_client-actions.js
+++ b/apps/web/src/client/components/file-uploader/_client-actions.js
@@ -15,6 +15,8 @@ import { relevantRepresentationsAttachmentUpload } from './_relevant_representat
 const clientActions = (uploadForm) => {
 	/** @type {NodeListOf<HTMLElement> | null} */
 	const uploadDescriptions = uploadForm.querySelectorAll('.pins-file-upload--text');
+	/** @type {HTMLElement| null} */
+	const uploadLabel = uploadForm.querySelector('.pins-file-upload--label');
 	/** @type {HTMLElement | null} */
 	const uploadButton = uploadForm.querySelector('.pins-file-upload--button');
 	/** @type {HTMLElement | null} */
@@ -55,7 +57,7 @@ const clientActions = (uploadForm) => {
 	 *
 	 */
 	const updateButtonText = () => {
-		const isMultipleUploadAllowed = uploadForm.dataset.multiple || false;
+		const isMultipleUploadAllowed = uploadForm.dataset.multiple === 'true';
 		const filesRowsNumber = globalDataTransfer.files.length;
 
 		if (isMultipleUploadAllowed) {
@@ -64,8 +66,8 @@ const clientActions = (uploadForm) => {
 			uploadCounter.textContent =
 				filesRowsNumber > 0 ? `${filesRowsNumber} files` : 'No file chosen';
 		} else {
-			for (const uploadDescription of [...uploadDescriptions]) {
-				uploadDescription.style.display = filesRowsNumber > 0 ? 'none' : 'block';
+			if (uploadLabel instanceof HTMLElement) {
+				uploadLabel.style.display = filesRowsNumber > 0 ? 'none' : 'block';
 			}
 			uploadButton.style.display = filesRowsNumber > 0 ? 'none' : 'block';
 			uploadCounter.style.display = filesRowsNumber > 0 ? 'none' : 'block';
@@ -78,6 +80,10 @@ const clientActions = (uploadForm) => {
 	 */
 	const checkSelectedFile = (selectedFile) => {
 		const allowedMimeTypes = (uploadForm.dataset.allowedTypes || '').split(',');
+
+		const isZip =
+			selectedFile.type === 'appliocation/zip' ||
+			selectedFile.type === 'application/x-zip-compressed';
 
 		if (selectedFile.name.length > 255) {
 			return { message: 'NAME_SINGLE_FILE' };
@@ -99,7 +105,9 @@ const clientActions = (uploadForm) => {
 				return extensionMatch[1];
 			})();
 
-		if (!(type && allowedMimeTypes.includes(type))) {
+		if (
+			!(type && (allowedMimeTypes.includes(type) || (isZip && allowedMimeTypes.includes('.zip'))))
+		) {
 			return { message: 'TYPE_SINGLE_FILE' };
 		}
 

--- a/apps/web/src/server/app/components/__tests__/file-uploader.component.test.js
+++ b/apps/web/src/server/app/components/__tests__/file-uploader.component.test.js
@@ -89,5 +89,46 @@ describe('file-uploader.component', () => {
 				]
 			});
 		});
+		describe('validate zip file signatures', () => {
+			it('should accept valid zip signatures for both zip MIME types', async () => {
+				request = {
+					body: [
+						{
+							fileRowId: 'zip1',
+							fileType: 'application/zip',
+							hexSignature: '504B03041400'
+						},
+						{
+							fileRowId: 'zip2',
+							fileType: 'application/x-zip-compressed',
+							hexSignature: '504B03041400'
+						}
+					]
+				};
+
+				await postValidateFileSignatures(request, response);
+
+				expect(response.send).toHaveBeenCalledWith({
+					invalidSignatures: []
+				});
+			});
+			it('should reject invalid zip signature', async () => {
+				request = {
+					body: [
+						{
+							fileRowId: 'zip3',
+							fileType: 'application/zip',
+							hexSignature: '1234567890'
+						}
+					]
+				};
+
+				await postValidateFileSignatures(request, response);
+
+				expect(response.send).toHaveBeenCalledWith({
+					invalidSignatures: ['zip3']
+				});
+			});
+		});
 	});
 });

--- a/apps/web/src/server/app/components/file-uploader.component.js
+++ b/apps/web/src/server/app/components/file-uploader.component.js
@@ -97,7 +97,9 @@ export async function postValidateFileSignatures({ body }, response) {
 			hexSignature: '4F504C4461746162, 61736546696C65, 036E0C017E010000'
 		},
 		/* .shp  */ 'application/vnd.shp': { hexSignature: '' },
-		/* .shx  */ 'application/vnd.shx': { hexSignature: '' }
+		/* .shx  */ 'application/vnd.shx': { hexSignature: '' },
+		/* .zip  */ 'application/zip': { hexSignature: '504B0304' },
+		/* .zip  */ 'application/x-zip-compressed': { hexSignature: '504B0304' }
 		// Add more file signatures as needed
 	};
 	const invalidSignatures = body

--- a/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
+++ b/apps/web/src/server/applications/case/documentation/__tests__/__snapshots__/applications-documentation.test.js.snap
@@ -23460,30 +23460,53 @@ exports[`applications documentation Document upload new version page should rend
         <form class="govuk-grid-column-two-thirds">
             <div class="pins-file-upload--container">
                 <div class="govuk-body colour--secondary pins-file-upload--instructions">
-                    <label class='pins-file-upload--text' for="upload-file-1">Choose a single file to upload.</label><span class='pins-file-upload--text'> Your file must be DBF, DOC, DOCX, HTML, JPEG, JPG, MOV, MP3, MP4, MPEG, MSG, PDF, PNG, PPT, PPTX, PRJ, SHP, SHX, TIF, TIFF, XLS, XLSM, 	or XLSX.</span>
-                    <span                     class='pins-file-upload--text'>Your uploaded file must be smaller than 1 GB.</span>
-                        <div class="middle-errors-hook"></div>
-                </div>
-                <div class="display--flex">
-                    <input class="display--none" id="upload-file-1" accept=".dbf,application/x-dbf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.html,text/html,.jpeg,image/jpeg,.jpg,image/jpeg,.mov,video/quicktime,.mp3,audio/mpeg,.mp4,video/mp4,.mpeg,video/mpeg,.msg,application/vnd.ms-outlook,.pdf,application/pdf,.png,image/png,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.prj,application/x-anjuta-project,.shp,application/vnd.shp,.shx,application/vnd.shx,.tif,image/tiff,.tiff,image/tiff,.xls,application/vnd.ms-excel,.xlsm,application/vnd.ms-excel.sheet.macroEnabled.12,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,"
-                    type="file" name="files" value="Choose file" aria-controls="file-list-1">
-                    <button type='button' class="pins-file-upload--button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload--counter'> No file chosen</span>
-                </div>
-                <div id="file-list-1">
-                    <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
-                    <ul class="pins-file-upload--files-rows" aria-describedby="file-list-title-1"
-                    aria-live="polite"></ul>
-                </div>
+                    <label class='pins-file-upload--label' for="upload-file-1">Choose a single file to upload.</label><span class='pins-file-upload--text'> Your file must be
+									DBF,
+									DOC,
+									DOCX,
+									HTML,
+									JPEG,
+									JPG,
+									MOV,
+									MP3,
+									MP4,
+									MPEG,
+									MSG,
+									PDF,
+									PNG,
+									PPT,
+									PPTX,
+									PRJ,
+									SHP,
+									SHX,
+									TIF,
+									TIFF,
+									XLS,
+									XLSM,
+									or XLSX
+.</span><span class='pins-file-upload--text'> Your uploaded file must be smaller than 1 GB.</span>
+                    <div                     class="middle-errors-hook"></div>
             </div>
-            <div class="govuk-inset-text">Uploading a new version changes the document status to ‘Not checked’.
-                If there’s a previous version in the publishing queue, it will be removed</div>
-            <div             class="display--flex">
-                <button type="submit" class="govuk-button pins-file-upload--submit" data-module="govuk-button"
-                id="submit-button-1">Upload</button>
-                <div class="progress-hook"></div>
+            <div class="display--flex">
+                <input class="display--none" id="upload-file-1" accept=".dbf,application/x-dbf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.html,text/html,.jpeg,image/jpeg,.jpg,image/jpeg,.mov,video/quicktime,.mp3,audio/mpeg,.mp4,video/mp4,.mpeg,video/mpeg,.msg,application/vnd.ms-outlook,.pdf,application/pdf,.png,image/png,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.prj,application/x-anjuta-project,.shp,application/vnd.shp,.shx,application/vnd.shx,.tif,image/tiff,.tiff,image/tiff,.xls,application/vnd.ms-excel,.xlsm,application/vnd.ms-excel.sheet.macroEnabled.12,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,"
+                type="file" name="files" value="Choose file" aria-controls="file-list-1">
+                <button type='button' class="pins-file-upload--button govuk-button">Choose file</button><span role="status" aria-live="assertive" class='govuk-body pins-file-upload--counter'> No file chosen</span>
+            </div>
+            <div id="file-list-1">
+                <h2 class="display--sr-only" id="file-list-title-1">List of files to upload</h2>
+                <ul class="pins-file-upload--files-rows" aria-describedby="file-list-title-1"
+                aria-live="polite"></ul>
+            </div>
     </div>
-    </form>
-    </div>
+    <div class="govuk-inset-text">Uploading a new version changes the document status to ‘Not checked’.
+        If there’s a previous version in the publishing queue, it will be removed</div>
+    <div     class="display--flex">
+        <button type="submit" class="govuk-button pins-file-upload--submit" data-module="govuk-button"
+        id="submit-button-1">Upload</button>
+        <div class="progress-hook"></div>
+        </div>
+        </form>
+        </div>
 </main>"
 `;
 
@@ -23536,9 +23559,32 @@ exports[`applications documentation GET /case/123/project-documentation/21/sub-f
         <form class="govuk-grid-column-two-thirds">
             <div class="pins-file-upload--container">
                 <div class="govuk-body colour--secondary pins-file-upload--instructions">
-                    <label class='pins-file-upload--text' for="upload-file-1">Choose a single or multiple files to upload.</label><span class='pins-file-upload--text'> Your file must be DBF, DOC, DOCX, HTML, JPEG, JPG, MOV, MP3, MP4, MPEG, MSG, PDF, PNG, PPT, PPTX, PRJ, SHP, SHX, TIF, TIFF, XLS, XLSM, 	or XLSX.</span>
-                    <span                     class='pins-file-upload--text'>The total of your uploaded files must be smaller than 1 GB.</span>
-                        <div                         class="middle-errors-hook"></div>
+                    <label class='pins-file-upload--label' for="upload-file-1">Choose a single or multiple files to upload.</label><span class='pins-file-upload--text'> Your file must be
+									DBF,
+									DOC,
+									DOCX,
+									HTML,
+									JPEG,
+									JPG,
+									MOV,
+									MP3,
+									MP4,
+									MPEG,
+									MSG,
+									PDF,
+									PNG,
+									PPT,
+									PPTX,
+									PRJ,
+									SHP,
+									SHX,
+									TIF,
+									TIFF,
+									XLS,
+									XLSM,
+									or XLSX
+.</span><span class='pins-file-upload--text'> The total of your uploaded files must be smaller than 1 GB.</span>
+                    <div                     class="middle-errors-hook"></div>
             </div>
             <div class="display--flex">
                 <input class="display--none" id="upload-file-1" accept=".dbf,application/x-dbf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.html,text/html,.jpeg,image/jpeg,.jpg,image/jpeg,.mov,video/quicktime,.mp3,audio/mpeg,.mp4,video/mp4,.mpeg,video/mpeg,.msg,application/vnd.ms-outlook,.pdf,application/pdf,.png,image/png,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.prj,application/x-anjuta-project,.shp,application/vnd.shp,.shx,application/vnd.shx,.tif,image/tiff,.tiff,image/tiff,.xls,application/vnd.ms-excel,.xlsm,application/vnd.ms-excel.sheet.macroEnabled.12,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,"

--- a/apps/web/src/server/applications/case/documentation/__tests__/applications-documentation.config.test.js
+++ b/apps/web/src/server/applications/case/documentation/__tests__/applications-documentation.config.test.js
@@ -1,0 +1,74 @@
+import { getUploadConfigForFolder } from '../applications-documentation.config.js';
+
+describe('getUploadConfigForFolder', () => {
+	describe('gis-shapefiles folder', () => {
+		it('should return shapefile-specific config', () => {
+			const result = getUploadConfigForFolder('gis-shapefiles');
+
+			expect(result).toEqual({
+				isGisShapefilesFolder: true,
+				allowedTypes: ['zip'],
+				multiple: false,
+				showUploadLabel: false,
+				fileTypeText:
+					'Your file must be a ZIP file containing exactly one geospatial SHP file, with any supporting files included',
+				sizeText: 'The total size of your uploaded files must be smaller than 1GB',
+				disclaimerText:
+					'Saved shapefiles will be processed into a GeoJSON file with a document status of ‘not checked’'
+			});
+		});
+
+		it('should only allow zip files', () => {
+			const result = getUploadConfigForFolder('gis-shapefiles');
+
+			expect(result.allowedTypes).toEqual(['zip']);
+		});
+
+		it('should disable multiple uploads', () => {
+			const result = getUploadConfigForFolder('gis-shapefiles');
+
+			expect(result.multiple).toBe(false);
+		});
+	});
+
+	describe('default folders', () => {
+		it('should return default config for unknown folder', () => {
+			const result = getUploadConfigForFolder('some-other-folder');
+
+			expect(result.isGisShapefilesFolder).toBe(false);
+			expect(result.multiple).toBe(true);
+			expect(result.allowedTypes).toContain('pdf');
+			expect(result.allowedTypes).toContain('docx');
+		});
+
+		it('should include full default allowed types list', () => {
+			const result = getUploadConfigForFolder('anything');
+
+			expect(result.allowedTypes).toEqual(
+				expect.arrayContaining(['pdf', 'doc', 'docx', 'png', 'jpg', 'xls', 'xlsx'])
+			);
+		});
+
+		it('should not allow zip files in default config', () => {
+			const result = getUploadConfigForFolder('anything');
+
+			expect(result.allowedTypes).not.toContain('zip');
+		});
+
+		it('should include default disclaimer text', () => {
+			const result = getUploadConfigForFolder('anything');
+
+			expect(result.disclaimerText).toBe(
+				'Saving files will default them to ‘Unredacted’ and ‘Not checked’'
+			);
+		});
+
+		it('should not include GIS-specific fields', () => {
+			const result = getUploadConfigForFolder('anything');
+
+			expect(result.fileTypeText).toBeUndefined();
+			expect(result.sizeText).toBeUndefined();
+			expect(result.showUploadLabel).toBeUndefined();
+		});
+	});
+});

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.config.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.config.js
@@ -8,3 +8,55 @@ export const redactionStatusDisplayValues = {
 	ai_suggestions_review_required: 'Redactions suggested',
 	ai_suggestions_reviewed: 'Suggestions reviewed'
 };
+
+/**
+ * @param {string} folderName
+ */
+export const getUploadConfigForFolder = (folderName) => {
+	const defaultAllowedTypes = [
+		'dbf',
+		'doc',
+		'docx',
+		'html',
+		'jpeg',
+		'jpg',
+		'mov',
+		'mp3',
+		'mp4',
+		'mpeg',
+		'msg',
+		'pdf',
+		'png',
+		'ppt',
+		'pptx',
+		'prj',
+		'shp',
+		'shx',
+		'tif',
+		'tiff',
+		'xls',
+		'xlsm',
+		'xlsx'
+	];
+
+	if (folderName === 'gis-shapefiles') {
+		return {
+			isGisShapefilesFolder: true,
+			allowedTypes: ['zip'],
+			multiple: false,
+			showUploadLabel: false,
+			fileTypeText:
+				'Your file must be a ZIP file containing exactly one geospatial SHP file, with any supporting files included',
+			sizeText: 'The total size of your uploaded files must be smaller than 1GB',
+			disclaimerText:
+				'Saved shapefiles will be processed into a GeoJSON file with a document status of ‘not checked’'
+		};
+	}
+
+	return {
+		isGisShapefilesFolder: false,
+		allowedTypes: defaultAllowedTypes,
+		multiple: true,
+		disclaimerText: 'Saving files will default them to ‘Unredacted’ and ‘Not checked’'
+	};
+};

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -52,6 +52,7 @@ import { canRequestAiRedaction } from './utils/can-request-ai-redaction.js';
 import { buildAiRedactionPayload } from './utils/build-ai-redaction-payload.js';
 import { getAiRedactionBannerFromStatus } from './utils/get-ai-redaction-banner-from-status.js';
 import { isGisShapefilesFolder } from './utils/is-gis-shapefiles-folder.js';
+import { getUploadConfigForFolder } from './applications-documentation.config.js';
 
 /**
  * Redirects to the folder view if the folder is the GIS Shapefiles folder.
@@ -134,7 +135,6 @@ export async function viewApplicationsCaseDocumentationFolder(request, response)
 			document.redactedStatus
 		)
 	}));
-
 	const { session } = request;
 
 	documentationSessionHandlers.deleteMoveDocumentsSession(session);
@@ -218,7 +218,16 @@ export async function updateApplicationsCaseDocumentationFolder(request, respons
  * @type {import('@pins/express').RenderHandler<CaseDocumentationUploadProps, {}>}
  */
 export async function viewApplicationsCaseDocumentationUpload(request, response) {
-	response.render(`applications/case-documentation/documentation-upload`);
+	const { folders } = request.params;
+	const { caseId, currentFolder } = response.locals;
+
+	const uploadConfig = getUploadConfigForFolder(folders);
+
+	response.render(`applications/case-documentation/documentation-upload`, {
+		caseId,
+		currentFolder,
+		...uploadConfig
+	});
 }
 
 /**

--- a/apps/web/src/server/applications/case/representations/representation/attachment-upload/__tests__/__snapshots__/attachment-upload.controller.test.js.snap
+++ b/apps/web/src/server/applications/case/representations/representation/attachment-upload/__tests__/__snapshots__/attachment-upload.controller.test.js.snap
@@ -12,9 +12,30 @@ exports[`Representation attachment-upload page GET /applications-service/case/1/
                 <form class="govuk-grid-column-two-thirds">
                     <div class="pins-file-upload--container">
                         <div class="govuk-body colour--secondary pins-file-upload--instructions">
-                            <label class='pins-file-upload--text' for="upload-file-1">Choose a single or multiple files to upload.</label><span class='pins-file-upload--text'> Your file must be PDF, DOC, DOCX, PPT, PPTX, XLS, XLSM, XLSX, JPG, JPEG, MPEG, MP3, MP4, MOV, PNG, TIF, TIFF, PRJ, DBF, SHP, 	or SHX.</span>
-                            <span                             class='pins-file-upload--text'>The total of your uploaded files must be smaller than 1 GB.</span>
-                                <div                                 class="middle-errors-hook"></div>
+                            <label class='pins-file-upload--label' for="upload-file-1">Choose a single or multiple files to upload.</label><span class='pins-file-upload--text'> Your file must be
+									PDF,
+									DOC,
+									DOCX,
+									PPT,
+									PPTX,
+									XLS,
+									XLSM,
+									XLSX,
+									JPG,
+									JPEG,
+									MPEG,
+									MP3,
+									MP4,
+									MOV,
+									PNG,
+									TIF,
+									TIFF,
+									PRJ,
+									DBF,
+									SHP,
+									or SHX
+.</span><span class='pins-file-upload--text'> The total of your uploaded files must be smaller than 1 GB.</span>
+                            <div                             class="middle-errors-hook"></div>
                     </div>
                     <div class="display--flex">
                         <input class="display--none" id="upload-file-1" accept=".pdf,application/pdf,.doc,application/msword,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.ppt,application/vnd.ms-powerpoint,.pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation,.xls,application/vnd.ms-excel,.xlsm,application/vnd.ms-excel.sheet.macroEnabled.12,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.jpg,image/jpeg,.jpeg,image/jpeg,.mpeg,video/mpeg,.mp3,audio/mpeg,.mp4,video/mp4,.mov,video/quicktime,.png,image/png,.tif,image/tiff,.tiff,image/tiff,.prj,application/x-anjuta-project,.dbf,application/x-dbf,.shp,application/vnd.shp,.shx,application/vnd.shx,"

--- a/apps/web/src/server/lib/nunjucks-filters/mime-type.js
+++ b/apps/web/src/server/lib/nunjucks-filters/mime-type.js
@@ -22,7 +22,13 @@ export const MIMEs = {
 	prj: 'application/x-anjuta-project',
 	dbf: 'application/x-dbf',
 	shp: 'application/vnd.shp',
-	shx: 'application/vnd.shx'
+	shx: 'application/vnd.shx',
+	zip: 'application/zip'
+};
+
+/** @type {Record<string, string>} */
+const MIME_ALIASES = {
+	'application/x-zip-compressed': 'application/zip'
 };
 
 /**
@@ -42,8 +48,10 @@ export const MIME = (extension) => {
  * @returns {string}
  */
 export const fileType = (mime) => {
+	const normalisedMime = MIME_ALIASES[mime] || mime;
+
 	const MIMEList = Object.values(MIMEs);
-	const mimeIndex = MIMEList.indexOf(mime);
+	const mimeIndex = MIMEList.indexOf(normalisedMime);
 
 	if (mimeIndex < 0) return '';
 

--- a/apps/web/src/server/views/app/components/file-uploader.component.njk
+++ b/apps/web/src/server/views/app/components/file-uploader.component.njk
@@ -16,21 +16,40 @@
 		<form class="govuk-grid-column-two-thirds">
 			<div class="pins-file-upload--container">
 				<div class="govuk-body colour--secondary pins-file-upload--instructions">
-					{% if params.multiple %}
-						<label class='pins-file-upload--text' for="upload-file-{{ params.formId }}">Choose a single or multiple files to upload.</label>
-					{% else %}
-						<label class='pins-file-upload--text' for="upload-file-{{ params.formId }}">Choose a single file to upload.</label>
+					{% if params.showUploadLabel !== false %}
+						<label class='pins-file-upload--label' for="upload-file-{{ params.formId }}">
+							{% if params.multiple %}
+								Choose a single or multiple files to upload.
+							{% else %}
+								Choose a single file to upload.
+							{% endif %}
+						</label>
 					{% endif %}
 					<span class='pins-file-upload--text'>
-					Your file must be {% for extension in params.allowedTypes %}
-							{% if loop.index !== params.allowedTypes.length %}{{ extension|upper }}, {% else %}	or {{ extension|upper }}{% endif %}
-						{% endfor %}.
+						{% if params.fileTypeText %}
+							{{ params.fileTypeText }}
+						{% else %}
+							Your file must be
+							{% for extension in params.allowedTypes %}
+								{% if loop.index !== params.allowedTypes.length %}
+									{{ extension | upper }},
+								{% else %}
+									or {{ extension | upper }}
+								{% endif %}
+							{% endfor %}.
+						{% endif %}
 					</span>
-					{% if params.multiple %}
-						<span class='pins-file-upload--text'>The total of your uploaded files must be smaller than 1 GB.</span>
-					{% else %}
-						<span class='pins-file-upload--text'>Your uploaded file must be smaller than 1 GB.</span>
-					{% endif %}
+					<span class='pins-file-upload--text'>
+						{% if params.sizeText %}
+							{{ params.sizeText }}
+					    {% else %}
+							{% if params.multiple %}
+								The total of your uploaded files must be smaller than 1 GB.
+							{% else %}
+								Your uploaded file must be smaller than 1 GB.
+							{% endif %}
+						{% endif %}
+					</span>
 					<div class="middle-errors-hook"></div>
 				</div>
 				<div class="display--flex">

--- a/apps/web/src/server/views/applications/case-documentation/documentation-upload.njk
+++ b/apps/web/src/server/views/applications/case-documentation/documentation-upload.njk
@@ -4,7 +4,11 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 
-{% set serviceName = ["Upload files in ", currentFolder.displayNameEn, " folder"] | join  %}
+{% if isGisShapefilesFolder %}
+	{% set serviceName = ["Upload shapefile to ", currentFolder.displayNameEn, " folder"] | join %}
+{% else %}
+	{% set serviceName = ["Upload files in ", currentFolder.displayNameEn, " folder"] | join %}
+{% endif %}
 
 {% block pageHeading %}{% endblock %}
 
@@ -28,9 +32,12 @@
 		folderId: currentFolder.id,
 		formTitle: serviceName,
 		nextPageUrl: 'document-category'|url({caseId:caseId, documentationCategory: currentFolder}),
-		allowedTypes: ['dbf', 'doc', 'docx', 'html', 'jpeg', 'jpg', 'mov', 'mp3', 'mp4', 'mpeg', 'msg', 'pdf', 'png', 'ppt', 'pptx', 'prj', 'shp','shx','tif','tiff', 'xls', 'xlsm', 'xlsx'],
-		disclaimerText: "Saving files will default them to ‘Unredacted’ and ‘Not checked’",
-		multiple: true
+		allowedTypes: allowedTypes,
+		showUploadLabel: showUploadLabel,
+		fileTypeText: fileTypeText,
+		sizeText: sizeText,
+		disclaimerText: disclaimerText,
+		multiple: multiple
 	}) }}
 
 {% endblock %}


### PR DESCRIPTION
## Describe your changes

This PR enables zip file uploads to the new gis shapefiles folder.
It only allows zip files for this folder and only allows 1 file to be uploaded when uploading.
I have added/ updated unit tests.

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[ticket idas-192](https://pins-ds.atlassian.net/jira/software/c/projects/IDAS/boards/1034?selectedIssue=IDAS-192)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
