### PR TITLE
fix(api): fix corrupted uploads being set to published (idas-612)

### DIFF
--- a/apps/api/src/server/applications/application/documents/document.service.js
+++ b/apps/api/src/server/applications/application/documents/document.service.js
@@ -444,6 +444,9 @@ export const createDocumentVersion = async (
 	newDocumentVersion.datePublished = isMigrationPublish
 		? previousDocumentVersion.publishedDate
 		: null;
+	newDocumentVersion.publishedStatus = isMigrationPublish
+		? previousDocumentVersion.publishedStatus
+		: 'awaiting_upload';
 	newDocumentVersion.publishedBlobPath = null;
 	newDocumentVersion.publishedBlobContainer = null;
 	newDocumentVersion.publishedStatusPrev = null;


### PR DESCRIPTION
## Describe your changes

The bug was due to the publishedStatus not being updated; when a new version of a file is uploaded all the metadata is copied over, except for a few fields that are explicitly overwritten. publishedStatus was not being overwritten, causing it to initially be set to published, which is relevant because the unpublish function looks for any versions with the publishedStatus set as published.
 
The reason this only affected corrupted versions is because the virus check that runs on a successful file upload overwrites the published status with a not_checked status, masking the issue.

We fix this by simply overwriting the publishedStatus field at the time of creating a new version.

## Issue ticket number and link

[IDAS-612](https://pins-ds.atlassian.net/jira/software/c/projects/IDAS/boards/1034?selectedIssue=IDAS-612)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [ ] I have referenced the ticket number above
- [ ] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes


[IDAS-612]: https://pins-ds.atlassian.net/browse/IDAS-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ