### PR TITLE
fix(web): save rr notes when status changes (idas-285)

### DIFF
--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/__tests__/__snapshots__/representation-status-notes.test.js.snap
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/__tests__/__snapshots__/representation-status-notes.test.js.snap
@@ -11,10 +11,12 @@ exports[`Change representation status page GET /applications-service/case/1/rele
                         <div class="govuk-radios" data-module="govuk-radios"></div>
                     </fieldset>
                 </div>
-                <div class="govuk-form-group">
+                <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                data-maxlength="6000">
                     <div id="notes-hint" class="govuk-hint">Use this space to provide more details.</div>
-                    <textarea class="govuk-textarea"
-                    id="notes" name="notes" rows="5" aria-describedby="notes-hint"></textarea>
+                    <textarea class="govuk-textarea govuk-js-character-count"
+                    id="notes" name="notes" rows="5" aria-describedby="notes-info notes-hint">Some notes</textarea>
+                    <div id="notes-info" class="govuk-hint govuk-character-count__message">You can enter up to 6000 characters</div>
                 </div>
                 <button type="submit" class="govuk-button govuk-!-margin-top-3" data-module="govuk-button">Save changes</button>
             </form>

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.constants.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.constants.js
@@ -1,0 +1,1 @@
+export const NOTES_CHARACTER_LIMIT = 6000;

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.controller.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.controller.js
@@ -43,12 +43,14 @@ export const postRepresentationStatusNotesController = async (req, res) => {
 	const { status: oldStatus } = representationDetails;
 
 	if (errors) {
+		const submittedNotes = /** @type {Record<string, any>} */ (body)['notes'];
 		return res.render(view, {
 			...getRepresentationStatusNotesViewModel(
 				caseId,
 				representationId,
 				representationDetails,
-				newStatus
+				newStatus,
+				submittedNotes
 			),
 			errors,
 			errorSummary: getFormattedErrorSummary(errors)

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.validators.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.validators.js
@@ -1,5 +1,6 @@
 import { body } from 'express-validator';
 import { createValidator } from '@pins/express';
+import { NOTES_CHARACTER_LIMIT } from './representation-status-notes.constants.js';
 
 const validateStatusChange = createValidator(
 	body('statusResult').custom((value, { req: { query } }) => {
@@ -20,4 +21,11 @@ const validateStatusChange = createValidator(
 	})
 );
 
-export const representationStatusNotesValidation = [validateStatusChange];
+const validateNotes = createValidator(
+	body('notes')
+		.optional({ checkFalsy: true })
+		.isLength({ max: NOTES_CHARACTER_LIMIT })
+		.withMessage(`Notes must be ${NOTES_CHARACTER_LIMIT} characters or fewer`)
+);
+
+export const representationStatusNotesValidation = [validateStatusChange, validateNotes];

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
@@ -2,6 +2,7 @@ import {
 	getRepresentationDetailsPageUrl,
 	getChangeStatusPageUrl
 } from '../representation-status.utils.js';
+import { NOTES_CHARACTER_LIMIT } from './representation-status-notes.constants.js';
 
 /**
  * @typedef {import('../../../relevant-representation.types.js').Representation} Representation
@@ -106,6 +107,11 @@ export const getRepresentationStatusNotesViewModel = (
 	representationDetails,
 	newStatus
 ) => {
+	const latestReferralAction = (representationDetails?.representationActions ?? []).find(
+		(action) => action.status === 'REFERRED'
+	);
+	const latestReferralNote = latestReferralAction?.notes ?? null;
+
 	return {
 		caseId,
 		repId,
@@ -113,6 +119,8 @@ export const getRepresentationStatusNotesViewModel = (
 		pageHeading: getPageContentByStatus(newStatus).pageHeading,
 		radioItems: getPageContentByStatus(newStatus).radioItems,
 		summaryPageLinkUrl: getRepresentationDetailsPageUrl(caseId, repId),
-		backLinkUrl: `${getChangeStatusPageUrl(caseId, repId)}?changeStatus=${newStatus}`
+		backLinkUrl: `${getChangeStatusPageUrl(caseId, repId)}?changeStatus=${newStatus}`,
+		latestReferralNote,
+		notesCharacterLimit: NOTES_CHARACTER_LIMIT
 	};
 };

--- a/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
+++ b/apps/web/src/server/applications/case/representations/representation-details/representation-status/representation-status-notes/representation-status-notes.view-model.js
@@ -105,12 +105,13 @@ export const getRepresentationStatusNotesViewModel = (
 	caseId,
 	repId,
 	representationDetails,
-	newStatus
+	newStatus,
+	submittedNotes = undefined
 ) => {
 	const latestReferralAction = (representationDetails?.representationActions ?? []).find(
 		(action) => action.status === 'REFERRED'
 	);
-	const latestReferralNote = latestReferralAction?.notes ?? null;
+	const latestReferralNote = submittedNotes ?? latestReferralAction?.notes ?? null;
 
 	return {
 		caseId,

--- a/apps/web/src/server/views/applications/representations/representation-details/representation-status/representation-status-notes.njk
+++ b/apps/web/src/server/views/applications/representations/representation-details/representation-status/representation-status-notes.njk
@@ -1,7 +1,7 @@
 {% extends "applications/layouts/applications.layout.njk" %}
 
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
@@ -34,9 +34,11 @@
 						}
 					}) }}
 
-                    {{ govukTextarea({
+                    {{ govukCharacterCount({
                     name: "notes",
                     id: "notes",
+                    value: latestReferralNote,
+                    maxlength: notesCharacterLimit,
                     label: {
                         text: radioItems|length and "Notes (optional)",
                         classes: "govuk-label--m",
@@ -44,6 +46,9 @@
                     },
                     hint: {
                         text: "Use this space to provide more details."
+                    },
+                    errorMessage: errors["notes"] and {
+                        text: errors["notes"].msg
                     }
                     }) }}
 


### PR DESCRIPTION
## Describe your changes
<!--
    Please include a summary of the change along with any relevant context.
    List any dependencies that are required for this change.
-->
- extracted latest referred action notes to prepopulate text field
- added a character limit to text field
- used govukCharacterCount component to display character counter
- added a fix to save referrals which are being wiped

## Issue ticket number and link
[\[IDAS-285\] Save RR notes when user changes status](https://pins-ds.atlassian.net/browse/IDAS-285)

Currently every time a referral is made the notes are wiped, this means Case Officers and CAT team lose visibility of the full conversation history and cannot refer back to earlier notes. This fix changes the behaviour to outcome requested in ACs

## Type of change 🧩

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain in the description section above)

## Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have double checked this work does not include any hardcoded secrets or passwords
- [ ] I have made corresponding changes to the documentation
- [ ] I have provided details on how I have tested my code
- [x] I have referenced the ticket number above
- [x] I have provided a description of the ticket
- [ ] I have included unit tests to cover any testable code changes
