### PR TITLE
fix(api): document unpublish auditing fix (idas-605)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.controller.js
+++ b/apps/api/src/server/applications/application/documents/document.controller.js
@@ -247,7 +247,7 @@ export const moveDocumentsToAnotherFolder = async ({ body }, response) => {
  * @type {import('express').RequestHandler<{id: number}, any, { documents: { guid: string }[] }, any>}
  * */
 export const unpublishDocuments = async ({ body }, response) => {
-	const { documents } = body;
+	const { documents, username } = body;
 
 	const guids = documents.map(({ guid }) => guid);
 
@@ -258,7 +258,7 @@ export const unpublishDocuments = async ({ body }, response) => {
 	}));
 
 	const publishedGuids = guids.filter((guid) => !nonPublishedDocuments.includes(guid));
-	const results = await unpublishDocumentGuids(publishedGuids);
+	const results = await unpublishDocumentGuids(publishedGuids, username);
 	const updateErrors = publishedGuids
 		.filter((guid) => !results.includes(guid))
 		.map((guid) => ({ guid, msg: 'Something went wrong.' }));

--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -1012,9 +1012,10 @@ export const separateNonPublishedDocuments = async (guids) => {
  * Unpublish a list of documents
  *
  * @param {string[]} guids
+ * @param {string} username
  * @returns {Promise<string[]>} // array of unpublished doc guids
  * */
-export const unpublishDocuments = async (guids) => {
+export const unpublishDocuments = async (guids, username) => {
 	const versionPromises = guids.map(documentVersionRepository.getPublished);
 	const versions = await Promise.all(versionPromises);
 
@@ -1032,7 +1033,7 @@ export const unpublishDocuments = async (guids) => {
 			documentActivityLogRepository.create({
 				documentGuid: version.documentGuid,
 				version: version.version,
-				user: version.owner ?? '',
+				user: username || version.owner || 'System',
 				status: 'unpublished'
 			})
 		)

--- a/apps/api/src/server/applications/s51advice/s51-advice.controller.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.controller.js
@@ -549,8 +549,9 @@ export const deleteS51Advice = async ({ params: { adviceId } }, response) => {
 export const unpublishS51Advice = async ({ body, params }, response) => {
 	const adviceId = params.adviceId;
 	const payload = body[''];
+	const username = body.username || '';
 
-	const updatedS51Advice = await unpublishS51(adviceId);
+	const updatedS51Advice = await unpublishS51(adviceId, username);
 
 	const docs = await s51AdviceDocumentRepository.getForAdvice(adviceId);
 	// @ts-ignore

--- a/apps/api/src/server/applications/s51advice/s51-advice.service.js
+++ b/apps/api/src/server/applications/s51advice/s51-advice.service.js
@@ -200,9 +200,10 @@ export const publishS51Items = async (ids) => {
  * Unpublish S51 advice item and associated documents
  *
  * @param {number} id
+ * @param {string} username
  * @returns {Promise<S51AdviceWithS51AdviceDocuments>}
  * */
-export const unpublishS51 = async (id) => {
+export const unpublishS51 = async (id, username) => {
 	const advice = await s51AdviceRepository.get(id);
 	if (!advice) {
 		throw new BackOfficeAppError(`no S51 advice found with id ${id}`, 404);
@@ -218,7 +219,7 @@ export const unpublishS51 = async (id) => {
 			(/** @type {S51AdviceDocument} */ advice) => advice.documentGuid
 		);
 
-		await unpublishDocuments(docs);
+		await unpublishDocuments(docs, username);
 	}
 
 	return updateResponseInTable;

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.controller.js
@@ -547,13 +547,16 @@ export async function removeApplicationsCaseDocumentationPublishingQueue(request
 /**
  * Handle unpublishing multiple documents
  *
+ * @param {*} request
+ * @param {*} response
  * @type {import('@pins/express').RenderHandler<{}, {}, {documentGuids: string[]}, {}, {}>}
  * */
 export async function postUnpublishDocuments({ body, session }, response) {
 	const { documentGuids } = body;
 	const { caseId } = response.locals;
+	const username = session.account?.name;
 
-	const { errors } = await unpublishCaseDocumentationFiles(caseId, documentGuids);
+	const { errors } = await unpublishCaseDocumentationFiles(caseId, documentGuids, username);
 
 	const documentationFiles = await getCaseManyDocumentationFilesInfo(caseId, documentGuids);
 

--- a/apps/web/src/server/applications/case/documentation/applications-documentation.service.js
+++ b/apps/web/src/server/applications/case/documentation/applications-documentation.service.js
@@ -130,13 +130,15 @@ export const updateDocumentsFolderId = async (
 /**
  * @param {number} caseId
  * @param {string[]} documentGuids
+ * @param {string} username
  * @returns {Promise<{errors: {guid: string, msg: string}[]}>};
  * */
-export const unpublishCaseDocumentationFiles = async (caseId, documentGuids) => {
+export const unpublishCaseDocumentationFiles = async (caseId, documentGuids, username) => {
 	try {
 		return await patch(`applications/${caseId}/documents/unpublish`, {
 			json: {
-				documents: documentGuids.map((guid) => ({ guid }))
+				documents: documentGuids.map((guid) => ({ guid })),
+				username
 			}
 		});
 	} catch (/** @type {*} */ error) {

--- a/apps/web/src/server/applications/case/s51/applications-s51.controller.js
+++ b/apps/web/src/server/applications/case/s51/applications-s51.controller.js
@@ -593,9 +593,11 @@ export async function viewUnpublishAdvice({ params }, response) {
 /**
  * Show page for editing s51 advice item
  *
+ * @param {*} request
+ * @param {*} response
  * @type {import('@pins/express').RenderHandler<{}, {}, {}, {success: string}, {caseId: string, adviceId: string, step: string, folderId: string}>}
  */
-export async function postUnpublishAdvice({ params }, response) {
+export async function postUnpublishAdvice({ params, session }, response) {
 	const { caseId, adviceId } = params;
 
 	const s51Advice = await getS51Advice(Number(caseId), Number(adviceId));
@@ -606,7 +608,7 @@ export async function postUnpublishAdvice({ params }, response) {
 		});
 	}
 
-	await unpublishS51Advice(Number(caseId), Number(adviceId));
+	await unpublishS51Advice(Number(caseId), Number(adviceId), session.account?.name || '');
 	response.render('applications/case-s51/s51-successfully-unpublished', {
 		gs51CaseReference: BO_GENERAL_S51_CASE_REF
 	});

--- a/apps/web/src/server/applications/case/s51/applications-s51.service.js
+++ b/apps/web/src/server/applications/case/s51/applications-s51.service.js
@@ -260,12 +260,15 @@ export const publishS51AdviceItems = async (caseId, { publishAll, ids }) => {
  *
  * @param {number} caseId
  * @param {number} adviceId
+ * @param {string} username
  * @returns {Promise<{newS51Advice?: S51Advice, errors?: ValidationErrors}>}
  * */
-export const unpublishS51Advice = async (caseId, adviceId) => {
+export const unpublishS51Advice = async (caseId, adviceId, username) => {
 	let response;
 	try {
-		response = await patch(`applications/${caseId}/s51-advice/${adviceId}/unpublish`, { json: {} });
+		response = await patch(`applications/${caseId}/s51-advice/${adviceId}/unpublish`, {
+			json: { username }
+		});
 	} catch (/** @type {*} */ error) {
 		pino.error(`[API] ${error?.response?.body?.errors?.message || 'Unknown error'}`);
 


### PR DESCRIPTION
## Describe your changes

Correcting the audit trail for unpublishing documents and S51 advice, so it shows the person unpublishing not the owner as the unpublisher.

## Issue ticket number and link
[IDAS-605](https://pins-ds.atlassian.net/browse/IDAS-605)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[IDAS-605]: https://pins-ds.atlassian.net/browse/IDAS-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ