### PR TITLE
Fix/duplicate document refs idas 428v2

### DIFF
--- a/apps/api/setup-tests.js
+++ b/apps/api/setup-tests.js
@@ -406,6 +406,7 @@ class MockPrismaClient {
 const mockPrismaUse = jest.fn().mockResolvedValue();
 
 MockPrismaClient.prototype.$executeRawUnsafe = mockExecuteRawUnsafe;
+MockPrismaClient.prototype.$queryRaw = jest.fn().mockResolvedValue([]);
 MockPrismaClient.prototype.$use = mockPrismaUse;
 
 class MockPrisma {

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -172,7 +172,6 @@ export const addDocuments = async ({ params, body }, response) => {
 		throw new BackOfficeAppError(`Case with id: ${caseId} not found.`, 404);
 	}
 
-	// find the latest document reference for this case, and then add 1 for the next free one
 	// Wrapped in a transaction with UPDLOCK to prevent duplicate references under concurrency
 	const { duplicates, deleted, remainder } = await extractDuplicatesAndDeleted(
 		adviceId,
@@ -184,6 +183,7 @@ export const addDocuments = async ({ params, body }, response) => {
 	);
 
 	const { response: dbResponse, failedDocuments } = await executeInTransaction(async (tx) => {
+		// find the latest document reference for this case, and then add 1 for the next free one
 		const latestDocumentReference = await getLatestDocReferenceByCaseIdExcludingMigrated(
 			{ caseId },
 			tx

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -33,7 +33,10 @@ import BackOfficeAppError from '#utils/app-error.js';
 import { mapDateStringToUnixTimestamp } from '#utils/mapping/map-date-string-to-unix-timestamp.js';
 import logger from '#utils/logger.js';
 import isCaseWelsh from '#utils/is-case-welsh.js';
-import { getLatestDocReferenceByCaseIdExcludingMigrated } from '#repositories/document.repository.js';
+import {
+	getLatestDocReferenceByCaseIdExcludingMigrated,
+	executeInTransaction
+} from '#repositories/document.repository.js';
 
 /**
  * @typedef {import('@pins/applications.api').Schema.Folder} Folder
@@ -170,15 +173,7 @@ export const addDocuments = async ({ params, body }, response) => {
 	}
 
 	// find the latest document reference for this case, and then add 1 for the next free one
-	const latestDocumentReference = await getLatestDocReferenceByCaseIdExcludingMigrated({
-		caseId
-	});
-
-	const lastReferenceIndex = latestDocumentReference
-		? getIndexFromReference(latestDocumentReference)
-		: 1;
-	let nextDocumentReferenceIndex = lastReferenceIndex ? lastReferenceIndex + 1 : 1;
-
+	// Wrapped in a transaction with UPDLOCK to prevent duplicate references under concurrency
 	const { duplicates, deleted, remainder } = await extractDuplicatesAndDeleted(
 		adviceId,
 		/** @type {DocumentToSaveExtended[]} */ (documentsToUpload).map((doc) => doc.documentName)
@@ -188,19 +183,27 @@ export const addDocuments = async ({ params, body }, response) => {
 		(doc) => remainder.includes(doc.documentName)
 	);
 
-	for (const doc of filteredToUpload) {
-		doc.documentReference = makeDocumentReference(theCase.reference, nextDocumentReferenceIndex);
-		doc.folderId = Number(doc.folderId);
+	const { response: dbResponse, failedDocuments } = await executeInTransaction(async (tx) => {
+		const latestDocumentReference = await getLatestDocReferenceByCaseIdExcludingMigrated(
+			{ caseId },
+			tx
+		);
 
-		nextDocumentReferenceIndex++;
-	}
+		const lastReferenceIndex = latestDocumentReference
+			? getIndexFromReference(latestDocumentReference)
+			: 1;
+		let nextDocumentReferenceIndex = lastReferenceIndex ? lastReferenceIndex + 1 : 1;
 
-	// create document records
-	const { response: dbResponse, failedDocuments } = await createDocuments(
-		filteredToUpload,
-		caseId,
-		true
-	);
+		for (const doc of filteredToUpload) {
+			doc.documentReference = makeDocumentReference(theCase.reference, nextDocumentReferenceIndex);
+			doc.folderId = Number(doc.folderId);
+
+			nextDocumentReferenceIndex++;
+		}
+
+		// create document records within the transaction
+		return await createDocuments(filteredToUpload, caseId, true, tx);
+	});
 
 	if (dbResponse === null) {
 		response.status(409).send({ failedDocuments, duplicates });

--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -94,9 +94,12 @@ export const getDocumentVersionsByCaseId = async (caseId) => {
 
 /**
  * Get latest document reference (excluding ones from migration (with -M-)
- * Includes deleted docs, and orders by documentReference descending
+ * (Migration created doc references are `${document.caseRef}-M-${documentId}`, so we want to exclude that when finding latest one)
+ * Includes deleted docs, and orders by documentReference descending.
+ * Uses UPDLOCK + HOLDLOCK table hints to acquire an exclusive lock on the row,
+ * preventing concurrent transactions from reading the same reference until this transaction commits.
  *
- * @param {{ caseId: number, skipValue?: number, pageSize?: number }} params
+ * @param {{ caseId: number }} params
  * @param {import('@prisma/client').Prisma.TransactionClient} [tx] - Optional transaction client or default to databaseConnector
  * @returns {Promise<string | null>}
  */
@@ -104,24 +107,23 @@ export const getLatestDocReferenceByCaseIdExcludingMigrated = async (
 	{ caseId },
 	tx = databaseConnector
 ) => {
-	const latestDoc = await tx.document.findMany({
-		where: {
-			caseId,
-			NOT: { documentReference: { contains: '-M-' } } // Migration created doc references are `${document.caseRef}-M-${documentId}`, so we want to exclude that when finding latest one
-		},
-		take: 1,
-		orderBy: [
-			{
-				documentReference: 'desc'
-			}
-		]
-	});
-	return latestDoc.length > 0 ? latestDoc[0]?.documentReference : null;
+	/** @type {{ documentReference: string }[]} */
+	const result = await tx.$queryRaw`
+		SELECT TOP 1 documentReference
+		FROM [Document] WITH (UPDLOCK, HOLDLOCK)
+		WHERE caseId = ${caseId}
+		  AND documentReference NOT LIKE '%-M-%'
+		ORDER BY documentReference DESC
+	`;
+
+	return result.length > 0 ? result[0].documentReference : null;
 };
 
 /**
- * Transaction wrapper to execute multiple database operations atomically with isolation
- * The transaction itself is wrapped with a retry logic handling transient Prisma errors
+ * Transaction wrapper to execute multiple database operations atomically with isolation.
+ * Uses Serializable isolation level combined with explicit lock hints in queries
+ * to prevent concurrent transactions from generating duplicate document references.
+ * The transaction itself is wrapped with retry logic handling transient Prisma errors (including deadlocks).
  *
  * @template T
  * @param {(tx: import('@prisma/client').Prisma.TransactionClient) => Promise<T>} cb
@@ -130,7 +132,7 @@ export const getLatestDocReferenceByCaseIdExcludingMigrated = async (
 export const executeInTransaction = async (cb) => {
 	return withRetry(() =>
 		databaseConnector.$transaction(cb, {
-			isolationLevel: 'RepeatableRead',
+			isolationLevel: 'Serializable',
 			maxWait: 60000,
 			timeout: 30000
 		})

--- a/apps/api/src/server/utils/query-with-retry.js
+++ b/apps/api/src/server/utils/query-with-retry.js
@@ -50,7 +50,8 @@ export const withRetry = async (query, options = {}) => {
 				throw error;
 			}
 
-			const delay = Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs);
+			const jitter = Math.random() * baseDelayMs;
+			const delay = Math.min(baseDelayMs * Math.pow(2, attempt - 1) + jitter, maxDelayMs);
 			await sleep(delay);
 		}
 	}


### PR DESCRIPTION
## Describe your changes

This fix ensure the documenet reference is aquired and locked for the duration of the transaction.
However, this surfaced a Prisma bug where individual timeouts for a transaction are not respectred, and timing out after default15s, which is a problem when 20 documents are being sent from FO and are processed in sequence (to avoid duplicate references) in CBOS. To mitigate that, documents have been staggered in FO (https://github.com/Planning-Inspectorate/applications-service/pull/1736)

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
