### PR TITLE
bug/idas-643 shapefile processing blob copy fix by uri normalization

### DIFF
--- a/apps/functions/applications-background-jobs/common/util.js
+++ b/apps/functions/applications-background-jobs/common/util.js
@@ -3,7 +3,11 @@
  * @returns {string}
  */
 export const extractBlobNameFromUri = (uri) => {
-	return new URL(uri).pathname.split('/').slice(2).join('/');
+	return new URL(uri).pathname
+		.split('/')
+		.slice(2)
+		.map((segment) => decodeURIComponent(segment))
+		.join('/');
 };
 
 /**

--- a/apps/functions/applications-background-jobs/process-shapefile/__tests__/index.test.js
+++ b/apps/functions/applications-background-jobs/process-shapefile/__tests__/index.test.js
@@ -109,6 +109,56 @@ describe('process-shapefile function', () => {
 		);
 	});
 
+	test('should derive GeoJSON name from multi-dot ZIP name (file.jpg.zip)', async () => {
+		const zipBuffer = Buffer.from('zip-content');
+		downloadZipBuffer.mockResolvedValue(zipBuffer);
+		validateShapefileContents.mockResolvedValue({
+			valid: true,
+			missingExtensions: [],
+			fileNames: ['test.shp', 'test.shx', 'test.dbf'],
+			parseError: null
+		});
+		shpZipToGeoJson.mockResolvedValue({ type: 'FeatureCollection', features: [] });
+		applyGeoJsonMetadata.mockReturnValue({ type: 'FeatureCollection', features: [], metadata: {} });
+
+		await index(context, {
+			...message,
+			originalFilename: 'file.jpg.zip'
+		});
+
+		expect(notifyShapefileProcessingResult).toHaveBeenCalledWith(
+			documentId,
+			expect.objectContaining({
+				geoJsonFileName: 'file.jpg.geojson'
+			})
+		);
+	});
+
+	test('should process double-zip suffix names (file2.zip.zip)', async () => {
+		const zipBuffer = Buffer.from('zip-content');
+		downloadZipBuffer.mockResolvedValue(zipBuffer);
+		validateShapefileContents.mockResolvedValue({
+			valid: true,
+			missingExtensions: [],
+			fileNames: ['test.shp', 'test.shx', 'test.dbf'],
+			parseError: null
+		});
+		shpZipToGeoJson.mockResolvedValue({ type: 'FeatureCollection', features: [] });
+		applyGeoJsonMetadata.mockReturnValue({ type: 'FeatureCollection', features: [], metadata: {} });
+
+		await index(context, {
+			...message,
+			originalFilename: 'file2.zip.zip'
+		});
+
+		expect(notifyShapefileProcessingResult).toHaveBeenCalledWith(
+			documentId,
+			expect.objectContaining({
+				geoJsonFileName: 'file2.zip.geojson'
+			})
+		);
+	});
+
 	test('should mark as invalid and NOT re-throw on validation error', async () => {
 		// GIVEN
 		downloadZipBuffer.mockResolvedValue(Buffer.from('zip'));

--- a/apps/functions/applications-background-jobs/publish-document/__tests__/publish-document.test.js
+++ b/apps/functions/applications-background-jobs/publish-document/__tests__/publish-document.test.js
@@ -108,6 +108,19 @@ describe('Publishing document', () => {
 			...baseTestCaseProperties,
 			blobName: `${TEST_CASE_REFERENCE}/horizonweb:${TEST_BLOB_GUID}:${TEST_BLOB_VERSION}`,
 			expectedDestinationName: `${TEST_CASE_REFERENCE}-001-${TEST_BLOB_FILE_NAME}.jpeg`
+		},
+		{
+			name: 'Source URL with spaces is encoded before copy',
+			document: {
+				...baseDocumentProperties,
+				documentURI: `https://${TEST_BLOB_ACCOUNT}.blob.core.windows.net/${TEST_BLOB_SOURCE_CONTAINER}/application/${TEST_CASE_REFERENCE}/${TEST_BLOB_GUID}/my boundary.geojson`,
+				filename: 'my boundary.geojson',
+				originalFilename: 'my boundary.geojson',
+				mime: 'application/geo+json'
+			},
+			...baseTestCaseProperties,
+			blobName: `application/${TEST_CASE_REFERENCE}/${TEST_BLOB_GUID}/my boundary.geojson`,
+			expectedDestinationName: `${TEST_CASE_REFERENCE}-001-my boundary.geojson`
 		}
 	];
 
@@ -136,12 +149,13 @@ describe('Publishing document', () => {
 			expect(mockGetBlobProperties).toHaveBeenCalledTimes(1);
 			expect(mockGetBlobProperties).toHaveBeenCalledWith(TEST_BLOB_SOURCE_CONTAINER, blobName);
 			expect(mockDownloadStream).toHaveBeenCalledTimes(Number(isHtml)); // true = 1 | false = 0
+			const expectedSourceUrl = new URL(document.documentURI).toString();
 			expect(mockCopyFile).toHaveBeenCalledTimes(1);
 			expect(mockCopyFile).toHaveBeenCalledWith({
-				sourceUrl: document.documentURI,
+				sourceUrl: expectedSourceUrl,
 				destinationContainerName: TEST_BLOB_PUBLISH_CONTAINER,
 				destinationBlobName: expectedDestinationName,
-				newContentType: baseDocumentProperties.mime
+				newContentType: document.mime
 			});
 			expect(mockGotPost).toHaveBeenCalledTimes(1);
 			expect(mockGotPost).toHaveBeenCalledWith(

--- a/apps/functions/applications-background-jobs/publish-document/index.js
+++ b/apps/functions/applications-background-jobs/publish-document/index.js
@@ -54,6 +54,10 @@ export const index = async (
 		originalFilename
 	});
 
+	// Normalise and encode source URL (e.g. spaces in generated GeoJSON filenames)
+	// so Storage SDK copy operations receive a valid URL.
+	documentURI = new URL(documentURI).toString();
+
 	context.log(
 		`Deploying source blob ${documentURI} to destination ${publishFileName} for caseId ${caseId}`
 	);
@@ -100,10 +104,9 @@ export const index = async (
 		try {
 			await rebuildMasterGeoJson(context.log);
 		} catch (error) {
-			context.log,
-				error(
-					`Failed to rebuild master GeoJson after publishing GIS boundary ${documentId}: ${error}`
-				);
+			context.log(
+				`Failed to rebuild master GeoJson after publishing GIS boundary ${documentId}: ${error}`
+			);
 		}
 	}
 };


### PR DESCRIPTION
## Describe your changes

<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->

The publishing function which publishes GIS boundary files could fail when source filenames contains spaces or other encoded characters. This PR normalizes source document URIs before copy so Azure Blob Storage receives a valid URL, and decodes URI path segments when extracting blob names to ensure that the publishing happens smoothly without getting "stuck".

Also includes tests that cover:

- Source URL encoding before copy for filenames with spaces.
- GeoJSON filename derivation for multi-dot zip names.
- Double suffix handling.
- Correct MIME type passed during publish copy.
- Improved error logging path for GeoJSON rebuild failures.

## Issue ticket number and link
[\[IDAS-643\] GeoJSON file stuck at Publishing status](https://pins-ds.atlassian.net/browse/IDAS-643)

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [x] I have included unit tests to cover any testable code changes
