### PR TITLE
Feat/idas 222 master geo json

### DIFF
--- a/apps/api/src/server/applications/application/documents/__tests__/get-all-gis-boundary-documents.test.js
+++ b/apps/api/src/server/applications/application/documents/__tests__/get-all-gis-boundary-documents.test.js
@@ -1,0 +1,108 @@
+import { jest } from '@jest/globals';
+import { request } from '#app-test';
+const { databaseConnector } = await import('#utils/database-connector.js');
+
+describe('Published GIS boundary documents', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test('returns published GIS boundary GeoJSON document metadata', async () => {
+		// GIVEN
+		const publishedGisBoundaryDocument = {
+			guid: '1234',
+			caseId: 1,
+			documentType: 'GIS shapefile',
+			isDeleted: false,
+			case: {
+				id: 1,
+				reference: 'EN0110001',
+				title: 'EN0110001 - NI Case 3 Name'
+			},
+			documentVersion: [
+				{
+					documentGuid: '1234',
+					version: 2,
+					publishedStatus: 'published',
+					isDeleted: false,
+					mime: 'application/geo+json',
+					publishedBlobContainer: 'published-documents',
+					publishedBlobPath: 'gis-boundaries/EN0110001-boundary.geojson',
+					datePublished: '2026-05-05T10:00:00.000Z'
+				}
+			]
+		};
+
+		databaseConnector.document.findMany.mockResolvedValue([publishedGisBoundaryDocument]);
+
+		// WHEN
+		const response = await request.get('/applications/documents/gis-boundaries/published');
+
+		// THEN
+		expect(response.status).toEqual(200);
+
+		expect(databaseConnector.document.findMany).toHaveBeenCalledWith({
+			where: {
+				isDeleted: false,
+				documentVersion: {
+					some: {
+						publishedStatus: 'published',
+						documentType: 'GIS shapefile',
+						isDeleted: false,
+						publishedBlobContainer: { not: null },
+						publishedBlobPath: { not: null },
+						mime: 'application/geo+json'
+					}
+				}
+			},
+			include: {
+				case: {
+					select: {
+						id: true,
+						reference: true,
+						title: true
+					}
+				},
+				documentVersion: {
+					where: {
+						publishedStatus: 'published',
+						documentType: 'GIS shapefile',
+						isDeleted: false,
+						publishedBlobContainer: { not: null },
+						publishedBlobPath: { not: null },
+						mime: 'application/geo+json'
+					},
+					orderBy: {
+						version: 'desc'
+					},
+					take: 1
+				}
+			}
+		});
+
+		expect(response.body).toEqual([
+			{
+				caseId: 1,
+				caseReference: 'EN0110001',
+				projectName: 'EN0110001 - NI Case 3 Name',
+				documentGuid: '1234',
+				version: 2,
+				publishedBlobContainer: 'published-documents',
+				publishedBlobPath: 'gis-boundaries/EN0110001-boundary.geojson',
+				datePublished: '2026-05-05T10:00:00.000Z'
+			}
+		]);
+	});
+
+	test('returns an empty array when there are no published GIS boundary documents', async () => {
+		// GIVEN
+		databaseConnector.document.findMany.mockResolvedValue([]);
+
+		// WHEN
+		const response = await request.get('/applications/documents/gis-boundaries/published');
+
+		// THEN
+		expect(response.status).toEqual(200);
+		expect(response.body).toEqual([]);
+	});
+});

--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -30,7 +30,8 @@ import {
 	deleteDocument,
 	revertDocumentStatusToPrevious,
 	updateDocumentsFolderId,
-	attachMetadataToDocuments
+	attachMetadataToDocuments,
+	getPublishedGisBoundaryDocuments as getPublishedGisBoundaryDocumentsService
 } from './document.service.js';
 import { validateDocumentVersionMetadataBody } from './document.validators.js';
 
@@ -683,4 +684,13 @@ export const searchDocuments = async ({ params, query }, response) => {
 
 	const paginatedDocuments = await getDocumentsInCase(caseId, criteria, page, pageSize);
 	response.send(paginatedDocuments);
+};
+
+/**
+ * @type {import('express').RequestHandler}
+ */
+export const getPublishedGisBoundaryDocuments = async (_request, response) => {
+	const documents = await getPublishedGisBoundaryDocumentsService();
+
+	response.status(200).send(documents);
 };

--- a/apps/api/src/server/applications/application/documents/document.routes.js
+++ b/apps/api/src/server/applications/application/documents/document.routes.js
@@ -22,7 +22,8 @@ import {
 	unpublishDocuments,
 	searchDocuments,
 	getManyDocumentsProperties,
-	moveDocumentsToAnotherFolder
+	moveDocumentsToAnotherFolder,
+	getPublishedGisBoundaryDocuments
 } from './document.controller.js';
 import {
 	validateDocumentIds,
@@ -34,6 +35,43 @@ import {
 } from './document.validators.js';
 
 const router = createRouter();
+
+router.get(
+	'/documents/gis-boundaries/published',
+	/*
+		#swagger.tags = ['Applications']
+		#swagger.path = '/applications/documents/gis-boundaries/published'
+		#swagger.description = 'Gets all published GIS shapefile GeoJSON document versions used to build the master GeoJSON FeatureCollection'
+		#swagger.parameters['x-service-name'] = {
+			in: 'header',
+			type: 'string',
+			description: 'Service name header',
+			default: 'swagger'
+		}
+		#swagger.parameters['x-api-key'] = {
+			in: 'header',
+			type: 'string',
+			description: 'API key header',
+			default: '123'
+		}
+		#swagger.responses[200] = {
+			description: 'Published GIS boundary GeoJSON documents',
+			schema: [
+				{
+					caseId: 1,
+					caseReference: 'BC0110001',
+					projectName: 'Example Project',
+					documentGuid: '0084b156-006b-48b1-a47f-e7176414db29',
+					version: 2,
+					publishedBlobContainer: 'published-documents',
+					publishedBlobPath: 'BC0110001-example.geojson',
+					datePublished: '2026-05-05T10:00:00.000Z'
+				}
+			]
+		}
+	*/
+	asyncHandler(getPublishedGisBoundaryDocuments)
+);
 
 router.post(
 	'/:id/documents/:guid/metadata',

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -1197,3 +1197,22 @@ export const buildDocumentFolderPath = async (folderId, caseRef, filename) => {
 
 	return folderPath;
 };
+
+export const getPublishedGisBoundaryDocuments = async () => {
+	const documents = await documentRepository.getPublishedGisBoundaryDocuments();
+
+	return documents.map((document) => {
+		const publishedVersion = document.documentVersion[0];
+
+		return {
+			caseId: document.caseId,
+			caseReference: document.case.reference,
+			projectName: document.case.title,
+			documentGuid: document.guid,
+			version: publishedVersion.version,
+			publishedBlobContainer: publishedVersion.publishedBlobContainer,
+			publishedBlobPath: publishedVersion.publishedBlobPath,
+			datePublished: publishedVersion.datePublished
+		};
+	});
+};

--- a/apps/api/src/server/repositories/document.repository.js
+++ b/apps/api/src/server/repositories/document.repository.js
@@ -703,3 +703,49 @@ export const getInFolderByName = (folderId, fileName, includeDeleted) => {
 		}
 	});
 };
+
+/**
+ * Returns all published GIS boundary documents
+ *
+ * @returns {import('#database-client').PrismaPromise<Document[]>}
+ */
+export const getPublishedGisBoundaryDocuments = () => {
+	return databaseConnector.document.findMany({
+		where: {
+			isDeleted: false,
+			documentVersion: {
+				some: {
+					publishedStatus: 'published',
+					documentType: 'GIS shapefile',
+					isDeleted: false,
+					publishedBlobContainer: { not: null },
+					publishedBlobPath: { not: null },
+					mime: 'application/geo+json'
+				}
+			}
+		},
+		include: {
+			case: {
+				select: {
+					id: true,
+					reference: true,
+					title: true
+				}
+			},
+			documentVersion: {
+				where: {
+					publishedStatus: 'published',
+					documentType: 'GIS shapefile',
+					isDeleted: false,
+					publishedBlobContainer: { not: null },
+					publishedBlobPath: { not: null },
+					mime: 'application/geo+json'
+				},
+				orderBy: {
+					version: 'desc'
+				},
+				take: 1
+			}
+		}
+	});
+};

--- a/apps/functions/applications-background-jobs/common/__tests__/master-geojson.test.js
+++ b/apps/functions/applications-background-jobs/common/__tests__/master-geojson.test.js
@@ -1,0 +1,216 @@
+import { Readable } from 'node:stream';
+import { jest } from '@jest/globals';
+
+const mockGetPublishedGisBoundaryDocuments = jest.fn();
+const mockUploadStream = jest.fn();
+const mockDownloadStream = jest.fn();
+
+jest.unstable_mockModule('../../gis-boundary-api-client.js', () => ({
+	getPublishedGisBoundaryDocuments: mockGetPublishedGisBoundaryDocuments
+}));
+
+jest.unstable_mockModule('../../blob-client.js', () => ({
+	blobClient: {
+		uploadStream: mockUploadStream,
+		downloadStream: mockDownloadStream
+	}
+}));
+
+jest.unstable_mockModule('../../config.js', () => ({
+	default: {
+		BLOB_PUBLISH_CONTAINER: 'published-documents'
+	}
+}));
+
+const { assertValidGeoJsonFeatureCollection, rebuildMasterGeoJson } = await import(
+	'../master-geojson.js'
+);
+
+describe('master-geojson', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	test('throws when GeoJSON is not a FeatureCollection', () => {
+		expect(() => assertValidGeoJsonFeatureCollection({ type: 'Feature' })).toThrow(
+			'Invalid GeoJSON FeatureCollection'
+		);
+	});
+
+	test('rebuilds the master GeoJSON from published GIS boundary documents', async () => {
+		// GIVEN
+		mockGetPublishedGisBoundaryDocuments.mockResolvedValue([
+			{
+				caseId: 1,
+				caseReference: 'EN0110001',
+				projectName: 'Project One',
+				documentGuid: 'D1234',
+				version: 2,
+				publishedBlobContainer: 'published-documents',
+				publishedBlobPath: 'gis-boundaries/project-one.geojson'
+			},
+			{
+				caseId: 2,
+				caseReference: 'EN0110002',
+				projectName: 'Project Two',
+				documentGuid: 'D5678',
+				version: 1,
+				publishedBlobContainer: 'published-documents',
+				publishedBlobPath: 'gis-boundaries/project-two.geojson'
+			}
+		]);
+
+		const projectOneGeoJson = {
+			type: 'FeatureCollection',
+			features: [
+				{
+					type: 'Feature',
+					properties: {
+						caseReference: 'EN0110001',
+						projectName: 'Project One'
+					},
+					geometry: {
+						type: 'Polygon',
+						coordinates: []
+					}
+				}
+			]
+		};
+
+		const projectTwoGeoJson = {
+			type: 'FeatureCollection',
+			features: [
+				{
+					type: 'Feature',
+					properties: {
+						caseReference: 'EN0110002',
+						projectName: 'Project Two'
+					},
+					geometry: {
+						type: 'Polygon',
+						coordinates: []
+					}
+				}
+			]
+		};
+
+		mockDownloadStream
+			.mockResolvedValueOnce({
+				readableStreamBody: Readable.from([Buffer.from(JSON.stringify(projectOneGeoJson))])
+			})
+			.mockResolvedValueOnce({
+				readableStreamBody: Readable.from([Buffer.from(JSON.stringify(projectTwoGeoJson))])
+			});
+
+		let uploadedJson = '';
+
+		mockUploadStream.mockImplementation(async (_container, stream) => {
+			for await (const chunk of stream) {
+				uploadedJson += chunk.toString();
+			}
+		});
+
+		const mockLog = {
+			info: jest.fn()
+		};
+
+		// WHEN
+		await rebuildMasterGeoJson(mockLog);
+
+		// THEN
+		expect(mockGetPublishedGisBoundaryDocuments).toHaveBeenCalledTimes(1);
+
+		expect(mockDownloadStream).toHaveBeenCalledTimes(2);
+
+		expect(mockDownloadStream).toHaveBeenNthCalledWith(
+			1,
+			'published-documents',
+			'gis-boundaries/project-one.geojson'
+		);
+
+		expect(mockDownloadStream).toHaveBeenNthCalledWith(
+			2,
+			'published-documents',
+			'gis-boundaries/project-two.geojson'
+		);
+
+		expect(mockUploadStream).toHaveBeenCalledWith(
+			'published-documents',
+			expect.anything(),
+			'gis-boundaries/all-project-boundaries.geojson',
+			'application/geo+json'
+		);
+
+		const parsedMasterGeoJson = JSON.parse(uploadedJson);
+
+		expect(parsedMasterGeoJson).toEqual({
+			type: 'FeatureCollection',
+			features: [
+				expect.objectContaining({
+					properties: expect.objectContaining({
+						caseReference: 'EN0110001',
+						projectName: 'Project One'
+					})
+				}),
+				expect.objectContaining({
+					properties: expect.objectContaining({
+						caseReference: 'EN0110002',
+						projectName: 'Project Two'
+					})
+				})
+			]
+		});
+	});
+
+	test('throws when upload fails', async () => {
+		mockGetPublishedGisBoundaryDocuments.mockResolvedValue([]);
+
+		mockUploadStream.mockRejectedValue(new Error('Upload failed'));
+
+		await expect(
+			rebuildMasterGeoJson({
+				info: jest.fn()
+			})
+		).rejects.toThrow('Upload failed');
+	});
+
+	test('throws when downloaded blob contains invalid JSON', async () => {
+		mockGetPublishedGisBoundaryDocuments.mockResolvedValue([
+			{
+				caseReference: 'EN0110001',
+				publishedBlobContainer: 'published-documents',
+				publishedBlobPath: 'gis-boundaries/project-one.geojson'
+			}
+		]);
+
+		mockDownloadStream.mockResolvedValue({
+			readableStreamBody: Readable.from([Buffer.from('{invalid-json')])
+		});
+
+		await expect(
+			rebuildMasterGeoJson({
+				info: jest.fn()
+			})
+		).rejects.toThrow();
+	});
+
+	test('throws when downloaded project GeoJSON is invalid', async () => {
+		mockGetPublishedGisBoundaryDocuments.mockResolvedValue([
+			{
+				caseReference: 'EN0110001',
+				publishedBlobContainer: 'published-documents',
+				publishedBlobPath: 'gis-boundaries/project-one.geojson'
+			}
+		]);
+
+		mockDownloadStream.mockResolvedValue({
+			readableStreamBody: Readable.from([Buffer.from(JSON.stringify({ type: 'Feature' }))])
+		});
+
+		await expect(
+			rebuildMasterGeoJson({
+				info: jest.fn()
+			})
+		).rejects.toThrow('Invalid GeoJSON FeatureCollection');
+	});
+});

--- a/apps/functions/applications-background-jobs/common/gis-boundary-api-client.js
+++ b/apps/functions/applications-background-jobs/common/gis-boundary-api-client.js
@@ -1,0 +1,19 @@
+import { requestWithApiKey } from './backend-api-request.js';
+import config from './config.js';
+
+/**
+ * @returns {Promise<Array<{
+ * caseId: number,
+ * caseReference: string,
+ * projectName: string,
+ * documentGuid: string,
+ * version: number,
+ * publishedBlobContainer: string,
+ * publishedBlobPath: string
+ * }>>}
+ */
+export const getPublishedGisBoundaryDocuments = async () => {
+	return requestWithApiKey
+		.get(`https://${config.API_HOST}/applications/documents/gis-boundaries/published`)
+		.json();
+};

--- a/apps/functions/applications-background-jobs/common/master-geojson.js
+++ b/apps/functions/applications-background-jobs/common/master-geojson.js
@@ -1,0 +1,107 @@
+import { PassThrough } from 'node:stream';
+import { blobClient } from './blob-client.js';
+import config from './config.js';
+import { getPublishedGisBoundaryDocuments } from './gis-boundary-api-client.js';
+
+/**
+ * @param {NodeJS.WritableStream} stream
+ * @param {string} data
+ * @returns {Promise<void>}
+ */
+export const writeAsync = (stream, data) =>
+	new Promise((resolve, reject) => {
+		stream.write(data, (error) => (error ? reject(error) : resolve()));
+	});
+
+/**
+ * @param {unknown} geoJson
+ */
+export const assertValidGeoJsonFeatureCollection = (geoJson) => {
+	if (!geoJson || geoJson.type !== 'FeatureCollection' || !Array.isArray(geoJson.features)) {
+		throw new Error('Invalid GeoJSON FeatureCollection');
+	}
+};
+
+/**
+ * Downloads a project GeoJSON blob and parses it.
+ * This keeps only one project boundary file in memory at a time.
+ *
+ * @param {string} container
+ * @param {string} blobPath
+ */
+export const downloadProjectGeoJson = async (container, blobPath) => {
+	const response = await blobClient.downloadStream(container, blobPath);
+
+	const chunks = [];
+
+	for await (const chunk of response.readableStreamBody) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+
+	const geoJson = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+
+	assertValidGeoJsonFeatureCollection(geoJson);
+
+	return geoJson;
+};
+
+const MASTER_GEOJSON_BLOB_PATH = 'gis-boundaries/all-project-boundaries.geojson';
+
+/**
+ * Streams all currently published GIS boundaries into one master GeoJSON blob.
+ *
+ * Possible race condition however it would be uncommon for more than one document
+ * of this type to be published a week
+ *
+ * @param {import('@azure/functions').Logger} log
+ * @returns {Promise<void>}
+ */
+export const rebuildMasterGeoJson = async (log) => {
+	log.info('[MASTER_GEOJSON] Rebuilding master GeoJSON');
+
+	const publishedDocuments = await getPublishedGisBoundaryDocuments();
+
+	const stream = new PassThrough();
+
+	const uploadPromise = blobClient.uploadStream(
+		config.BLOB_PUBLISH_CONTAINER,
+		stream,
+		MASTER_GEOJSON_BLOB_PATH,
+		'application/geo+json'
+	);
+
+	await writeAsync(stream, '{"type":"FeatureCollection","features":[');
+
+	let isFirstFeature = true;
+
+	for (const document of publishedDocuments) {
+		log.info(
+			`[MASTER_GEOJSON] Adding boundary for ${document.caseReference} from ${document.publishedBlobContainer}/${document.publishedBlobPath}`
+		);
+
+		const projectGeoJson = await downloadProjectGeoJson(
+			document.publishedBlobContainer,
+			document.publishedBlobPath
+		);
+
+		for (const feature of projectGeoJson.features) {
+			if (!isFirstFeature) {
+				await writeAsync(stream, ',');
+			}
+
+			await writeAsync(stream, JSON.stringify(feature));
+
+			isFirstFeature = false;
+		}
+	}
+
+	await writeAsync(stream, ']}');
+
+	stream.end();
+
+	await uploadPromise;
+
+	log.info(
+		`[MASTER_GEOJSON] Master GeoJSON rebuilt at ${config.BLOB_PUBLISH_CONTAINER}/${MASTER_GEOJSON_BLOB_PATH}`
+	);
+};

--- a/apps/functions/applications-background-jobs/common/util.js
+++ b/apps/functions/applications-background-jobs/common/util.js
@@ -26,3 +26,11 @@ export const ensureTrailingSlash = (str) => {
 	}
 	return str;
 };
+
+/**
+ * @param {{ documentType?: string, mime?: string } | undefined} document
+ * @returns {boolean}
+ */
+export const isGisBoundaryGeoJsonDocument = (document) => {
+	return document?.documentType === 'GIS shapefile' && document?.mime === 'application/geo+json';
+};

--- a/apps/functions/applications-background-jobs/publish-document/index.js
+++ b/apps/functions/applications-background-jobs/publish-document/index.js
@@ -6,6 +6,8 @@ import {
 } from './src/util.js';
 import { isScannedFileHtml, isUploadedHtmlValid } from '../common/html-validation.js';
 import { handleHtmlValidityFail } from './src/handle-html-validity-fail.js';
+import { isGisBoundaryGeoJsonDocument } from '../common/util.js';
+import { rebuildMasterGeoJson } from '../common/master-geojson.js';
 import config from '../common/config.js';
 import { blobClient } from '../common/blob-client.js';
 
@@ -67,10 +69,12 @@ export const index = async (
 
 	context.log(`Making POST request to ${requestUri}`);
 
+	let publishedDocument;
+
 	// Check is to maintain original publishing date when migrating docs from ODW
 	// - remove after migration is done, just keep contents of 'else' statement
 	if (context.bindingData?.applicationProperties?.migrationPublishing) {
-		await requestWithApiKey
+		publishedDocument = await requestWithApiKey
 			.post(requestUri, {
 				json: {
 					publishedBlobContainer: config.BLOB_PUBLISH_CONTAINER,
@@ -79,7 +83,7 @@ export const index = async (
 			})
 			.json();
 	} else {
-		await requestWithApiKey
+		publishedDocument = await requestWithApiKey
 			.post(requestUri, {
 				json: {
 					publishedBlobContainer: config.BLOB_PUBLISH_CONTAINER,
@@ -88,5 +92,18 @@ export const index = async (
 				}
 			})
 			.json();
+	}
+
+	if (isGisBoundaryGeoJsonDocument(publishedDocument)) {
+		context.log(`Rebuilding master GeoJson after publishing GIS boundary ${documentId}`);
+
+		try {
+			await rebuildMasterGeoJson(context.log);
+		} catch (error) {
+			context.log,
+				error(
+					`Failed to rebuild master GeoJson after publishing GIS boundary ${documentId}: ${error}`
+				);
+		}
 	}
 };

--- a/apps/functions/applications-background-jobs/unpublish-document/index.js
+++ b/apps/functions/applications-background-jobs/unpublish-document/index.js
@@ -6,6 +6,8 @@ import { requestWithApiKey } from '../common/backend-api-request.js';
 import { blobClient } from '../common/blob-client.js';
 import config from '../common/config.js';
 import { extractPublishedBlobName } from './src/util.js';
+import { isGisBoundaryGeoJsonDocument } from '../common/util.js';
+import { rebuildMasterGeoJson } from '../common/master-geojson.js';
 
 /**
  * @type {import('@azure/functions').AzureFunction}
@@ -40,5 +42,17 @@ export const index = async (context, { caseId, documentId, version, publishedDoc
 
 	context.log(`Making POST request to ${requestUri} for caseId ${caseId}`);
 
-	await requestWithApiKey.post(requestUri);
+	const unpublishedDocument = await requestWithApiKey.post(requestUri).json();
+
+	if (isGisBoundaryGeoJsonDocument(unpublishedDocument)) {
+		context.log(`Rebuilding master GeoJson after unpublishing GIS boundary ${documentId}`);
+
+		try {
+			await rebuildMasterGeoJson(context.log);
+		} catch (error) {
+			context.log.error(
+				`Failed to rebuild master GeoJson after unpublishing GIS boundary ${documentId}: ${error}`
+			);
+		}
+	}
 };


### PR DESCRIPTION
## Describe your changes

adds a new api route to find all published gis boundary docs
when a document is published or unpublished all the published boundary docs are uploaded in a single master file geoJson which is saved straight to the published-documents blob so it can be accessed by FO

I have added tests and checked the functionality in the dev env, the master geoJson file successfully gets built in the published doc blob store

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

## Issue ticket number and link

[ticket 222](https://pins-ds.atlassian.net/jira/software/c/projects/IDAS/boards/1034?selectedIssue=IDAS-222)

## Type of change 🧩

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [x] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
